### PR TITLE
Introducing the val.modules file

### DIFF
--- a/.changeset/spicy-bats-teach.md
+++ b/.changeset/spicy-bats-teach.md
@@ -1,0 +1,13 @@
+---
+"@valbuild/server": minor
+"@valbuild/shared": minor
+"@valbuild/core": minor
+"@valbuild/next": minor
+"@valbuild/ui": minor
+"@valbuild/cli": minor
+"@valbuild/eslint-plugin": minor
+"@valbuild/init": minor
+"@valbuild/react": minor
+---
+
+Introduce val.modules file

--- a/examples/next/README.md
+++ b/examples/next/README.md
@@ -7,6 +7,7 @@ This is a Next JS project with Val enabled.
 The following files are required in Val NextJS project:
 
 - `/val.config.ts` - this is the main Val config file
+- `/val.modules.ts` - defines the modules that are editable by Val
 - `/app/(val)/api/val/[[...val]]/route.ts` - all API call to Val goes via these endpoints
 - `/app/(val)/val/[[...val]]/page.tsx` - this is the URL to the Val full-screen app
 - `/val/server.ts` - this is the helper library for server related functions

--- a/examples/next/val.modules.ts
+++ b/examples/next/val.modules.ts
@@ -1,0 +1,9 @@
+import { modules } from "@valbuild/next";
+import { config } from "./val.config";
+
+export default modules(config, [
+  { def: () => import("./content/authors.val") },
+  { def: () => import("./app/content.val") },
+  { def: () => import("./components/clientContent.val") },
+  { def: () => import("./components/reactServerContent.val") },
+]);

--- a/examples/next/val/server.ts
+++ b/examples/next/val/server.ts
@@ -2,8 +2,10 @@ import "server-only";
 import { initValServer } from "@valbuild/next/server";
 import { config } from "../val.config";
 import { draftMode } from "next/headers";
