### PR TITLE
Add eslint no define with variable

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -33,6 +33,7 @@
     "minimatch": "^3.0.4"
   },
   "scripts": {
+    "test": "jest",
     "typecheck": "tsc -p jsconfig.json"
   }
 }

--- a/packages/eslint-plugin/src/index.js
+++ b/packages/eslint-plugin/src/index.js
@@ -9,6 +9,7 @@
 import noIllegalModulePaths from "./rules/noIllegalModulePaths";
 import noIllegalImports from "./rules/noIllegalImports";
 import exportContentMustBeValid from "./rules/exportContentMustBeValid";
+import noDefineWithVariable from "./rules/noDefineWithVariable";
 
 /**
  * @type {Plugin["rules"]}
@@ -17,6 +18,7 @@ export let rules = {
   "no-illegal-module-paths": noIllegalModulePaths,
   "no-illegal-imports": noIllegalImports,
   "export-content-must-be-valid": exportContentMustBeValid,
+  "no-define-with-variable": noDefineWithVariable,
 };
 
 /**
@@ -34,6 +36,7 @@ export const configs = {
       "@valbuild/no-illegal-module-paths": "error",
       "@valbuild/no-illegal-imports": "error",
       "@valbuild/export-content-must-be-valid": "error",
+      "@valbuild/no-define-with-variable": "error",
     },
   },
 };

--- a/packages/eslint-plugin/src/rules/noDefineWithVariable.js
+++ b/packages/eslint-plugin/src/rules/noDefineWithVariable.js
@@ -1,0 +1,43 @@
+// @ts-check
+
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Cannot c.define with a variable",
+      recommended: true,
+    },
+    fixable: "code",
+    schema: [],
+  },
+  create: function (context) {
+    return {
+      ExportDefaultDeclaration(node) {
+        const decl = node.declaration;
+        if (decl.type === "CallExpression") {
+          const callee = decl.callee;
+          const isDefine =
+            callee.type === "MemberExpression" &&
+            callee.object.type === "Identifier" &&
+            callee.object.name === "c" &&
+            callee.property.type === "Identifier" &&
+            callee.property.name === "define";
+
+          if (isDefine) {
+            const args = decl.arguments;
+            const valueArg = args[2];
+            if (valueArg.type === "Identifier") {
+              context.report({
+                node: valueArg,
+                message: "Val: third argument of c.define cannot be a variable",
+              });
+            }
+          }
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin/test/rules/noDefineWithVariable.test.js
+++ b/packages/eslint-plugin/test/rules/noDefineWithVariable.test.js
@@ -1,0 +1,42 @@
+import { RuleTester } from "eslint";
+import { rules as valRules } from "@valbuild/eslint-plugin";
+import path from "path";
+
+const rule = valRules["no-define-with-variable"];
+
+RuleTester.setDefaultConfig({
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: "module",
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-define-with-variable", rule, {
+  valid: [
+    {
+      filename: path.join(process.cwd(), "./foo/test.val.ts"),
+      code: `import { c, s } from '../val.config.ts';
+      export const schema = s.string();
+      export default c.define('/foo/test.val.ts', schema, 'String')`,
+    },
+  ],
+  invalid: [
+    {
+      filename: path.join(process.cwd(), "./foo/test.val.ts"),
+      code: `import { c, s } from '../val.config.ts';
+      export const schema = s.string();
+      const str = 'String'
+      export default c.define('/foo/test.val.ts', schema, str)`,
+      errors: [
+        {
+          message: "Val: third argument of c.define cannot be a variable",
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
If developer users a variable in c.define patching will fail so we needed a rule to make sure this doesn't happen