### PR TITLE
[DRAFT] Selector 2: Electric boogaloo

### DIFF
--- a/examples/next13/app/blogs.val.ts
+++ b/examples/next13/app/blogs.val.ts
@@ -13,6 +13,14 @@ export default val.content(
        * The rank is some arbitrary number we sort by.
        */
       rank: s.number(),
+      foo: s.taggedUnion("disc", [
+        s.object({
+          disc: s.literal("hello"),
+        }),
+        s.object({
+          disc: s.literal("goodbye"),
+        }),
+      ]),
     })
   ),
   [
@@ -22,6 +30,9 @@ export default val.content(
       },
       text: "Vi gjør mange ting sammen i Blank, men det vi lever av er å designe og utvikle digitale tjenester for kundene våre.\n\n    Noen av selskapene vi jobber med er små, andre er store. Alle har de høye ambisjoner for sine digitale løsninger, og stiller høye krav til hvem de jobber med.\n    \n    Noen ganger starter vi nye, egne, selskaper også, mest fordi det er gøy (og fordi vi liker å bygge ting), men også fordi smarte folk har gode idéer som fortjener å bli realisert.\n    Ting vi har bygd for kundene våre",
       rank: 100,
+      foo: {
+        disc: "hello",
+      },
     },
     {
       title: {
@@ -29,6 +40,9 @@ export default val.content(
       },
       text: "I Blank er vi en gjeng på omtrent 50 ulike folk som er ekstremt dyktige i faget vår - digital produktutvikling. Vi er en tredjedel designere og resten teknologer.",
       rank: 10,
+      foo: {
+        disc: "goodbye",
+      },
     },
     {
       title: {
@@ -36,6 +50,9 @@ export default val.content(
       },
       text: "Vi startet Blank fordi vi \u00F8nsket oss et konsulentselskap hvor vi kan l\u00E6re og utfordre oss selv, et selskap hvor det er veldig fint \u00E5 jobbe - og kanskje aller mest fordi vi liker \u00E5 bygge ting.\n  test\n      I tillegg \u00F8nsket vi \u00E5 forandre bransjen og hvordan et konsulentselskap kan fungere. Mer om det senere..\n      \n      ",
       rank: 1,
+      foo: {
+        disc: "goodbye",
+      },
     },
   ]
 );