+import valModules from "../val.modules";
 
 const { valNextAppRouter } = initValServer(
+  valModules,
   { ...config },
   {
     draftMode,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export { initVal } from "./initVal";
+export { modules, type ValModules } from "./modules";
 export type {
   InitVal,
   ValConfig,

--- a/packages/core/src/modules.ts
+++ b/packages/core/src/modules.ts
@@ -1,0 +1,40 @@
+import { ValConfig } from "./initVal";
+import { ValModule } from "./module";
+import { SelectorSource } from "./selector";
+
+export type ValModules = {
+  config: ValConfig;
+  modules: {
+    /**
+     * A module definition defined as a function that returns a promise that resolves to the module.
+     *
+     * @example
+     * { def: () => import('./module.val') }
+     */
+    def: () => Promise<{
+      default: ValModule<SelectorSource>;
+    }>;
+  }[];
+};
+
+/**
+ * Define the set of modules that can be edited using the Val UI.
+ *
+ * @example
+ * import { modules } from "@valbuild/next";
+ * import { config } from "./val.config";
+ *
+ * export default modules(config, [
+ *  { def: () => import("./app/page.val.ts") },
+ *  { def: () => import("./app/another/page.val.ts") },
+ * ]);
+ */
+export function modules(
+  config: ValConfig,
+  modules: ValModules["modules"]
+): ValModules {
+  return {
+    config,
+    modules,
+  };
+}

--- a/packages/next/src/client/initValClient.ts
+++ b/packages/next/src/client/initValClient.ts
@@ -17,8 +17,8 @@ import { useValEvents } from "../ValContext";
 export type UseValType<T extends SelectorSource> =
   SelectorOf<T> extends GenericSelector<infer S> ? StegaOfSource<S> : never;
 function useValStega<T extends SelectorSource>(selector: T): UseValType<T> {
-  const valEvents = useValEvents();
   const [enabled, setEnabled] = React.useState(false);
+  const valEvents = useValEvents();
   React.useEffect(() => {
     setEnabled(
       document.cookie.includes(`${Internal.VAL_ENABLE_COOKIE_NAME}=true`)

--- a/packages/next/src/external_exempt_from_val_quickjs.ts
+++ b/packages/next/src/external_exempt_from_val_quickjs.ts
@@ -12,6 +12,7 @@ export {
   type SourcePath,
   type JsonOfSource,
 } from "@valbuild/core";
+export { modules, type ValModules } from "@valbuild/core";
 export type { Json, JsonPrimitive } from "@valbuild/core";
 export type { ValidationErrors, ValidationError } from "@valbuild/core";
 export type { ValidationFix } from "@valbuild/core";

--- a/packages/next/src/server/initValServer.ts
+++ b/packages/next/src/server/initValServer.ts
@@ -1,4 +1,4 @@
-import { Internal, ValConfig } from "@valbuild/core";
+import { Internal, ValConfig, ValModules } from "@valbuild/core";
 import { createValApiRouter } from "@valbuild/server";
 import { createValServer } from "@valbuild/server";
 import type { draftMode } from "next/headers";
@@ -6,6 +6,7 @@ import { NextResponse } from "next/server";
 import { VERSION } from "../version";
 
 const initValNextAppRouter = (
+  valModules: ValModules,
   config: ValConfig,
   nextConfig: ValServerNextConfig
 ) => {
@@ -22,6 +23,7 @@ const initValNextAppRouter = (
   return createValApiRouter(
     route,
     createValServer(
+      valModules,
       route,
       {
         versions: {
@@ -101,6 +103,7 @@ type ValServerNextConfig = {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function initValServer(
+  valModules: ValModules,
   config: ValConfig & {
     disableCache?: boolean;
   },
@@ -109,6 +112,6 @@ export function initValServer(
   valNextAppRouter: ReturnType<typeof initValNextAppRouter>;
 } {
   return {
-    valNextAppRouter: initValNextAppRouter(config, nextConfig),
+    valNextAppRouter: initValNextAppRouter(valModules, config, nextConfig),
   };
 }

--- a/packages/server/src/ValServer.test.ts
+++ b/packages/server/src/ValServer.test.ts
@@ -132,6 +132,23 @@ class TestValServer extends ValServer {
     super(
       projectRoot,
       {
+        config: {},
+        modules: [
+          {
+            def: () =>
+              import(
+                "../test/example-projects/basic-next-src-typescript/src/pages/blogs.val"
+              ),
+          },
+          {
+            def: () =>
+              import(
+                "../test/example-projects/basic-next-src-typescript/src/pages/metadata-tests.val"
+              ),
+          },
+        ],
+      },
+      {
         git: FAKE_GIT,
       },
       {
@@ -187,6 +204,7 @@ class TestValServer extends ValServer {
     return result.ok(undefined);
   }
 
+  // TODO: remove this:
   protected async getModule(
     moduleId: ModuleId,
     options: { source: boolean; schema: boolean }
@@ -198,6 +216,7 @@ class TestValServer extends ValServer {
     });
   }
 
+  // TODO: remove this:
   protected async getAllModules(treePath: string): Promise<ModuleId[]> {
     const moduleIds: ModuleId[] = this.remoteFS
       .readDirectory(

--- a/packages/server/src/ValServer.test.ts
+++ b/packages/server/src/ValServer.test.ts
@@ -134,18 +134,7 @@ class TestValServer extends ValServer {
       {
         config: {},
         modules: [
-          {
-            def: () =>
-              import(
-                "../test/example-projects/basic-next-src-typescript/src/pages/blogs.val"
-              ),
-          },
-          {
-            def: () =>
-              import(
-                "../test/example-projects/basic-next-src-typescript/src/pages/metadata-tests.val"
-              ),
-          },
+          // TODO:
         ],
       },
       {

--- a/packages/server/src/ValServer.ts
+++ b/packages/server/src/ValServer.ts
@@ -7,7 +7,6 @@ import {
   ApiDeletePatchResponse,
   ApiPostValidationResponse,
   Internal,
-  ValModule,
   ValModules,
 } from "@valbuild/core";
 import {

--- a/packages/server/src/ValServer.ts
+++ b/packages/server/src/ValServer.ts
@@ -7,6 +7,8 @@ import {
   ApiDeletePatchResponse,
   ApiPostValidationResponse,
   Internal,
+  ValModule,
+  ValModules,
 } from "@valbuild/core";
 import {
   VAL_ENABLE_COOKIE_NAME,
@@ -59,6 +61,7 @@ const ops = new JSONOps();
 export abstract class ValServer implements IValServer {
   constructor(
     readonly cwd: string,
+    readonly valModules: ValModules,
     readonly options: ValServerOptions,
     readonly callbacks: ValServerCallbacks
   ) {}

--- a/packages/server/src/createValApiRouter.ts
+++ b/packages/server/src/createValApiRouter.ts
@@ -4,7 +4,7 @@ import { LocalValServer, LocalValServerOptions } from "./LocalValServer";
 import { ProxyValServer, ProxyValServerOptions } from "./ProxyValServer";
 import { promises as fs } from "fs";
 import * as path from "path";
-import { Internal, ValConfig } from "@valbuild/core";
+import { Internal, ValConfig, ValModules } from "@valbuild/core";
 import { ValServerGenericResult } from "@valbuild/shared/internal";
 import { createUIRequestHandler } from "@valbuild/ui/server";
 
@@ -127,6 +127,7 @@ type ValServerOverrides = Partial<{
 }>;
 
 export async function createValServer(
+  valModules: ValModules,
   route: string,
   opts: ValApiOptions,
   callbacks: ValServerCallbacks
@@ -134,9 +135,15 @@ export async function createValServer(
   const serverOpts = await initHandlerOptions(route, opts);
   if (serverOpts.mode === "proxy") {
     const projectRoot = process.cwd(); //[process.cwd(), opts.root || ""]      .filter((seg) => seg)      .join("/");
-    return new ProxyValServer(projectRoot, serverOpts, opts, callbacks);
+    return new ProxyValServer(
+      projectRoot,
+      valModules,
+      serverOpts,
+      opts,
+      callbacks
+    );
   } else {
-    return new LocalValServer(serverOpts, callbacks);
+    return new LocalValServer(valModules, serverOpts, callbacks);
   }
 }
 

--- a/packages/shared/src/internal/ValStore.ts
+++ b/packages/shared/src/internal/ValStore.ts
@@ -51,9 +51,9 @@ export class ValStore {
         });
         return result.err({
           message:
-            "Could not fetch data. Could not find the module: " +
+            "Could not fetch data.\nCould not find the module:\n" +
             moduleId +
-            ". Verify that the module id and file name is correct.",
+            "\n\nVerify that the val.modules file includes this module.",
         });
       }
       const fetchedSource = data.value.modules[moduleId].source;

--- a/packages/ui/spa/components/ValOverlay.tsx
+++ b/packages/ui/spa/components/ValOverlay.tsx
@@ -255,9 +255,16 @@ export function ValOverlay({
                   return (
                     <div key={path}>
                       <span>
-                        {path}: {data.status}
+                        {path}
+                        {data.status !== "error" && (
+                          <span>: {data.status}</span>
+                        )}
                       </span>
-                      {data.status === "error" && <pre>{data.error}</pre>}
+                      {data.status === "error" && (
+                        <pre className="text-red-600 whitespace-pre-wrap">
+                          {data.error}
+                        </pre>
+                      )}
                     </div>
                   );
                 }


### PR DESCRIPTION
Users must now add modules that are editable to this file. This is the disadvantage.

The advantage is that Val no longer needs to evaluate files using QuickJS. So no need for QuickJS, no need for heavy caching in the content server, nor will the proxy need to load files from github (before patching). Now the proxy simply reads the val.modules files instead of loading this from github.
Overall there's less magic.
Everything will load much faster both in dev and prod. We also believe this is a concept that should be relatively familiar to many people, in particular those used to sanity. The val.modules files can be extended also be used to hide or give permissions on modules or how files are shown in the UI...
If we can remove the QuickJS dependency altogether we will no longer have any requirements to .val files: you can import and basically do whatever you want as long as the default export is a val.module.

The plan is to test this out first before changing too much making it harder to revert (yes: we could git revert but that might not be easy once we start piling on commits). That means we will keep QuickJS and the Service class that can evaluate files for now.

There's a lot of questions around whether this is a good idea.
Will it even work in proxy / prod mode? Can we get hot module replacement working when Val is enabled? Did it work before? What do we do now with the VS code extension - will it use quickjs or will it use something else? 

Finally, although we believe this makes Val less magical, it is another thing for users to remember - to add a editable module you must declare it val.modules - it will be something easy to forget. Some tooling is expected to be necessary to make up for that, but will this tooling hurt devex too much? Will the tooling be expensive to make / maintain?