### PR TITLE
Improve auto-tagging

### DIFF
--- a/.changeset/real-moose-prove.md
+++ b/.changeset/real-moose-prove.md
@@ -1,0 +1,13 @@
+---
+"@valbuild/react": patch
+"@valbuild/next": patch
+"@valbuild/cli": patch
+"@valbuild/core": patch
+"@valbuild/eslint-plugin": patch
+"@valbuild/init": patch
+"@valbuild/server": patch
+"@valbuild/shared": patch
+"@valbuild/ui": patch
+---
+
+Fix auto-tag issues for non-intrinsic elements

--- a/examples/next/components/ClientComponent.tsx
+++ b/examples/next/components/ClientComponent.tsx
@@ -1,6 +1,8 @@
 "use client";
+import Link from "next/link";
 import { useVal } from "../val/client";
 import clientContentVal, { ClientContent } from "./clientContent.val";
+import linksVal from "./links.val";
 
 export function ClientComponent() {
   const content = useVal(clientContentVal);
@@ -24,6 +26,7 @@ function SubComponent({
   content: ClientContent;
   arrays: ClientContent["arrays"];
 }) {
+  const links = useVal(linksVal);
   return (
     <div>
       <h1>
@@ -52,6 +55,15 @@ function SubComponent({
           ? "This value is now lit-1"
           : "Value is something else than lit-1"}
       </div>
+      <Link
+        href={links.homepage}
+        style={{
+          color: "blue",
+          textDecoration: "underline",
+        }}
+      >
+        Val homepage (using next/link and rendered on client)
+      </Link>
     </div>
   );
 }

--- a/examples/next/components/ReactServerComponent.tsx
+++ b/examples/next/components/ReactServerComponent.tsx
@@ -1,12 +1,25 @@
+import Link from "next/link";
 import { fetchVal } from "../val/rsc";
 import reactServerContentVal from "./reactServerContent.val";
+import linksVal from "./links.val";
 
 export async function ReactServerComponent() {
   const content = await fetchVal(reactServerContentVal);
+  const links = await fetchVal(linksVal);
   return (
     <div>
       <h1>ReactServer Component</h1>
       <span>{content}</span>
+      <div>Link:</div>
+      <Link
+        href={links.homepage}
+        style={{
+          color: "blue",
+          textDecoration: "underline",
+        }}
+      >
+        Val homepage (using next/link and rendered in RSC)
+      </Link>
     </div>
   );
 }

--- a/examples/next/components/links.val.ts
+++ b/examples/next/components/links.val.ts
@@ -1,0 +1,11 @@
+import { c, s } from "../val.config";
+
+export default c.define(
+  "/components/links",
+  s.object({
+    homepage: s.string(),
+  }),
+  {
+    homepage: "https://val.build",
+  }
+);

--- a/examples/next/components/links.val.ts
+++ b/examples/next/components/links.val.ts
@@ -1,7 +1,7 @@
 import { c, s } from "../val.config";
 
 export default c.define(
-  "/components/links",
+  "/components/links.val.ts",
   s.object({
     homepage: s.string(),
   }),

--- a/packages/next/src/ValNextProvider.tsx
+++ b/packages/next/src/ValNextProvider.tsx
@@ -6,6 +6,7 @@ import { usePathname, useRouter } from "next/navigation";
 import Script from "next/script";
 import React from "react";
 import { ValContext, ValEvents } from "./ValContext";
+import { SET_AUTO_TAG_JSX_ENABLED } from "@valbuild/react/stega";
 
 export const ValNextProvider = (props: {
   children: React.ReactNode | React.ReactNode[];
@@ -34,6 +35,7 @@ export const ValNextProvider = (props: {
 
   React.useEffect(() => {
     if (enabled) {
+      SET_AUTO_TAG_JSX_ENABLED(true);
       const valEventListener = (event: Event) => {
         if (event instanceof CustomEvent) {
           if (event.detail.type === "module-update") {
@@ -60,6 +62,7 @@ export const ValNextProvider = (props: {
         window.removeEventListener("val-event", valEventListener);
       };
     } else {
+      SET_AUTO_TAG_JSX_ENABLED(false);
       if (
         process.env["NODE_ENV"] === "development" &&
         !document.cookie.includes(`${Internal.VAL_ENABLE_COOKIE_NAME}=true`)

--- a/packages/next/src/rsc/initValRsc.ts
+++ b/packages/next/src/rsc/initValRsc.ts
@@ -1,4 +1,8 @@
-import { stegaEncode, type StegaOfSource } from "@valbuild/react/stega";
+import {
+  SET_AUTO_TAG_JSX_ENABLED,
+  stegaEncode,
+  type StegaOfSource,
+} from "@valbuild/react/stega";
 import {
   SelectorSource,
   SelectorOf,
@@ -36,6 +40,7 @@ const initFetchValStega =
     }
 
     if (enabled) {
+      SET_AUTO_TAG_JSX_ENABLED(true);
       let headers;
       try {
         headers = getHeaders();

--- a/packages/react/src/stega/index.ts
+++ b/packages/react/src/stega/index.ts
@@ -9,3 +9,10 @@ export {
 } from "./stegaEncode";
 export { type Image } from "./stegaEncode";
 export { stegaDecodeString } from "./stegaDecodeString";
+let autoTagJSXEnabled = false;
+export function IS_AUTO_TAG_JSX_ENABLED() {
+  return autoTagJSXEnabled;
+}
+export function SET_AUTO_TAG_JSX_ENABLED(enabled: boolean) {
+  autoTagJSXEnabled = enabled;
+}


### PR DESCRIPTION
Earlier auto-tagging would not clean up (remove stega) in non-intrinsic components (e.g. NextJS Link). This PR should fix those issues