### PR TITLE
Only use ValEncodedString on strings that will be encoded...

### DIFF
--- a/examples/next13/app/blogs.val.ts
+++ b/examples/next13/app/blogs.val.ts
@@ -3,6 +3,7 @@ import { s, val } from "../val.config";
 export const schema = s.array(
   s.object({
     title: s.string(),
+    configString: s.string().optional().raw(),
     /**
      * Blog image. We only allow png and jpg.
      */
@@ -27,6 +28,7 @@ export const schema = s.array(
 export default val.content("/app/blogs", schema, [
   {
     title: "HVA? \n",
+    configString: "foo-bar",
     image: val.file("/public/val/app/blogs/image1.jpg", {
       width: 512,
       height: 512,
@@ -42,6 +44,7 @@ export default val.content("/app/blogs", schema, [
   },
   {
     title: "HVEM ER VI?",
+    configString: null,
     image: val.file("/public/val/app/blogs/image2.jpg", {
       width: 512,
       height: 512,
@@ -53,6 +56,7 @@ export default val.content("/app/blogs", schema, [
   },
   {
     title: "HVORFOR? ikke?",
+    configString: null,
     image: val.file("/public/val/app/blogs/image3.jpg", {
       width: 512,
       height: 512,
@@ -64,6 +68,7 @@ export default val.content("/app/blogs", schema, [
   },
   {
     title: "HVEM ER VI?",
+    configString: null,
     image: val.file("/public/val/app/blogs/image2.jpg", {
       width: 512,
       height: 512,
@@ -75,6 +80,7 @@ export default val.content("/app/blogs", schema, [
   },
   {
     title: "HVORFOR? ikke?",
+    configString: null,
     image: val.file("/public/val/app/blogs/image3.jpg", {
       width: 512,
       height: 512,

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -23,6 +23,7 @@ import {
 import { FileSource } from "./source/file";
 import { AnyRichTextOptions, RichText } from "./source/richtext";
 import { RecordSchema, SerializedRecordSchema } from "./schema/record";
+import { RawString } from "./schema/string";
 
 const brand = Symbol("ValModule");
 export type ValModule<T extends SelectorSource> = SelectorOf<T> &
@@ -35,13 +36,26 @@ export type ValModuleBrand = {
 export type TypeOfValModule<T extends ValModule<SelectorSource>> =
   T extends GenericSelector<infer S> ? S : never;
 
+type ReplaceRawStringWithString<T extends SelectorSource> =
+  SelectorSource extends T
+    ? T
+    : T extends RawString
+    ? string
+    : T extends { [key in string]: SelectorSource }
+    ? {
+        [key in keyof T]: ReplaceRawStringWithString<T[key]>;
+      }
+    : T extends SelectorSource[]
+    ? ReplaceRawStringWithString<T[number]>[]
+    : T;
+
 export function content<T extends Schema<SelectorSource>>(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   id: string,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   schema: T,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  source: SchemaTypeOf<T>
+  source: ReplaceRawStringWithString<SchemaTypeOf<T>>
 ): ValModule<SchemaTypeOf<T>> {
   return {
     [GetSource]: source,

--- a/packages/core/src/schema/string.ts
+++ b/packages/core/src/schema/string.ts
@@ -15,6 +15,9 @@ export type SerializedStringSchema = {
   raw: boolean;
 };
 
+const brand = Symbol("string");
+export type RawString = string & { readonly [brand]: "raw" };
+
 export class StringSchema<Src extends string | null> extends Schema<Src> {
   constructor(
     readonly options?: StringOptions,
@@ -49,8 +52,12 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
     return new StringSchema<Src | null>(this.options, true, this.isRaw);
   }
 
-  raw(): StringSchema<Src> {
-    return new StringSchema<Src>(this.options, this.opt, true);
+  raw(): StringSchema<Src extends null ? RawString | null : RawString> {
+    return new StringSchema<Src extends null ? RawString | null : RawString>(
+      this.options,
+      this.opt,
+      true
+    );
   }
 
   serialize(): SerializedSchema {

--- a/packages/react/src/stega/stegaEncode.ts
+++ b/packages/react/src/stega/stegaEncode.ts
@@ -12,6 +12,7 @@ import { FileSource, Source, SourceObject } from "@valbuild/core";
 import { JsonPrimitive } from "@valbuild/core";
 import { SourceArray } from "@valbuild/core";
 import { parseRichTextSource } from "@valbuild/ui";
+import { RawString } from "@valbuild/core/src/schema/string";
 
 declare const brand: unique symbol;
 
@@ -39,6 +40,8 @@ export type StegaOfSource<T extends Source> = Json extends T
     }
   : T extends SourceArray
   ? StegaOfSource<T[number]>[]
+  : T extends RawString
+  ? string
   : T extends string
   ? ValEncodedString
   : T extends JsonPrimitive


### PR DESCRIPTION
Raw strings are not encoded, so should be string.

Blogs in the next13 example should now be:
```ts
const blogs: {
    title: ValEncodedString;
    configString: string | null;
    image: {
        url: ValEncodedString;
    };
    text: RichText<{
        headings: ("h1" | "h2")[];
        img: true;
        bold: true;
        italic: true;
        lineThrough: true;
    }>;
    rank: number;
}[]
```