### PR TITLE
Implement schema assert

### DIFF
--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -111,7 +111,10 @@ export function getSourceAtPath(
 function isObjectSchema(
   schema: Schema<SelectorSource> | SerializedSchema,
 ): schema is
-  | ObjectSchema<{ [key: string]: Schema<SelectorSource> }>
+  | ObjectSchema<
+      { [key: string]: Schema<SelectorSource> },
+      { [key: string]: SelectorSource }
+    >
   | SerializedObjectSchema {
   return (
     schema instanceof ObjectSchema ||
@@ -121,7 +124,9 @@ function isObjectSchema(
 
 function isRecordSchema(
   schema: Schema<SelectorSource> | SerializedSchema,
-): schema is RecordSchema<Schema<SelectorSource>> | SerializedRecordSchema {
+): schema is
+  | RecordSchema<Schema<SelectorSource>, Record<string, SelectorSource>>
+  | SerializedRecordSchema {
   return (
     schema instanceof RecordSchema ||
     (typeof schema === "object" && "type" in schema && schema.type === "record")
@@ -130,7 +135,9 @@ function isRecordSchema(
 
 function isArraySchema(
   schema: Schema<SelectorSource> | SerializedSchema,
-): schema is ArraySchema<Schema<SelectorSource>> | SerializedArraySchema {
+): schema is
+  | ArraySchema<Schema<SelectorSource>, SelectorSource[]>
+  | SerializedArraySchema {
   return (
     schema instanceof ArraySchema ||
     (typeof schema === "object" && "type" in schema && schema.type === "array")
@@ -149,7 +156,7 @@ function isArraySchema(
 function isUnionSchema(
   schema: Schema<SelectorSource> | SerializedSchema,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): schema is UnionSchema<string, any> | SerializedUnionSchema {
+): schema is UnionSchema<string, any, any> | SerializedUnionSchema {
   return (
     schema instanceof UnionSchema ||
     (typeof schema === "object" && "type" in schema && schema.type === "union")
@@ -202,6 +209,7 @@ export function resolvePath<
   schema: Sch;
   source: Src;
 } {
+  // TODO: use schema assert while resolving (and emit errors if any)
   const parts = parsePath(path);
   const origParts = [...parts];
   let resolvedSchema: Schema<SelectorSource> | SerializedSchema = schema;
@@ -319,7 +327,8 @@ export function resolvePath<
           `Invalid path: union source ${resolvedSchema} did not have required key ${key} in path: ${path}`,
         );
       }
-      const schemaOfUnionKey = resolvedSchema.items.find(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const schemaOfUnionKey: any = resolvedSchema.items.find(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (child: any) => child?.items?.[key]?.value === keyValue,
       );

--- a/packages/core/src/schema/array.test.ts
+++ b/packages/core/src/schema/array.test.ts
@@ -1,17 +1,18 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
-import { Schema } from ".";
 import { SourcePath } from "../val";
 import { array } from "./array";
 import { number } from "./number";
 
-describe("NumberSchema", () => {
-  test("assert: should return true if src is a number", () => {
-    const schema: Schema<{ test: string }> = {} as any;
-    const a = schema.assert("foo" as SourcePath, [1]);
-    if (a.success) {
-      a.data;
-    }
+describe("ArraySchema", () => {
+  test("assert: should return success if src is an array", () => {
+    const schema = array(number());
+    expect(schema.assert("path" as SourcePath, [])).toEqual({
+      success: true,
+      data: [],
+    });
   });
-  test("assert: should return false if src is a string", () => {});
+
+  test("assert: should return error if src is string", () => {
+    const schema = array(number());
+    expect(schema.assert("path" as SourcePath, "").success).toEqual(false);
+  });
 });

--- a/packages/core/src/schema/array.test.ts
+++ b/packages/core/src/schema/array.test.ts
@@ -1,0 +1,17 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { Schema } from ".";
+import { SourcePath } from "../val";
+import { array } from "./array";
+import { number } from "./number";
+
+describe("NumberSchema", () => {
+  test("assert: should return true if src is a number", () => {
+    const schema: Schema<{ test: string }> = {} as any;
+    const a = schema.assert("foo" as SourcePath, [1]);
+    if (a.success) {
+      a.data;
+    }
+  });
+  test("assert: should return false if src is a string", () => {});
+});

--- a/packages/core/src/schema/array.ts
+++ b/packages/core/src/schema/array.ts
@@ -24,9 +24,12 @@ export type SerializedArraySchema = {
 
 export class ArraySchema<
   T extends Schema<SelectorSource>,
-  Src extends SelectorOfSchema<T>[] | null
+  Src extends SelectorOfSchema<T>[] | null,
 > extends Schema<Src> {
-  constructor(readonly item: T, readonly opt: boolean = false) {
+  constructor(
+    readonly item: T,
+    readonly opt: boolean = false,
+  ) {
     super();
   }
 
@@ -115,7 +118,7 @@ export class ArraySchema<
 }
 
 export const array = <S extends Schema<SelectorSource>>(
-  schema: S
+  schema: S,
 ): Schema<SelectorOfSchema<S>[]> => {
   return new ArraySchema(schema);
 };

--- a/packages/core/src/schema/array.ts
+++ b/packages/core/src/schema/array.ts
@@ -44,7 +44,8 @@ export class ArraySchema<
     let error: Record<SourcePath, ValidationError[]> = {};
     for (const [idx, i] of Object.entries(assertRes.data)) {
       const subPath = unsafeCreateSourcePath(path, Number(idx));
-      const subError = this.item.validate(subPath, i);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const subError = this.item.validate(subPath, i as any);
       if (subError) {
         error = {
           ...subError,

--- a/packages/core/src/schema/array.ts
+++ b/packages/core/src/schema/array.ts
@@ -98,31 +98,6 @@ export class ArraySchema<T extends Schema<SelectorSource>> extends Schema<
         },
       };
     }
-    let error: ValidationErrors = false;
-    for (const idx in src) {
-      const subPath = createValPathOfItem(path, idx);
-      if (!subPath) {
-        error = this.appendValidationError(
-          error,
-          path,
-          `Internal error: could not create path at ${
-            !path && typeof path === "string" ? "<empty string>" : path
-          } at index ${idx}`, // Should! never happen
-          src
-        );
-      } else {
-        const subAssertRes = this.item.assert(subPath, src[idx]);
-        if (!subAssertRes.success) {
-          error = subAssertRes.errors;
-        }
-      }
-    }
-    if (error) {
-      return {
-        success: false,
-        errors: error,
-      };
-    }
     return {
       success: true,
       data: src,

--- a/packages/core/src/schema/boolean.test.ts
+++ b/packages/core/src/schema/boolean.test.ts
@@ -1,0 +1,17 @@
+import { SourcePath } from "../val";
+import { boolean } from "./boolean";
+
+describe("BooleanSchema", () => {
+  test("assert: should return success if src is a boolean", () => {
+    const schema = boolean();
+    expect(schema.assert("path" as SourcePath, true)).toEqual({
+      success: true,
+      data: true,
+    });
+  });
+
+  test("assert: should return error if src is string", () => {
+    const schema = boolean();
+    expect(schema.assert("path" as SourcePath, "").success).toEqual(false);
+  });
+});

--- a/packages/core/src/schema/boolean.ts
+++ b/packages/core/src/schema/boolean.ts
@@ -26,18 +26,23 @@ export class BooleanSchema<Src extends boolean | null> extends Schema<Src> {
     return false;
   }
 
-  assert(path: SourcePath, src: Src): SchemaAssertResult<Src> {
+  assert(path: SourcePath, src: unknown): SchemaAssertResult<Src> {
     if (this.opt && src === null) {
       return {
         success: true,
         data: src,
-      };
+      } as SchemaAssertResult<Src>;
     }
     if (src === null) {
       return {
         success: false,
         errors: {
-          [path]: [{ message: "Expected 'boolean', got 'null'", value: src }],
+          [path]: [
+            {
+              message: "Expected 'boolean', got 'null'",
+              typeError: true,
+            },
+          ],
         },
       };
     }
@@ -46,7 +51,10 @@ export class BooleanSchema<Src extends boolean | null> extends Schema<Src> {
         success: false,
         errors: {
           [path]: [
-            { message: `Expected 'boolean', got '${typeof src}'`, value: src },
+            {
+              message: `Expected 'boolean', got '${typeof src}'`,
+              typeError: true,
+            },
           ],
         },
       };
@@ -54,7 +62,7 @@ export class BooleanSchema<Src extends boolean | null> extends Schema<Src> {
     return {
       success: true,
       data: src,
-    };
+    } as SchemaAssertResult<Src>;
   }
 
   nullable(): Schema<Src | null> {
@@ -69,5 +77,5 @@ export class BooleanSchema<Src extends boolean | null> extends Schema<Src> {
 }
 
 export const boolean = (): Schema<boolean> => {
-  return new BooleanSchema();
+  return new BooleanSchema() as Schema<boolean>;
 };

--- a/packages/core/src/schema/boolean.ts
+++ b/packages/core/src/schema/boolean.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { Schema, SerializedSchema } from ".";
+import { Schema, SchemaAssertResult, SerializedSchema } from ".";
 import { SourcePath } from "../val";
 import { ValidationErrors } from "./validation/ValidationError";
 
@@ -26,11 +26,35 @@ export class BooleanSchema<Src extends boolean | null> extends Schema<Src> {
     return false;
   }
 
-  assert(src: Src): boolean {
-    if (this.opt && (src === null || src === undefined)) {
-      return true;
+  assert(path: SourcePath, src: Src): SchemaAssertResult<Src> {
+    if (this.opt && src === null) {
+      return {
+        success: true,
+        data: src,
+      };
     }
-    return typeof src === "boolean";
+    if (src === null) {
+      return {
+        success: false,
+        errors: {
+          [path]: [{ message: "Expected 'boolean', got 'null'", value: src }],
+        },
+      };
+    }
+    if (typeof src !== "boolean") {
+      return {
+        success: false,
+        errors: {
+          [path]: [
+            { message: `Expected 'boolean', got '${typeof src}'`, value: src },
+          ],
+        },
+      };
+    }
+    return {
+      success: true,
+      data: src,
+    };
   }
 
   nullable(): Schema<Src | null> {

--- a/packages/core/src/schema/date.test.ts
+++ b/packages/core/src/schema/date.test.ts
@@ -1,0 +1,20 @@
+import { SourcePath } from "../val";
+import { date } from "./date";
+
+describe("DateSchema", () => {
+  test("assert: should return success if src is a string", () => {
+    const schema = date();
+    expect(schema.assert("path" as SourcePath, "2012-12-12")).toEqual({
+      success: true,
+      data: "2012-12-12",
+    });
+  });
+
+  test("assert: should return success if src is a date / string", () => {
+    const schema = date();
+    expect(schema.assert("path" as SourcePath, "something else")).toEqual({
+      success: true,
+      data: "something else",
+    });
+  });
+});

--- a/packages/core/src/schema/date.ts
+++ b/packages/core/src/schema/date.ts
@@ -53,7 +53,7 @@ export class DateSchema<Src extends string | null> extends Schema<Src> {
             {
               message: `From date ${this.options.from} is after to date ${this.options.to}`,
               value: src,
-              fatal: true,
+              typeError: true,
             },
           ],
         } as ValidationErrors;
@@ -101,18 +101,23 @@ export class DateSchema<Src extends string | null> extends Schema<Src> {
     return false;
   }
 
-  assert(path: SourcePath, src: Src): SchemaAssertResult<Src> {
+  assert(path: SourcePath, src: unknown): SchemaAssertResult<Src> {
     if (this.opt && src === null) {
       return {
         success: true,
         data: src,
-      };
+      } as SchemaAssertResult<Src>;
     }
     if (src === null) {
       return {
         success: false,
         errors: {
-          [path]: [{ message: "Expected 'string', got 'null'", value: src }],
+          [path]: [
+            {
+              message: "Expected 'string', got 'null'",
+              typeError: true,
+            },
+          ],
         },
       };
     }
@@ -121,7 +126,10 @@ export class DateSchema<Src extends string | null> extends Schema<Src> {
         success: false,
         errors: {
           [path]: [
-            { message: `Expected 'string', got '${typeof src}'`, value: src },
+            {
+              message: `Expected 'string', got '${typeof src}'`,
+              typeError: true,
+            },
           ],
         },
       };
@@ -130,7 +138,7 @@ export class DateSchema<Src extends string | null> extends Schema<Src> {
     return {
       success: true,
       data: src,
-    };
+    } as SchemaAssertResult<Src>;
   }
 
   from(from: string): DateSchema<Src> {

--- a/packages/core/src/schema/date.ts
+++ b/packages/core/src/schema/date.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { Schema, SerializedSchema } from ".";
+import { Schema, SchemaAssertResult, SerializedSchema } from ".";
 import { SourcePath } from "../val";
 import { RawString } from "./string";
 import { ValidationErrors } from "./validation/ValidationError";
@@ -101,11 +101,36 @@ export class DateSchema<Src extends string | null> extends Schema<Src> {
     return false;
   }
 
-  assert(src: Src): boolean {
-    if (this.opt && (src === null || src === undefined)) {
-      return true;
+  assert(path: SourcePath, src: Src): SchemaAssertResult<Src> {
+    if (this.opt && src === null) {
+      return {
+        success: true,
+        data: src,
+      };
     }
-    return typeof src === "string";
+    if (src === null) {
+      return {
+        success: false,
+        errors: {
+          [path]: [{ message: "Expected 'string', got 'null'", value: src }],
+        },
+      };
+    }
+    if (typeof src !== "string") {
+      return {
+        success: false,
+        errors: {
+          [path]: [
+            { message: `Expected 'string', got '${typeof src}'`, value: src },
+          ],
+        },
+      };
+    }
+
+    return {
+      success: true,
+      data: src,
+    };
   }
 
   from(from: string): DateSchema<Src> {

--- a/packages/core/src/schema/deserialize.ts
+++ b/packages/core/src/schema/deserialize.ts
@@ -56,8 +56,10 @@ export function deserializeSchema(
       return new UnionSchema(
         typeof serialized.key === "string"
           ? serialized.key
-          : deserializeSchema(serialized.key),
-        serialized.items.map(deserializeSchema),
+          : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (deserializeSchema(serialized.key) as any), // TODO: we do not really need any here - right?
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        serialized.items.map(deserializeSchema) as any, // TODO: we do not really need any here - right?
         serialized.opt,
       );
     case "richtext":

--- a/packages/core/src/schema/file.test.ts
+++ b/packages/core/src/schema/file.test.ts
@@ -1,0 +1,15 @@
+import { SourcePath } from "../val";
+import { file } from "./file";
+import { file as sourceFile } from "../source/file";
+
+describe("FileSchema", () => {
+  test("assert: should return success if src is a file", () => {
+    const schema = file();
+    const src = sourceFile("/public/val/features.pdf");
+    const res = schema.assert("path" as SourcePath, src);
+    expect(res).toEqual({
+      success: true,
+      data: src,
+    });
+  });
+});

--- a/packages/core/src/schema/file.ts
+++ b/packages/core/src/schema/file.ts
@@ -184,7 +184,7 @@ export class FileSchema<
         errors: {
           [path]: [
             {
-              message: `Expected object with file reference 'file'. Got: ${src[FILE_REF_PROP]}`,
+              message: `Value of this schema must use: 'c.file' (error type: missing_ref_prop)`,
             },
           ],
         },
@@ -196,7 +196,7 @@ export class FileSchema<
         errors: {
           [path]: [
             {
-              message: `Expected object with file extension 'file'. Got: ${src[VAL_EXTENSION]}`,
+              message: `Value of this schema must use: 'c.file' (error type: missing_file_extension)`,
             },
           ],
         },

--- a/packages/core/src/schema/file.ts
+++ b/packages/core/src/schema/file.ts
@@ -155,48 +155,57 @@ export class FileSchema<
     } as ValidationErrors;
   }
 
-  assert(path: SourcePath, src: Src): SchemaAssertResult<Src> {
+  assert(path: SourcePath, src: unknown): SchemaAssertResult<Src> {
     if (this.opt && src === null) {
       return {
         success: true,
         data: src,
+      } as SchemaAssertResult<Src>;
+    }
+    if (src === null) {
+      return {
+        success: false,
+        errors: {
+          [path]: [
+            { message: `Expected 'object', got 'null'`, typeError: true },
+          ],
+        },
       };
     }
     if (typeof src !== "object") {
       return {
         success: false,
         errors: {
-          [path]: [{ message: `Expected object, got '${typeof src}'` }],
+          [path]: [
+            {
+              message: `Expected object, got '${typeof src}'`,
+              typeError: true,
+            },
+          ],
         },
       };
     }
-    if (src === null) {
-      return {
-        success: false,
-        errors: {
-          [path]: [{ message: `Expected object with file reference` }],
-        },
-      };
-    }
-    if (src[FILE_REF_PROP] !== "file") {
+    if (!(FILE_REF_PROP in src)) {
       return {
         success: false,
         errors: {
           [path]: [
             {
               message: `Value of this schema must use: 'c.file' (error type: missing_ref_prop)`,
+              typeError: true,
             },
           ],
         },
       };
     }
-    if (src?.[VAL_EXTENSION] !== "file") {
+    if (!(VAL_EXTENSION in src && src[VAL_EXTENSION] === "file")) {
       return {
         success: false,
         errors: {
           [path]: [
             {
               message: `Value of this schema must use: 'c.file' (error type: missing_file_extension)`,
+              typeError: true,
             },
           ],
         },
@@ -205,7 +214,7 @@ export class FileSchema<
     return {
       success: true,
       data: src,
-    };
+    } as SchemaAssertResult<Src>;
   }
 
   nullable(): Schema<Src | null> {
@@ -224,7 +233,7 @@ export class FileSchema<
 export const file = (
   options?: FileOptions,
 ): Schema<FileSource<FileMetadata>> => {
-  return new FileSchema(options);
+  return new FileSchema(options) as Schema<FileSource<FileMetadata>>;
 };
 
 export function convertFileSource<

--- a/packages/core/src/schema/future/i18n.ts
+++ b/packages/core/src/schema/future/i18n.ts
@@ -1,5 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { Schema, SelectorOfSchema, SerializedSchema } from "..";
+import {
+  Schema,
+  SchemaAssertResult,
+  SelectorOfSchema,
+  SerializedSchema,
+} from "..";
 import { I18nCompatibleSource, I18nSource } from "../../source/future/i18n";
 import { SourcePath } from "../../val";
 import { ValidationErrors } from "../validation/ValidationError";
@@ -30,8 +35,11 @@ export class I18nSchema<Locales extends readonly string[]> extends Schema<
   }
 
   assert(
+    path: SourcePath,
     src: I18nSource<Locales, SelectorOfSchema<Schema<I18nCompatibleSource>>>,
-  ): boolean {
+  ): SchemaAssertResult<
+    I18nSource<Locales, SelectorOfSchema<Schema<I18nCompatibleSource>>>
+  > {
     throw new Error("Method not implemented.");
   }
 
@@ -65,5 +73,7 @@ export const i18n =
   <S extends Schema<I18nCompatibleSource>>(
     schema: S,
   ): Schema<I18nSource<Locales, SelectorOfSchema<S>>> => {
-    return new I18nSchema(locales, schema);
+    return new I18nSchema(locales, schema) as Schema<
+      I18nSource<Locales, SelectorOfSchema<S>>
+    >;
   };

--- a/packages/core/src/schema/future/oneOf.ts
+++ b/packages/core/src/schema/future/oneOf.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { Schema, SerializedSchema } from "..";
+import { Schema, SchemaAssertResult, SerializedSchema } from "..";
 import { ValModuleBrand } from "../../module";
 import { GenericSelector } from "../../selector/future";
 import { RichTextSelector } from "../../selector/richtext";
@@ -37,7 +37,10 @@ export class OneOfSchema<
   validate(path: SourcePath, src: OneOfSelector<Sel>): ValidationErrors {
     throw new Error("Method not implemented.");
   }
-  assert(src: OneOfSelector<Sel>): boolean {
+  assert(
+    path: SourcePath,
+    src: OneOfSelector<Sel>
+  ): SchemaAssertResult<OneOfSelector<Sel>> {
     throw new Error("Method not implemented.");
   }
   nullable(): Schema<OneOfSelector<Sel> | null> {

--- a/packages/core/src/schema/future/oneOf.ts
+++ b/packages/core/src/schema/future/oneOf.ts
@@ -39,7 +39,7 @@ export class OneOfSchema<
   }
   assert(
     path: SourcePath,
-    src: OneOfSelector<Sel>
+    src: OneOfSelector<Sel>,
   ): SchemaAssertResult<OneOfSelector<Sel>> {
     throw new Error("Method not implemented.");
   }

--- a/packages/core/src/schema/image.test.ts
+++ b/packages/core/src/schema/image.test.ts
@@ -1,0 +1,20 @@
+import { SourcePath } from "../val";
+import { image } from "./image";
+import { file as sourceFile } from "../source/file";
+
+describe("ImageSchema", () => {
+  test("assert: should return success if src is a file", () => {
+    const schema = image();
+    const src = sourceFile("/public/val/features.png");
+    expect(schema.assert("path" as SourcePath, src)).toEqual({
+      success: true,
+      data: src,
+    });
+  });
+
+  test("assert: should return error if src is string", () => {
+    const schema = image();
+    const src = "test";
+    expect(schema.assert("path" as SourcePath, src).success).toEqual(false);
+  });
+});

--- a/packages/core/src/schema/image.ts
+++ b/packages/core/src/schema/image.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { Schema, SerializedSchema } from ".";
+import { Schema, SchemaAssertResult, SerializedSchema } from ".";
 import { VAL_EXTENSION } from "../source";
 import { FileSource, FILE_REF_PROP } from "../source/file";
 import { ImageSource } from "../source/image";
@@ -166,11 +166,57 @@ export class ImageSchema<
     } as ValidationErrors;
   }
 
-  assert(src: Src): boolean {
-    if (this.opt && (src === null || src === undefined)) {
-      return true;
+  assert(path: SourcePath, src: Src): SchemaAssertResult<Src> {
+    if (this.opt && src === null) {
+      return {
+        success: true,
+        data: src,
+      };
     }
-    return src?.[FILE_REF_PROP] === "image" && src?.[VAL_EXTENSION] === "file";
+    if (src === null) {
+      return {
+        success: false,
+        errors: {
+          [path]: [{ message: "Expected 'image', got 'null'", value: src }],
+        },
+      };
+    }
+    if (typeof src !== "object") {
+      return {
+        success: false,
+        errors: {
+          [path]: [{ message: `Expected 'object', got '${typeof src}'` }],
+        },
+      };
+    }
+    if (src?.[FILE_REF_PROP] !== "image") {
+      return {
+        success: false,
+        errors: {
+          [path]: [
+            {
+              message: `Expected object with file reference 'image'. Got: ${src?.[FILE_REF_PROP]}`,
+            },
+          ],
+        },
+      };
+    }
+    if (src?.[VAL_EXTENSION] !== "file") {
+      return {
+        success: false,
+        errors: {
+          [path]: [
+            {
+              message: `Expected object with file extension 'file'. Got: ${src?.[VAL_EXTENSION]}`,
+            },
+          ],
+        },
+      };
+    }
+    return {
+      success: true,
+      data: src,
+    };
   }
 
   nullable(): Schema<Src | null> {

--- a/packages/core/src/schema/image.ts
+++ b/packages/core/src/schema/image.ts
@@ -173,29 +173,29 @@ export class ImageSchema<
         data: src,
       };
     }
-    if (src === null) {
-      return {
-        success: false,
-        errors: {
-          [path]: [{ message: "Expected 'image', got 'null'", value: src }],
-        },
-      };
-    }
     if (typeof src !== "object") {
       return {
         success: false,
         errors: {
-          [path]: [{ message: `Expected 'object', got '${typeof src}'` }],
+          [path]: [{ message: `Expected object, got '${typeof src}'` }],
         },
       };
     }
-    if (src?.[FILE_REF_PROP] !== "image") {
+    if (src === null) {
+      return {
+        success: false,
+        errors: {
+          [path]: [{ message: `Expected object with file reference` }],
+        },
+      };
+    }
+    if (src[FILE_REF_PROP] !== "image") {
       return {
         success: false,
         errors: {
           [path]: [
             {
-              message: `Expected object with file reference 'image'. Got: ${src?.[FILE_REF_PROP]}`,
+              message: `Value of this schema must use: 'c.image' (error type: missing_ref_prop)`,
             },
           ],
         },
@@ -207,7 +207,7 @@ export class ImageSchema<
         errors: {
           [path]: [
             {
-              message: `Expected object with file extension 'file'. Got: ${src?.[VAL_EXTENSION]}`,
+              message: `Value of this schema must use: 'c.image' (error type: missing_file_extension)`,
             },
           ],
         },

--- a/packages/core/src/schema/image.ts
+++ b/packages/core/src/schema/image.ts
@@ -166,48 +166,57 @@ export class ImageSchema<
     } as ValidationErrors;
   }
 
-  assert(path: SourcePath, src: Src): SchemaAssertResult<Src> {
+  assert(path: SourcePath, src: unknown): SchemaAssertResult<Src> {
     if (this.opt && src === null) {
       return {
         success: true,
         data: src,
+      } as SchemaAssertResult<Src>;
+    }
+    if (src === null) {
+      return {
+        success: false,
+        errors: {
+          [path]: [
+            { message: `Expected 'object', got 'null'`, typeError: true },
+          ],
+        },
       };
     }
     if (typeof src !== "object") {
       return {
         success: false,
         errors: {
-          [path]: [{ message: `Expected object, got '${typeof src}'` }],
+          [path]: [
+            {
+              message: `Expected 'object', got '${typeof src}'`,
+              typeError: true,
+            },
+          ],
         },
       };
     }
-    if (src === null) {
-      return {
-        success: false,
-        errors: {
-          [path]: [{ message: `Expected object with file reference` }],
-        },
-      };
-    }
-    if (src[FILE_REF_PROP] !== "image") {
+    if (!(FILE_REF_PROP in src)) {
       return {
         success: false,
         errors: {
           [path]: [
             {
               message: `Value of this schema must use: 'c.image' (error type: missing_ref_prop)`,
+              typeError: true,
             },
           ],
         },
       };
     }
-    if (src?.[VAL_EXTENSION] !== "file") {
+    if (!(VAL_EXTENSION in src && src[VAL_EXTENSION] === "file")) {
       return {
         success: false,
         errors: {
           [path]: [
             {
               message: `Value of this schema must use: 'c.image' (error type: missing_file_extension)`,
+              typeError: true,
             },
           ],
         },
@@ -216,7 +225,7 @@ export class ImageSchema<
     return {
       success: true,
       data: src,
-    };
+    } as SchemaAssertResult<Src>;
   }
 
   nullable(): Schema<Src | null> {

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -39,15 +39,22 @@ export type SchemaAssertResult<T> =
   | { data: T; success: true }
   | { success: false; errors: ValidationErrors };
 export abstract class Schema<Src extends SelectorSource> {
-  /** Validate the source  */
+  /** Validate the value of source content */
   abstract validate(path: SourcePath, src: Src): ValidationErrors;
   /**
-   * Check if the type of source is correct
-   * NOTE: the difference between validate and assert is that assert
-   *       verifies that the type of the source is correct, while validate
-   *       checks the value of the source.
-   *      For example assert fails for a StringSchema if the source is not a string,
-   *       while validate will check the length, ...
+   * Check if the **root** **type** of source is correct.
+   *
+   * The difference between assert and validate is:
+   * - assert verifies that the root **type** of the source is correct (it does not recurse down). Therefore, assert can be used as a runtime type check.
+   * - validate checks the **value** of the source in addition to the type. It recurses down the source.
+   *
+   * For example assert fails for a StringSchema if the source is not a string,
+   * it will not fail if the length is not correct.
+   * Validate will check the length and all other constraints.
+   *
+   * Assert is useful if you have a generic schema and need to make sure the root type is valid.
+   * When using assert, you must assert recursively if you want to verify the entire source.
+   * For example, if you have an object schema, you must assert each key / value pair manually.
    */
   abstract assert(path: SourcePath, src: Src): SchemaAssertResult<Src>;
   abstract nullable(): Schema<Src | null>;

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -35,9 +35,21 @@ export type SerializedSchema =
   | SerializedDateSchema
   | SerializedImageSchema;
 
+export type SchemaAssertResult<T> =
+  | { data: T; success: true }
+  | { success: false; errors: ValidationErrors };
 export abstract class Schema<Src extends SelectorSource> {
+  /** Validate the source  */
   abstract validate(path: SourcePath, src: Src): ValidationErrors;
-  abstract assert(src: Src): boolean; // TODO: false | Record<SourcePath, string[]>;
+  /**
+   * Check if the type of source is correct
+   * NOTE: the difference between validate and assert is that assert
+   *       verifies that the type of the source is correct, while validate
+   *       checks the value of the source.
+   *      For example assert fails for a StringSchema if the source is not a string,
+   *       while validate will check the length, ...
+   */
+  abstract assert(path: SourcePath, src: Src): SchemaAssertResult<Src>;
   abstract nullable(): Schema<Src | null>;
   abstract serialize(): SerializedSchema;
   // remote(): Src extends RemoteCompatibleSource

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -57,15 +57,15 @@ export type SchemaAssertResult<Src extends SelectorSource> =
       data: Src extends RawString
         ? string
         : // eslint-disable-next-line @typescript-eslint/ban-types
-        Src extends RichTextSource<{}>
-        ? GenericRichTextSourceNode[]
-        : Src extends Primitives
-        ? Src
-        : Src extends Array<SelectorSource>
-        ? SelectorSource[]
-        : Src extends { [key: string]: SelectorSource }
-        ? { [key in keyof Src]: SelectorSource }
-        : never;
+          Src extends RichTextSource<{}>
+          ? GenericRichTextSourceNode[]
+          : Src extends Primitives
+            ? Src
+            : Src extends Array<SelectorSource>
+              ? SelectorSource[]
+              : Src extends { [key: string]: SelectorSource }
+                ? { [key in keyof Src]: SelectorSource }
+                : never;
       success: true;
     }
   | { success: false; errors: Record<SourcePath, AssertError[]> };
@@ -102,7 +102,7 @@ export abstract class Schema<Src extends SelectorSource> {
     current: ValidationErrors,
     path: SourcePath,
     message: string,
-    value: unknown
+    value: unknown,
   ): ValidationErrors {
     if (current) {
       if (current[path]) {

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -11,12 +11,12 @@ import { SerializedNumberSchema } from "./number";
 import { SerializedObjectSchema } from "./object";
 import { SerializedRecordSchema } from "./record";
 import { SerializedRichTextSchema } from "./richtext";
-import { SerializedStringSchema } from "./string";
+import { RawString, SerializedStringSchema } from "./string";
 import { SerializedUnionSchema } from "./union";
 import { SerializedDateSchema } from "./date";
 import { ValidationErrors } from "./validation/ValidationError";
 import { FileSource } from "../source/file";
-import { ImageSource } from "../source/image";
+import { GenericRichTextSourceNode, RichTextSource } from "../source/richtext";
 // import { SerializedI18nSchema } from "./future/i18n";
 // import { SerializedOneOfSchema } from "./future/oneOf";
 
@@ -38,19 +38,37 @@ export type SerializedSchema =
   | SerializedImageSchema;
 
 type Primitives = number | string | boolean | null | FileSource;
+export type AssertError =
+  | {
+      message: string;
+      schemaError: true;
+    }
+  | {
+      message: string;
+      typeError: true;
+    }
+  | {
+      message: string;
+      internalError: true;
+    };
 export type SchemaAssertResult<Src extends SelectorSource> =
   | {
       // It would be more elegant if we derived this in the individual schema classes, however we must support the case when the abstract class is the only thing available (Schema<string[]> does not dispatch on type-level to ArraySchema)
-      data: Src extends Primitives
+      data: Src extends RawString
+        ? string
+        : // eslint-disable-next-line @typescript-eslint/ban-types
+        Src extends RichTextSource<{}>
+        ? GenericRichTextSourceNode[]
+        : Src extends Primitives
         ? Src
         : Src extends Array<SelectorSource>
         ? SelectorSource[]
-        : Src extends Record<string, SelectorSource>
-        ? Record<string, SelectorSource | undefined>
+        : Src extends { [key: string]: SelectorSource }
+        ? { [key in keyof Src]: SelectorSource }
         : never;
       success: true;
     }
-  | { success: false; errors: ValidationErrors };
+  | { success: false; errors: Record<SourcePath, AssertError[]> };
 export abstract class Schema<Src extends SelectorSource> {
   /** Validate the value of source content */
   abstract validate(path: SourcePath, src: Src): ValidationErrors;
@@ -69,7 +87,7 @@ export abstract class Schema<Src extends SelectorSource> {
    * When using assert, you must assert recursively if you want to verify the entire source.
    * For example, if you have an object schema, you must assert each key / value pair manually.
    */
-  abstract assert(path: SourcePath, src: unknown): SchemaAssertResult<Src>;
+  abstract assert(path: SourcePath, src: unknown): SchemaAssertResult<Src>; // TODO: rename to parse? or _assert / _parse to indicate it is private? Or make protected (requires us to have some sort of calling it in the UX Val code)
   abstract nullable(): Schema<Src | null>;
   abstract serialize(): SerializedSchema;
   // remote(): Src extends RemoteCompatibleSource
@@ -84,7 +102,7 @@ export abstract class Schema<Src extends SelectorSource> {
     current: ValidationErrors,
     path: SourcePath,
     message: string,
-    value?: unknown,
+    value: unknown
   ): ValidationErrors {
     if (current) {
       if (current[path]) {
@@ -94,7 +112,9 @@ export abstract class Schema<Src extends SelectorSource> {
       }
       return current;
     } else {
-      return { [path]: [{ message, value }] } as ValidationErrors;
+      return {
+        [path]: [{ message, value }],
+      } as ValidationErrors;
     }
   }
 }

--- a/packages/core/src/schema/keyOf.test.ts
+++ b/packages/core/src/schema/keyOf.test.ts
@@ -10,7 +10,7 @@ describe("KeyOfSchema", () => {
     const schema = keyOf(
       define("/path2", record(object({ key: string() })), {
         one: { key: "test" },
-      })
+      }),
     );
     const src = "one";
     const res = schema.assert("path" as SourcePath, src);

--- a/packages/core/src/schema/keyOf.test.ts
+++ b/packages/core/src/schema/keyOf.test.ts
@@ -1,0 +1,22 @@
+import { define } from "../module";
+import { SourcePath } from "../val";
+import { keyOf } from "./keyOf";
+import { object } from "./object";
+import { record } from "./record";
+import { string } from "./string";
+
+describe("KeyOfSchema", () => {
+  test("assert: should return success if src is a keyOf value", () => {
+    const schema = keyOf(
+      define("/path2", record(object({ key: string() })), {
+        one: { key: "test" },
+      })
+    );
+    const src = "one";
+    const res = schema.assert("path" as SourcePath, src);
+    expect(res).toEqual({
+      success: true,
+      data: src,
+    });
+  });
+});

--- a/packages/core/src/schema/keyOf.ts
+++ b/packages/core/src/schema/keyOf.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { Schema, SerializedSchema } from "../schema";
+import { Schema, SchemaAssertResult, SerializedSchema } from "../schema";
 import { ValModuleBrand } from "../module";
 import { GenericSelector, GetSchema, Path } from "../selector";
 import { Source, SourceArray, SourceObject } from "../source";
@@ -106,9 +106,15 @@ export class KeyOfSchema<
     return false;
   }
 
-  assert(src: KeyOfSelector<Sel>): boolean {
-    if (this.opt && (src === null || src === undefined)) {
-      return true;
+  assert(
+    path: SourcePath,
+    src: KeyOfSelector<Sel>
+  ): SchemaAssertResult<KeyOfSelector<Sel>> {
+    if (this.opt && src === null) {
+      return {
+        success: true,
+        data: src,
+      };
     }
     const schema = this.schema;
     if (!schema) {

--- a/packages/core/src/schema/keyOf.ts
+++ b/packages/core/src/schema/keyOf.ts
@@ -118,7 +118,16 @@ export class KeyOfSchema<
     }
     const schema = this.schema;
     if (!schema) {
-      return false;
+      return {
+        success: false,
+        errors: {
+          [path]: [
+            {
+              message: `Neither key nor schema was found. keyOf is missing an argument.`,
+            },
+          ],
+        },
+      };
     }
     const serializedSchema = schema;
 
@@ -129,24 +138,65 @@ export class KeyOfSchema<
         serializedSchema.type === "record"
       )
     ) {
-      return false;
-    }
-    if (serializedSchema.opt && (src === null || src === undefined)) {
-      return true;
+      return {
+        success: false,
+        errors: {
+          [path]: [
+            {
+              message: `Schema of first argument must be either: 'array', 'object' or 'record'. Found '${serializedSchema.type}'`,
+            },
+          ],
+        },
+      };
     }
     if (serializedSchema.type === "array" && typeof src !== "number") {
-      return false;
+      return {
+        success: false,
+        errors: {
+          [path]: [
+            {
+              message: `Value of keyOf (array) must be 'number', got '${typeof src}'`,
+              value: src,
+            },
+          ],
+        },
+      };
     }
     if (serializedSchema.type === "record" && typeof src !== "string") {
-      return false;
+      return {
+        success: false,
+        errors: {
+          [path]: [
+            {
+              message: `Value of keyOf (record) must be 'string', got '${typeof src}'`,
+              value: src,
+            },
+          ],
+        },
+      };
     }
     if (serializedSchema.type === "object") {
       const keys = Object.keys(serializedSchema.items);
       if (!keys.includes(src as string)) {
-        return false;
+        return {
+          success: false,
+          errors: {
+            [path]: [
+              {
+                message: `Value of keyOf (object) must be: ${keys.join(
+                  ", "
+                )}. Found: ${src}`,
+                value: src,
+              },
+            ],
+          },
+        };
       }
     }
-    return true;
+    return {
+      success: true,
+      data: src,
+    };
   }
 
   nullable(): Schema<KeyOfSelector<Sel> | null> {

--- a/packages/core/src/schema/keyOf.ts
+++ b/packages/core/src/schema/keyOf.ts
@@ -20,22 +20,22 @@ type KeyOfSelector<Sel extends GenericSelector<SourceArray | SourceObject>> =
     ? S extends readonly Source[]
       ? number
       : S extends SourceObject
-      ? string extends keyof S
-        ? RawString
-        : keyof S
-      : S extends Record<string, Source> // do we need record?
-      ? RawString
-      : never
+        ? string extends keyof S
+          ? RawString
+          : keyof S
+        : S extends Record<string, Source> // do we need record?
+          ? RawString
+          : never
     : never;
 
 export class KeyOfSchema<
   Sel extends GenericSelector<SourceArray | SourceObject>,
-  Src extends KeyOfSelector<Sel> | null
+  Src extends KeyOfSelector<Sel> | null,
 > extends Schema<Src> {
   constructor(
     readonly schema?: SerializedSchema,
     readonly sourcePath?: SourcePath,
-    readonly opt: boolean = false
+    readonly opt: boolean = false,
   ) {
     super();
   }
@@ -97,7 +97,7 @@ export class KeyOfSchema<
           [path]: [
             {
               message: `Value of keyOf (object) must be: ${keys.join(
-                ", "
+                ", ",
               )}. Found: ${src}`,
             },
           ],
@@ -200,7 +200,7 @@ export class KeyOfSchema<
             [path]: [
               {
                 message: `Value of keyOf (object) must be: ${keys.join(
-                  ", "
+                  ", ",
                 )}. Found: ${src}`,
                 typeError: true,
               },
@@ -219,7 +219,7 @@ export class KeyOfSchema<
     return new KeyOfSchema(
       this.schema,
       this.sourcePath,
-      true
+      true,
     ) as Schema<Src | null>;
   }
 
@@ -227,7 +227,7 @@ export class KeyOfSchema<
     const path = this.sourcePath;
     if (!path) {
       throw new Error(
-        "Cannot serialize keyOf schema with empty selector. TIP: keyOf must be used with a Val Module."
+        "Cannot serialize keyOf schema with empty selector. TIP: keyOf must be used with a Val Module.",
       );
     }
     const serializedSchema = this.schema;
@@ -248,7 +248,7 @@ export class KeyOfSchema<
         break;
       default:
         throw new Error(
-          `Cannot serialize keyOf schema with selector of type '${serializedSchema.type}'. keyOf must be used with a Val Module.`
+          `Cannot serialize keyOf schema with selector of type '${serializedSchema.type}'. keyOf must be used with a Val Module.`,
         );
     }
     return {
@@ -262,12 +262,12 @@ export class KeyOfSchema<
 }
 
 export const keyOf = <
-  Src extends GenericSelector<SourceArray | SourceObject> & ValModuleBrand // ValModuleBrand enforces call site to pass in a val module - selectors are not allowed. The reason is that this should make it easier to patch. We might be able to relax this constraint in the future
+  Src extends GenericSelector<SourceArray | SourceObject> & ValModuleBrand, // ValModuleBrand enforces call site to pass in a val module - selectors are not allowed. The reason is that this should make it easier to patch. We might be able to relax this constraint in the future
 >(
-  valModule: Src
+  valModule: Src,
 ): Schema<KeyOfSelector<Src>> => {
   return new KeyOfSchema(
     valModule?.[GetSchema]?.serialize(),
-    getValPath(valModule)
+    getValPath(valModule),
   ) as Schema<KeyOfSelector<Src>>;
 };

--- a/packages/core/src/schema/literal.test.ts
+++ b/packages/core/src/schema/literal.test.ts
@@ -1,0 +1,13 @@
+import { SourcePath } from "../val";
+import { literal } from "./literal";
+
+describe("LiteralSchema", () => {
+  test("assert: should return success if src is a literal", () => {
+    const schema = literal("val");
+    const src = "val";
+    expect(schema.assert("path" as SourcePath, src)).toEqual({
+      success: true,
+      data: src,
+    });
+  });
+});

--- a/packages/core/src/schema/literal.ts
+++ b/packages/core/src/schema/literal.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { Schema, SerializedSchema } from ".";
+import { Schema, SchemaAssertResult, SerializedSchema } from ".";
 import { SourcePath } from "../val";
 import { ValidationErrors } from "./validation/ValidationError";
 
@@ -41,7 +41,7 @@ export class LiteralSchema<Src extends string | null> extends Schema<Src> {
     return false;
   }
 
-  assert(src: Src): boolean {
+  assert(path: SourcePath, src: Src): SchemaAssertResult<Src> {
     if (this.opt && (src === null || src === undefined)) {
       return true;
     }

--- a/packages/core/src/schema/literal.ts
+++ b/packages/core/src/schema/literal.ts
@@ -41,18 +41,31 @@ export class LiteralSchema<Src extends string | null> extends Schema<Src> {
     return false;
   }
 
-  assert(path: SourcePath, src: Src): SchemaAssertResult<Src> {
+  assert(path: SourcePath, src: unknown): SchemaAssertResult<Src> {
     if (this.opt && src === null) {
       return {
         success: true,
         data: src,
+      } as SchemaAssertResult<Src>;
+    }
+    if (src === null) {
+      return {
+        success: false,
+        errors: {
+          [path]: [
+            {
+              message: `Expected 'string', got 'null'`,
+              typeError: true,
+            },
+          ],
+        },
       };
     }
     if (typeof src === "string" && src === this.value) {
       return {
         success: true,
         data: src,
-      };
+      } as SchemaAssertResult<Src>;
     }
     return {
       success: false,
@@ -60,7 +73,7 @@ export class LiteralSchema<Src extends string | null> extends Schema<Src> {
         [path]: [
           {
             message: `Expected literal '${this.value}', got '${src}'`,
-            value: src,
+            typeError: true,
           },
         ],
       },

--- a/packages/core/src/schema/literal.ts
+++ b/packages/core/src/schema/literal.ts
@@ -42,10 +42,29 @@ export class LiteralSchema<Src extends string | null> extends Schema<Src> {
   }
 
   assert(path: SourcePath, src: Src): SchemaAssertResult<Src> {
-    if (this.opt && (src === null || src === undefined)) {
-      return true;
+    if (this.opt && src === null) {
+      return {
+        success: true,
+        data: src,
+      };
     }
-    return typeof src === "string";
+    if (typeof src === "string" && src === this.value) {
+      return {
+        success: true,
+        data: src,
+      };
+    }
+    return {
+      success: false,
+      errors: {
+        [path]: [
+          {
+            message: `Expected literal '${this.value}', got '${src}'`,
+            value: src,
+          },
+        ],
+      },
+    };
   }
 
   nullable(): Schema<Src | null> {
@@ -61,6 +80,6 @@ export class LiteralSchema<Src extends string | null> extends Schema<Src> {
   }
 }
 
-export const literal = <T extends string>(value: T): Schema<T> => {
+export const literal = <T extends string>(value: T): LiteralSchema<T> => {
   return new LiteralSchema(value);
 };

--- a/packages/core/src/schema/number.test.ts
+++ b/packages/core/src/schema/number.test.ts
@@ -4,7 +4,11 @@ import { number } from "./number";
 
 describe("NumberSchema", () => {
   test("assert: should return true if src is a number", () => {
-    const schema = number();
+    const schema = number().nullable();
+    const test = schema.assert("foo" as SourcePath, 1);
+    if (test.success) {
+      test.data;
+    }
     expect(schema.assert("foo" as SourcePath, 1)).toEqual({
       success: true,
       data: 1,

--- a/packages/core/src/schema/number.test.ts
+++ b/packages/core/src/schema/number.test.ts
@@ -17,7 +17,7 @@ describe("NumberSchema", () => {
   test("assert: should return errors if src is a string", () => {
     const schema = number();
     expect(schema.assert("foo" as SourcePath, "1" as any).success).toEqual(
-      false
+      false,
     );
   });
 });

--- a/packages/core/src/schema/number.test.ts
+++ b/packages/core/src/schema/number.test.ts
@@ -1,0 +1,19 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { SourcePath } from "../val";
+import { number } from "./number";
+
+describe("NumberSchema", () => {
+  test("assert: should return true if src is a number", () => {
+    const schema = number();
+    expect(schema.assert("foo" as SourcePath, 1)).toEqual({
+      success: true,
+      data: 1,
+    });
+  });
+  test("assert: should return false if src is a string", () => {
+    const schema = number();
+    expect(schema.assert("foo" as SourcePath, "1" as any).success).toEqual(
+      false
+    );
+  });
+});

--- a/packages/core/src/schema/number.ts
+++ b/packages/core/src/schema/number.ts
@@ -88,5 +88,5 @@ export class NumberSchema<Src extends number | null> extends Schema<Src> {
 }
 
 export const number = (options?: NumberOptions): Schema<number> => {
-  return new NumberSchema(options);
+  return new NumberSchema(options) as Schema<number>;
 };

--- a/packages/core/src/schema/number.ts
+++ b/packages/core/src/schema/number.ts
@@ -35,31 +35,47 @@ export class NumberSchema<Src extends number | null> extends Schema<Src> {
     return false;
   }
 
-  assert(path: SourcePath, src: unknown) {
+  assert(path: SourcePath, src: unknown): SchemaAssertResult<Src> {
     if (this.opt && src === null) {
       return {
         success: true,
         data: src,
+      } as SchemaAssertResult<Src>;
+    }
+    if (src === null) {
+      return {
+        success: false,
+        errors: {
+          [path]: [
+            {
+              message: "Expected 'number', got 'null'",
+              typeError: true,
+            },
+          ],
+        },
       };
     }
     if (typeof src === "number") {
       return {
         success: true,
         data: src,
-      };
+      } as SchemaAssertResult<Src>;
     }
     return {
       success: false,
       errors: {
         [path]: [
-          { message: `Expected 'number', got '${typeof src}'`, value: src },
+          {
+            message: `Expected 'number', got '${typeof src}'`,
+            typeError: true,
+          },
         ],
       },
     };
   }
 
-  nullable(): Schema<number | null> {
-    return new NumberSchema<Src | null>(this.options, true);
+  nullable(): Schema<Src> {
+    return new NumberSchema<Src | null>(this.options, true) as Schema<Src>;
   }
 
   serialize(): SerializedSchema {

--- a/packages/core/src/schema/number.ts
+++ b/packages/core/src/schema/number.ts
@@ -36,10 +36,26 @@ export class NumberSchema<Src extends number | null> extends Schema<Src> {
   }
 
   assert(path: SourcePath, src: Src): SchemaAssertResult<Src> {
-    if (this.opt && (src === null || src === undefined)) {
-      return true;
+    if (this.opt && src === null) {
+      return {
+        success: true,
+        data: src,
+      };
     }
-    return typeof src === "number";
+    if (typeof src === "number") {
+      return {
+        success: true,
+        data: src,
+      };
+    }
+    return {
+      success: false,
+      errors: {
+        [path]: [
+          { message: `Expected 'number', got '${typeof src}'`, value: src },
+        ],
+      },
+    };
   }
 
   nullable(): Schema<Src | null> {

--- a/packages/core/src/schema/number.ts
+++ b/packages/core/src/schema/number.ts
@@ -35,7 +35,7 @@ export class NumberSchema<Src extends number | null> extends Schema<Src> {
     return false;
   }
 
-  assert(path: SourcePath, src: Src): SchemaAssertResult<Src> {
+  assert(path: SourcePath, src: unknown) {
     if (this.opt && src === null) {
       return {
         success: true,
@@ -58,9 +58,10 @@ export class NumberSchema<Src extends number | null> extends Schema<Src> {
     };
   }
 
-  nullable(): Schema<Src | null> {
+  nullable(): Schema<number | null> {
     return new NumberSchema<Src | null>(this.options, true);
   }
+
   serialize(): SerializedSchema {
     return {
       type: "number",

--- a/packages/core/src/schema/number.ts
+++ b/packages/core/src/schema/number.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { Schema, SerializedSchema } from ".";
+import { Schema, SchemaAssertResult, SerializedSchema } from ".";
 import { SourcePath } from "../val";
 import { ValidationErrors } from "./validation/ValidationError";
 
@@ -35,7 +35,7 @@ export class NumberSchema<Src extends number | null> extends Schema<Src> {
     return false;
   }
 
-  assert(src: Src): boolean {
+  assert(path: SourcePath, src: Src): SchemaAssertResult<Src> {
     if (this.opt && (src === null || src === undefined)) {
       return true;
     }

--- a/packages/core/src/schema/object.test.ts
+++ b/packages/core/src/schema/object.test.ts
@@ -1,0 +1,43 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { SourcePath } from "../val";
+import { number } from "./number";
+import { object } from "./object";
+
+describe("ObjectSchema", () => {
+  test("assert: should return success if object with keys are correct", () => {
+    const schema = object({
+      test: number().nullable(),
+    }).nullable();
+    const src = {
+      test: 1,
+    };
+    expect(schema.assert("foo" as SourcePath, src)).toEqual({
+      success: true,
+      data: src,
+    });
+  });
+
+  test("assert: should return success even if object has superfluous keys", () => {
+    const schema = object({
+      test: number().nullable(),
+    }).nullable();
+    const src = {
+      test: null,
+      ops: 1,
+    };
+    expect(schema.assert("foo" as SourcePath, src)).toEqual({
+      success: true,
+      data: src,
+    });
+  });
+
+  test("assert: should return errors if object is missing keys", () => {
+    const schema = object({
+      test: number().nullable(),
+    }).nullable();
+    const src = {
+      ops: 1,
+    };
+    expect(schema.assert("foo" as SourcePath, src).success).toEqual(false);
+  });
+});

--- a/packages/core/src/schema/object.ts
+++ b/packages/core/src/schema/object.ts
@@ -1,5 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { Schema, SelectorOfSchema, SerializedSchema } from ".";
+import {
+  Schema,
+  SchemaAssertResult,
+  SelectorOfSchema,
+  SerializedSchema,
+} from ".";
 import { SelectorSource } from "../selector";
 import { createValPathOfItem } from "../selector/SelectorProxy";
 import { SourcePath } from "../val";
@@ -87,7 +92,10 @@ export class ObjectSchema<Props extends ObjectSchemaProps> extends Schema<
     return error;
   }
 
-  assert(src: ObjectSchemaSrcOf<Props>): boolean {
+  assert(
+    path: SourcePath,
+    src: ObjectSchemaSrcOf<Props>
+  ): SchemaAssertResult<ObjectSchemaSrcOf<Props>> {
     if (this.opt && (src === null || src === undefined)) {
       return true;
     }

--- a/packages/core/src/schema/record.test.ts
+++ b/packages/core/src/schema/record.test.ts
@@ -1,0 +1,27 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { SourcePath } from "../val";
+import { number } from "./number";
+import { object } from "./object";
+
+describe("RecordSchema", () => {
+  test("assert: should return success if record is object", () => {
+    const schema = object({
+      test: number().nullable(),
+    }).nullable();
+    const src = {
+      test: 1,
+    };
+    expect(schema.assert("foo" as SourcePath, src)).toEqual({
+      success: true,
+      data: src,
+    });
+  });
+
+  test("assert: should return errors if record is string", () => {
+    const schema = object({
+      test: number().nullable(),
+    }).nullable();
+    const src = "BOOM";
+    expect(schema.assert("foo" as SourcePath, src).success).toEqual(false);
+  });
+});

--- a/packages/core/src/schema/record.ts
+++ b/packages/core/src/schema/record.ts
@@ -79,19 +79,32 @@ export class RecordSchema<T extends Schema<SelectorSource>> extends Schema<
     path: SourcePath,
     src: Record<string, SelectorOfSchema<T>>
   ): SchemaAssertResult<Record<string, SelectorOfSchema<T>>> {
-    if (this.opt && (src === null || src === undefined)) {
-      return true;
+    if (this.opt && src === null) {
+      return {
+        success: true,
+        data: src,
+      };
     }
-    if (!src) {
-      return false;
+    if (typeof src !== "object") {
+      return {
+        success: false,
+        errors: {
+          [path]: [{ message: `Expected 'object', got '${typeof src}'` }],
+        },
+      };
     }
-
-    for (const [, item] of Object.entries(src)) {
-      if (!this.item.assert(item)) {
-        return false;
-      }
+    if (Array.isArray(src)) {
+      return {
+        success: false,
+        errors: {
+          [path]: [{ message: `Expected 'object', got 'array'` }],
+        },
+      };
     }
-    return typeof src === "object" && !Array.isArray(src);
+    return {
+      success: true,
+      data: src,
+    };
   }
 
   nullable(): Schema<Record<string, SelectorOfSchema<T>> | null> {

--- a/packages/core/src/schema/record.ts
+++ b/packages/core/src/schema/record.ts
@@ -1,5 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { Schema, SelectorOfSchema, SerializedSchema } from ".";
+import {
+  Schema,
+  SchemaAssertResult,
+  SelectorOfSchema,
+  SerializedSchema,
+} from ".";
 import { initVal } from "../initVal";
 import { SelectorSource } from "../selector";
 import { createValPathOfItem } from "../selector/SelectorProxy";
@@ -70,7 +75,10 @@ export class RecordSchema<T extends Schema<SelectorSource>> extends Schema<
     return error;
   }
 
-  assert(src: Record<string, SelectorOfSchema<T>>): boolean {
+  assert(
+    path: SourcePath,
+    src: Record<string, SelectorOfSchema<T>>
+  ): SchemaAssertResult<Record<string, SelectorOfSchema<T>>> {
     if (this.opt && (src === null || src === undefined)) {
       return true;
     }

--- a/packages/core/src/schema/richtext.test.ts
+++ b/packages/core/src/schema/richtext.test.ts
@@ -81,7 +81,7 @@ describe("RichTextSchema", () => {
         [
           `/richtext.val.ts?p=1`,
           `/richtext.val.ts?p=2."children".0."children".0."children".1`,
-        ].sort()
+        ].sort(),
       );
       const errorAtPath =
         res.errors[

--- a/packages/core/src/schema/richtext.test.ts
+++ b/packages/core/src/schema/richtext.test.ts
@@ -1,0 +1,94 @@
+import { SourcePath } from "../val";
+import { richtext } from "./richtext";
+
+describe("RichTextSchema", () => {
+  test("assert: should return success if src is richtext", () => {
+    const schema = richtext();
+    const src = [
+      { tag: "p", children: ["Val is a CMS, which is useful because:"] },
+      {
+        tag: "ul",
+        children: [
+          {
+            tag: "li",
+            children: [
+              {
+                tag: "p",
+                children: [
+                  "It",
+                  { tag: "span", styles: ["bold"], children: ["just"] },
+                  " works",
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        tag: "p",
+        children: [
+          "Visit ",
+          { tag: "a", href: "https://val.build", children: ["Val"] },
+          " for more information.",
+        ],
+      },
+    ];
+    expect(schema.assert("/richtext.val.ts" as SourcePath, src)).toEqual({
+      success: true,
+      data: src,
+    });
+  });
+
+  test("assert: should return errors if src is invalid richtext", () => {
+    const schema = richtext();
+    const src = [
+      { tag: "p", children: ["Val is a CMS, which is useful because:"] },
+      {
+        tag: 1, // <- error 1
+      },
+      {
+        tag: "ul",
+        children: [
+          {
+            tag: "li",
+            children: [
+              {
+                tag: "p",
+                children: [
+                  "It",
+                  42, // <- error
+                  { tag: "span", styles: ["bold"], children: ["just"] },
+                  " works",
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        tag: "p",
+        children: [
+          "Visit ",
+          { tag: "a", href: "https://val.build", children: ["Val"] },
+          " for more information.",
+        ],
+      },
+    ];
+    const res = schema.assert("/richtext.val.ts" as SourcePath, src);
+    expect(res.success).toEqual(false);
+    if (!res.success) {
+      expect(Object.keys(res.errors).sort()).toEqual(
+        [
+          `/richtext.val.ts?p=1`,
+          `/richtext.val.ts?p=2."children".0."children".0."children".1`,
+        ].sort()
+      );
+      const errorAtPath =
+        res.errors[
+          `/richtext.val.ts?p=2."children".0."children".0."children".1` as SourcePath
+        ];
+      expect(errorAtPath).toBeDefined();
+      expect(errorAtPath).toHaveLength(1);
+    }
+  });
+});

--- a/packages/core/src/schema/richtext.ts
+++ b/packages/core/src/schema/richtext.ts
@@ -38,13 +38,33 @@ export class RichTextSchema<
   }
 
   assert(path: SourcePath, src: Src): SchemaAssertResult<Src> {
+    if (this.opt && src === null) {
+      return {
+        success: true,
+        data: src,
+      };
+    }
+    if (!Array.isArray(src)) {
+      return {
+        success: false,
+        errors: {
+          [path]: [
+            {
+              message: `Expected 'array', got '${typeof src}'`,
+              value: src,
+            },
+          ],
+        },
+      };
+    }
+
     return {
       success: true,
       data: src,
     };
   }
 
-  nullable(): Schema<RichTextSource<O> | null> {
+  nullable(): Schema<Src | null> {
     return new RichTextSchema(this.options, true);
   }
 

--- a/packages/core/src/schema/richtext.ts
+++ b/packages/core/src/schema/richtext.ts
@@ -88,7 +88,7 @@ export class RichTextSchema<
   private recursiveAssert(
     path: string,
     node: unknown,
-    errors: Record<string, AssertError[]>
+    errors: Record<string, AssertError[]>,
   ) {
     if (typeof node !== "object") {
       if (!errors[path]) {
@@ -147,7 +147,7 @@ export class RichTextSchema<
           const child = node.children[i];
           const pathAtError = unsafeCreateSourcePath(
             unsafeCreateSourcePath(path, "children"),
-            i
+            i,
           );
           if (typeof child === "object") {
             this.recursiveAssert(pathAtError, child, errors);

--- a/packages/core/src/schema/richtext.ts
+++ b/packages/core/src/schema/richtext.ts
@@ -1,5 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { Schema, SchemaAssertResult, SerializedSchema } from ".";
+import { AssertError, Schema, SchemaAssertResult, SerializedSchema } from ".";
+import {
+  createValPathOfItem,
+  unsafeCreateSourcePath,
+} from "../selector/SelectorProxy";
 import { RichTextSource, RichTextOptions } from "../source/richtext";
 import { SourcePath } from "../val";
 import { ValidationErrors } from "./validation/ValidationError";
@@ -34,15 +38,22 @@ export class RichTextSchema<
         ],
       };
     }
-    return false; //TODO
+    const assertRes = this.assert(path, src);
+    if (!assertRes.success) {
+      return {
+        [path]: assertRes.errors[path],
+      };
+    }
+    // TODO validate options
+    return false;
   }
 
-  assert(path: SourcePath, src: Src): SchemaAssertResult<Src> {
+  assert(path: SourcePath, src: unknown): SchemaAssertResult<Src> {
     if (this.opt && src === null) {
       return {
         success: true,
         data: src,
-      };
+      } as SchemaAssertResult<Src>;
     }
     if (!Array.isArray(src)) {
       return {
@@ -51,21 +62,138 @@ export class RichTextSchema<
           [path]: [
             {
               message: `Expected 'array', got '${typeof src}'`,
-              value: src,
+              typeError: true,
             },
           ],
         },
       };
     }
-
+    const errors: Record<string, AssertError[]> = {};
+    for (let i = 0; i < src.length; i++) {
+      this.recursiveAssert(unsafeCreateSourcePath(path, i), src[i], errors);
+    }
+    if (Object.keys(errors).length > 0) {
+      return {
+        success: false,
+        errors,
+      };
+    }
+    // TODO: validate options
     return {
       success: true,
       data: src,
-    };
+    } as SchemaAssertResult<Src>;
+  }
+
+  private recursiveAssert(
+    path: string,
+    node: unknown,
+    errors: Record<string, AssertError[]>
+  ) {
+    if (typeof node !== "object") {
+      if (!errors[path]) {
+        errors[path] = [];
+      }
+      errors[path].push({
+        message: `Expected 'object', got '${typeof node}'`,
+        typeError: true,
+      });
+      return;
+    }
+    if (Array.isArray(node)) {
+      if (!errors[path]) {
+        errors[path] = [];
+      }
+      errors[path].push({
+        message: `Expected 'object', got 'array'`,
+        typeError: true,
+      });
+      return;
+    }
+    if (node === null) {
+      if (!errors[path]) {
+        errors[path] = [];
+      }
+      errors[path].push({
+        message: `Expected 'object', got 'null'`,
+        typeError: true,
+      });
+      return;
+    }
+    if ("tag" in node) {
+      if (typeof node.tag !== "string") {
+        if (!errors[path]) {
+          errors[path] = [];
+        }
+        errors[path].push({
+          message: `Expected 'string', got '${typeof node.tag}'`,
+          typeError: true,
+        });
+        return;
+      }
+    }
+    if ("children" in node) {
+      if (!Array.isArray(node.children)) {
+        if (!errors[path]) {
+          errors[path] = [];
+        }
+        errors[path].push({
+          message: `Expected 'array', got '${typeof node.children}'`,
+          typeError: true,
+        });
+        return;
+      } else {
+        for (let i = 0; i < node.children.length; i++) {
+          const child = node.children[i];
+          const pathAtError = unsafeCreateSourcePath(
+            unsafeCreateSourcePath(path, "children"),
+            i
+          );
+          if (typeof child === "object") {
+            this.recursiveAssert(pathAtError, child, errors);
+          } else if (typeof child === "string") {
+            continue;
+          } else {
+            if (!errors[pathAtError]) {
+              errors[pathAtError] = [];
+            }
+            errors[pathAtError].push({
+              message: `Expected 'object' or 'string', got '${typeof child}'`,
+              typeError: true,
+            });
+          }
+        }
+      }
+    }
+    if ("styles" in node) {
+      if (!Array.isArray(node.styles)) {
+        if (!errors[path]) {
+          errors[path] = [];
+        }
+        errors[path].push({
+          message: `Expected 'array', got '${typeof node.styles}'`,
+          typeError: true,
+        });
+      } else {
+        for (let i = 0; i < node.styles.length; i++) {
+          const style = node.styles[i];
+          if (typeof style !== "string") {
+            const pathAtError = unsafeCreateSourcePath(path, i);
+            if (!errors[pathAtError]) {
+              errors[pathAtError] = [];
+            }
+            errors[pathAtError].push({
+              message: `Expected 'string', got '${typeof style}'`,
+              typeError: true,
+            });
+          }
+        }
+      }
+    }
   }
 
   nullable(): Schema<Src | null> {
-    return new RichTextSchema(this.options, true);
+    return new RichTextSchema(this.options, true) as Schema<Src | null>;
   }
 
   serialize(): SerializedSchema {

--- a/packages/core/src/schema/richtext.ts
+++ b/packages/core/src/schema/richtext.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { Schema, SerializedSchema } from ".";
+import { Schema, SchemaAssertResult, SerializedSchema } from ".";
 import { RichTextSource, RichTextOptions } from "../source/richtext";
 import { SourcePath } from "../val";
 import { ValidationErrors } from "./validation/ValidationError";
@@ -37,8 +37,11 @@ export class RichTextSchema<
     return false; //TODO
   }
 
-  assert(src: Src): boolean {
-    return true; // TODO
+  assert(path: SourcePath, src: Src): SchemaAssertResult<Src> {
+    return {
+      success: true,
+      data: src,
+    };
   }
 
   nullable(): Schema<RichTextSource<O> | null> {

--- a/packages/core/src/schema/string.test.ts
+++ b/packages/core/src/schema/string.test.ts
@@ -3,7 +3,7 @@ import { SourcePath } from "../val";
 import { number } from "./number";
 
 describe("NumberSchema", () => {
-  test("assert: should return success if src is a number", () => {
+  test("assert: should return true if src is a number", () => {
     const schema = number().nullable();
     const test = schema.assert("foo" as SourcePath, 1);
     if (test.success) {
@@ -14,7 +14,7 @@ describe("NumberSchema", () => {
       data: 1,
     });
   });
-  test("assert: should return errors if src is a string", () => {
+  test("assert: should return false if src is a string", () => {
     const schema = number();
     expect(schema.assert("foo" as SourcePath, "1" as any).success).toEqual(
       false

--- a/packages/core/src/schema/string.test.ts
+++ b/packages/core/src/schema/string.test.ts
@@ -17,7 +17,7 @@ describe("NumberSchema", () => {
   test("assert: should return false if src is a string", () => {
     const schema = number();
     expect(schema.assert("foo" as SourcePath, "1" as any).success).toEqual(
-      false
+      false,
     );
   });
 });

--- a/packages/core/src/schema/string.ts
+++ b/packages/core/src/schema/string.ts
@@ -98,13 +98,25 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
   }
 
   assert(path: SourcePath, src: Src): SchemaAssertResult<Src> {
-    if (this.opt && (src === null || src === undefined)) {
+    if (this.opt && src === null) {
       return {
-        success: false,
+        success: true,
+        data: src,
+      };
+    }
+    if (typeof src === "string") {
+      return {
+        success: true,
+        data: src,
       };
     }
     return {
       success: false,
+      errors: {
+        [path]: [
+          { message: `Expected 'string', got '${typeof src}'`, value: src },
+        ],
+      },
     };
   }
 

--- a/packages/core/src/schema/string.ts
+++ b/packages/core/src/schema/string.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { Schema, SerializedSchema } from ".";
+import { Schema, SchemaAssertResult, SerializedSchema } from ".";
 import { SourcePath } from "../val";
 import { ValidationErrors } from "./validation/ValidationError";
 
@@ -97,11 +97,15 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
     return false;
   }
 
-  assert(src: Src): boolean {
+  assert(path: SourcePath, src: Src): SchemaAssertResult<Src> {
     if (this.opt && (src === null || src === undefined)) {
-      return true;
+      return {
+        success: false,
+      };
     }
-    return typeof src === "string";
+    return {
+      success: false,
+    };
   }
 
   nullable(): StringSchema<Src | null> {

--- a/packages/core/src/schema/string.ts
+++ b/packages/core/src/schema/string.ts
@@ -97,24 +97,28 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
     return false;
   }
 
-  assert(path: SourcePath, src: Src): SchemaAssertResult<Src> {
+  assert(path: SourcePath, src: unknown): SchemaAssertResult<Src> {
     if (this.opt && src === null) {
       return {
         success: true,
         data: src,
-      };
+      } as SchemaAssertResult<Src>;
     }
     if (typeof src === "string") {
       return {
         success: true,
         data: src,
-      };
+      } as SchemaAssertResult<Src>;
     }
     return {
       success: false,
       errors: {
         [path]: [
-          { message: `Expected 'string', got '${typeof src}'`, value: src },
+          {
+            message: `Expected 'string', got '${typeof src}'`,
+            value: src,
+            typeError: true,
+          },
         ],
       },
     };

--- a/packages/core/src/schema/string.ts
+++ b/packages/core/src/schema/string.ts
@@ -116,7 +116,6 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
         [path]: [
           {
             message: `Expected 'string', got '${typeof src}'`,
-            value: src,
             typeError: true,
           },
         ],

--- a/packages/core/src/schema/union.test.ts
+++ b/packages/core/src/schema/union.test.ts
@@ -4,25 +4,48 @@ import { literal } from "./literal";
 import { SourcePath } from "../val";
 
 describe("UnionSchema", () => {
-  test("assert: should return true for valid tagged unions", () => {
+  // tagged unions:
+  test("assert: tagged unions should return success for valid tagged unions", () => {
     const schema = union("type", object({ type: literal("string") }));
-    expect(schema.assert("foo" as SourcePath, { type: "string" })).toEqual({
+    const res = schema.assert("foo" as SourcePath, { type: "string" });
+    expect(res).toEqual({
       success: true,
       data: { type: "string" },
     });
   });
-  test("assert: should return true for valid string unions", () => {
+
+  test("assert: tagged unions should return success if value is a string", () => {
+    const schema = union("type", object({ type: literal("string") }));
+    const res = schema.assert("foo" as SourcePath, { type: "string" });
+    expect(res).toEqual({
+      success: true,
+      data: { type: "string" },
+    });
+  });
+
+  test("assert: tagged unions should return error if value is a string", () => {
+    const schema = union(
+      "type",
+      object({ type: literal("string") }),
+      object({ type: literal("number") })
+    );
+    const res = schema.assert("foo" as SourcePath, { wrongKey: "string" });
+    expect(res.success).toEqual(false);
+  });
+
+  // string unions:
+  test("assert: string unions should return success for valid string unions", () => {
     const schema = union(literal("one"), literal("two"));
-    expect(schema.assert("foo" as SourcePath, "one")).toEqual({
+    const res = schema.assert("foo" as SourcePath, "one");
+    expect(res).toEqual({
       success: true,
       data: "one",
     });
   });
-  test("assert: should return false if value is a string", () => {
-    const schema = union("type", object({ type: literal("string") }));
-    expect(schema.assert("foo" as SourcePath, { type: "string" })).toEqual({
-      success: true,
-      data: { type: "string" },
-    });
+
+  test("assert: string unions should return error for valid string unions", () => {
+    const schema = union(literal("one"), literal("two"));
+    const res = schema.assert("foo" as SourcePath, "false");
+    expect(res.success).toEqual(false);
   });
 });

--- a/packages/core/src/schema/union.test.ts
+++ b/packages/core/src/schema/union.test.ts
@@ -1,0 +1,28 @@
+import { object } from "./object";
+import { union } from "./union";
+import { literal } from "./literal";
+import { SourcePath } from "../val";
+
+describe("UnionSchema", () => {
+  test("assert: should return true for valid tagged unions", () => {
+    const schema = union("type", object({ type: literal("string") }));
+    expect(schema.assert("foo" as SourcePath, { type: "string" })).toEqual({
+      success: true,
+      data: { type: "string" },
+    });
+  });
+  test("assert: should return true for valid string unions", () => {
+    const schema = union(literal("one"), literal("two"));
+    expect(schema.assert("foo" as SourcePath, "one")).toEqual({
+      success: true,
+      data: "one",
+    });
+  });
+  test("assert: should return false if value is a string", () => {
+    const schema = union("type", object({ type: literal("string") }));
+    expect(schema.assert("foo" as SourcePath, { type: "string" })).toEqual({
+      success: true,
+      data: { type: "string" },
+    });
+  });
+});

--- a/packages/core/src/schema/union.test.ts
+++ b/packages/core/src/schema/union.test.ts
@@ -27,7 +27,7 @@ describe("UnionSchema", () => {
     const schema = union(
       "type",
       object({ type: literal("string") }),
-      object({ type: literal("number") })
+      object({ type: literal("number") }),
     );
     const res = schema.assert("foo" as SourcePath, { wrongKey: "string" });
     expect(res.success).toEqual(false);

--- a/packages/core/src/schema/union.ts
+++ b/packages/core/src/schema/union.ts
@@ -21,9 +21,9 @@ type SourceOf<
     Key extends string
       ? SourceObject & { [k in Key]: string }
       : Key extends Schema<string>
-      ? string
-      : unknown
-  >[]
+        ? string
+        : unknown
+  >[],
 > = T extends Schema<infer S>[]
   ? S extends SelectorSource
     ? S | (Key extends Schema<infer K> ? K : never)
@@ -36,10 +36,10 @@ export class UnionSchema<
     Key extends string
       ? SourceObject & { [k in Key]: string }
       : Key extends Schema<string>
-      ? string
-      : unknown
+        ? string
+        : unknown
   >[],
-  Src extends SourceOf<Key, T> | null
+  Src extends SourceOf<Key, T> | null,
 > extends Schema<Src> {
   validate(path: SourcePath, src: Src): ValidationErrors {
     const unknownSrc = src as unknown;
@@ -91,11 +91,12 @@ export class UnionSchema<
         }
       >[];
       const serializedSchemas = objectSchemas.map((schema) =>
-        schema.serialize()
+        schema.serialize(),
       );
       const illegalSchemas = serializedSchemas.filter(
         (schema) =>
-          !(schema.type === "object") || !(schema.items[key].type === "literal")
+          !(schema.type === "object") ||
+          !(schema.items[key].type === "literal"),
       );
 
       if (illegalSchemas.length > 0) {
@@ -105,7 +106,7 @@ export class UnionSchema<
               message: `All schema items must be objects with a key: ${key} that is a literal schema. Found: ${JSON.stringify(
                 illegalSchemas,
                 null,
-                2
+                2,
               )}`,
               schemaError: true,
             },
@@ -115,7 +116,7 @@ export class UnionSchema<
       const serializedObjectSchemas =
         serializedSchemas as SerializedObjectSchema[];
       const optionalLiterals = serializedObjectSchemas.filter(
-        (schema) => schema.items[key].opt
+        (schema) => schema.items[key].opt,
       );
       if (optionalLiterals.length > 1) {
         return {
@@ -170,7 +171,7 @@ export class UnionSchema<
         }
       }
       const objectSchemaAtKey = objectSchemas.find(
-        (schema) => !schema.items[key].validate(path, objectSrc[key])
+        (schema) => !schema.items[key].validate(path, objectSrc[key]),
       );
       if (!objectSchemaAtKey) {
         const keyPath = createValPathOfItem(path, key);
@@ -178,7 +179,7 @@ export class UnionSchema<
           throw new Error(
             `Internal error: could not create path at ${
               !path && typeof path === "string" ? "<empty string>" : path
-            } at key ${key}`
+            } at key ${key}`,
           );
         }
         return {
@@ -197,8 +198,8 @@ export class UnionSchema<
                       `Expected literal schema, got ${JSON.stringify(
                         keySchema,
                         null,
-                        2
-                      )}`
+                        2,
+                      )}`,
                     );
                   }
                 })
@@ -225,7 +226,7 @@ export class UnionSchema<
       const literalItems = [key, ...this.items] as LiteralSchema<string>[];
       if (typeof unknownSrc === "string") {
         const isMatch = literalItems.some(
-          (item) => !item.validate(path, unknownSrc)
+          (item) => !item.validate(path, unknownSrc),
         );
         if (!isMatch) {
           return {
@@ -301,7 +302,7 @@ export class UnionSchema<
       let success = false;
       const errors: Record<SourcePath, AssertError[]> = {};
       for (const itemSchema of [this.key as Schema<string>].concat(
-        ...(this.items as Schema<string>[])
+        ...(this.items as Schema<string>[]),
       )) {
         if (!(itemSchema instanceof LiteralSchema)) {
           return {
@@ -414,7 +415,7 @@ export class UnionSchema<
   constructor(
     readonly key: Key,
     readonly items: T,
-    readonly opt: boolean = false
+    readonly opt: boolean = false,
   ) {
     super();
   }
@@ -426,9 +427,9 @@ export const union = <
     Key extends string
       ? SourceObject & { [k in Key]: string }
       : Key extends Schema<string>
-      ? string
-      : unknown
-  >[]
+        ? string
+        : unknown
+  >[],
 >(
   key: Key,
   ...objects: T

--- a/packages/core/src/schema/union.ts
+++ b/packages/core/src/schema/union.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { Schema, SerializedSchema } from ".";
+import { Schema, SchemaAssertResult, SerializedSchema } from ".";
 import { createValPathOfItem } from "../selector/SelectorProxy";
 import { SelectorSource } from "../selector/index";
 import { SourceObject } from "../source";
@@ -244,12 +244,18 @@ export class UnionSchema<
     }
     return errors;
   }
-  assert(src: SourceOf<Key, T>): boolean {
+
+  assert(
+    path: SourcePath,
+    src: SourceOf<Key, T>
+  ): SchemaAssertResult<SourceOf<Key, T>> {
     return true;
   }
+
   nullable(): Schema<SourceOf<Key, T> | null> {
     return new UnionSchema(this.key, this.items, true);
   }
+
   serialize(): SerializedSchema {
     if (typeof this.key === "string") {
       return {

--- a/packages/core/src/schema/validation/ValidationError.ts
+++ b/packages/core/src/schema/validation/ValidationError.ts
@@ -4,7 +4,8 @@ import { ValidationFix } from "./ValidationFix";
 export type ValidationError = {
   message: string;
   value?: unknown;
-  fatal?: boolean;
+  typeError?: boolean;
+  schemaError?: boolean;
   fixes?: ValidationFix[];
 };
 

--- a/packages/core/src/selector/SelectorProxy.ts
+++ b/packages/core/src/selector/SelectorProxy.ts
@@ -98,7 +98,8 @@ export function newSelectorProxy(
                     )
                     .filter((a) => {
                       if (f && f instanceof Schema) {
-                        return f.assert(unValify(a));
+                        return f.assert(path || ("" as SourcePath), unValify(a))
+                          .success;
                       } else {
                         return unValify(f(a));
                       }

--- a/packages/core/src/selector/SelectorProxy.ts
+++ b/packages/core/src/selector/SelectorProxy.ts
@@ -227,6 +227,29 @@ export function createValPathOfItem(
   )}` as SourcePath;
 }
 
+// TODO: replace createValPathOfItem everywhere with this newer implementation (that does not return undefined but throws)
+export function unsafeCreateSourcePath(
+  path: string,
+  itemKey: string | number | symbol
+) {
+  if (typeof itemKey === "symbol") {
+    throw Error(
+      `Cannot create val path of array item with symbol prop: ${itemKey.toString()}`
+    );
+  }
+  if (!path) {
+    throw Error(
+      `Cannot create val path of array item of empty or missing path: ${path}. Item: ${itemKey}`
+    );
+  }
+  if (path.includes(Internal.ModuleFilePathSep)) {
+    return `${path}.${JSON.stringify(itemKey)}` as SourcePath;
+  }
+  return `${path}${Internal.ModuleFilePathSep}${JSON.stringify(
+    itemKey
+  )}` as SourcePath;
+}
+
 export function selectorToVal(s: any): any {
   const v = selectorAsVal(s?.[GetSource]);
   return {

--- a/packages/core/src/selector/SelectorProxy.ts
+++ b/packages/core/src/selector/SelectorProxy.ts
@@ -230,23 +230,23 @@ export function createValPathOfItem(
 // TODO: replace createValPathOfItem everywhere with this newer implementation (that does not return undefined but throws)
 export function unsafeCreateSourcePath(
   path: string,
-  itemKey: string | number | symbol
+  itemKey: string | number | symbol,
 ) {
   if (typeof itemKey === "symbol") {
     throw Error(
-      `Cannot create val path of array item with symbol prop: ${itemKey.toString()}`
+      `Cannot create val path of array item with symbol prop: ${itemKey.toString()}`,
     );
   }
   if (!path) {
     throw Error(
-      `Cannot create val path of array item of empty or missing path: ${path}. Item: ${itemKey}`
+      `Cannot create val path of array item of empty or missing path: ${path}. Item: ${itemKey}`,
     );
   }
   if (path.includes(Internal.ModuleFilePathSep)) {
     return `${path}.${JSON.stringify(itemKey)}` as SourcePath;
   }
   return `${path}${Internal.ModuleFilePathSep}${JSON.stringify(
-    itemKey
+    itemKey,
   )}` as SourcePath;
 }
 

--- a/packages/core/src/selector/future/SelectorProxy.ts
+++ b/packages/core/src/selector/future/SelectorProxy.ts
@@ -98,7 +98,8 @@ export function newSelectorProxy(
                     )
                     .filter((a) => {
                       if (f && f instanceof Schema) {
-                        return f.assert(unValify(a));
+                        return f.assert(path || ("" as SourcePath), unValify(a))
+                          .success;
                       } else {
                         return unValify(f(a));
                       }

--- a/packages/core/src/source/richtext.ts
+++ b/packages/core/src/source/richtext.ts
@@ -75,6 +75,14 @@ export type Styles<O extends RichTextOptions> =
   | Italic<O>
   | Bold<O>;
 
+export type GenericRichTextSourceNode = {
+  tag: string;
+  styles?: string[];
+  href?: string;
+  src?: ImageSource;
+  children?: (string | GenericRichTextSourceNode)[];
+};
+
 //#region Paragraph
 export type ParagraphNode<O extends RichTextOptions> = {
   tag: "p";


### PR DESCRIPTION
Schema assert is a non-recursive method that is meant to provide runtime type-checking of Val sources. The idea is that it will be used by UX as well as other places where we cannot be certain that the source types are matching the schema.
Assert is meant to be "fatal" errors, meaning that the type checker would normally pick this up. Val still needs to be able operate under those circumstances though (for developer ergonomics).
