### PR TITLE
Fix publish button tooltip reachability, naming and box model

### DIFF
--- a/.changeset/val-menu-publish-tooltip.md
+++ b/.changeset/val-menu-publish-tooltip.md
@@ -1,0 +1,9 @@
+---
+"@valbuild/ui": patch
+---
+
+Make the tooltip on the publish button in the Val menu reachable and give the icon-only button a name that says what it does.
+
+The button is icon-only in the menu, so the tooltip is the only place it explains itself — but it was unreachable in exactly the states where it matters most. `TooltipContent` rendered inline, and the menu sits inside a transformed, `overflow-hidden` wrapper that clips the (position `fixed`) tooltip away entirely; it now takes a `container` and is portalled out of the menu, the same way `HoverCardContent` already is. And when the button is disabled — validation errors, nothing pending — the design system makes it `pointer-events-none` and takes it out of the tab order, so it could receive neither hover nor focus: the tooltip now hangs off a focusable wrapper that carries the name and disabled state of the action instead.
+
+The accessible name of the compact button was `"Ready"` / `"Save"`, which is the state it is in rather than what pressing it does. It is now the same wording as the tooltip: "Publish pending changes", "Pushing changes", "Save to disk", "Saving changes to disk". The full-size button in the Studio toolbar keeps its visible label as its name, so the two still match.

--- a/packages/ui/spa/components/PublishButton.tsx
+++ b/packages/ui/spa/components/PublishButton.tsx
@@ -16,7 +16,7 @@ import {
 } from "./designSystem/popover";
 import { PopoverClose } from "@radix-ui/react-popover";
 import { PublishSummary } from "./PublishSummary";
