### PR TITLE
Refactor val. => c. in val files

### DIFF
--- a/.changeset/six-dancers-explain.md
+++ b/.changeset/six-dancers-explain.md
@@ -1,0 +1,12 @@
+---
+"@valbuild/eslint-plugin": minor
+"@valbuild/server": minor
+"@valbuild/shared": minor
+"@valbuild/react": minor
+"@valbuild/core": minor
+"@valbuild/init": minor
+"@valbuild/next": minor
+"@valbuild/ui": minor
+---
+
+Breaking API change: Change from val.{content,file} => c.define, c.file etc

--- a/examples/next/README.md
+++ b/examples/next/README.md
@@ -18,4 +18,4 @@ Additionally the following files are needed:
 
 ### Content
 
-See the `.val.ts` for where content is defined how it is used.
+Check out the `.val.ts` files where content is defined to learn more.

--- a/examples/next/app/content.val.ts
+++ b/examples/next/app/content.val.ts
@@ -1,6 +1,6 @@
 import { InferSchemaType } from "@valbuild/next";
 import authorsVal from "../content/authors.val";
-import { s, val } from "../val.config";
+import { s, c } from "../val.config";
 import image from "../schema/image.val";
 
 export const schema = s.object({
@@ -46,15 +46,15 @@ export const schema = s.object({
 
 export type Content = InferSchemaType<typeof schema>;
 export type Image = InferSchemaType<typeof image>;
-export default val.content("/app/content", schema, {
-  video: val.file("/public/file_example.webm", {
+export default c.define("/app/content", schema, {
+  video: c.file("/public/file_example.webm", {
     sha256: "9bb98735d0430e5a825173cb7db5e4d5aee32c1c283c3db90f1c9c532f73505e",
     mimeType: "video/webm",
   }),
   hero: {
     title: "Content as code",
     image: {
-      data: val.file("/public/logo_e211b.png", {
+      data: c.file("/public/logo_e211b.png", {
         width: 944,
         height: 944,
         sha256:
@@ -66,7 +66,7 @@ export default val.content("/app/content", schema, {
   },
   tags: ["CMS", "react", "github", "NextJS"],
   author: 0,
-  text: val.richtext`
+  text: c.richtext`
 Val is a CMS where **content** is **code** in your git repo.
 
 <br />

--- a/examples/next/app/content.val.ts
+++ b/examples/next/app/content.val.ts
@@ -1,5 +1,4 @@
-import type { t } from "@valbuild/next";
-import { s, c } from "../val.config";
+import { s, c, type t } from "../val.config";
 import authorsVal from "../content/authors.val";
 import image from "../schema/image.val";
 

--- a/examples/next/app/content.val.ts
+++ b/examples/next/app/content.val.ts
@@ -1,6 +1,6 @@
-import { InferSchemaType } from "@valbuild/next";
-import authorsVal from "../content/authors.val";
+import type { t } from "@valbuild/next";
 import { s, c } from "../val.config";
+import authorsVal from "../content/authors.val";
 import image from "../schema/image.val";
 
 export const schema = s.object({
@@ -44,8 +44,8 @@ export const schema = s.object({
   }),
 });
 
-export type Content = InferSchemaType<typeof schema>;
-export type Image = InferSchemaType<typeof image>;
+export type Content = t.inferSchema<typeof schema>;
+export type Image = t.inferSchema<typeof image>;
 export default c.define("/app/content", schema, {
   video: c.file("/public/file_example.webm", {
     sha256: "9bb98735d0430e5a825173cb7db5e4d5aee32c1c283c3db90f1c9c532f73505e",

--- a/examples/next/components/clientContent.val.ts
+++ b/examples/next/components/clientContent.val.ts
@@ -1,5 +1,4 @@
-import type { t } from "@valbuild/next";
-import { s, c } from "../val.config";
+import { s, c, type t } from "../val.config";
 
 export const schema = s.object({
   text: s.string(),

--- a/examples/next/components/clientContent.val.ts
+++ b/examples/next/components/clientContent.val.ts
@@ -1,4 +1,4 @@
-import type { InferSchemaType } from "@valbuild/next";
+import type { t } from "@valbuild/next";
 import { s, c } from "../val.config";
 
 export const schema = s.object({
@@ -20,7 +20,7 @@ export const schema = s.object({
     s.literal("lit-2")
   ),
 });
-export type ClientContent = InferSchemaType<typeof schema>;
+export type ClientContent = t.inferSchema<typeof schema>;
 
 export default c.define("/components/clientContent", schema, {
   text: "Clientf components works",

--- a/examples/next/components/clientContent.val.ts
+++ b/examples/next/components/clientContent.val.ts
@@ -1,5 +1,5 @@
 import type { InferSchemaType } from "@valbuild/next";
-import { s, val } from "../val.config";
+import { s, c } from "../val.config";
 
 export const schema = s.object({
   text: s.string(),
@@ -22,7 +22,7 @@ export const schema = s.object({
 });
 export type ClientContent = InferSchemaType<typeof schema>;
 
-export default val.content("/components/clientContent", schema, {
+export default c.define("/components/clientContent", schema, {
   text: "Clientf components works",
   objectUnions: {
     type: "object-type-2",

--- a/examples/next/components/reactServerContent.val.ts
+++ b/examples/next/components/reactServerContent.val.ts
@@ -1,8 +1,8 @@
-import { s, val } from "../val.config";
+import { s, c } from "../val.config";
 
 export const schema = s.string();
 
-export default val.content(
+export default c.define(
   "/components/reactServerContent",
   schema,
   "React Sffefrver comffponents also worksf"

--- a/examples/next/content/authors.val.ts
+++ b/examples/next/content/authors.val.ts
@@ -1,4 +1,4 @@
-import type { InferSchemaType } from "@valbuild/next";
+import type { t } from "@valbuild/next";
 import { s, c } from "../val.config";
 
 export const schema = s.array(
@@ -7,7 +7,7 @@ export const schema = s.array(
   })
 );
 
-export type Author = InferSchemaType<typeof schema>;
+export type Author = t.inferSchema<typeof schema>;
 export default c.define("/content/authors", schema, [
   {
     name: "Fredrik Ekholdt",

--- a/examples/next/content/authors.val.ts
+++ b/examples/next/content/authors.val.ts
@@ -1,5 +1,5 @@
 import type { InferSchemaType } from "@valbuild/next";
-import { s, val } from "../val.config";
+import { s, c } from "../val.config";
 
 export const schema = s.array(
   s.object({
@@ -8,7 +8,7 @@ export const schema = s.array(
 );
 
 export type Author = InferSchemaType<typeof schema>;
-export default val.content("/content/authors", schema, [
+export default c.define("/content/authors", schema, [
   {
     name: "Fredrik Ekholdt",
   },

--- a/examples/next/content/authors.val.ts
+++ b/examples/next/content/authors.val.ts
@@ -1,5 +1,4 @@
-import type { t } from "@valbuild/next";
-import { s, c } from "../val.config";
+import { s, c, type t } from "../val.config";
 
 export const schema = s.array(
   s.object({

--- a/examples/next/val.config.ts
+++ b/examples/next/val.config.ts
@@ -4,4 +4,5 @@ const { s, c, val, config } = initVal({
   valCloud: "valbuild/val-next-example",
 });
 
+export type { t } from "@valbuild/next";
 export { s, c, val, config };

--- a/examples/next/val.config.ts
+++ b/examples/next/val.config.ts
@@ -1,7 +1,7 @@
 import { initVal } from "@valbuild/next";
 
-const { s, val, config } = initVal({
+const { s, c, val, config } = initVal({
   valCloud: "valbuild/val-next-example",
 });
 
-export { s, val, config };
+export { s, c, val, config };

--- a/package-lock.json
+++ b/package-lock.json
@@ -28115,6 +28115,111 @@
         "@rollup/rollup-win32-x64-msvc": "4.9.5",
         "fsevents": "~2.3.2"
       }
+    },
+    "packages/next/node_modules/@next/swc-darwin-arm64": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.0.4.tgz",
+      "integrity": "sha512-mF05E/5uPthWzyYDyptcwHptucf/jj09i2SXBPwNzbgBNc+XnwzrL0U6BmPjQeOL+FiB+iG1gwBeq7mlDjSRPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/next/node_modules/@next/swc-darwin-x64": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.0.4.tgz",
+      "integrity": "sha512-IZQ3C7Bx0k2rYtrZZxKKiusMTM9WWcK5ajyhOZkYYTCc8xytmwSzR1skU7qLgVT/EY9xtXDG0WhY6fyujnI3rw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/next/node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.0.4.tgz",
+      "integrity": "sha512-VwwZKrBQo/MGb1VOrxJ6LrKvbpo7UbROuyMRvQKTFKhNaXjUmKTu7wxVkIuCARAfiI8JpaWAnKR+D6tzpCcM4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/next/node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.0.4.tgz",
+      "integrity": "sha512-8QftwPEW37XxXoAwsn+nXlodKWHfpMaSvt81W43Wh8dv0gkheD+30ezWMcFGHLI71KiWmHK5PSQbTQGUiidvLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/next/node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.0.4.tgz",
+      "integrity": "sha512-7Wv4PRiWIAWbm5XrGz3D8HUkCVDMMz9igffZG4NB1p4u1KoItwx9qjATHz88kwCEal/HXmbShucaslXCQXUM5w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/next/node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.0.4.tgz",
+      "integrity": "sha512-zLeNEAPULsl0phfGb4kdzF/cAVIfaC7hY+kt0/d+y9mzcZHsMS3hAS829WbJ31DkSlVKQeHEjZHIdhN+Pg7Gyg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/next/node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.0.4.tgz",
+      "integrity": "sha512-yEh2+R8qDlDCjxVpzOTEpBLQTEFAcP2A8fUFLaWNap9GitYKkKv1//y2S6XY6zsR4rCOPRpU7plYDR+az2n30A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/packages/core/ROADMAP.md
+++ b/packages/core/ROADMAP.md
@@ -11,15 +11,15 @@ export const schema = s.array(
   s.i18n(s.object({ title: s.string(), text: s.richtext() }))
 );
 
-export default val.content("/blogs", schema, [
+export default c.define("/blogs", schema, [
   {
     en_US: {
       title: "Title 1",
-      text: val.richtext("Richtext 1"),
+      text: c.richtext("Richtext 1"),
     },
     nb_NO: {
       title: "Tittel 1",
-      text: val.richtext("Riktekst?"),
+      text: c.richtext("Riktekst?"),
     },
   },
 ]);
@@ -52,10 +52,10 @@ export const schema = s
   .array(s.object({ title: s.string(), text: s.richtext() }))
   .remote();
 
-export default val.content(
+export default c.define(
   "/blogs",
   schema,
-  val.remote("4ba7c33b32a60be06b1b26dff8cc5d8d967660ab") // a change in content, will result in a new reference
+  c.remote("4ba7c33b32a60be06b1b26dff8cc5d8d967660ab") // a change in content, will result in a new reference
 );
 
 // file: ./components/ServerComponent.ts
@@ -84,7 +84,7 @@ Example:
 
 export schema = s.array(s.object({ name: s.string() }));
 
-export default val.content('/employees', schema, [{
+export default c.define('/employees', schema, [{
   name: 'John Smith',
 }]);
 
@@ -96,7 +96,7 @@ export schema = s.object({
   hr: s.oneOf(employeesVal),
 });
 
-export default val.content('/contacts', schema, {
+export default c.define('/contacts', schema, {
   hr: employeesVal[0]
 });
 

--- a/packages/core/src/future/fetchVal.test.ts
+++ b/packages/core/src/future/fetchVal.test.ts
@@ -1,5 +1,5 @@
 import { initSchema } from "../initSchema";
-import { content } from "../module";
+import { define } from "../module";
 import { getValPath } from "../val";
 import { serializedValOfSelectorSource, fetchVal } from "./fetchVal";
 
@@ -10,7 +10,7 @@ describe("serialization of val", () => {
   test("serialized val: string", () => {
     const schema = s.string();
 
-    const testVal = content("/app", schema, "foo");
+    const testVal = define("/app", schema, "foo");
 
     expect(serializedValOfSelectorSource(testVal)).toStrictEqual({
       val: "foo",
@@ -21,7 +21,7 @@ describe("serialization of val", () => {
   test("serialized val: array", () => {
     const schema = s.array(s.string());
 
-    const testVal = content("/app", schema, ["foo", "bar"]);
+    const testVal = define("/app", schema, ["foo", "bar"]);
 
     expect(serializedValOfSelectorSource(testVal)).toStrictEqual({
       val: [
@@ -40,7 +40,7 @@ describe("serialization of val", () => {
   test("serialized val: object", () => {
     const schema = s.object({ foo: s.object({ bar: s.array(s.string()) }) });
 
-    const testVal = content("/app", schema, { foo: { bar: ["foo", "bar"] } });
+    const testVal = define("/app", schema, { foo: { bar: ["foo", "bar"] } });
 
     expect(serializedValOfSelectorSource(testVal)).toStrictEqual({
       val: {
@@ -69,7 +69,7 @@ describe("fetchVal", () => {
   test("valuate: string", async () => {
     const schema = s.string();
 
-    const testVal = content("/app", schema, "foo");
+    const testVal = define("/app", schema, "foo");
 
     const test = await fetchVal(testVal);
     //     ^? should be Val<string>
@@ -80,7 +80,7 @@ describe("fetchVal", () => {
   test("valuate: array", async () => {
     const schema = s.array(s.string());
 
-    const testVal = content("/app", schema, ["foo", "bar"]);
+    const testVal = define("/app", schema, ["foo", "bar"]);
 
     const test = await fetchVal(testVal);
     //      ^? should be Val<string[]>
@@ -94,7 +94,7 @@ describe("fetchVal", () => {
   test("valuate: object", async () => {
     const schema = s.object({ foo: s.object({ bar: s.array(s.string()) }) });
 
-    const testVal = content("/app", schema, { foo: { bar: ["foo", "bar"] } });
+    const testVal = define("/app", schema, { foo: { bar: ["foo", "bar"] } });
 
     const test = await fetchVal(testVal);
     //      ^? should be Val<{ foo: { bar: string[] } }>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export type { SourceObject, SourcePrimitive, Source } from "./source";
 export type { FileSource } from "./source/file";
 export type { RawString } from "./schema/string";
 export type { ImageSource } from "./source/image";
+export { RT_IMAGE_TAG } from "./source/richtext";
 export type {
   AnyRichTextOptions,
   Bold,
@@ -51,7 +52,7 @@ export type {
 import type { ValidationErrors } from "./schema/validation/ValidationError";
 export type { ValidationFix } from "./schema/validation/ValidationFix";
 export * as expr from "./expr/";
-export { FILE_REF_PROP } from "./source/file";
+export { FILE_REF_PROP, FILE_REF_SUBTYPE_TAG } from "./source/file";
 export { VAL_EXTENSION, type SourceArray } from "./source";
 export { derefPatch } from "./patch/deref";
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,10 @@
 export { initVal } from "./initVal";
-export type { InitVal, ValConfig, ValConstructor } from "./initVal";
+export type {
+  InitVal,
+  ValConfig,
+  ValConstructor,
+  ContentConstructor,
+} from "./initVal";
 export { Schema, type SerializedSchema, type SelectorOfSchema } from "./schema";
 export type { ImageMetadata } from "./schema/image";
 export type { FileMetadata } from "./schema/file";

--- a/packages/core/src/initVal.ts
+++ b/packages/core/src/initVal.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-unnecessary-type-constraint */
-import { content } from "./module";
+import { define } from "./module";
 import { InitSchema, initSchema } from "./initSchema";
 import { getValPath as getPath } from "./val";
 import { file } from "./source/file";
@@ -9,13 +9,18 @@ import { link } from "./source/link";
 // import { i18n, I18n } from "./source/future/i18n";
 // import { remote } from "./source/future/remote";
 
-export type ValConstructor = {
-  content: typeof content;
-  getPath: typeof getPath;
+export type ContentConstructor = {
+  define: typeof define;
   // remote: typeof remote;
   file: typeof file;
-  link: typeof link;
+  rt: {
+    image: typeof file;
+    link: typeof link;
+  };
   richtext: typeof richtext;
+};
+export type ValConstructor = {
+  getPath: typeof getPath;
 };
 
 export type ValConfig = {
@@ -25,6 +30,7 @@ export type ValConfig = {
   valConfigPath?: string;
 };
 export type InitVal = {
+  c: ContentConstructor;
   val: ValConstructor;
   s: InitSchema;
   config: ValConfig;
@@ -67,12 +73,17 @@ InitVal => {
   // }
   return {
     val: {
-      content,
-      // remote,
       getPath,
+    },
+    c: {
+      content: define,
+      // remote,
       file,
       richtext,
-      link,
+      rt: {
+        image: file,
+        link,
+      },
     },
     s,
     config: {},

--- a/packages/core/src/initVal.ts
+++ b/packages/core/src/initVal.ts
@@ -76,7 +76,7 @@ InitVal => {
       getPath,
     },
     c: {
-      content: define,
+      define,
       // remote,
       file,
       richtext,

--- a/packages/core/src/initVal.ts
+++ b/packages/core/src/initVal.ts
@@ -4,7 +4,7 @@ import { define } from "./module";
 import { InitSchema, initSchema } from "./initSchema";
 import { getValPath as getPath } from "./val";
 import { file } from "./source/file";
-import { richtext } from "./source/richtext";
+import { richtext, image as rtImage } from "./source/richtext";
 import { link } from "./source/link";
 // import { i18n, I18n } from "./source/future/i18n";
 // import { remote } from "./source/future/remote";
@@ -81,7 +81,7 @@ InitVal => {
       file,
       richtext,
       rt: {
-        image: file,
+        image: rtImage,
         link,
       },
     },

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -53,9 +53,9 @@ type ReplaceRawStringWithString<T extends SelectorSource> =
     ? ReplaceRawStringWithString<T[number]>[]
     : T;
 
-export function content<T extends Schema<SelectorSource>>(
+export function define<T extends Schema<SelectorSource>>(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  id: string,
+  id: string, // TODO: `/${string}`
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   schema: T,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/core/src/schema/validation.test.ts
+++ b/packages/core/src/schema/validation.test.ts
@@ -19,7 +19,7 @@ import {
 import { richtext } from "./richtext";
 import { record } from "./record";
 import { keyOf } from "./keyOf";
-import { content } from "../module";
+import { define } from "../module";
 import { union } from "./union";
 
 const testPath = "/test" as SourcePath;
@@ -241,32 +241,32 @@ const ValidationTestCases: {
   {
     description: "basic keyOf(array)",
     input: 1,
-    schema: keyOf(content("/keyof-module", array(string()), [])),
+    schema: keyOf(define("/keyof-module", array(string()), [])),
     expected: false,
   },
   {
     description: "failing keyOf(record)",
     input: "1",
-    schema: keyOf(content("/keyof-module", array(string()), [])),
+    schema: keyOf(define("/keyof-module", array(string()), [])),
     expected: [testPath],
   },
   {
     description: "basic keyOf(record)",
     input: "one",
-    schema: keyOf(content("/keyof-module", record(string()), {})),
+    schema: keyOf(define("/keyof-module", record(string()), {})),
     expected: false,
   },
   {
     description: "failing keyOf(record)",
     input: 1,
-    schema: keyOf(content("/keyof-module", record(string()), {})),
+    schema: keyOf(define("/keyof-module", record(string()), {})),
     expected: [testPath],
   },
   {
     description: "basic keyOf(object)",
     input: "test1",
     schema: keyOf(
-      content("/keyof-module", object({ test1: string(), test2: string() }), {
+      define("/keyof-module", object({ test1: string(), test2: string() }), {
         test1: "",
         test2: "",
       })
@@ -277,7 +277,7 @@ const ValidationTestCases: {
     description: "failing keyOf(object)",
     input: "test",
     schema: keyOf(
-      content("/keyof-module", object({ test1: string(), test2: string() }), {
+      define("/keyof-module", object({ test1: string(), test2: string() }), {
         test1: "",
         test2: "",
       })

--- a/packages/core/src/schema/validation.test.ts
+++ b/packages/core/src/schema/validation.test.ts
@@ -464,7 +464,6 @@ describe("validation", () => {
     'validate ($description): "$expected"',
     ({ input, schema, expected, fixes }) => {
       const result = schema.validate(testPath, input);
-      console.log(JSON.stringify({ result }, null, 2));
       if (result) {
         expect(Object.keys(result)).toStrictEqual(expected);
         if (fixes) {

--- a/packages/core/src/source/file.ts
+++ b/packages/core/src/source/file.ts
@@ -17,6 +17,7 @@ export type FileSource<
 > = {
   readonly [FILE_REF_PROP]: string;
   readonly [VAL_EXTENSION]: "file";
+  readonly [FILE_REF_SUBTYPE_TAG]?: string;
   readonly metadata?: Metadata;
 };
 

--- a/packages/core/src/source/file.ts
+++ b/packages/core/src/source/file.ts
@@ -2,6 +2,7 @@ import { VAL_EXTENSION } from ".";
 import { Json } from "../Json";
 
 export const FILE_REF_PROP = "_ref" as const;
+export const FILE_REF_SUBTYPE_TAG = "_tag" as const;
 
 export type FileMetadata = { readonly [key: string]: Json };
 

--- a/packages/core/src/source/richtext.ts
+++ b/packages/core/src/source/richtext.ts
@@ -177,3 +177,5 @@ export function richtext<O extends RichTextOptions>(
       nodes as RichTextSource<AnyRichTextOptions>["exprs"] as RichTextSource<O>["exprs"],
   };
 }
+
+export const RT_IMAGE_TAG = "rt_image";

--- a/packages/core/src/source/richtext.ts
+++ b/packages/core/src/source/richtext.ts
@@ -1,7 +1,6 @@
 import { VAL_EXTENSION } from ".";
-import { LinkSource, link } from "./link";
+import { LinkSource } from "./link";
 import { ImageSource } from "./image";
-import { file } from "./file";
 
 export type RichTextOptions = {
   headings?: ("h1" | "h2" | "h3" | "h4" | "h5" | "h6")[];

--- a/packages/core/src/source/richtext.ts
+++ b/packages/core/src/source/richtext.ts
@@ -1,6 +1,8 @@
 import { VAL_EXTENSION } from ".";
 import { LinkSource } from "./link";
 import { ImageSource } from "./image";
+import { ImageMetadata } from "../schema/image";
+import { FILE_REF_PROP, FILE_REF_SUBTYPE_TAG, FileSource } from "./file";
 
 export type RichTextOptions = {
   headings?: ("h1" | "h2" | "h3" | "h4" | "h5" | "h6")[];
@@ -178,3 +180,16 @@ export function richtext<O extends RichTextOptions>(
 }
 
 export const RT_IMAGE_TAG = "rt_image";
+
+export type RTImageMetadata = ImageMetadata;
+export function image(
+  ref: `/public/${string}`,
+  metadata?: RTImageMetadata
+): FileSource<RTImageMetadata> {
+  return {
+    [FILE_REF_PROP]: ref,
+    [FILE_REF_SUBTYPE_TAG]: RT_IMAGE_TAG,
+    [VAL_EXTENSION]: "file",
+    metadata,
+  } as FileSource<RTImageMetadata>;
+}

--- a/packages/core/src/source/richtext.ts
+++ b/packages/core/src/source/richtext.ts
@@ -1,6 +1,7 @@
 import { VAL_EXTENSION } from ".";
-import { LinkSource } from "./link";
+import { LinkSource, link } from "./link";
 import { ImageSource } from "./image";
+import { file } from "./file";
 
 export type RichTextOptions = {
   headings?: ("h1" | "h2" | "h3" | "h4" | "h5" | "h6")[];

--- a/packages/eslint-plugin/src/rules/exportContentMustBeValid.js
+++ b/packages/eslint-plugin/src/rules/exportContentMustBeValid.js
@@ -7,12 +7,12 @@ export default {
   meta: {
     type: "problem",
     docs: {
-      description: "Export val.content should only happen in .val files.",
+      description: "Export c.define should only happen in .val files.",
       recommended: true,
     },
     messages: {
       "val/export-content-must-be-valid":
-        "Val: val.content should only be exported from .val files",
+        "Val: c.define should only be exported from .val files",
     },
     schema: [],
   },
@@ -24,9 +24,9 @@ export default {
           node.declaration.type === "CallExpression" &&
           node.declaration.callee.type === "MemberExpression" &&
           node.declaration.callee.object.type === "Identifier" &&
-          node.declaration.callee.object.name === "val" &&
+          node.declaration.callee.object.name === "c" &&
           node.declaration.callee.property.type === "Identifier" &&
-          node.declaration.callee.property.name === "content"
+          node.declaration.callee.property.name === "define"
         ) {
           const filename = context.filename || context.getFilename();
           if (

--- a/packages/eslint-plugin/src/rules/noIllegalModuleIds.js
+++ b/packages/eslint-plugin/src/rules/noIllegalModuleIds.js
@@ -78,7 +78,7 @@ export default {
           if (firstArg.type === "TemplateLiteral") {
             context.report({
               node: firstArg,
-              message: "Val: val.content id should not be a template literal",
+              message: "Val: c.define id should not be a template literal",
               fix: (fixer) => fixer.replaceText(firstArg, `"${expectedValue}"`),
             });
           }
@@ -91,7 +91,7 @@ export default {
               if (rawArg) {
                 context.report({
                   node: firstArg,
-                  message: `Val: val.content id should match the filename. Expected: '${expectedValue}'. Found: '${firstArg.value}'`,
+                  message: `Val: c.define id should match the filename. Expected: '${expectedValue}'. Found: '${firstArg.value}'`,
                   fix: (fixer) =>
                     fixer.replaceText(
                       firstArg,

--- a/packages/eslint-plugin/test/plugin.test.js
+++ b/packages/eslint-plugin/test/plugin.test.js
@@ -29,11 +29,11 @@ describe("plugin", () => {
   });
 
   test("no illegal modules for monorepos (projects that are not at root)", async () => {
-    const code = `import { s, val } from "../val.config";
+    const code = `import { s, c } from "../val.config";
 
 export const schema = s.string();
 
-export default val.content(
+export default c.define(
   "/something",
   schema,
   "React Server components also works"
@@ -48,11 +48,11 @@ export default val.content(
   });
 
   test("no illegal modules for monorepos (projects that are not at root) - nested", async () => {
-    const code = `import { s, val } from "../../../../val.config";
+    const code = `import { s, c } from "../../../../val.config";
 
 export const schema = s.string();
 
-export default val.content(
+export default c.define(
   "/something",
   schema,
   "React Server components also works"
@@ -68,11 +68,11 @@ export default val.content(
     );
   });
   test("no illegal modules for monorepos (projects that are not at root) - src", async () => {
-    const code = `import { s, val } from "../../../../val.config";
+    const code = `import { s, c } from "../../../../val.config";
 
 export const schema = s.string();
 
-export default val.content(
+export default c.define(
   "/something",
   schema,
   "React Server components also works"

--- a/packages/eslint-plugin/test/rules/exportContentMustBeValid.test.js
+++ b/packages/eslint-plugin/test/rules/exportContentMustBeValid.test.js
@@ -19,36 +19,36 @@ ruleTester.run("export-content-must-be-valid", rule, {
     {
       filename: path.join(process.cwd(), "./foo/test.val.ts"),
       code: `
-import { val, s } from '../val.config';
+import { c, s } from '../val.config';
 
 export const schema = s.string();
-export default val.content('/foo/test', schema, '')`,
+export default c.define('/foo/test', schema, '')`,
     },
   ],
   invalid: [
     {
       filename: path.join(process.cwd(), "./foo/test.ts"),
       code: `
-import { val, s } from '../val.config';
+import { c, s } from '../val.config';
 
 export const schema = s.string();
-export default val.content('/foo/test', schema, '')`,
+export default c.define('/foo/test', schema, '')`,
       errors: [
         {
-          message: "Val: val.content should only be exported from .val files",
+          message: "Val: c.define should only be exported from .val files",
         },
       ],
     },
     {
       filename: path.join(process.cwd(), "./foo/test.js"),
       code: `
-import { val, s } from '../val.config';
+import { c, s } from '../val.config';
 
 export const schema = s.string();
-export default val.content('/foo/test', schema, '')`,
+export default c.define('/foo/test', schema, '')`,
       errors: [
         {
-          message: "Val: val.content should only be exported from .val files",
+          message: "Val: c.define should only be exported from .val files",
         },
       ],
     },

--- a/packages/eslint-plugin/test/rules/noIllegalImports.test.js
+++ b/packages/eslint-plugin/test/rules/noIllegalImports.test.js
@@ -20,59 +20,59 @@ ruleTester.run("no-illegal-imports", rule, {
     {
       filename: path.join(process.cwd(), "./foo/test.val.ts"),
       code: `
-import { val, s } from '../val.config';
+import { c, s } from '../val.config';
 import { eventSchema } from './event.val';
 
 export const schema = s.array(eventSchema);
-export default val.content('/foo/test', schema, [])`,
+export default c.define('/foo/test', schema, [])`,
     },
     {
       filename: path.join(process.cwd(), "./foo/test.val.ts"),
       code: `
-import { val, s } from '../val.config.ts';
+import { c, s } from '../val.config.ts';
 import { eventSchema } from './event.val.ts';
 
 export const schema = s.array(eventSchema);
-export default val.content('/foo/test', schema, [])`,
+export default c.define('/foo/test', schema, [])`,
     },
     {
       filename: path.join(process.cwd(), "./foo/test.val.ts"),
       code: `
-import { val, s } from '../val.config.ts';
+import { c, s } from '../val.config.ts';
 import type { Event } from './eventSchema';
 
 export const schema = s.array(s.string());
 type Test = Event;
-export default val.content('/foo/test', schema, [])`,
+export default c.define('/foo/test', schema, [])`,
     },
     {
       filename: path.join(process.cwd(), "./foo/test.val.ts"),
       code: `
-import { val, s } from '../val.config.ts';
+import { c, s } from '../val.config.ts';
 import { type Event } from './eventSchema';
 
 export const schema = s.array(s.string());
 type Test = Event;
-export default val.content('/foo/test', schema, [])`,
+export default c.define('/foo/test', schema, [])`,
     },
     {
       filename: path.join(process.cwd(), "./foo/test.val.ts"),
       code: `
-import { val, s } from '../val.config.ts';
+import { c, s } from '../val.config.ts';
 
 export const schema = s.string();
-export default val.content('/foo/test', schema, 'String')`,
+export default c.define('/foo/test', schema, 'String')`,
     },
   ],
   invalid: [
     {
       filename: path.join(process.cwd(), "./foo/test.val.ts"),
       code: `
-import { val, s } from '../val.config';
+import { c, s } from '../val.config';
 import { eventSchema } from './event';
 
 export const schema = s.array(eventSchema);
-export default val.content('/foo/test', schema, [])`,
+export default c.define('/foo/test', schema, [])`,
       errors: [
         {
           message:
@@ -83,12 +83,12 @@ export default val.content('/foo/test', schema, [])`,
     {
       filename: path.join(process.cwd(), "./foo/test.val.ts"),
       code: `
-import { val, s } from '../val.config';
+import { c, s } from '../val.config';
 import { eventSchema, type Unused } from './event';
 
 export const schema = s.array(eventSchema);
 type Event = Unused;
-export default val.content('/foo/test', schema, [])`,
+export default c.define('/foo/test', schema, [])`,
       errors: [
         {
           message:

--- a/packages/eslint-plugin/test/rules/noIllegalModuleIds.test.js
+++ b/packages/eslint-plugin/test/rules/noIllegalModuleIds.test.js
@@ -20,55 +20,55 @@ ruleTester.run("no-illegal-module-ids", rule, {
   valid: [
     {
       filename: path.join(process.cwd(), "./foo/test.val.ts"),
-      code: `import { val, s } from '../val.config.ts';
+      code: `import { c, s } from '../val.config.ts';
       export const schema = s.string();
-      export default val.content('/foo/test', schema, 'String')`,
+      export default c.define('/foo/test', schema, 'String')`,
     },
   ],
   invalid: [
     {
       filename: path.join(process.cwd(), "./foo/test.val.ts"),
-      code: `import { val, s } from '../val.config.ts';
+      code: `import { c, s } from '../val.config.ts';
       export const schema = s.string();
-      export default val.content('foo', schema, 'String')`,
+      export default c.define('foo', schema, 'String')`,
       errors: [
         {
           message:
-            "Val: val.content id should match the filename. Expected: '/foo/test'. Found: 'foo'",
+            "Val: c.define id should match the filename. Expected: '/foo/test'. Found: 'foo'",
         },
       ],
-      output: `import { val, s } from '../val.config.ts';
+      output: `import { c, s } from '../val.config.ts';
       export const schema = s.string();
-      export default val.content('/foo/test', schema, 'String')`,
+      export default c.define('/foo/test', schema, 'String')`,
     },
     {
       filename: path.join(process.cwd(), "./foo/test.val.ts"),
-      code: `import { val, s } from "../val.config.ts";
+      code: `import { c, s } from "../val.config.ts";
       export const schema = s.string();
-      export default val.content("foo", schema, 'String')`,
+      export default c.define("foo", schema, 'String')`,
       errors: [
         {
           message:
-            "Val: val.content id should match the filename. Expected: '/foo/test'. Found: 'foo'",
+            "Val: c.define id should match the filename. Expected: '/foo/test'. Found: 'foo'",
         },
       ],
-      output: `import { val, s } from "../val.config.ts";
+      output: `import { c, s } from "../val.config.ts";
       export const schema = s.string();
-      export default val.content("/foo/test", schema, 'String')`,
+      export default c.define("/foo/test", schema, 'String')`,
     },
     {
       filename: path.join(process.cwd(), "./foo/test.val.ts"),
-      code: `import { val, s } from "../val.config.ts";
+      code: `import { c, s } from "../val.config.ts";
       export const schema = s.string();
-      export default val.content(\`foo\`, schema, 'String')`,
+      export default c.define(\`foo\`, schema, 'String')`,
       errors: [
         {
-          message: "Val: val.content id should not be a template literal",
+          message: "Val: c.define id should not be a template literal",
         },
       ],
-      output: `import { val, s } from "../val.config.ts";
+      output: `import { c, s } from "../val.config.ts";
       export const schema = s.string();
-      export default val.content("/foo/test", schema, 'String')`,
+      export default c.define("/foo/test", schema, 'String')`,
     },
   ],
 });

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -10,6 +10,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
+    "typecheck": "tsc --noEmit",
     "test": "jest"
   },
   "bin": {

--- a/packages/init/src/init.ts
+++ b/packages/init/src/init.ts
@@ -389,7 +389,7 @@ async function plan(
 
   plan.createConfigFile = {
     path: valConfigPath,
-    source: VAL_CONFIG({}),
+    source: VAL_CONFIG(!!analysis.isTypeScript, {}),
   };
 
   const valUtilsDir = path.join(analysis.srcDir, "val");

--- a/packages/init/src/templates.ts
+++ b/packages/init/src/templates.ts
@@ -44,12 +44,14 @@ type ValConfig = {
   valConfigPath?: string;
 };
 export const VAL_CONFIG = (
+  isTypeScript: boolean,
   options: ValConfig
 ) => `import { initVal } from "@valbuild/next";
 
-const { s, val, config } = initVal(${JSON.stringify(options, null, 2)});
+const { s, c, val, config } = initVal(${JSON.stringify(options, null, 2)});
 
-export { s, val, config };
+${isTypeScript ? 'export type { t } from "@valbuild/next";' : ""};
+export { s, c, val, config };
 `;
 
 export const VAL_API_ROUTER = (

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -345,7 +345,7 @@ s.richtext({
 To initialize some text content using a RichText schema, you can use follow the example below:
 
 ```ts
-import { s, val } from "./val.config";
+import { s, c } from "./val.config";
 
 export const schema = s.richtext({
   // styling:
@@ -411,7 +411,7 @@ s.image();
 Local images must be stored under the `.public` folder.
 
 ```ts
-import { s, val } from "../val.config";
+import { s, c } from "../val.config";
 
 export const schema = s.image();
 

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -363,7 +363,7 @@ export const schema = s.richtext({
 export default c.define(
   "/src/app/content",
   schema,
-  val.richtext`
+  c.richtext`
 NOTE: this is markdown.
 
 **Bold** text.

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -158,11 +158,9 @@ npm install @valbuild/next@latest @valbuild/eslint-plugin@latest
 npx @valbuild/init
 ```
 
-- In order to let editors make updates you can go to https://val.build, sign up and import you project. From there you can share links to preview builds so that editors can update content.
-
 ### Add editor support
 
-To make it possible to do non-local edits, head over to [val.build](https://val.build) and import your repository.
+To make it possible to do non-local edits, head over to [val.build](https://val.build), sign up and import your repository.
 
 **NOTE**: your content is yours. No subscription (or similar) is required to host content from your repository.
 
@@ -178,11 +176,11 @@ Content in Val is always defined in `.val.ts` files.
 
 **NOTE**: Val also works with `.js` files.
 
-They must export a default `val.content` where the first argument equals the path of the file relative to the `val.config.ts` file.
+They must export a default content definition (`c.define`) where the first argument equals the path of the file relative to the `val.config.ts` file.
 
 **NOTE**: `val.ts` files are _evaluated_ by Val, therefore they have a specific set of requirements:
 
-- They must have a default export that is `val.content`, they must have a `export const schema` with the Schema; and
+- They must have a default export that is `c.define`, they must have a `export const schema` with the Schema; and
 - they CANNOT import anything other than `val.config` and `@valbuild/core`
 
 ### Example of a `.val.ts` file
@@ -190,7 +188,7 @@ They must export a default `val.content` where the first argument equals the pat
 ```ts
 // ./src/app/content.val.ts
 
-import { s, val } from "../../../val.config";
+import { s, c } from "../../../val.config";
 
 export const schema = s.object({
   title: s.string().optional(), //  <- NOTE: optional()
@@ -204,7 +202,7 @@ export const schema = s.object({
   ),
 });
 
-export default val.content(
+export default c.define(
   "/src/app/content", // <- NOTE: this must be the same path as the file
   schema,
   {
@@ -212,7 +210,7 @@ export default val.content(
     sections: [
       {
         title: "Section 1",
-        text: val.richtext`
+        text: c.richtext`
 RichText is **awesome**`,
       },
     ],
@@ -362,7 +360,7 @@ export const schema = s.richtext({
   //ol: true, // enables ordered lists
 });
 
-export default val.content(
+export default c.define(
   "/src/app/content",
   schema,
   val.richtext`
@@ -417,7 +415,7 @@ import { s, val } from "../val.config";
 
 export const schema = s.image();
 
-export default val.content("/image", schema, val.file("/public/myfile.jpg"));
+export default c.define("/image", schema, c.file("/public/myfile.jpg"));
 ```
 
 **NOTE**: This will not validate, since images requires `width`, `height` and a `sha256` checksum. You can fix this validation in the UI by opening the image and clicking the Fix button.

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -44,9 +44,4 @@ import { autoTagJSX } from "@valbuild/react/stega";
 autoTagJSX();
 
 // Convenience types
-import type { UseValType } from "./client/initValClient";
-import { Schema, SelectorSource } from "@valbuild/core";
-import { SelectorOfSchema } from "@valbuild/core";
-export type InferSchemaType<S extends Schema<SelectorSource>> = UseValType<
-  SelectorOfSchema<S>
->;
+export type * as t from "./types";

--- a/packages/next/src/initVal.ts
+++ b/packages/next/src/initVal.ts
@@ -15,7 +15,7 @@ export const initVal = (
     decodeValPathOfString: typeof decodeValPathOfString;
   };
 } => {
-  const { s, val, config: systemConfig } = createValSystem();
+  const { s, c, val, config: systemConfig } = createValSystem();
   const currentConfig = {
     ...systemConfig,
     ...config,
@@ -23,6 +23,7 @@ export const initVal = (
   };
   return {
     s,
+    c,
     val: {
       ...val,
       decodeValPathOfString,

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -1,0 +1,8 @@
+// Convenience types
+import type { UseValType } from "./client/initValClient";
+import { Schema, SelectorSource } from "@valbuild/core";
+import { SelectorOfSchema } from "@valbuild/core";
+
+export type inferSchema<S extends Schema<SelectorSource>> = UseValType<
+  SelectorOfSchema<S>
+>;

--- a/packages/react/src/stega/stegaEncode.test.ts
+++ b/packages/react/src/stega/stegaEncode.test.ts
@@ -2,7 +2,7 @@ import { getModuleIds, stegaEncode } from "./stegaEncode";
 import { initVal } from "@valbuild/core";
 import { vercelStegaDecode, vercelStegaSplit } from "@vercel/stega";
 
-const { s, val } = initVal();
+const { s, c } = initVal();
 
 describe("stega transform", () => {
   test("basic", () => {
@@ -15,26 +15,26 @@ describe("stega transform", () => {
       })
     );
 
-    const valModule = val.content("/test", schema, [
+    const valModule = c.define("/test", schema, [
       {
-        image: val.file("/public/test1.png", {
+        image: c.file("/public/test1.png", {
           sha256: "1231",
           width: 100,
           height: 100,
           mimeType: "image/png",
         }),
-        text: val.richtext`Test`,
+        text: c.richtext`Test`,
         n: 1,
         b: true,
       },
       {
-        image: val.file("/public/test2.png", {
+        image: c.file("/public/test2.png", {
           sha256: "1232",
           width: 100,
           height: 100,
           mimeType: "image/png",
         }),
-        text: val.richtext`Test`,
+        text: c.richtext`Test`,
         n: 2,
         b: false,
       },
@@ -73,10 +73,10 @@ describe("stega transform", () => {
     expect(
       getModuleIds({
         foo: [
-          { test: val.content("/test1", schema, ["one", "two"]) },
-          { test: val.content("/test2", schema, ["one", "two"]) },
+          { test: c.define("/test1", schema, ["one", "two"]) },
+          { test: c.define("/test2", schema, ["one", "two"]) },
         ],
-        test: val.content("/test3", schema, ["one", "two"]),
+        test: c.define("/test3", schema, ["one", "two"]),
       })
     ).toStrictEqual(["/test1", "/test2", "/test3"]);
   });
@@ -84,7 +84,7 @@ describe("stega transform", () => {
   test("basic transform with get modules", () => {
     const schema = s.array(s.string());
     const transformed = stegaEncode(
-      val.content("/test1", schema, ["one", "two"]),
+      c.define("/test1", schema, ["one", "two"]),
       {
         getModule: (moduleId) => {
           if (moduleId === "/test1") {
@@ -106,7 +106,7 @@ describe("stega transform", () => {
   test("Dont stegaEncode raw strings schema", () => {
     const schema = s.object({ str: s.string(), rawStr: s.string().raw() });
     const transformed = stegaEncode(
-      val.content("/test1", schema, { str: "one", rawStr: "two" }),
+      c.define("/test1", schema, { str: "one", rawStr: "two" }),
       {}
     );
     //expect(transformed.str).toStrictEqual("one");
@@ -117,10 +117,10 @@ describe("stega transform", () => {
     const transformed = stegaEncode(
       {
         foo: [
-          { test: val.content("/test1", schema, ["one", "two"]) },
-          { test: val.content("/test2", schema, ["one", "two"]) },
+          { test: c.define("/test1", schema, ["one", "two"]) },
+          { test: c.define("/test2", schema, ["one", "two"]) },
         ],
-        test: val.content("/test3", schema, ["one", "two"]),
+        test: c.define("/test3", schema, ["one", "two"]),
       },
       {
         getModule: (moduleId) => {

--- a/packages/server/src/patch/ts/ops.test.ts
+++ b/packages/server/src/patch/ts/ops.test.ts
@@ -3,7 +3,12 @@ import { TSOps } from "./ops";
 import { result, array, pipe } from "@valbuild/core/fp";
 import { PatchError, JSONValue } from "@valbuild/core/patch";
 import { ValSyntaxError } from "./syntax";
-import { FILE_REF_PROP, VAL_EXTENSION } from "@valbuild/core";
+import {
+  FILE_REF_PROP,
+  FILE_REF_SUBTYPE_TAG,
+  RT_IMAGE_TAG,
+  VAL_EXTENSION,
+} from "@valbuild/core";
 
 function testSourceFile(expression: string): ts.SourceFile {
   return ts.createSourceFile(
@@ -142,20 +147,20 @@ describe("TSOps", () => {
       expected: result.err(PatchError),
     },
     {
-      name: "val.file",
+      name: "c.file",
       input: `{ foo: "bar" }`,
       path: ["image"],
       value: { _ref: "/public/val/image.jpg" },
       expected: result.ok(
-        `{ foo: "bar", image: val.file("/public/val/image.jpg") }`
+        `{ foo: "bar", image: c.file("/public/val/image.jpg") }`
       ),
     },
     {
-      name: "ref prop to val.file",
-      input: `val.file("/public/val/foo.jpg")`,
+      name: "ref prop to c.file",
+      input: `c.file("/public/val/foo.jpg")`,
       path: ["_ref"],
       value: "/public/val/bar.jpg",
-      expected: result.ok(`val.file("/public/val/bar.jpg")`),
+      expected: result.ok(`c.file("/public/val/bar.jpg")`),
     },
     {
       name: "ref prop",
@@ -165,8 +170,8 @@ describe("TSOps", () => {
       expected: result.err(PatchError),
     },
     {
-      name: "prop on val.file TODO",
-      input: `{ foo: "bar", image: val.file("/public/val/image.jpg") }`,
+      name: "prop on c.file",
+      input: `{ foo: "bar", image: c.file("/public/val/image.jpg") }`,
       path: ["image", "metadata"],
       value: {
         width: 123,
@@ -174,19 +179,19 @@ describe("TSOps", () => {
         sha256: "abc",
       },
       expected: result.ok(
-        `{ foo: "bar", image: val.file("/public/val/image.jpg", { width: 123, height: 456, sha256: "abc" }) }`
+        `{ foo: "bar", image: c.file("/public/val/image.jpg", { width: 123, height: 456, sha256: "abc" }) }`
       ),
     },
     {
-      name: "null prop of name ref on val.file",
-      input: `{ foo: "bar", image: val.file("/public/val/image.jpg") }`,
+      name: "null prop of name ref on c.file",
+      input: `{ foo: "bar", image: c.file("/public/val/image.jpg") }`,
       path: ["image", "_ref"],
       value: null,
       expected: result.err(PatchError),
     },
     {
-      name: "to ref on val.file",
-      input: `{ foo: "bar", image: val.file("/public/val/image.jpg") }`,
+      name: "to ref on c.file",
+      input: `{ foo: "bar", image: c.file("/public/val/image.jpg") }`,
       path: ["image", "_ref", "zoo"],
       value: null,
       expected: result.err(PatchError),
@@ -270,20 +275,20 @@ describe("TSOps", () => {
       expected: result.err(PatchError),
     },
     {
-      name: "val.file from array",
-      input: `[val.file("/public/val/image1.jpg"), val.file("/public/val/image2.jpg")]`,
+      name: "c.file from array",
+      input: `[c.file("/public/val/image1.jpg"), c.file("/public/val/image2.jpg")]`,
       path: ["0"],
-      expected: result.ok(`[val.file("/public/val/image2.jpg")]`),
+      expected: result.ok(`[c.file("/public/val/image2.jpg")]`),
     },
     {
-      name: "val.file from object",
-      input: `[{ foo: "bar", image: val.file("/public/val/image.jpg") }]`,
+      name: "c.file from object",
+      input: `[{ foo: "bar", image: c.file("/public/val/image.jpg") }]`,
       path: ["0", "image"],
       expected: result.ok(`[{ foo: "bar" }]`),
     },
     {
-      name: "ref prop from val.file",
-      input: `{ image: val.file("/public/val/image.jpg") }`,
+      name: "ref prop from c.file",
+      input: `{ image: c.file("/public/val/image.jpg") }`,
       path: ["image", "_ref"],
       expected: result.err(PatchError),
     },
@@ -377,50 +382,50 @@ describe("TSOps", () => {
       expected: result.err(PatchError),
     },
     {
-      name: "val.files",
-      input: `val.file("/public/val/foo/bar.jpg")`,
+      name: "c.files",
+      input: `c.file("/public/val/foo/bar.jpg")`,
       path: ["_ref"],
       value: "/public/val/foo/bar2.jpg",
-      expected: result.ok(`val.file("/public/val/foo/bar2.jpg")`),
+      expected: result.ok(`c.file("/public/val/foo/bar2.jpg")`),
     },
     {
-      name: "val.file ref with options",
-      input: `val.file("/public/val/foo/bar.jpg", { checksum: "123", width: 456, height: 789 })`,
+      name: "c.file ref with options",
+      input: `c.file("/public/val/foo/bar.jpg", { checksum: "123", width: 456, height: 789 })`,
       path: ["_ref"],
       value: "/public/val/foo/bar2.jpg",
       expected: result.ok(
-        `val.file("/public/val/foo/bar2.jpg", { checksum: "123", width: 456, height: 789 })`
+        `c.file("/public/val/foo/bar2.jpg", { checksum: "123", width: 456, height: 789 })`
       ),
     },
     // TODO:
     // {
-    //   name: "val.file non metadata",
-    //   input: `val.file("/public/val/foo/bar.jpg", { checksum: "123", width: 456, height: 789 })`,
+    //   name: "c.file non metadata",
+    //   input: `c.file("/public/val/foo/bar.jpg", { checksum: "123", width: 456, height: 789 })`,
     //   path: ["failure", "checksum"],
     //   value: "101112",
     //   expected: result.err(PatchError),
     // },
     {
-      name: "val.file checksum",
-      input: `val.file("/public/val/foo/bar.jpg", { checksum: "123", width: 456, height: 789 })`,
+      name: "c.file checksum",
+      input: `c.file("/public/val/foo/bar.jpg", { checksum: "123", width: 456, height: 789 })`,
       path: ["metadata", "checksum"],
       value: "101112",
       expected: result.ok(
-        `val.file("/public/val/foo/bar.jpg", { checksum: "101112", width: 456, height: 789 })`
+        `c.file("/public/val/foo/bar.jpg", { checksum: "101112", width: 456, height: 789 })`
       ),
     },
     {
-      name: "deep val.files",
-      input: `{ foo: { bar: val.file("/public/val/foo/bar/zoo.jpg") } }`,
+      name: "deep c.files",
+      input: `{ foo: { bar: c.file("/public/val/foo/bar/zoo.jpg") } }`,
       path: ["foo", "bar", "_ref"],
       value: "/public/val/foo/bar/zoo2.jpg",
       expected: result.ok(
-        `{ foo: { bar: val.file("/public/val/foo/bar/zoo2.jpg") } }`
+        `{ foo: { bar: c.file("/public/val/foo/bar/zoo2.jpg") } }`
       ),
     },
     {
-      name: "prop on val.file",
-      input: `{ foo: "bar", image: val.file("/public/val/image.jpg") }`,
+      name: "prop on c.file",
+      input: `{ foo: "bar", image: c.file("/public/val/image.jpg") }`,
       path: ["image", "metadata"],
       value: {
         width: 123,
@@ -430,52 +435,52 @@ describe("TSOps", () => {
       expected: result.err(PatchError),
     },
     {
-      name: "null prop of name ref on val.file",
-      input: `{ foo: "bar", image: val.file("/public/val/image.jpg") }`,
+      name: "null prop of name ref on c.file",
+      input: `{ foo: "bar", image: c.file("/public/val/image.jpg") }`,
       path: ["image", "_ref"],
       value: null,
       expected: result.err(PatchError),
     },
     {
-      name: "number prop of name ref on val.file",
-      input: `{ foo: "bar", image: val.file("/public/val/image.jpg") }`,
+      name: "number prop of name ref on c.file",
+      input: `{ foo: "bar", image: c.file("/public/val/image.jpg") }`,
       path: ["image", "_ref"],
       value: 1,
       expected: result.err(PatchError),
     },
     {
-      name: "to ref on val.file",
-      input: `{ foo: "bar", image: val.file("/public/val/image.jpg") }`,
+      name: "to ref on c.file",
+      input: `{ foo: "bar", image: c.file("/public/val/image.jpg") }`,
       path: ["image", "_ref", "zoo"],
       value: null,
       expected: result.err(PatchError),
     },
     {
-      name: "val.richtext basic no nodes",
-      input: "val.richtext`Test`",
+      name: "c.richtext basic no nodes",
+      input: "c.richtext`Test`",
       path: [],
       value: {
         [VAL_EXTENSION]: "richtext",
         templateStrings: ["Test 2"],
         exprs: [],
       },
-      expected: result.ok("val.richtext `Test 2`"),
+      expected: result.ok("c.richtext `Test 2`"),
     },
     {
-      name: "val.richtext advanced no nodes",
-      input: "val.richtext`Test`",
+      name: "c.richtext advanced no nodes",
+      input: "c.richtext`Test`",
       path: [],
       value: {
         [VAL_EXTENSION]: "richtext",
         templateStrings: ["# Title 1\nTest 2"],
         exprs: [],
       },
-      expected: result.ok(`val.richtext \`# Title 1
+      expected: result.ok(`c.richtext \`# Title 1
 Test 2\``),
     },
     {
-      name: "val.richtext basic nodes",
-      input: "val.richtext`Test`",
+      name: "c.richtext basic nodes",
+      input: "c.richtext`Test`",
       path: [],
       value: {
         [VAL_EXTENSION]: "richtext",
@@ -483,18 +488,19 @@ Test 2\``),
         exprs: [
           {
             [VAL_EXTENSION]: "file",
+            [FILE_REF_SUBTYPE_TAG]: RT_IMAGE_TAG,
             [FILE_REF_PROP]: "/public/test",
             metadata: { width: 100, height: 100, sha256: "123" },
           },
         ],
       },
-      expected: result.ok(`val.richtext \`# Title 1
+      expected: result.ok(`c.richtext \`# Title 1
 Test 2
-\${val.file("/public/test", { width: 100, height: 100, sha256: "123" })}\``),
+\${c.rt.image("/public/test", { width: 100, height: 100, sha256: "123" })}\``),
     },
     {
-      name: "val.richtext advanced nodes",
-      input: "val.richtext`Test`",
+      name: "c.richtext advanced nodes",
+      input: "c.richtext`Test`",
       path: [],
       value: {
         [VAL_EXTENSION]: "richtext",
@@ -502,24 +508,26 @@ Test 2
         exprs: [
           {
             [VAL_EXTENSION]: "file",
+            [FILE_REF_SUBTYPE_TAG]: RT_IMAGE_TAG,
             [FILE_REF_PROP]: "/public/test1",
             metadata: { width: 100, height: 100, sha256: "123" },
           },
           {
             [VAL_EXTENSION]: "file",
+            [FILE_REF_SUBTYPE_TAG]: RT_IMAGE_TAG,
             [FILE_REF_PROP]: "/public/test2",
             metadata: { width: 100, height: 100, sha256: "123" },
           },
         ],
       },
-      expected: result.ok(`val.richtext \`# Title 1
-\${val.file("/public/test1", { width: 100, height: 100, sha256: "123" })}
-\${val.file("/public/test2", { width: 100, height: 100, sha256: "123" })}
+      expected: result.ok(`c.richtext \`# Title 1
+\${c.rt.image("/public/test1", { width: 100, height: 100, sha256: "123" })}
+\${c.rt.image("/public/test2", { width: 100, height: 100, sha256: "123" })}
 Test 2\``),
     },
     {
-      name: "val.richtext link",
-      input: "val.richtext`Test`",
+      name: "c.richtext link",
+      input: "c.richtext`Test`",
       path: [],
       value: {
         [VAL_EXTENSION]: "richtext",
@@ -532,19 +540,20 @@ Test 2\``),
           },
           {
             [VAL_EXTENSION]: "file",
+            [FILE_REF_SUBTYPE_TAG]: RT_IMAGE_TAG,
             [FILE_REF_PROP]: "/public/test2",
             metadata: { width: 100, height: 100, sha256: "123" },
           },
         ],
       },
-      expected: result.ok(`val.richtext \`# Title 1
-\${val.link("https://example.com", { href: "https://example.com" })}
-\${val.file("/public/test2", { width: 100, height: 100, sha256: "123" })}\``),
+      expected: result.ok(`c.richtext \`# Title 1
+\${c.rt.link("https://example.com", { href: "https://example.com" })}
+\${c.rt.image("/public/test2", { width: 100, height: 100, sha256: "123" })}\``),
     },
     {
-      name: "val.richtext empty head",
+      name: "c.richtext empty head",
       input:
-        "{ text: val.richtext`${val.file('/public/test1', { height: 100 })}` }",
+        "{ text: c.richtext`${c.rt.image('/public/test1', { height: 100 })}` }",
       path: ["text"],
       value: {
         [VAL_EXTENSION]: "richtext",
@@ -552,19 +561,21 @@ Test 2\``),
         exprs: [
           {
             [VAL_EXTENSION]: "file",
+            [FILE_REF_SUBTYPE_TAG]: RT_IMAGE_TAG,
             [FILE_REF_PROP]: "/public/test1",
             metadata: { width: 100, height: 100, sha256: "123" },
           },
           {
             [VAL_EXTENSION]: "file",
+            [FILE_REF_SUBTYPE_TAG]: RT_IMAGE_TAG,
             [FILE_REF_PROP]: "/public/test2",
             metadata: { width: 100, height: 100, sha256: "123" },
           },
         ],
       },
       expected:
-        result.ok(`{ text: val.richtext \`\${val.file("/public/test1", { width: 100, height: 100, sha256: "123" })}
-\${val.file("/public/test2", { width: 100, height: 100, sha256: "123" })}
+        result.ok(`{ text: c.richtext \`\${c.rt.image("/public/test1", { width: 100, height: 100, sha256: "123" })}
+\${c.rt.image("/public/test2", { width: 100, height: 100, sha256: "123" })}
 Test 2\` }`),
     },
   ])("replace $name", ({ input, path, value, expected }) => {
@@ -657,28 +668,28 @@ Test 2\` }`),
       expected: result.err(PatchError),
     },
     {
-      name: "val.file to root of document",
-      input: `{ foo: null, baz: val.file("/public/val/foo/bar.jpg") }`,
+      name: "c.file to root of document",
+      input: `{ foo: null, baz: c.file("/public/val/foo/bar.jpg") }`,
       from: ["baz"],
       path: ["bar"],
       expected: result.ok(
-        `{ foo: null, bar: val.file("/public/val/foo/bar.jpg") }`
+        `{ foo: null, bar: c.file("/public/val/foo/bar.jpg") }`
       ),
     },
     {
-      name: "ref out of val.file",
-      input: `{ foo: null, baz: val.file("/public/val/foo/bar.jpg") }`,
+      name: "ref out of c.file",
+      input: `{ foo: null, baz: c.file("/public/val/foo/bar.jpg") }`,
       from: ["baz", "_ref"],
       path: ["bar"],
       expected: result.err(PatchError),
     },
     {
-      name: "object into val.file",
-      input: `{ foo: { bar: "zoo" }, baz: val.file("/public/val/foo/bar.jpg") }`,
+      name: "object into c.file",
+      input: `{ foo: { bar: "zoo" }, baz: c.file("/public/val/foo/bar.jpg") }`,
       from: ["foo"],
       path: ["baz", "metadata"],
       expected: result.ok(
-        `{ baz: val.file("/public/val/foo/bar.jpg", { bar: "zoo" }) }`
+        `{ baz: c.file("/public/val/foo/bar.jpg", { bar: "zoo" }) }`
       ),
     },
   ])("move $name", ({ input, from, path, expected }) => {
@@ -778,19 +789,19 @@ Test 2\` }`),
       expected: result.err(PatchError),
     },
     {
-      name: "val.file to root of object",
-      input: `{ foo: val.file("/public/val/image1.jpg") }`,
+      name: "c.file to root of object",
+      input: `{ foo: c.file("/public/val/image1.jpg") }`,
       from: ["foo"],
       path: [],
-      expected: result.ok(`val.file("/public/val/image1.jpg")`),
+      expected: result.ok(`c.file("/public/val/image1.jpg")`),
     },
     {
-      name: "object into val.file",
-      input: `{ foo: val.file("/public/val/image1.jpg"), bar: null }`,
+      name: "object into c.file",
+      input: `{ foo: c.file("/public/val/image1.jpg"), bar: null }`,
       from: ["bar"],
       path: ["foo", "metadata"],
       expected: result.ok(
-        `{ foo: val.file("/public/val/image1.jpg", null), bar: null }`
+        `{ foo: c.file("/public/val/image1.jpg", null), bar: null }`
       ),
     },
   ])("copy $name", ({ input, from, path, expected }) => {
@@ -907,22 +918,22 @@ Test 2\` }`),
       expected: result.err(PatchError),
     },
     {
-      name: "val.file ref",
-      input: `val.file("/public/val/foo/bar.jpg")`,
+      name: "c.file ref",
+      input: `c.file("/public/val/foo/bar.jpg")`,
       path: ["_ref"],
       value: "/public/val/foo/bar.jpg",
       expected: result.ok(true),
     },
     {
-      name: "val.file",
-      input: `val.file("/public/val/foo/bar.jpg")`,
+      name: "c.file",
+      input: `c.file("/public/val/foo/bar.jpg")`,
       path: [],
       value: { _ref: "/public/val/foo/bar.jpg", _type: "file" },
       expected: result.ok(true),
     },
     {
-      name: "nested val.file",
-      input: `{ foo: { bar: val.file("/public/val/foo/bar/zoo.jpg") } }`,
+      name: "nested c.file",
+      input: `{ foo: { bar: c.file("/public/val/foo/bar/zoo.jpg") } }`,
       path: ["foo", "bar", "_ref"],
       value: "/public/val/foo/bar/zoo.jpg",
       expected: result.ok(true),

--- a/packages/server/src/patch/ts/syntax.ts
+++ b/packages/server/src/patch/ts/syntax.ts
@@ -292,7 +292,7 @@ export function isValFileMethodCall(
     ts.isCallExpression(node) &&
     ts.isPropertyAccessExpression(node.expression) &&
     ts.isIdentifier(node.expression.expression) &&
-    node.expression.expression.text === "val" &&
+    node.expression.expression.text === "c" &&
     node.expression.name.text === "file"
   );
 }

--- a/packages/server/src/patch/ts/syntax.ts
+++ b/packages/server/src/patch/ts/syntax.ts
@@ -129,10 +129,7 @@ export function shallowValidateExpression(
     ts.isObjectLiteralExpression(value) ||
     isValFileMethodCall(value)
     ? undefined
-    : new ValSyntaxError(
-        "Expression must be a literal or call val.file",
-        value
-      );
+    : new ValSyntaxError("Expression must be a literal or call c.file", value);
 }
 
 /**
@@ -170,7 +167,7 @@ export function deepValidateExpression(
       if (!ts.isStringLiteralLike(value.arguments[0])) {
         return result.err(
           new ValSyntaxError(
-            "First argument of val.file must be a string literal",
+            "First argument of c.file must be a string literal",
             value.arguments[0]
           )
         );
@@ -180,7 +177,7 @@ export function deepValidateExpression(
       if (!ts.isObjectLiteralExpression(value.arguments[1])) {
         return result.err(
           new ValSyntaxError(
-            "Second argument of val.file must be an object literal",
+            "Second argument of c.file must be an object literal",
             value.arguments[1]
           )
         );
@@ -189,7 +186,7 @@ export function deepValidateExpression(
     return result.voidOk;
   } else {
     return result.err(
-      new ValSyntaxError("Expression must be a literal or call val.file", value)
+      new ValSyntaxError("Expression must be a literal or call c.file", value)
     );
   }
 }
@@ -261,7 +258,7 @@ export function evaluateExpression(
     );
   } else {
     return result.err(
-      new ValSyntaxError("Expression must be a literal or call val.file", value)
+      new ValSyntaxError("Expression must be a literal or call c.file", value)
     );
   }
 }
@@ -305,19 +302,19 @@ export function findValFileNodeArg(
 ): result.Result<ts.StringLiteral, ValSyntaxErrorTree> {
   if (node.arguments.length === 0) {
     return result.err(
-      new ValSyntaxError(`Invalid val.file() call: missing ref argument`, node)
+      new ValSyntaxError(`Invalid c.file() call: missing ref argument`, node)
     );
   } else if (node.arguments.length > 2) {
     return result.err(
       new ValSyntaxError(
-        `Invalid val.file() call: too many arguments ${node.arguments.length}}`,
+        `Invalid c.file() call: too many arguments ${node.arguments.length}}`,
         node
       )
     );
   } else if (!ts.isStringLiteral(node.arguments[0])) {
     return result.err(
       new ValSyntaxError(
-        `Invalid val.file() call: ref must be a string literal`,
+        `Invalid c.file() call: ref must be a string literal`,
         node
       )
     );
@@ -330,12 +327,12 @@ export function findValFileMetadataArg(
 ): result.Result<ts.ObjectLiteralExpression | undefined, ValSyntaxErrorTree> {
   if (node.arguments.length === 0) {
     return result.err(
-      new ValSyntaxError(`Invalid val.file() call: missing ref argument`, node)
+      new ValSyntaxError(`Invalid c.file() call: missing ref argument`, node)
     );
   } else if (node.arguments.length > 2) {
     return result.err(
       new ValSyntaxError(
-        `Invalid val.file() call: too many arguments ${node.arguments.length}}`,
+        `Invalid c.file() call: too many arguments ${node.arguments.length}}`,
         node
       )
     );
@@ -343,7 +340,7 @@ export function findValFileMetadataArg(
     if (!ts.isObjectLiteralExpression(node.arguments[1])) {
       return result.err(
         new ValSyntaxError(
-          `Invalid val.file() call: metadata must be a object literal`,
+          `Invalid c.file() call: metadata must be a object literal`,
           node
         )
       );

--- a/packages/server/src/patch/ts/valModule.test.ts
+++ b/packages/server/src/patch/ts/valModule.test.ts
@@ -3,8 +3,8 @@ import ts from "typescript";
 import { analyzeValModule, ValModuleAnalysis } from "./valModule";
 
 test("analyzeValModule", () => {
-  const sourceText = `import {s, val } from "./val.config";
-export default val.content("/test", s.string(), "test");`;
+  const sourceText = `import {s, c } from "./val.config";
+export default c.define("/test", s.string(), "test");`;
   const sourceFile = ts.createSourceFile(
     "test.ts",
     sourceText,

--- a/packages/server/src/patch/ts/valModule.ts
+++ b/packages/server/src/patch/ts/valModule.ts
@@ -46,33 +46,33 @@ function validateArguments(
 function analyzeDefaultExport(
   node: ts.ExportAssignment
 ): result.Result<ValModuleAnalysis, ValSyntaxErrorTree> {
-  const valContentCall = node.expression;
-  if (!ts.isCallExpression(valContentCall)) {
+  const cDefine = node.expression;
+  if (!ts.isCallExpression(cDefine)) {
     return result.err(
       new ValSyntaxError(
         "Expected default expression to be a call expression",
-        valContentCall
+        cDefine
       )
     );
   }
 
-  if (!isPath(valContentCall.expression, ["val", "content"])) {
+  if (!isPath(cDefine.expression, ["c", "define"])) {
     return result.err(
       new ValSyntaxError(
-        "Expected default expression to be calling val.content",
-        valContentCall.expression
+        "Expected default expression to be calling c.define",
+        cDefine.expression
       )
     );
   }
 
   return pipe(
-    validateArguments(valContentCall, [
+    validateArguments(cDefine, [
       (id: ts.Node) => {
         // TODO: validate ID value here?
         if (!ts.isStringLiteralLike(id)) {
           return result.err(
             new ValSyntaxError(
-              "Expected first argument to val.content to be a string literal",
+              "Expected first argument to c.define to be a string literal",
               id
             )
           );
@@ -87,7 +87,7 @@ function analyzeDefaultExport(
       },
     ]),
     result.map(() => {
-      const [, schema, source] = valContentCall.arguments;
+      const [, schema, source] = cDefine.arguments;
       return { schema, source };
     })
   );

--- a/packages/server/src/readValFile.ts
+++ b/packages/server/src/readValFile.ts
@@ -85,13 +85,13 @@ globalThis.valModule = {
       ) {
         if (valModule.id !== id) {
           fatalErrors.push(
-            `Wrong val.content id! Expected: '${id}', found: '${valModule.id}'`
+            `Wrong c.define id! Expected: '${id}', found: '${valModule.id}'`
           );
         } else if (
           encodeURIComponent(valModule.id).replace(/%2F/g, "/") !== valModule.id
         ) {
           fatalErrors.push(
-            `Invalid val.content id! Must be a web-safe path without escape characters, found: '${
+            `Invalid c.define id! Must be a web-safe path without escape characters, found: '${
               valModule.id
             }', which was encoded as: '${encodeURIComponent(
               valModule.id

--- a/packages/server/test/example-projects/basic-next-javascript/pages/blogs.val.js
+++ b/packages/server/test/example-projects/basic-next-javascript/pages/blogs.val.js
@@ -1,6 +1,6 @@
-import { s, val } from "../val.config";
+import { s, c } from "../val.config";
 
-export default val.content(
+export default c.define(
   "/pages/blogs",
   s.array(s.object({ title: s.string({ maxLength: 1 }), text: s.string() })),
   [

--- a/packages/server/test/example-projects/basic-next-javascript/val.config.js
+++ b/packages/server/test/example-projects/basic-next-javascript/val.config.js
@@ -1,4 +1,4 @@
 import { initVal } from "@valbuild/core";
 
-const { s, val } = initVal();
-export { s, val };
+const { s, c } = initVal();
+export { s, c };

--- a/packages/server/test/example-projects/basic-next-src-typescript/src/pages/blogs.val.ts
+++ b/packages/server/test/example-projects/basic-next-src-typescript/src/pages/blogs.val.ts
@@ -1,6 +1,6 @@
-import { s, val } from "src/val.config";
+import { s, c } from "src/val.config";
 
-export default val.content(
+export default c.define(
   "/pages/blogs",
   s.array(s.object({ title: s.string({ maxLength: 1 }), text: s.string() })),
   [

--- a/packages/server/test/example-projects/basic-next-src-typescript/src/val.config.ts
+++ b/packages/server/test/example-projects/basic-next-src-typescript/src/val.config.ts
@@ -1,5 +1,4 @@
 import { initVal } from "@valbuild/core";
 
-const { s, val } = initVal();
-
-export { s, val };
+const { s, c } = initVal();
+export { s, c };

--- a/packages/server/test/example-projects/basic-next-typescript/pages/blogs.val.ts
+++ b/packages/server/test/example-projects/basic-next-typescript/pages/blogs.val.ts
@@ -1,6 +1,6 @@
-import { s, val } from "../val.config";
+import { s, c } from "../val.config";
 
-export default val.content(
+export default c.define(
   "/pages/blogs",
   s.array(s.object({ title: s.string({ maxLength: 1 }), text: s.string() })),
   [

--- a/packages/server/test/example-projects/basic-next-typescript/val.config.ts
+++ b/packages/server/test/example-projects/basic-next-typescript/val.config.ts
@@ -1,5 +1,4 @@
 import { initVal } from "@valbuild/core";
 
-const { s, val } = initVal();
-
-export { s, val };
+const { s, c } = initVal();
+export { s, c };

--- a/packages/server/test/example-projects/typescript-description-files/pages/blogs.val.js
+++ b/packages/server/test/example-projects/typescript-description-files/pages/blogs.val.js
@@ -1,5 +1,5 @@
-import { s, val } from "../val.config";
-export default val.content(
+import { s, c } from "../val.config";
+export default c.define(
   "/pages/blogs",
   s.array(s.object({ title: s.string({ maxLength: 1 }), text: s.string() })),
   [

--- a/packages/server/test/example-projects/typescript-description-files/val.config.d.ts
+++ b/packages/server/test/example-projects/typescript-description-files/val.config.d.ts
@@ -1,3 +1,3 @@
 import { InitVal } from "@valbuild/core";
 
-export declare const s: InitVal["s"], val: InitVal["val"]; // Other .d.ts files in this package were generated, this was hand-written.
+export declare const s: InitVal["s"], c: InitVal["c"]; // Other .d.ts files in this package were generated, this was hand-written.

--- a/packages/server/test/example-projects/typescript-description-files/val.config.js
+++ b/packages/server/test/example-projects/typescript-description-files/val.config.js
@@ -1,5 +1,4 @@
 import { initVal } from "@valbuild/core";
 
-const { s, val } = initVal();
-
-export { s, val };
+const { s, c } = initVal();
+export { s, c };

--- a/packages/shared/src/internal/richtext/conversion/conversion.test.ts
+++ b/packages/shared/src/internal/richtext/conversion/conversion.test.ts
@@ -5,14 +5,14 @@ import { remirrorToRichTextSource } from "./remirrorToRichTextSource";
 import { richTextToRemirror } from "./richTextToRemirror";
 import { stringifyRichTextSource } from "./stringifyRichTextSource";
 
-const { val } = initVal();
+const { c } = initVal();
 const cases: {
   description: string;
   input: RichTextSource<AnyRichTextOptions>;
 }[] = [
   {
     description: "basic",
-    input: val.richtext`
+    input: c.richtext`
 # Title 1
 
 ## Title 2
@@ -38,7 +38,7 @@ Formatting: **bold**, _italic_, ~~line-through~~, ***bold and italic***.
   },
   {
     description: "all features",
-    input: val.richtext`
+    input: c.richtext`
 # Title 1
 
 Title 1 content.
@@ -69,19 +69,19 @@ Formatting: **bold**, _italic_, ~~line-through~~, ***bold and italic***.
     1. List 1.1
     1. List 1.2
 
-Inline link: ${val.link("**link**", { href: "https://link.com" })}
+Inline link: ${c.rt.link("**link**", { href: "https://link.com" })}
 
 <br />
 
 Block link:
 
-${val.link("**link**", { href: "https://link.com" })}
+${c.rt.link("**link**", { href: "https://link.com" })}
 
 <br />
 
 Block Image:
 
-${val.file("/public/test.jpg", {
+${c.rt.image("/public/test.jpg", {
   width: 100,
   height: 100,
   sha256: "123",

--- a/packages/shared/src/internal/richtext/conversion/parseRichTextSource.test.ts
+++ b/packages/shared/src/internal/richtext/conversion/parseRichTextSource.test.ts
@@ -1,19 +1,19 @@
 import { initVal } from "@valbuild/core";
 import { parseRichTextSource } from "./parseRichTextSource";
 
-const { val } = initVal();
+const { c } = initVal();
 
 //MD to HTML
 describe("richtext", () => {
   test("basic h1", () => {
-    const r = val.richtext`# Title 1`;
+    const r = c.richtext`# Title 1`;
     expect(parseRichTextSource(r).children).toStrictEqual([
       { tag: "h1", children: ["Title 1"] },
     ]);
   });
 
   test("basic complete", () => {
-    const r = val.richtext`# Title 1
+    const r = c.richtext`# Title 1
 ## Title 2
 
 Paragraph 1 2 3 4 5. Words *italic* **bold**
@@ -34,7 +34,7 @@ Paragraph 1 2 3 4 5. Words *italic* **bold**
   });
 
   test("strong and emphasis merged spans", () => {
-    const r = val.richtext`Which classes?
+    const r = c.richtext`Which classes?
 ***All of them!***
 `;
     expect(parseRichTextSource(r).children).toStrictEqual([
@@ -54,7 +54,7 @@ Paragraph 1 2 3 4 5. Words *italic* **bold**
 
   test("line through", () => {
     // TODO: currently we do not merge
-    const r = val.richtext`~~line through~~`;
+    const r = c.richtext`~~line through~~`;
     expect(parseRichTextSource(r).children).toStrictEqual([
       {
         tag: "p",
@@ -70,7 +70,7 @@ Paragraph 1 2 3 4 5. Words *italic* **bold**
   });
 
   test("2 paragraphs", () => {
-    const r = val.richtext`# Title 1
+    const r = c.richtext`# Title 1
 
 First paragraph
 
@@ -84,7 +84,7 @@ Second paragraph
   });
 
   test("basic lists", () => {
-    const r = val.richtext`A bullet list:
+    const r = c.richtext`A bullet list:
 
 - bullet 1
 - bullet 2
@@ -102,7 +102,7 @@ Second paragraph
   });
 
   test("lists with line breaks", () => {
-    const r = val.richtext`A bullet list:
+    const r = c.richtext`A bullet list:
   
   - bullet 1
   - bullet 2
@@ -131,7 +131,7 @@ break this line
   });
 
   test("special chars", () => {
-    const r = val.richtext`# "Title 1"
+    const r = c.richtext`# "Title 1"
 
 Beautiful "quotes" and 'single quotes'
 
@@ -149,7 +149,7 @@ Ampersand: &
   });
 
   test("lists", () => {
-    const r = val.richtext`# Title 1
+    const r = c.richtext`# Title 1
 
 A paragraph
 
@@ -224,7 +224,7 @@ A nested list:
   });
 
   test("br tokens", () => {
-    const r = val.richtext`1 år 400,- kinokveld  
+    const r = c.richtext`1 år 400,- kinokveld  
 5 år 5000,- en kveld i tretoppene`;
     expect(parseRichTextSource(r).children).toStrictEqual([
       {
@@ -239,7 +239,7 @@ A nested list:
   });
 
   test("multiple br tokens", () => {
-    const r = val.richtext`1 år 400,- kinokveld  
+    const r = c.richtext`1 år 400,- kinokveld  
 2 år 1000,- kulturell opplevelse  
 3 år 2000,- mat i fjeset  
 4 år 500,- nørding i bokhandel  
@@ -269,11 +269,11 @@ A nested list:
   });
 
   test("image", () => {
-    const r = val.richtext`# Title 1
+    const r = c.richtext`# Title 1
 
 Below we have an image block:
 
-${val.file("/public/foo.png", {
+${c.file("/public/foo.png", {
   width: 100,
   height: 100,
   sha256: "123",
@@ -299,7 +299,7 @@ ${val.file("/public/foo.png", {
   });
 
   test("markdown link", () => {
-    const r = val.richtext`# Title 1
+    const r = c.richtext`# Title 1
 
 Below we have a url: [google](https://google.com)`;
     expect(parseRichTextSource(r).children).toStrictEqual([
@@ -319,11 +319,11 @@ Below we have a url: [google](https://google.com)`;
   });
 
   test("block link", () => {
-    const r = val.richtext`# Title 1
+    const r = c.richtext`# Title 1
 
 Below we have a url:
 
-${val.link("google", { href: "https://google.com" })}`;
+${c.rt.link("google", { href: "https://google.com" })}`;
     expect(parseRichTextSource(r).children).toStrictEqual([
       { tag: "h1", children: ["Title 1"] },
       { tag: "p", children: ["Below we have a url:"] },
@@ -341,9 +341,9 @@ ${val.link("google", { href: "https://google.com" })}`;
   });
 
   test("inline link", () => {
-    const r = val.richtext`# Title 1
+    const r = c.richtext`# Title 1
 
-Below we have a url: ${val.link("google", { href: "https://google.com" })}`;
+Below we have a url: ${c.rt.link("google", { href: "https://google.com" })}`;
     expect(parseRichTextSource(r).children).toStrictEqual([
       { tag: "h1", children: ["Title 1"] },
       {
@@ -361,9 +361,9 @@ Below we have a url: ${val.link("google", { href: "https://google.com" })}`;
   });
 
   test("inline link with bold", () => {
-    const r = val.richtext`# Title 1
+    const r = c.richtext`# Title 1
 
-Inline link -> ${val.link("**google**", { href: "https://google.com" })}`;
+Inline link -> ${c.rt.link("**google**", { href: "https://google.com" })}`;
 
     // source:
     expect(parseRichTextSource(r).children).toStrictEqual([
@@ -389,9 +389,9 @@ Inline link -> ${val.link("**google**", { href: "https://google.com" })}`;
   });
 
   test("https:// in link description", () => {
-    const r = val.richtext`# Title 1
+    const r = c.richtext`# Title 1
 
-Inline link -> ${val.link("https://google.com", {
+Inline link -> ${c.rt.link("https://google.com", {
       href: "https://google.com",
     })}`;
 
@@ -412,7 +412,7 @@ Inline link -> ${val.link("https://google.com", {
   });
 
   test("auto link does nothing", () => {
-    const r = val.richtext`# Title 1
+    const r = c.richtext`# Title 1
 
 No transform here -> https://google.com
 
@@ -441,7 +441,7 @@ Transform this:
   });
 
   test("breaks", () => {
-    const r = val.richtext`
+    const r = c.richtext`
 # Title 1
 
 Foo
@@ -468,7 +468,7 @@ Bar
     ]);
   });
   test("list with formatting and breaks", () => {
-    const r = val.richtext`
+    const r = c.richtext`
 # Title 1
 
 - Item _one_
@@ -477,7 +477,7 @@ Bar
 - With breaks:
     1. Formatted **list**
 Test 123
-- With links: ${val.link("**link**", { href: "https://link.com" })}
+- With links: ${c.rt.link("**link**", { href: "https://link.com" })}
 `;
     // source:
     expect(parseRichTextSource(r).children).toStrictEqual([

--- a/packages/shared/src/internal/richtext/conversion/remirrorToRichTextSource.ts
+++ b/packages/shared/src/internal/richtext/conversion/remirrorToRichTextSource.ts
@@ -7,6 +7,8 @@ import {
   AnyRichTextOptions,
   ImageSource,
   Classes,
+  RT_IMAGE_TAG,
+  FILE_REF_SUBTYPE_TAG,
 } from "@valbuild/core";
 import {
   filenameToMimeType,
@@ -265,6 +267,7 @@ function fromRemirrorImageNode(
     return {
       [VAL_EXTENSION]: "file" as const,
       [FILE_REF_PROP]: filePath as `/public/${string}`,
+      [FILE_REF_SUBTYPE_TAG]: RT_IMAGE_TAG,
       metadata: {
         width: typeof node.attrs.width === "number" ? node.attrs.width : 0,
         height: typeof node.attrs.height === "number" ? node.attrs.height : 0,
@@ -280,6 +283,7 @@ function fromRemirrorImageNode(
       [FILE_REF_PROP]: `/public${
         node.attrs.src.split("?")[0]
       }` as `/public/${string}`,
+      [FILE_REF_SUBTYPE_TAG]: RT_IMAGE_TAG,
       metadata: {
         width: typeof node.attrs.width === "number" ? node.attrs.width : 0,
         height: typeof node.attrs.height === "number" ? node.attrs.height : 0,

--- a/packages/shared/src/internal/richtext/conversion/stringifyRichTextSource.ts
+++ b/packages/shared/src/internal/richtext/conversion/stringifyRichTextSource.ts
@@ -5,7 +5,7 @@ import {
 } from "@valbuild/core";
 
 /**
- * Create something that looks like the val.richtext input
+ * Create something that looks like the c.richtext input
  *
  * **SHOULD ONLY BE USED IN TESTS / DEBUGGING**
  **/
@@ -20,11 +20,11 @@ export function stringifyRichTextSource({
     lines += line;
     if (expr) {
       if (expr._type === "file") {
-        lines += `\${val.file("${expr[FILE_REF_PROP]}", ${JSON.stringify(
+        lines += `\${c.rt.image("${expr[FILE_REF_PROP]}", ${JSON.stringify(
           expr.metadata
         )})}`;
       } else if (expr._type === "link") {
-        lines += `\${val.link("${expr.children[0]}", ${JSON.stringify({
+        lines += `\${c.rt.link("${expr.children[0]}", ${JSON.stringify({
           href: expr.href,
         })})}`;
       } else {

--- a/packages/ui/src/components/RichTextEditor.stories.tsx
+++ b/packages/ui/src/components/RichTextEditor.stories.tsx
@@ -19,7 +19,7 @@ import {
 import { RemirrorJSON as ValidRemirrorJSON } from "@valbuild/shared/internal";
 
 const DEBUG = true;
-const { val } = initVal();
+const { c } = initVal();
 
 type StoryType = {
   defaultValue: RichTextSource<AnyRichTextOptions>;
@@ -78,7 +78,7 @@ type Story = StoryObj<StoryType>;
 
 export const Default: Story = {
   args: {
-    defaultValue: val.richtext`Testing 1-2-3
+    defaultValue: c.richtext`Testing 1-2-3
     
 New line!`,
   },
@@ -96,7 +96,7 @@ export const Basics: Story = {
       ul: true,
       ol: true,
     } satisfies AnyRichTextOptions,
-    defaultValue: val.richtext`
+    defaultValue: c.richtext`
 # Title 1
 
 ## Title 2
@@ -107,7 +107,7 @@ export const Basics: Story = {
 1. List item 1
 1. List item 2
 
-${val.link("Link to ValBuild", { href: "https://val.build" })}
+${c.rt.link("Link to ValBuild", { href: "https://val.build" })}
 `,
   },
 };
@@ -167,11 +167,11 @@ function stringifyRichTextSource({
     lines += line;
     if (expr) {
       if (expr._type === "file") {
-        lines += `\${val.file("${expr[FILE_REF_PROP]}", ${JSON.stringify(
+        lines += `\${c.rt.image("${expr[FILE_REF_PROP]}", ${JSON.stringify(
           expr.metadata
         )})}`;
       } else if (expr._type === "link") {
-        lines += `\${val.link("${expr.children[0]}", ${JSON.stringify({
+        lines += `\${c.rt.link("${expr.children[0]}", ${JSON.stringify({
           href: expr.href,
         })})}`;
       } else {

--- a/packages/ui/src/components/RichTextEditor.tsx
+++ b/packages/ui/src/components/RichTextEditor.tsx
@@ -318,7 +318,9 @@ const Toolbar = ({
             mark="link"
             isOption={options?.ol}
             isActive={active.link()}
-            onToggle={(chain) => chain.updateLink({ href: "" }).focus().run()}
+            onToggle={(chain) =>
+              chain.selectMark("link").updateLink({ href: "" }).focus().run()
+            }
           />
           {(options?.img || active.image()) && (
             <label


### PR DESCRIPTION
The current API design is starting to feel good, except for 2 issues:

- the `val` object contains too many methods which can be used both in `.val.ts` (content) files and generally elsewhere in the app. For example we may want to add a `val.attrs` that can be used to manually tag JSX elements with data (`<div {...val.attrs(myContent)} />`). 
- it is confusing when to use which `val` methods: `val.link` can only be used in richtext. `val.file` can be used both in richtext and outside. 

Generally, "what and when can I use something" is should be questions a good API design addresses.

To fix these issues which will be hard to fix after launch we are going to do the following changes:
- [x] introduce a `c` (for content) import in .val files. This way we can add eslint rules that enforces that s and c are imported and only those.
- [x] the name of the `val.content` method was one that we never really liked. When we have a `c` import we can finally find a good name: `c.define` (content define) 
- [x] remove val.link and replace it c.rt.link. All methods that can be used inside a val.richtext will be prefixed with c.rt. This is also something we can create eslint rules for. NOTE: we considered renaming val.richtext to rt (but that hurts discoverability), or possibly have c.richtext.link (which also might be hard to find, since it is the same as an excisting function, and also a drag to write).
- [x] we will split val.file => c.file and c.rt.image (for richtext)
- [x] change c.rt.image to be an object which includes the `c.file`, but also more fields such as optional alt text or perhaps add in on metadata. This is important to be able to add for aria. This way we can also extend the c.rt.image with captions etc later.
- [X] change the `InferSchemaType` to called like this:  ~~`c.InferFromSchema` (reads: content infer from schema)~~ `t.inferSchema` (reads: infer (content from) Schema) - weren't able to add types on a return type of initVal. 
- [ ] Finally as an aside, we'll review all methods available previously on val and mark the once we are uncertain about with `unstable_`.  


We are going to do these changes now, since we are still controlling the usage of Val. Later these changes will hurt more.

Other work items:
- [x] Check READMEs
- [x] Make sure patches are working
- [ ] Update the test projects we know of
- [ ] Verify that app.val.build can evaluate content still