### PR TITLE
Harden ask_user_question argument handling

### DIFF
--- a/.changeset/ask-question-arg-robustness.md
+++ b/.changeset/ask-question-arg-robustness.md
@@ -1,0 +1,9 @@
+---
+"@valbuild/ui": patch
+---
+
+Harden `ask_user_question` argument handling so a recoverable problem does not cost the whole clarification card:
+
+- A wrong type on a cosmetic field (`header`, `description`, `multiSelect`, `defaults`) now drops just that field instead of rejecting the call. Only the fields the card cannot render without — the questions themselves and their option labels — are still strict.
+- Validation failures report via `z.prettifyError` rather than the raw issue JSON, so the model gets a one-line reason instead of a dozen lines of noise in its context.
+- The call is rejected up front when there is no chat UI mounted to render the card. Previously it was recorded as pending with nothing to show and no result ever sent, which — since the tool sets `timeoutMs: null` — left the server waiting forever.

--- a/packages/ui/spa/hooks/useAI.ts
+++ b/packages/ui/spa/hooks/useAI.ts
@@ -403,27 +403,30 @@ const ASK_USER_QUESTION_TOOL: AITool = {
 // render rather than a lookup, so a malformed payload is not recoverable the
 // way a bad argument to a read tool is: with no questions there is no card to
 // submit, and since the tool intentionally sends no immediate result the turn
-// would sit on a spinner forever. Validate before rendering and report the
-// problem back instead — the tool description tells the model to fall back to
-// plain text when it gets an error.
+// would sit on a spinner forever.
+//
+// Only the fields the card cannot render without are strict. The cosmetic ones
+// use .catch so a wrong type drops just that field rather than rejecting an
+// otherwise perfectly answerable question.
 const AskUserQuestionArgs = z.object({
   questions: z
     .array(
       z.object({
         question: z.string(),
-        header: z.string().optional(),
+        header: z.string().optional().catch(undefined),
         options: z.array(
           z.object({
             label: z.string(),
-            description: z.string().optional(),
+            description: z.string().optional().catch(undefined),
           }),
         ),
-        multiSelect: z.boolean().optional(),
-        defaults: z.array(z.number()).optional(),
+        multiSelect: z.boolean().optional().catch(undefined),
+        defaults: z.array(z.number()).optional().catch(undefined),
       }),
     )
     .min(1),
 });
+type AskUserQuestions = z.infer<typeof AskUserQuestionArgs>["questions"];
 
 const ALL_TOOLS: AITool[] = [
   GET_ALL_SCHEMA_TOOL,
@@ -498,25 +501,34 @@ export function useAI(chatRef: React.RefObject<AIChatHandle | null>) {
       } else if (message.type === "ai_tool_call") {
         // ask_user_question renders a question card instead of the plain tool
         // indicator, so it needs a validated question payload up front.
-        const questionsRes =
-          message.name === "ask_user_question"
-            ? AskUserQuestionArgs.safeParse(message.arguments)
-            : null;
-        if (questionsRes && !questionsRes.success) {
-          console.error(
-            "Received malformed ask_user_question arguments",
-            questionsRes.error,
-          );
-          sendWsMessage({
-            type: "ai_tool_result",
-            toolCallId: message.toolCallId,
-            result: {
-              success: false,
-              error: `Malformed ask_user_question arguments: ${questionsRes.error.message}. Ask the user in plain text instead.`,
-            },
-            isError: true,
-          });
-          return;
+        let askQuestions: AskUserQuestions | undefined;
+        if (message.name === "ask_user_question") {
+          const parsed = AskUserQuestionArgs.safeParse(message.arguments);
+          // Anything that stops the card from rendering has to be reported
+          // back: the tool sends no result of its own, and timeoutMs: null
+          // means the server would otherwise wait for one forever.
+          let blockedReason: string | null = null;
+          if (!parsed.success) {
+            blockedReason = `Malformed arguments: ${z.prettifyError(parsed.error)}`;
+          } else if (!chatRef.current) {
+            blockedReason =
+              "The chat UI is not available to show the question.";
+          } else {
+            askQuestions = parsed.data.questions;
+          }
+          if (blockedReason) {
+            console.error("Cannot show ask_user_question card:", blockedReason);
+            sendWsMessage({
+              type: "ai_tool_result",
+              toolCallId: message.toolCallId,
+              result: {
+                success: false,
+                error: `${blockedReason} Ask the user in plain text instead.`,
+              },
+              isError: true,
+            });
+            return;
+          }
         }
         // Ensure assistant message is active so tool indicators can be shown
         if (chatRef.current) {
@@ -529,7 +541,7 @@ export function useAI(chatRef: React.RefObject<AIChatHandle | null>) {
             message.id,
             message.toolCallId,
             message.name,
-            questionsRes?.data.questions,
+            askQuestions,
           );
         }
         if (message.name === "ask_user_question") {


### PR DESCRIPTION
Follow-up review of the `ask_user_question` tool that landed in #440. Three cases where a recoverable problem cost more than it should:

**Strict optional fields threw away the whole card.** A wrong-typed `header` or `defaults` array rejected the entire call, even though the question and its options were perfectly answerable. Cosmetic fields (`header`, `description`, `multiSelect`, `defaults`) now use `.catch` so only the offending field is dropped. Question text and option labels stay strict — the card genuinely cannot render without them.

**The rejection message embedded zod's raw issue JSON**, roughly a dozen lines of noise going into the model's context on every malformed call. `z.prettifyError` reduces it to one line:

```
✖ Invalid input: expected array, received undefined
  → at questions[0].options
```

**A call arriving with no chat UI mounted hung the turn forever.** It was recorded in the pending map with no card to answer it and no result ever sent. Because the tool sets `timeoutMs: null` there is no server-side timeout to recover — it is now rejected up front, the same as the malformed case. `ChatWindow` keeps the chat mounted behind `display: none`, but `ToolsMenu` mounts `AIChat` conditionally while calling `useAI` unconditionally, so the two can diverge.

Verified: lint, format, `tsc --noEmit` across all packages, 1022 tests, and both builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)