-import { useState } from "react";
+import { type ReactElement, useState } from "react";
 import {
   Tooltip,
   TooltipContent,
@@ -25,6 +25,13 @@ import {
 
 // Matches the size of the MenuButton in ValOverlay: 16px icon + p-2 + border
 const compactButtonClassName = "h-auto w-auto p-2";
+
+// What the button does, rather than what state it is in: used both as the
+// tooltip text and - when the button is icon-only - as its accessible name
+const saveDescription = "Save to disk";
+const savingDescription = "Saving changes to disk";
+const publishDescription = "Publish pending changes";
+const pushingDescription = "Pushing changes";
 
 export function PublishButton({
   /**
@@ -54,50 +61,59 @@ export function PublishButton({
   const mode = useValMode();
   const portalContainer = useValPortal();
   const { autoPublish } = useAutoPublish();
-  const buttonProps = compact
-    ? ({ size: "icon-sm", className: compactButtonClassName } as const)
-    : ({ className: "flex gap-2 items-center" } as const);
+  const buttonClassName = compact
+    ? compactButtonClassName
+    : "flex gap-2 items-center";
 
   if (hasValidationErrors) {
+    // when compact the button is icon-only, so its name has to say what it
+    // does; otherwise it has to match the label the button actually shows
+    const label = compact
+      ? mode === "fs"
+        ? saveDescription
+        : publishDescription
+      : mode === "fs"
+        ? "Save"
+        : "Ready";
     return (
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button {...buttonProps} disabled={true}>
-            {mode === "fs" ? (
-              compact ? (
-                <Save size={16} />
-              ) : (
-                "Save"
-              )
+      <PublishTooltip
+        label={label}
+        description="Fix validation errors to continue"
+        disabled={true}
+        container={portalContainer}
+      >
+        <Button className={buttonClassName} disabled={true}>
+          {mode === "fs" ? (
+            compact ? (
+              <Save size={16} />
             ) : (
-              <>
-                {!compact && <span>{"Ready"}</span>}
-                <Upload size={16} />
-              </>
-            )}
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>
-          <div className="flex flex-col gap-2">
-            <p>Fix validation errors to continue</p>
-          </div>
-        </TooltipContent>
-      </Tooltip>
+              "Save"
+            )
+          ) : (
+            <>
+              {!compact && <span>{"Ready"}</span>}
+              <Upload size={16} />
+            </>
+          )}
+        </Button>
+      </PublishTooltip>
     );
   }
 
   if (mode === "fs") {
     const label = isPublishing ? "Saving" : "Save";
+    const description = isPublishing ? savingDescription : saveDescription;
+    const saveDisabled =
+      publishDisabled ||
+      autoPublish ||
+      pendingServerSidePatchIds.length === 0 ||
+      pendingClientSidePatchIds.length > 0;
     const saveButton = (
       <Button
-        {...buttonProps}
-        disabled={
-          publishDisabled ||
-          autoPublish ||
-          pendingServerSidePatchIds.length === 0 ||
-          pendingClientSidePatchIds.length > 0
-        }
-        aria-label={compact ? label : undefined}
+        className={buttonClassName}
+        disabled={saveDisabled}
+        // icon-only: the accessible name has to say what the button does
+        aria-label={compact ? description : undefined}
         onClick={() => {
           publish("No summary provided");
         }}
@@ -120,24 +136,27 @@ export function PublishButton({
       return saveButton;
     }
     return (
-      <Tooltip>
-        <TooltipTrigger asChild>{saveButton}</TooltipTrigger>
-        <TooltipContent>
-          <p>{isPublishing ? "Saving changes to disk" : "Save to disk"}</p>
-        </TooltipContent>
-      </Tooltip>
+      <PublishTooltip
+        label={description}
+        description={description}
+        disabled={saveDisabled}
+        container={portalContainer}
+      >
+        {saveButton}
+      </PublishTooltip>
     );
   }
-  const label = isPublishing ? "Pushing" : "Ready";
+  const description = isPublishing ? pushingDescription : publishDescription;
+  const publishIsDisabled =
+    publishDisabled ||
+    pendingServerSidePatchIds.length === 0 ||
+    pendingClientSidePatchIds.length > 0;
   const publishButton = (
     <Button
-      {...buttonProps}
-      disabled={
-        publishDisabled ||
-        pendingServerSidePatchIds.length === 0 ||
-        pendingClientSidePatchIds.length > 0
-      }
-      aria-label={compact ? label : undefined}
+      className={buttonClassName}
+      disabled={publishIsDisabled}
+      // icon-only: the accessible name has to say what the button does
+      aria-label={compact ? description : undefined}
       onClick={() => {
         setSummaryOpen(true);
         // Always generate a new summary when opening
@@ -173,7 +192,10 @@ export function PublishButton({
     </Button>
   );
   return (
-    <span>
+    // inline-flex, not a plain inline span: an inline box around the button
+    // adds the inherited line-height's descender space below it, which is
+    // exactly the misalignment this button is trying to avoid in the menu
+    <span className="inline-flex">
       <Popover
         open={summaryOpen}
         onOpenChange={(open) => {
@@ -181,16 +203,14 @@ export function PublishButton({
         }}
       >
         {compact ? (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <PopoverTrigger asChild>{publishButton}</PopoverTrigger>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>
-                {isPublishing ? "Pushing changes" : "Publish pending changes"}
-              </p>
-            </TooltipContent>
-          </Tooltip>
+          <PublishTooltip
+            label={description}
+            description={description}
+            disabled={publishIsDisabled}
+            container={portalContainer}
+          >
+            <PopoverTrigger asChild>{publishButton}</PopoverTrigger>
+          </PublishTooltip>
         ) : (
           <PopoverTrigger asChild>{publishButton}</PopoverTrigger>
         )}
@@ -218,5 +238,56 @@ export function PublishButton({
         </PopoverContent>
       </Popover>
     </span>
+  );
+}
+
+/**
+ * Tooltip on the publish button.
+ *
+ * When the button is disabled it cannot be the tooltip trigger itself: the
+ * design system gives disabled buttons `pointer-events-none` (so they never
+ * receive hover) and `disabled` takes them out of the tab order (so they
+ * never receive focus), which would leave the tooltip - the only place the
+ * icon-only button explains itself - impossible to open. In that state the
+ * trigger is a focusable wrapper that carries the name and the disabled state
+ * of the action, and the button below it is hidden from assistive technology
+ * so the action is not announced twice.
+ */
+function PublishTooltip({
+  label,
+  description,
+  disabled,
+  container,
+  children,
+}: {
+  label: string;
+  description: string;
+  disabled: boolean;
+  container: HTMLElement | null;
+  children: ReactElement;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        {disabled ? (
+          <span
+            className="inline-flex"
+            role="button"
+            tabIndex={0}
+            aria-disabled="true"
+            aria-label={label}
+          >
+            <span className="inline-flex" aria-hidden="true">
+              {children}
+            </span>
+          </span>
+        ) : (
+          children
+        )}
+      </TooltipTrigger>
+      <TooltipContent container={container}>
+        <p>{description}</p>
+      </TooltipContent>
+    </Tooltip>
   );
 }

--- a/packages/ui/spa/components/designSystem/tooltip.tsx
+++ b/packages/ui/spa/components/designSystem/tooltip.tsx
@@ -11,18 +11,39 @@ const TooltipTrigger = TooltipPrimitive.Trigger;
 
 const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
-  <TooltipPrimitive.Content
-    ref={ref}
-    sideOffset={sideOffset}
-    className={cn(
-      "z-50 overflow-hidden rounded-md border bg-bg-primary px-3 py-2 text-sm text-fg-primary shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-      className,
-    )}
-    {...props}
-  />
-));
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content> & {
+    /**
+     * Render the tooltip inside this element instead of inline next to the
+     * trigger. Needed whenever an ancestor clips overflow: the Val menu, for
+     * example, sits inside a transformed wrapper with `overflow-hidden`,
+     * which clips the (position: fixed) tooltip away entirely.
+     */
+    container?: HTMLElement | null;
+  }
+>(({ className, sideOffset = 4, container, ...props }, ref) => {
+  const content = (
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 overflow-hidden rounded-md border bg-bg-primary px-3 py-2 text-sm text-fg-primary shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+  // Only portal when we are given somewhere to portal to: the default
+  // container is document.body, which is outside the shadow root that carries
+  // our styles.
+  if (!container) {
+    return content;
+  }
+  return (
+    <TooltipPrimitive.Portal container={container}>
+      {content}
+    </TooltipPrimitive.Portal>
+  );
+});
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 
 export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };


### PR DESCRIPTION
Addresses the four Copilot review comments on #461, plus one bug the review turned up. Targets `fix-val-menu-button-alignment` so it folds into #461.

## The four review comments

**[Both branches of `buttonProps` asserted](https://github.com/valbuild/val/pull/461#discussion_r3791526604)** — the `as const` existed only to keep `size: "icon-sm"` a literal, but that variant (`h-8 w-8`) was fully overridden by `compactButtonClassName` (`h-auto w-auto p-2`) via twMerge, so it never did anything. Dropped `size`; both branches now differ only in `className` and no assertion is needed.

**[Tooltip unreachable on the disabled validation-error button](https://github.com/valbuild/val/pull/461#discussion_r3791526609)** — the tooltip now hangs off a focusable wrapper (`role="button"`, `tabIndex={0}`, `aria-disabled`, `aria-label`) with the button below it hidden from assistive technology. Extracted as a `PublishTooltip` helper and applied to every compact tooltip, not just the validation one: the save/publish buttons are also disabled whenever nothing is pending, which is the common case, and they had the same problem.

**[`aria-label="Ready"` describes state, not action](https://github.com/valbuild/val/pull/461#discussion_r3791526616)** — the compact accessible names now match the tooltip wording: "Publish pending changes", "Pushing changes", "Save to disk", "Saving changes to disk". The full-size button in the Studio toolbar keeps its visible label as its accessible name, so the two still match (WCAG 2.5.3).

**[Plain inline `span` around the cloud button](https://github.com/valbuild/val/pull/461#discussion_r3791526620)** — now `inline-flex`, so its box tracks the 34px button instead of adding descender space.

## Bug found while reviewing

**The compact tooltips never rendered at all.** `TooltipContent` is not portalled, and the menu sits inside `getPositionClassName`'s `fixed transform` wrapper (`packages/ui/spa/components/ValOverlay.tsx:1878`). That transform makes it the containing block for the Radix popper (`strategy: 'fixed'`, confirmed in the installed `@radix-ui/react-popper`), so `AnimateHeight`'s `overflow-hidden` clips the tooltip away entirely. This is why `HoverCardContent` already takes a `container` — every other menu button portals its hover card. Since #461 moves the button's only label into the tooltip, this would have shipped an icon with nothing explaining it.

`TooltipContent` now accepts an optional `container` and portals only when given one. The default container would be `document.body`, outside the shadow root that carries our styles, so existing call sites are deliberately left rendering inline.

## Looked at, left alone

- The badge's `aria-label` sits on a role-less `<span>`; name-from-content honors it, so the compare link announces "3 pending changes". The link has no accessible name when the count is zero, but that is pre-existing and true of every `MenuButton` in the menu.
- `useValPortal()` returns `null` on first render and does not re-render. Latent, but `PopoverContent` already depends on the same pattern throughout the repo.
- No component test: `packages/ui` has no jsdom/RTL setup (the jest config is empty and `@testing-library/react` is unused across the repo), so covering this would mean adding test infrastructure.

## Verification

`pnpm run lint`, `pnpm -w run format`, `pnpm run -r typecheck`, `pnpm test` (1046 passed), `pnpm run build`, and the `examples/next` build all pass. `pnpm preconstruct dev` was run afterwards to restore the source-mapped entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bg6KATqbswcjrpPUbassnD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bg6KATqbswcjrpPUbassnD)_