--- a/packages/lib/src/descriptor2.ts
+++ b/packages/lib/src/descriptor2.ts
@@ -1,0 +1,504 @@
+import type { Source, SourceObject } from "./index";
+import { deepEqual } from "./patch/util";
+
+export const DEBUG_STRING = Symbol("DEBUG_STRING");
+export const IS = Symbol("IS");
+
+export const ARRAY_VALUE = Symbol("ARRAY_VALUE");
+export const OBJECT_VALUE = Symbol("OBJECT_VALUE");
+export const STRING_BRAND = Symbol("STRING");
+export const NUMBER_BRAND = Symbol("NUMBER");
+export const BOOLEAN_BRAND = Symbol("BOOLEAN");
+export const NULL_BRAND = Symbol("NULL");
+
+export type Descriptor<V extends Source> = V extends readonly Source[]
+  ? {
+      [P in keyof V & number]: Descriptor<V[P]>;
+    } & {
+      [ARRAY_VALUE]: Descriptor<V[number]>;
+      length: Descriptor<V["length"]>;
+      [IS](v: Source): v is V;
+      [DEBUG_STRING](): string;
+    }
+  : V extends SourceObject
+  ? {
+      [P in keyof V]: Descriptor<V[P]>;
+    } & {
+      [OBJECT_VALUE]: Descriptor<V[keyof V]>;
+      [IS](v: Source): v is V;
+      [DEBUG_STRING](): string;
+    }
+  : V extends string
+  ? {
+      [STRING_BRAND]: unknown;
+      [IS](v: Source): v is V;
+      [DEBUG_STRING](): string;
+    }
+  : V extends number
+  ? {
+      [NUMBER_BRAND]: unknown;
+      [IS](v: Source): v is V;
+      [DEBUG_STRING](): string;
+    }
+  : V extends boolean
+  ? {
+      [BOOLEAN_BRAND]: unknown;
+      [IS](v: Source): v is V;
+      [DEBUG_STRING](): string;
+    }
+  : V extends null
+  ? {
+      [NULL_BRAND]: unknown;
+      [IS](v: Source): v is V;
+      [DEBUG_STRING](): string;
+    }
+  : never;
+
+type A<V extends Source> = Descriptor<V>[typeof IS];
+
+export const StringDescriptor: Descriptor<string> =
+  new (class StringDescriptor {
+    [STRING_BRAND]!: unknown;
+    [IS](v: Source): v is string {
+      return typeof v === "string";
+    }
+    [DEBUG_STRING](): string {
+      return "string";
+    }
+    static {
+      Object.defineProperty(this, STRING_BRAND, {});
+    }
+  })();
+export const NumberDescriptor: Descriptor<number> =
+  new (class NumberDescriptor {
+    [NUMBER_BRAND]!: unknown;
+    [IS](v: Source): v is number {
+      return typeof v === "number";
+    }
+    [DEBUG_STRING](): string {
+      return "number";
+    }
+    static {
+      Object.defineProperty(this, NUMBER_BRAND, {});
+    }
+  })();
+export const BooleanDescriptor: Descriptor<boolean> =
+  new (class BooleanDescriptor {
+    [BOOLEAN_BRAND]!: unknown;
+    [IS](v: Source): v is boolean {
+      return typeof v === "boolean";
+    }
+    [DEBUG_STRING](): string {
+      return "boolean";
+    }
+    static {
+      Object.defineProperty(this, BOOLEAN_BRAND, {});
+    }
+  })() as Descriptor<boolean>;
+export const NullDescriptor: Descriptor<null> = new (class NullDescriptor {
+  [NULL_BRAND]!: unknown;
+  [IS](v: Source): v is null {
+    return v === null;
+  }
+  [DEBUG_STRING](): string {
+    return "null";
+  }
+  static {
+    Object.defineProperty(this, NULL_BRAND, {});
+  }
+})();
+
+const unknownProxy = new Proxy(Object.create(null), {
+  get(_, p, receiver) {
+    if (p === IS) {
+      return () => true;
+    }
+    if (
+      typeof p === "string" ||
+      p === ARRAY_VALUE ||
+      p === OBJECT_VALUE ||
+      p === STRING_BRAND ||
+      p === NUMBER_BRAND ||
+      p === BOOLEAN_BRAND ||
+      p === NULL_BRAND
+    ) {
+      return receiver;
+    }
+    return undefined;
+  },
+  has(_, p) {
+    if (p === IS) {
+      return true;
+    }
+    if (
+      typeof p === "string" ||
+      p === ARRAY_VALUE ||
+      p === OBJECT_VALUE ||
+      p === STRING_BRAND ||
+      p === NUMBER_BRAND ||
+      p === BOOLEAN_BRAND ||
+      p === NULL_BRAND
+    ) {
+      return true;
+    }
+    return false;
+  },
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const AnyDescriptor: Descriptor<any> = Object.create(unknownProxy, {
+  [DEBUG_STRING]: { value: () => "any" },
+});
+export const UnknownDescriptor: Descriptor<Source> = Object.create(
+  unknownProxy,
+  {
+    [DEBUG_STRING]: { value: () => "unknown" },
+  }
+);
+export const NeverDescriptor: Descriptor<never> = Object.create(null, {
+  [IS]: {
+    value: () => false,
+  },
+  [DEBUG_STRING]: { value: () => "never" },
+}) as Descriptor<never>;
+
+const LITERAL_VALUE = Symbol("LITERAL_VALUE");
+export class LiteralDescriptor<V extends Source> {
+  [LITERAL_VALUE]: V;
+
+  private constructor(value: V) {
+    this[LITERAL_VALUE] = value;
+  }
+
+  [IS](v: Source): v is V {
+    return deepEqual(v, this[LITERAL_VALUE]);
+  }
+
+  [DEBUG_STRING]() {
+    return JSON.stringify(this[LITERAL_VALUE]);
+  }
+
+  static create<V extends Source>(value: V): Descriptor<V> {
+    let brand: typeof STRING_BRAND | typeof NUMBER_BRAND | typeof BOOLEAN_BRAND;
+    switch (typeof value) {
+      case "string":
+        brand = STRING_BRAND;
+        break;
+      case "number":
+        brand = NUMBER_BRAND;
+        break;
+      case "boolean":
+        brand = BOOLEAN_BRAND;
+        break;
+      case "object":
+        if (value === null) {
+          return NullDescriptor as Descriptor<V>;
+        } else if (Array.isArray(value)) {
+          return TupleDescriptor.create<Source[]>(
+            value.map(this.create<Source>)
+          ) as unknown as Descriptor<V>;
+        } else {
+          return ObjectDescriptor.create(
+            Object.fromEntries(
+              Object.entries(value).map(([k, v]) => [
+                k,
+                LiteralDescriptor.create(v),
+              ])
+            )
+          ) as Descriptor<V>;
+        }
+      default:
+        throw new Error("Unexpected literal type");
+    }
+
+    const desc = new LiteralDescriptor(value);
+    (desc as unknown as Record<typeof brand, unknown>)[brand] = undefined;
+    return desc as unknown as Descriptor<V>;
+  }
+}
+
+const TUPLE_LENGTH = Symbol("TUPLE_LENGTH");
+export class TupleDescriptor<V extends readonly Source[]> {
+  length: Descriptor<V["length"]>;
+  [ARRAY_VALUE]: Descriptor<V[number]>;
+  private [TUPLE_LENGTH]: V["length"];
+
+  private constructor(props: { [I in keyof V]: Descriptor<V[I]> }) {
+    Object.assign(this, props);
+    this.length = LiteralDescriptor.create<V["length"]>(props.length);
+    this[ARRAY_VALUE] = UnionDescriptor.create<V[number]>(
+      props as Descriptor<V[number]>[]
+    );
+    this[TUPLE_LENGTH] = props.length;
+  }
+
+  [IS](v: Source): v is V {
+    if (!Array.isArray(v)) {
+      return false;
+    }
+    return v.every((i, idx) =>
+      (this as { [I in keyof V]: Descriptor<V[I]> })[idx][IS](i)
+    );
+  }
+
+  [DEBUG_STRING]() {
+    return `[${Array.from({ length: this[TUPLE_LENGTH] }, (_, i) => {
+      return (this as { [I in keyof V]: Descriptor<V[I]> })[i][DEBUG_STRING]();
+    }).join(", ")}]`;
+  }
+
+  static create<V extends readonly Source[]>(props: {
+    [I in keyof V]: Descriptor<V[I]>;
+  }): Descriptor<V> {
+    return new TupleDescriptor(props) as unknown as Descriptor<V>;
+  }
+}
+
+export class ObjectDescriptor<V extends SourceObject> {
+  [OBJECT_VALUE]: Descriptor<V[keyof V]>;
+
+  private constructor(props: { [P in keyof V]: Descriptor<V[P]> }) {
+    Object.assign(this, props);
+    this[OBJECT_VALUE] = UnionDescriptor.create(Object.values(props));
+  }
+
+  [IS](v: Source): v is V {
+    if (typeof v !== "object" || v === null) {
+      return false;
+    }
+    return Object.entries(this as unknown as Descriptor<V>).every(
+      ([k, d]) => k in v && d[IS]((v as Record<string, Source>)[k])
+    );
+  }
+
+  [DEBUG_STRING]() {
+    return `{ ${Object.entries(this as unknown as Descriptor<V>)
+      .map(([k, v]) => `${JSON.stringify(k)}: ${v[DEBUG_STRING]()}`)
+      .join(", ")} }`;
+  }
+
+  static create<V extends SourceObject>(props: {
+    [P in keyof V]: Descriptor<V[P]>;
+  }): Descriptor<V> {
+    return new ObjectDescriptor(props) as Descriptor<V>;
+  }
+}
+
+export class ArrayDescriptor<V extends Source> {
+  [index: number]: Descriptor<V>;
+  [ARRAY_VALUE]: Descriptor<V>;
+  length!: Descriptor<number>;
+
+  private constructor(value: Descriptor<V>) {
+    this[ARRAY_VALUE] = value;
+    return new Proxy<ArrayDescriptor<V>>(this, ArrayDescriptor.proxyHandler);
+  }
+
+  [IS](v: Source): v is V[] {
+    return Array.isArray(v) && v.every((i) => this[ARRAY_VALUE][IS](i));
+  }
+
+  [DEBUG_STRING]() {
+    return `${this[ARRAY_VALUE][DEBUG_STRING]}`;
+  }
+
+  static {
+    Object.defineProperty(this, "length", {
+      get() {
+        return NumberDescriptor;
+      },
+    });
+  }
+
+  private static readonly proxyHandler = {
+    get<V extends Source>(desc: ArrayDescriptor<V>, p: string | symbol) {
+      if (
+        p === ARRAY_VALUE ||
+        p === DEBUG_STRING ||
+        p === IS ||
+        p === "length"
+      ) {
+        return desc[
+          p as typeof ARRAY_VALUE | typeof DEBUG_STRING | typeof IS | "length"
+        ];
+      }
+      if (typeof p === "string") {
+        if (/^(-?0|[1-9][0-9]*)$/g.test(p)) {
+          return desc[ARRAY_VALUE];
+        }
+        if (p === "length") {
+          // TODO: Indicate this is a number somehow?
+          return NumberDescriptor;
+        }
+      }
+      return undefined;
+    },
+    has<V extends Source>(_: ArrayDescriptor<V>, p: string | symbol) {
+      if (p === ARRAY_VALUE || p === DEBUG_STRING) {
+        return true;
+      }
+      if (typeof p === "string") {
+        if (/^(-?0|[1-9][0-9]*)$/g.test(p)) {
+          return true;
+        }
+        if (p === "length") {
+          return true;
+        }
+      }
+      return false;
+    },
+  };
+
+  static create<V extends Source>(value: Descriptor<V>): Descriptor<V[]> {
+    return new ArrayDescriptor(value) as Descriptor<V[]>;
+  }
+}
+
+export class RecordDescriptor<V extends Source> {
+  [prop: string]: Descriptor<V>;
+  [OBJECT_VALUE]!: Descriptor<V>;
+
+  private constructor(value: Descriptor<V>) {
+    this[OBJECT_VALUE] = value;
+    return new Proxy<RecordDescriptor<V>>(this, RecordDescriptor.proxyHandler);
+  }
+
+  [IS](v: Source): v is Record<string, V> {
+    if (typeof v !== "object" || v === null) {
+      return false;
+    }
+    return Object.values(v).every((i) => {
+      return this[OBJECT_VALUE][IS](i);
+    });
+  }
+
+  [DEBUG_STRING]() {
+    return `{[key: string]: ${this[OBJECT_VALUE][DEBUG_STRING]()}}}`;
+  }
+
+  private static readonly proxyHandler = {
+    get<V extends Source>(desc: RecordDescriptor<V>, p: string | symbol) {
+      if (p === OBJECT_VALUE || p === DEBUG_STRING || p === IS) {
+        return desc[p as typeof OBJECT_VALUE | typeof DEBUG_STRING | typeof IS];
+      }
+      if (typeof p === "string") {
+        return desc[OBJECT_VALUE];
+      }
+      return undefined;
+    },
+    has<V extends Source>(_: RecordDescriptor<V>, p: string | symbol) {
+      if (p === OBJECT_VALUE || p === DEBUG_STRING) {
+        return true;
+      }
+      return typeof p === "string";
+    },
+  };
+
+  static create<V extends Source>(
+    value: Descriptor<V>
+  ): Descriptor<Record<string, V>> {
+    return new RecordDescriptor(value) as Descriptor<Record<string, V>>;
+  }
+}
+
+export const UNION_OPTIONS = Symbol("UNION_OPTIONS");
+export class UnionDescriptor<V extends Source> {
+  public readonly [UNION_OPTIONS]: Descriptor<V>[];
+
+  private constructor(options: Descriptor<V>[]) {
+    this[UNION_OPTIONS] = options;
+    return new Proxy<UnionDescriptor<V>>(this, UnionDescriptor.proxyHandler);
+  }
+
+  [IS](v: Source): v is V {
+    return this[UNION_OPTIONS].some((o) => o[IS](v));
+  }
+
+  [DEBUG_STRING]() {
+    return this[UNION_OPTIONS].map((o) => o[DEBUG_STRING]()).join(" | ");
+  }
+
+  private static readonly proxyHandler = {
+    get<V extends Source>(desc: UnionDescriptor<V>, p: string | symbol) {
+      if (p === UNION_OPTIONS || p === DEBUG_STRING || p === IS) {
+        return desc[
+          p as typeof UNION_OPTIONS | typeof DEBUG_STRING | typeof IS
+        ];
+      }
+
+      if (typeof p === "string" || p === ARRAY_VALUE || p === OBJECT_VALUE) {
+        const descs: Descriptor<Source>[] = [];
+        for (const option of desc[UNION_OPTIONS]) {
+          if (p in option) {
+            descs.push(
+              (
+                option as unknown as {
+                  [p in
+                    | string
+                    | typeof ARRAY_VALUE
+                    | typeof OBJECT_VALUE]: Descriptor<Source>;
+                }
+              )[p as string | typeof ARRAY_VALUE | typeof OBJECT_VALUE]
+            );
+          }
+        }
+        if (descs.length === 0) {
+          return undefined;
+        }
+        return UnionDescriptor.create<Source>(descs);
+      }
+
+      return undefined;
+    },
+    has<V extends Source>(desc: UnionDescriptor<V>, p: string | symbol) {
+      for (const option of desc[UNION_OPTIONS]) {
+        if (p in option) {
+          return true;
+        }
+      }
+      return false;
+    },
+  };
+
+  private static flattenUnionOptions<V extends Source>(
+    options: Descriptor<V>[]
+  ): Descriptor<V>[] {
+    // TODO: Deduplication?
+    return options
+      .filter((o) => o !== NeverDescriptor)
+      .flatMap((o) => {
+        if (o instanceof UnionDescriptor) {
+          return o[UNION_OPTIONS] as Descriptor<V>[];
+        }
+        return o;
+      });
+  }
+
+  static create<V extends Source>(options: Descriptor<V>[]): Descriptor<V> {
+    if (options.length === 0) {
+      return NeverDescriptor;
+    } else if (options.length === 1) {
+      return options[0];
+    }
+
+    return new UnionDescriptor(
+      this.flattenUnionOptions(options)
+    ) as unknown as Descriptor<V>;
+  }
+}
+
+export function filter<V extends Source, U extends V>(
+  desc: Descriptor<V>,
+  f: (desc: Descriptor<V>) => desc is Descriptor<U>
+): Descriptor<U>;
+export function filter<V extends Source>(
+  desc: Descriptor<V>,
+  f: (desc: Descriptor<V>) => boolean
+): Descriptor<V> {
+  if (desc instanceof UnionDescriptor) {
+    return UnionDescriptor.create(
+      (desc[UNION_OPTIONS] as Descriptor<V>[]).filter(f)
+    ) as Descriptor<V>;
+  }
+  return f(desc) ? desc : NeverDescriptor;
+}

--- a/packages/lib/src/expr/index.ts
+++ b/packages/lib/src/expr/index.ts
@@ -15,6 +15,7 @@ export {
   andThen,
   objectLiteral,
   arrayLiteral,
+  match,
   primitiveLiteral,
   parse,
 } from "./expr";

--- a/packages/lib/src/initVal.ts
+++ b/packages/lib/src/initVal.ts
@@ -4,6 +4,7 @@ import { number } from "./schema/number";
 import { i18n } from "./schema/i18n";
 import { object } from "./schema/object";
 import { string } from "./schema/string";
+import { taggedUnion, literal } from "./schema/taggedUnion";
 
 const defaultVal = {
   val: {
@@ -15,6 +16,8 @@ const defaultVal = {
     number,
     object,
     string,
+    taggedUnion,
+    literal,
   },
 };
 

--- a/packages/lib/src/schema/desc2.ts
+++ b/packages/lib/src/schema/desc2.ts
@@ -1,0 +1,79 @@
+import {
+  ArrayDescriptor,
+  Descriptor,
+  LiteralDescriptor,
+  NullDescriptor,
+  NumberDescriptor,
+  ObjectDescriptor,
+  StringDescriptor,
+  UnionDescriptor,
+} from "../descriptor2";
+import { Source } from "../Source";
+import { ArraySchema } from "./array";
+import { I18nSchema } from "./i18n";
+import { NumberSchema } from "./number";
+import { ObjectSchema, SchemaObject } from "./object";
+import { LocalOf, Schema } from "./Schema";
+import { StringSchema } from "./string";
+import { LiteralSchema, TaggedUnionSchema } from "./taggedUnion";
+
+export type MaybeOptDesc<D extends Descriptor<Source>, Opt extends boolean> =
+  | (Opt extends true ? D | Descriptor<null> : never)
+  | (Opt extends false ? D : never);
+
+export function maybeOptDesc<D extends Descriptor<Source>, Opt extends boolean>(
+  desc: D,
+  opt: Opt
+): MaybeOptDesc<D, Opt> {
+  return (
+    opt
+      ? UnionDescriptor.create<D | null>([
+          desc as Descriptor<D | null>,
+          NullDescriptor,
+        ])
+      : desc
+  ) as MaybeOptDesc<D, Opt>;
+}
+
+export type LocalDescriptorOf<S extends Schema<never, Source>> = Descriptor<
+  LocalOf<S>
+>;
+
+export function localDescriptorOf<S extends Schema<never, Source>>(
+  s: S
+): LocalDescriptorOf<S> {
+  if (s instanceof ArraySchema) {
+    return maybeOptDesc(
+      ArrayDescriptor.create(localDescriptorOf(s.item) as any),
+      s.opt
+    ) as LocalDescriptorOf<S>;
+  } else if (s instanceof I18nSchema) {
+    return maybeOptDesc(
+      localDescriptorOf(s.schema),
+      s.opt
+    ) as LocalDescriptorOf<S>;
+  } else if (s instanceof ObjectSchema) {
+    const entries = Object.entries(s.props as SchemaObject).map(
+      ([prop, s]) => [prop, localDescriptorOf(s)] as const
+    );
+    return maybeOptDesc(
+      ObjectDescriptor.create(Object.fromEntries(entries)),
+      s.opt
+    ) as LocalDescriptorOf<S>;
+  } else if (s instanceof StringSchema) {
+    return maybeOptDesc(StringDescriptor, s.opt) as LocalDescriptorOf<S>;
+  } else if (s instanceof NumberSchema) {
+    return maybeOptDesc(NumberDescriptor, s.opt) as LocalDescriptorOf<S>;
+  } else if (s instanceof LiteralSchema) {
+    return maybeOptDesc(
+      LiteralDescriptor.create(s.value) as any,
+      s.opt
+    ) as LocalDescriptorOf<S>;
+  } else if (s instanceof TaggedUnionSchema) {
+    return maybeOptDesc(
+      UnionDescriptor.create([...s.schemas.values()].map(localDescriptorOf)),
+      s.opt
+    ) as LocalDescriptorOf<S>;
+  }
+  throw Error("Unsupported schema");
+}

--- a/packages/lib/src/schema/taggedUnion.test.ts
+++ b/packages/lib/src/schema/taggedUnion.test.ts
@@ -1,0 +1,32 @@
+import { object } from "./object";
+import { Schema, SrcOf } from "./Schema";
+import { string } from "./string";
+import { literal, taggedUnion } from "./taggedUnion";
+
+test("tagged union schema", () => {
+  const helloS = object({
+    d: literal("hello"),
+    hello: string(),
+  });
+  const goodbyeS = object({
+    d: literal("goodbye"),
+    goodbye: string(),
+  });
+  const helloV: SrcOf<typeof helloS> = {
+    d: "hello",
+    hello: "hello",
+  };
+  const goodbyeV: SrcOf<typeof goodbyeS> = {
+    d: "goodbye",
+    goodbye: "goodbye",
+  };
+
+  const schema = taggedUnion("d", [helloS, goodbyeS]);
+
+  expect(Schema.validate(schema, helloV)).toEqual(false);
+  expect(Schema.validate(schema, goodbyeV)).toEqual(false);
+
+  /* Schema.validate(schema, {
+    d: "morning",
+  }); */
+});

--- a/packages/lib/src/schema/taggedUnion.ts
+++ b/packages/lib/src/schema/taggedUnion.ts
@@ -1,0 +1,169 @@
+import {
+  Schema,
+  SrcOf,
+  LocalOf,
+  SerializedSchema,
+  OptIn,
+  OptOut,
+} from "./Schema";
+import { ObjectSchema } from "./object";
+
+export class LiteralSchema<T extends string> extends Schema<T, T> {
+  constructor(public readonly value: T) {
+    super(false);
+  }
+  protected validate(src: T): false | string[] {
+    return src === this.value ? false : [`Value must equal ${this.value}`];
+  }
+  hasI18n(): boolean {
+    return false;
+  }
+  protected localize(src: T): T {
+    return src;
+  }
+  protected delocalizePath(_src: T, localPath: string[]): string[] {
+    return localPath;
+  }
+  serialize(): SerializedSchema {
+    throw new Error("Method not implemented.");
+  }
+}
+export const literal = <T extends string>(value: T): LiteralSchema<T> => {
+  return new LiteralSchema(value);
+};
+
+type SchemaObject<D extends string> = {
+  [d in D]: LiteralSchema<string>;
+};
+
+export class TaggedUnionSchema<
+  D extends string,
+  T extends readonly SchemaObject<D>[],
+  Opt extends boolean
+> extends Schema<
+  OptIn<{ [I in number]: SrcOf<ObjectSchema<T[I], false>> }[number], Opt>,
+  OptOut<{ [I in number]: LocalOf<ObjectSchema<T[I], false>> }[number], Opt>
+> {
+  readonly schemas: Map<string, ObjectSchema<SchemaObject<D>, false>>;
+
+  constructor(
+    private readonly discriminator: D,
+    schemas: { [I in keyof T]: ObjectSchema<T[I], false> },
+    public readonly opt: Opt
+  ) {
+    super(opt);
+    this.schemas = new Map();
+    for (const schema of schemas) {
+      const discriminatorSchema = schema.props[discriminator];
+      const value = discriminatorSchema.value;
+      if (this.schemas.has(value)) {
+        throw Error(`Duplicate schema for discriminator value ${value}`);
+      }
+      this.schemas.set(value, schema);
+    }
+  }
+  protected validate(
+    src: OptIn<{ [I in number]: SrcOf<ObjectSchema<T[I], false>> }[number], Opt>
+  ): false | string[] {
+    if (src === null) {
+      if (!this.opt) return ["Required tagged union cannot be null"];
+      return false;
+    }
+
+    const value = src[this.discriminator];
+    const schema = this.schemas.get(value as string);
+    if (schema === undefined) {
+      return [`Tagged union has invalid discriminator value ${value}`];
+    }
+    return Schema.validate(schema, src);
+  }
+  hasI18n(): boolean {
+    for (const schema of this.schemas.values()) {
+      if (schema.hasI18n()) return true;
+    }
+    return false;
+  }
+  protected localize(
+    src: OptIn<
+      { [I in number]: SrcOf<ObjectSchema<T[I], false>> }[number],
+      Opt
+    >,
+    locale: "en_US"
+  ): OptOut<
+    { [I in number]: LocalOf<ObjectSchema<T[I], false>> }[number],
+    Opt
+  > {
+    if (src === null) {
+      if (!this.opt)
+        throw Error("Invalid value: Required tagged union cannot be null");
+      return src as any;
+    }
+
+    const value = src[this.discriminator];
+    const schema = this.schemas.get(value as string);
+    if (schema === undefined) {
+      throw Error(
+        `Invalid value: Tagged union has invalid discriminator value ${value}`
+      );
+    }
+    return Schema.localize(schema, src, locale) as any;
+  }
+  protected delocalizePath(
+    src: OptIn<
+      { [I in number]: SrcOf<ObjectSchema<T[I], false>> }[number],
+      Opt
+    >,
+    localPath: string[],
+    locale: "en_US"
+  ): string[] {
+    if (src === null) {
+      if (!this.opt) {
+        throw Error("Invalid value: Required tagged union cannot be null");
+      }
+
+      if (localPath.length > 0) {
+        throw Error(
+          "Invalid path: Cannot access property of optional tagged union whose value is null"
+        );
+      }
+      return localPath;
+    }
+
+    const value = src[this.discriminator];
+    const schema = this.schemas.get(value as string);
+    if (schema === undefined) {
+      throw Error(
+        `Invalid value: Tagged union has invalid discriminator value ${value}`
+      );
+    }
+    return Schema.delocalizePath(schema, src, localPath, locale);
+  }
+  serialize(): SerializedSchema {
+    throw new Error("Method not implemented.");
+  }
+  optional(): TaggedUnionSchema<D, T, true> {
+    if (this.opt) console.warn("Schema is already optional");
+    return new TaggedUnionSchema<D, T, true>(
+      this.discriminator,
+      [...this.schemas.values()] as {
+        [I in keyof T]: ObjectSchema<T[I], false>;
+      },
+      true
+    );
+  }
+}
+export const taggedUnion = <
+  D extends string,
+  T extends readonly SchemaObject<D>[]
+>(
+  discriminator: D,
+  schemas: { [I in keyof T]: ObjectSchema<T[I], false> }
+): TaggedUnionSchema<D, T, false> => {
+  return new TaggedUnionSchema<D, T, false>(discriminator, schemas, false);
+};
+taggedUnion.optional = <D extends string, T extends readonly SchemaObject<D>[]>(
+  discriminator: D,
+  schemas: { [I in keyof T]: ObjectSchema<T[I], false> }
+): TaggedUnionSchema<D, T, true> => {
+  return new TaggedUnionSchema<D, T, true>(discriminator, schemas, true);
+};

--- a/packages/lib/src/selector2/array.test.ts
+++ b/packages/lib/src/selector2/array.test.ts
@@ -1,0 +1,24 @@
+import {
+  ArrayDescriptor,
+  Descriptor,
+  ObjectDescriptor,
+  StringDescriptor,
+} from "../descriptor2";
+import { fromCtx } from "../expr";
+import { newSelector } from ".";
+
+test("array stuff", () => {
+  type V = {
+    foo: string;
+  }[];
+  const desc: Descriptor<V> = ArrayDescriptor.create(
+    ObjectDescriptor.create<{
+      foo: string;
+    }>({
+      foo: StringDescriptor,
+    })
+  );
+  const expr = fromCtx<never, 0>(0);
+  const selector = newSelector(desc, expr);
+  const asdf = selector.map<string>((v) => v.foo).find((v) => v.eq("hello"));
+});

--- a/packages/lib/src/selector2/array.ts
+++ b/packages/lib/src/selector2/array.ts
@@ -1,0 +1,95 @@
+import { Source } from "../Source";
+import { DESC, EXPR, Selected, Selector, newSelector } from ".";
+import {
+  ArrayDescriptor,
+  ARRAY_VALUE,
+  Descriptor,
+  NullDescriptor,
+  NumberDescriptor,
+  UnionDescriptor,
+} from "../descriptor2";
+import { expr } from "..";
+
+export function filter<V extends Source, Ctx>(
+  s: Selector<readonly V[], Ctx>,
+  predicate: <Ctx1>(v: Selector<V, Ctx1>) => Selected<Source, Ctx1>
+): Selector<V[], Ctx> {
+  type Ctx1 = readonly [V];
+
+  const itemDesc: Descriptor<V> = s[DESC][ARRAY_VALUE];
+  const predicateExpr = predicate<Ctx1>(
+    newSelector(itemDesc, expr.fromCtx<Ctx1, 0>(0))
+  )[EXPR];
+  const outDesc = ArrayDescriptor.create(itemDesc) as Descriptor<V[]>;
+  const outExpr = expr.filter<Ctx, V>(s[EXPR], predicateExpr);
+  return newSelector(outDesc, outExpr);
+}
+
+export function find<V extends Source, Ctx>(
+  s: Selector<readonly V[], Ctx>,
+  predicate: <Ctx1>(v: Selector<V, Ctx1>) => Selected<Source, Ctx1>
+): Selector<V | null, Ctx> {
+  type Ctx1 = readonly [V];
+
+  const itemDesc: Descriptor<V> = s[DESC][ARRAY_VALUE];
+  const predicateExpr = predicate<Ctx1>(
+    newSelector(itemDesc, expr.fromCtx<Ctx1, 0>(0))
+  )[EXPR];
+  const outDesc = UnionDescriptor.create<V | null>([itemDesc, NullDescriptor]);
+  const outExpr = expr.find<Ctx, V>(s[EXPR], predicateExpr);
+  return newSelector(outDesc, outExpr);
+}
+
+export function slice<V extends Source, Ctx>(
+  s: Selector<readonly V[], Ctx>,
+  begin: number,
+  end?: number
+): Selector<V[], Ctx> {
+  const itemDesc: Descriptor<V> = s[DESC][ARRAY_VALUE];
+  const outDesc = ArrayDescriptor.create(itemDesc);
+  const outExpr = expr.slice<Ctx, V>(s[EXPR], begin, end);
+  return newSelector(outDesc, outExpr);
+}
+
+export function sortBy<V extends Source, Ctx>(
+  s: Selector<readonly V[], Ctx>,
+  keyFn: <Ctx1>(v: Selector<V, Ctx1>) => Selected<number, Ctx1>
+): Selector<V[], Ctx> {
+  type Ctx1 = readonly [V];
+
+  const itemDesc: Descriptor<V> = s[DESC][ARRAY_VALUE];
+  const keyExpr = keyFn<Ctx1>(newSelector(itemDesc, expr.fromCtx<Ctx1, 0>(0)))[
+    EXPR
+  ];
+  const outDesc = ArrayDescriptor.create(itemDesc);
+  const outExpr = expr.sortBy<Ctx, V>(s[EXPR], keyExpr);
+  return newSelector(outDesc, outExpr);
+}
+
+export function reverse<V extends Source, Ctx>(
+  s: Selected<readonly V[], Ctx>
+): Selector<V[], Ctx> {
+  const itemDesc: Descriptor<V> = s[DESC][ARRAY_VALUE];
+  const outDesc = ArrayDescriptor.create(itemDesc);
+  const outExpr = expr.reverse<Ctx, V>(s[EXPR]);
+  return newSelector(outDesc, outExpr);
+}
+
+export function map<V extends Source, Ctx, U extends Source>(
+  s: Selector<readonly V[], Ctx>,
+  callback: <Ctx1>(
+    v: Selector<V, Ctx1>,
+    i: Selector<number, Ctx1>
+  ) => Selected<U, Ctx1>
+): Selector<U[], Ctx> {
+  type Ctx1 = readonly [V, number];
+
+  const itemDesc: Descriptor<V> = s[DESC][ARRAY_VALUE];
+  const callbackSelector = callback<Ctx1>(
+    newSelector(itemDesc, expr.fromCtx<Ctx1, 0>(0)),
+    newSelector(NumberDescriptor, expr.fromCtx<Ctx1, 1>(1))
+  );
+  const outDesc = ArrayDescriptor.create(callbackSelector[DESC]);
+  const outExpr = expr.map<Ctx, V, U>(s[EXPR], callbackSelector[EXPR]);
+  return newSelector(outDesc, outExpr);
+}

--- a/packages/lib/src/selector2/index.ts
+++ b/packages/lib/src/selector2/index.ts
@@ -1,0 +1,79 @@
+import { BooleanDescriptor, Descriptor } from "../descriptor2";
+import { expr } from "..";
+import { Source, SourceObject } from "../Source";
+import { Selector as SelectorImpl } from "./selector";
+
+type SelectorMethods<V extends Source, Ctx> = (V extends readonly Source[]
+  ? {
+      filter(
+        predicate: <Ctx1>(
+          v: Selector<V[number], Ctx1>
+        ) => Selected<Source, Ctx1>
+      ): Selector<V[number][], Ctx>;
+
+      find(
+        predicate: <Ctx1>(
+          v: Selector<V[number], Ctx1>
+        ) => Selected<Source, Ctx1>
+      ): Selector<V[number] | null, Ctx>;
+
+      slice(begin: number, end?: number): Selector<V, Ctx>;
+
+      sortBy(
+        keyFn: <Ctx1>(v: Selector<V[number], Ctx1>) => Selected<number, Ctx1>
+      ): Selector<V[number][], Ctx>;
+
+      reverse(): Selector<V[number][], Ctx>;
+
+      map<U extends Source>(
+        callback: <Ctx1>(
+          v: Selector<V[number], Ctx1>,
+          i: Selector<number, Ctx1>
+        ) => Selected<U, Ctx1>
+      ): Selector<U[], Ctx>;
+    }
+  : unknown) & {
+  eq(value: V): Selector<boolean, Ctx>;
+};
+
+type SelectorProps<V extends Source, Ctx> = V extends readonly Source[]
+  ? {
+      [P in keyof V & number]: Selector<V[P], Ctx>;
+    } & {
+      length: Selector<V["length"], Ctx>;
+    }
+  : V extends SourceObject
+  ? {
+      [P in keyof V]: Selector<V[P], Ctx>;
+    }
+  : unknown;
+
+export const DESC = Symbol("DESC");
+export const EXPR = Symbol("EXPR");
+
+export type Selected<V extends Source, Ctx> = {
+  [DESC]: Descriptor<V>;
+  [EXPR]: expr.Expr<Ctx, V>;
+};
+export type Selector<V extends Source, Ctx> = Selected<V, Ctx> &
+  SelectorProps<V, Ctx> &
+  SelectorMethods<V, Ctx>;
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type SelectorVarianceTest<in In extends Source, out Out extends Source> = (
+  v: Selector<In, never>
+) => Selector<Out, unknown>;
+
+export function newSelector<V extends Source, Ctx>(
+  desc: Descriptor<V>,
+  expr: expr.Expr<Ctx, V>
+): Selector<V, Ctx> {
+  return SelectorImpl.create(desc, expr);
+}
+
+export function eq<V extends Source, Ctx>(
+  s: Selector<V, Ctx>,
+  value: V
+): Selector<boolean, Ctx> {
+  return newSelector(BooleanDescriptor, expr.eq(s[EXPR], value));
+}

--- a/packages/lib/src/selector2/optional.test.ts
+++ b/packages/lib/src/selector2/optional.test.ts
@@ -1,0 +1,22 @@
+import {
+  NullDescriptor,
+  ObjectDescriptor,
+  StringDescriptor,
+  UnionDescriptor,
+} from "../descriptor2";
+import { fromCtx } from "../expr";
+import { newSelector } from ".";
+import { andThen } from "./optional";
+
+test("andThen", () => {
+  type A = {
+    foo: string;
+  };
+  const aD = ObjectDescriptor.create<A>({
+    foo: StringDescriptor,
+  });
+  const d = UnionDescriptor.create<A | null>([aD, NullDescriptor]);
+  const selector = newSelector<A | null, never>(d, fromCtx<never, 0>(0));
+
+  const asdf = andThen(selector, (v) => v.foo);
+});

--- a/packages/lib/src/selector2/optional.ts
+++ b/packages/lib/src/selector2/optional.ts
@@ -1,0 +1,30 @@
+import { Source } from "../Source";
+import { DESC, EXPR, Selected, Selector, newSelector } from ".";
+import {
+  Descriptor,
+  filter,
+  IS,
+  NullDescriptor,
+  UnionDescriptor,
+} from "../descriptor2";
+import { expr } from "..";
+
+// eslint-disable-next-line @typescript-eslint/ban-types -- Shush, non-null is intended!
+type NonNull<V extends Source> = V & {};
+
+export function andThen<V extends NonNull<Source>, Ctx, U extends Source>(
+  s: Selector<V | null, Ctx>,
+  callback: <Ctx1>(v: Selector<V, Ctx1>) => Selected<U, Ctx1>
+): Selector<U | null, Ctx> {
+  const vDesc = filter<V | null, V>(
+    s[DESC],
+    (desc): desc is Descriptor<V> => !desc[IS](null)
+  );
+
+  type Ctx1 = readonly [V];
+  const selector = newSelector<V, Ctx1>(vDesc, expr.fromCtx(0));
+  const out = callback<Ctx1>(selector);
+  const outDesc = UnionDescriptor.create<U | null>([out[DESC], NullDescriptor]);
+  const outExpr = expr.andThen<Ctx, V, U>(s[EXPR], out[EXPR]);
+  return newSelector(outDesc, outExpr);
+}

--- a/packages/lib/src/selector2/selector.ts
+++ b/packages/lib/src/selector2/selector.ts
@@ -1,0 +1,98 @@
+import { Source, SourceObject } from "../Source";
+import { DESC, eq, EXPR, Selected, Selector as SelectorT } from ".";
+import { expr } from "..";
+import { ARRAY_VALUE, DEBUG_STRING, Descriptor } from "../descriptor2";
+import * as ArrayFunctions from "./array";
+
+function getSelectorMethod<V extends Source, Ctx>(
+  desc: Descriptor<V>,
+  p: string | symbol
+): ((this: SelectorT<V, Ctx>, ...args: unknown[]) => unknown) | undefined {
+  if (ARRAY_VALUE in desc) {
+    const arrayFunction = ArrayFunctions[p as keyof typeof ArrayFunctions] as
+      | ((s: SelectorT<V, Ctx>, ...args: unknown[]) => Selected<Source, Ctx>)
+      | undefined;
+    if (arrayFunction) {
+      return function (this: SelectorT<V, Ctx>, ...args: unknown[]) {
+        return arrayFunction(this, ...args);
+      };
+    }
+  }
+
+  if (p === "eq") {
+    return function (this: SelectorT<V, Ctx>, value: unknown) {
+      return eq(this, value as V);
+    };
+  }
+
+  return undefined;
+}
+
+const APPLY = Symbol("APPLY");
+export class Selector<V extends Source, Ctx> {
+  readonly [DESC]: Descriptor<V>;
+  readonly [EXPR]: expr.Expr<Ctx, V>;
+  readonly [APPLY]?: (...args: unknown[]) => unknown;
+  constructor(
+    desc: Descriptor<V>,
+    expr: expr.Expr<Ctx, V>,
+    apply?: (this: SelectorT<V, Ctx>, ...args: unknown[]) => unknown
+  ) {
+    this[DESC] = desc;
+    this[EXPR] = expr;
+    this[APPLY] = apply;
+    return new Proxy(this, Selector.proxyHandler);
+  }
+
+  private static readonly proxyHandler = {
+    apply<V extends Source, Ctx>(
+      target: Selector<V, Ctx>,
+      thisArg: SelectorT<V, Ctx>,
+      argArray: unknown[]
+    ) {
+      if (target[APPLY]) {
+        return target[APPLY].apply(thisArg, argArray);
+      } else {
+        throw TypeError("Selector is not a function");
+      }
+    },
+    get<V extends Source, Ctx>(target: Selector<V, Ctx>, p: string | symbol) {
+      if (p === DESC || p === EXPR) {
+        return target[p as typeof DESC | typeof EXPR];
+      }
+
+      const desc = target[DESC];
+
+      const method = getSelectorMethod(desc, p);
+
+      if (typeof p === "string" && p in desc) {
+        return Selector.create<Source, Ctx>(
+          (desc as Descriptor<SourceObject>)[p],
+          expr.prop(target[EXPR] as expr.Expr<Ctx, SourceObject>, p),
+          method
+        );
+      }
+
+      if (method) {
+        return method;
+      }
+
+      throw Error(
+        `Select failed: "${p.toString()}" is not a known property or method of a value of type ${target[
+          DESC
+        ][DEBUG_STRING]()}`
+      );
+    },
+    set() {
+      throw TypeError("Cannot set property on selector");
+    },
+  };
+
+  static create<V extends Source, Ctx>(
+    desc: Descriptor<V>,
+    expr: expr.Expr<Ctx, V>,
+    apply?: (...args: unknown[]) => unknown
+  ): SelectorT<V, Ctx> {
+    return new Selector<V, Ctx>(desc, expr, apply) as SelectorT<V, Ctx>;
+  }
+}

--- a/packages/lib/src/selector2/union.test.ts
+++ b/packages/lib/src/selector2/union.test.ts
@@ -1,0 +1,73 @@
+import {
+  ArrayDescriptor,
+  LiteralDescriptor,
+  ObjectDescriptor,
+  StringDescriptor,
+  UnionDescriptor,
+} from "../descriptor2";
+import { fromCtx } from "../expr";
+import { newSelector } from ".";
+import { match } from "./union";
+
+test("match", () => {
+  type InnerV = {
+    foo: string;
+    barProp: string;
+  };
+  type FooV = {
+    d: "foo";
+    fooProp: InnerV;
+  };
+  type BarV = {
+    d: "bar";
+    barProp: InnerV;
+  };
+  const innerD = ObjectDescriptor.create<InnerV>({
+    foo: StringDescriptor,
+    barProp: StringDescriptor,
+  });
+  const unionD = UnionDescriptor.create<FooV | BarV>([
+    ObjectDescriptor.create<FooV>({
+      d: LiteralDescriptor.create("foo"),
+      fooProp: innerD,
+    }),
+    ObjectDescriptor.create<BarV>({
+      d: LiteralDescriptor.create("bar"),
+      barProp: innerD,
+    }),
+  ]);
+
+  const expr = fromCtx<never, 0>(0);
+  const selector = newSelector<FooV | BarV, never>(unionD, expr);
+
+  const matched = match(selector, "d", {
+    foo(v) {
+      return v.fooProp;
+    },
+    bar(v) {
+      return v.barProp;
+    },
+  });
+});
+
+test("disambiguate", () => {
+  type A = {
+    eq: {
+      hello: string;
+    };
+  };
+  const aD = ObjectDescriptor.create<A>({
+    eq: ObjectDescriptor.create<{
+      hello: string;
+    }>({
+      hello: StringDescriptor,
+    }),
+  });
+  type B = A[];
+  const bD = ArrayDescriptor.create<A>(aD);
+
+  const expr = fromCtx<never, 0>(0);
+  const selector = newSelector<B, never>(bD, expr);
+
+  const asdf = selector.map((v) => v.eq);
+});

--- a/packages/lib/src/selector2/union.ts
+++ b/packages/lib/src/selector2/union.ts
@@ -1,0 +1,64 @@
+import { Source, SourceObject } from "../Source";
+import { DESC, EXPR, newSelector, Selected, Selector } from ".";
+import { expr } from "..";
+import { Descriptor, filter, IS, UnionDescriptor } from "../descriptor2";
+
+export type CaseCallback<in In extends Source, out Out extends Source> = <Ctx>(
+  v: Selector<In, Ctx>
+) => Selected<Out, Ctx>;
+export type CaseOutput<C> = C extends <Ctx>(
+  v: Selector<never, Ctx>
+) => Selected<infer Out, Ctx>
+  ? Out
+  : never;
+
+type MatchableValue<K extends string> = {
+  [P in K]: string;
+};
+
+type Matcher<K extends string, in V extends MatchableValue<K>> = {
+  [U in V as U[K]]: <Ctx>(event: Selector<U, Ctx>) => Selected<Source, Ctx>;
+};
+
+export function match<
+  K extends string,
+  M extends Matcher<K, V>,
+  V extends MatchableValue<K>,
+  Ctx
+>(
+  s: Selector<V, Ctx>,
+  discriminator: K,
+  matcher: M
+): Selector<CaseOutput<M[keyof M]>, Ctx> {
+  const desc = s[DESC];
+  const entries = Object.entries(
+    matcher as unknown as { [s: string]: CaseCallback<V, Source> }
+  ).map(([key, callback]) => {
+    const vDesc = filter(
+      desc,
+      (desc): desc is Descriptor<V> =>
+        discriminator in desc &&
+        (desc as Descriptor<SourceObject>)[discriminator][IS](key)
+    );
+
+    type Ctx1 = readonly [V];
+    const selector = newSelector<V, Ctx1>(vDesc, expr.fromCtx(0));
+    return [key as V[K], callback(selector)] as const;
+  });
+
+  const outDesc = UnionDescriptor.create(
+    entries.map(
+      ([, selected]) => selected[DESC] as Descriptor<CaseOutput<M[keyof M]>>
+    )
+  );
+  const outExpr = expr.match<Ctx, K, V, CaseOutput<M[keyof M]>>(
+    s[EXPR],
+    discriminator,
+    Object.fromEntries(
+      entries.map(([key, selected]) => [key, selected[EXPR]] as const)
+    ) as {
+      [U in V as U[K]]: expr.Expr<readonly [V], CaseOutput<M[keyof M]>>;
+    }
+  );
+  return newSelector(outDesc, outExpr);
+}

--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -2,6 +2,8 @@
   "compilerOptions": {
     "strict": true,
     "isolatedModules": true,
-    "noEmit": true
+    "noEmit": true,
+    "target": "ES2015",
+    "moduleResolution": "node16"
   }
 }


### PR DESCRIPTION
New Selector API to facilitate unions, type assertions and any types in selectors.

TODO:

- [ ] Implement schema serialization of tagged unions
- [ ] Implement serialization of match expressions
- [ ] Integrate new selector API into ValModule and friends and remove the old one
- [ ] Add exports for selector functions
- [ ] Re-implement support for literals in Selected positions (unless we want to avoid this pattern due to possibly leaky abstractions)
- [ ] Figure out if we can/should re-implement .andThen method on nullable Selectors (this seems to break the variance if not done carefully)
- [ ] Review usage of type assertions
- [ ] Validate if new TSConfig is OK (or if the changes could be reverted, may not be necessary anymore)
- [ ] Tests
- [ ] More tests