### PR TITLE
Stop invalidating every module on each field edit

### DIFF
--- a/.changeset/tidy-moons-attack.md
+++ b/.changeset/tidy-moons-attack.md
@@ -1,0 +1,5 @@
+---
+"@valbuild/ui": patch
+---
+
+Stop invalidating every module while editing a field. A patch-id change no longer forces a full re-sync (the studio reads sources un-patched and folds patches in client-side, so patch ids cannot change them), and a full sync now only invalidates modules whose source actually changed.

--- a/packages/ui/spa/ValSyncEngine.test.ts
+++ b/packages/ui/spa/ValSyncEngine.test.ts
@@ -249,6 +249,103 @@ describe("ValSyncEngine", () => {
     ).toStrictEqual({ [ref]: metadata });
   });
 
+  test("editing one field does not invalidate every module", async () => {
+    // Regression test for the typing-is-slow issue: every keystroke that
+    // started a new patch changed the server-side patch id list, which used to
+    // set forceSyncAllModules and therefore re-fetched + invalidated every
+    // module in the project on the next stat callback.
+    const { s, c, config } = initVal();
+    const tester = new SyncEngineTester(
+      "fs",
+      [
+        c.define("/edited.val.ts", s.string(), "edited"),
+        c.define("/other1.val.ts", s.string(), "other1"),
+        c.define("/other2.val.ts", s.string(), "other2"),
+      ],
+      config,
+    );
+    const requests: { route: string; path: string | undefined }[] = [];
+    const mockClient = tester.createMockClient();
+    const spyingClient: any = (route: string, method: any, req: any) => {
+      requests.push({ route, path: req?.path });
+      return mockClient(route, method, req);
+    };
+    const syncEngine = new ValSyncEngine(spyingClient, undefined);
+    await syncEngine.init(
+      tester.getMode(),
+      tester.getBaseSha(),
+      tester.getSchemasSha(),
+      tester.getSourcesSha(),
+      tester.fakePatches.map((p) => p.patchId),
+      null,
+      tester.getCommitSha(),
+      tester.getNextNow(),
+    );
+
+    const invalidatedModules: ModuleFilePath[] = [];
+    const unsubscribes = (
+      ["/edited.val.ts", "/other1.val.ts", "/other2.val.ts"] as const
+    ).map((moduleFilePathS) => {
+      const moduleFilePath = toModuleFilePath(moduleFilePathS);
+      return syncEngine.subscribe(
+        "source",
+        moduleFilePath,
+      )(() => {
+        invalidatedModules.push(moduleFilePath);
+      });
+    });
+
+    // Type into a single field, then let the sync + stat cycle run.
+    syncEngine.addPatch(
+      toSourcePath("/edited.val.ts"),
+      "string",
+      [{ op: "replace", path: [], value: "edited!" }],
+      tester.getNextNow(),
+    );
+    tester.simulatePassingOfSeconds(5);
+    requests.length = 0;
+    invalidatedModules.length = 0;
+    expect(await tester.simulateStatCallback(syncEngine)).toMatchObject({
+      status: "done",
+    });
+
+    // Only the edited module may be re-fetched...
+    const sourceRequests = requests.filter((r) => r.route === "/sources/~");
+    for (const sourceRequest of sourceRequests) {
+      expect(sourceRequest.path).toBe("/edited.val.ts");
+    }
+    // ... and only the edited module may be invalidated.
+    expect(new Set(invalidatedModules)).toStrictEqual(
+      new Set([toModuleFilePath("/edited.val.ts")]),
+    );
+    expect(
+      syncEngine.getSourceSnapshot(toModuleFilePath("/edited.val.ts")).data,
+    ).toStrictEqual("edited!");
+
+    // The stat callback that reports the now-synced patch id must not drag
+    // the untouched modules along either.
+    requests.length = 0;
+    invalidatedModules.length = 0;
+    tester.simulatePassingOfSeconds(5);
+    expect(await tester.simulateStatCallback(syncEngine)).toMatchObject({
+      status: "done",
+    });
+    expect(requests.filter((r) => r.route === "/sources/~")).toStrictEqual([]);
+    expect(invalidatedModules).not.toContain(
+      toModuleFilePath("/other1.val.ts"),
+    );
+    expect(invalidatedModules).not.toContain(
+      toModuleFilePath("/other2.val.ts"),
+    );
+    expect(
+      syncEngine.getSourceSnapshot(toModuleFilePath("/other1.val.ts")).data,
+    ).toStrictEqual("other1");
+
+    for (const unsubscribe of unsubscribes) {
+      unsubscribe();
+    }
+  });
+
   test("basic reset", async () => {
     const { s, c, config } = initVal();
     const tester = new SyncEngineTester(

--- a/packages/ui/spa/ValSyncEngine.test.ts
+++ b/packages/ui/spa/ValSyncEngine.test.ts
@@ -346,6 +346,69 @@ describe("ValSyncEngine", () => {
     }
   });
 
+  test("patch errors are cleared once the server stops reporting them", async () => {
+    // The server omits `patches.errors` for a module that has none, so an
+    // absent field means "no errors" and has to clear what we held before.
+    const { s, c, config } = initVal();
+    const tester = new SyncEngineTester(
+      "fs",
+      [c.define("/test.val.ts", s.string(), "test")],
+      config,
+    );
+    const syncEngine = await tester.createInitializedSyncEngine();
+    const moduleFilePath = toModuleFilePath("/test.val.ts");
+
+    let patchErrorsListenerCalls = 0;
+    const unsubscribe = syncEngine.subscribe("patch-errors", [moduleFilePath])(
+      () => {
+        patchErrorsListenerCalls++;
+      },
+    );
+
+    const sourcesResponseWithPatchErrors = {
+      status: 200,
+      json: {
+        modules: {
+          [moduleFilePath]: {
+            source: "test",
+            patches: {
+              applied: [],
+              errors: {
+                ["some-patch-id" as PatchId]: { message: "Could not apply" },
+              },
+            },
+          },
+        },
+        sourcesSha: tester.getSourcesSha(),
+        schemaSha: tester.getSchemasSha(),
+      },
+    };
+    tester.setFakeResponse("/sources/~", "PUT", sourcesResponseWithPatchErrors);
+    // Force a sync that reads sources: a source file changed on disk.
+    tester.fakeSources = { ...tester.fakeSources, "/other.val.ts": "changed" };
+    tester.simulatePassingOfSeconds(5);
+    await tester.simulateStatCallback(syncEngine);
+
+    expect(syncEngine.getPatchErrorsSnapshot([moduleFilePath])).toStrictEqual({
+      [moduleFilePath]: {
+        ["some-patch-id" as PatchId]: { message: "Could not apply" },
+      },
+    });
+    expect(patchErrorsListenerCalls).toBeGreaterThan(0);
+
+    // The patch is fixed/removed server side, so `errors` is now omitted.
+    patchErrorsListenerCalls = 0;
+    tester.removeFakeResponse("/sources/~", "PUT");
+    tester.fakeSources = { ...tester.fakeSources, "/other.val.ts": "again" };
+    tester.simulatePassingOfSeconds(5);
+    await tester.simulateStatCallback(syncEngine);
+
+    expect(syncEngine.getPatchErrorsSnapshot([moduleFilePath])).toBeUndefined();
+    expect(patchErrorsListenerCalls).toBeGreaterThan(0);
+
+    unsubscribe();
+  });
+
   test("basic reset", async () => {
     const { s, c, config } = initVal();
     const tester = new SyncEngineTester(

--- a/packages/ui/spa/ValSyncEngine.ts
+++ b/packages/ui/spa/ValSyncEngine.ts
@@ -3061,19 +3061,19 @@ export class ValSyncEngine {
                 // /sources/~ is called with validate_sources=false.
                 this.requestModuleValidation(moduleFilePath);
               }
-              const nextPatchErrors = valModule.patches?.errors;
-              if (nextPatchErrors) {
-                const patchErrorsDidChange = !deepEqual(
-                  this.errors.patchErrors?.[moduleFilePath] ?? null,
-                  nextPatchErrors,
-                );
+              // The server omits `errors` entirely for a module that has none,
+              // so `undefined` here means "no patch errors" and has to clear
+              // whatever we held before — otherwise a module that once had a
+              // patch error keeps reporting it forever.
+              const nextPatchErrors = valModule.patches?.errors ?? null;
+              const previousPatchErrors =
+                this.errors.patchErrors?.[moduleFilePath] ?? null;
+              if (!deepEqual(previousPatchErrors, nextPatchErrors)) {
                 if (this.errors.patchErrors === undefined) {
                   this.errors.patchErrors = {};
                 }
                 this.errors.patchErrors[moduleFilePath] = nextPatchErrors;
-                if (patchErrorsDidChange) {
-                  this.invalidatePatchErrors(moduleFilePath);
-                }
+                this.invalidatePatchErrors(moduleFilePath);
               }
               for (const syncedPatchId of valModule.patches?.applied || []) {
                 this.syncedServerSidePatchIds.push(syncedPatchId);

--- a/packages/ui/spa/ValSyncEngine.ts
+++ b/packages/ui/spa/ValSyncEngine.ts
@@ -2021,6 +2021,7 @@ export class ValSyncEngine {
         );
       }
     }
+    const previousGlobalServerSidePatchIds = this.globalServerSidePatchIds;
     const patchIdsDidChange =
       this.globalServerSidePatchIds === null ||
       !deepEqual(this.globalServerSidePatchIds, patchIds);
@@ -2039,11 +2040,32 @@ export class ValSyncEngine {
       this.invalidateSavedServerSidePatchIds();
       this.invalidatePendingClientSidePatchIds();
     }
-    if (
-      !this.forceSyncAllModules &&
-      (sourcesShaDidChange || patchIdsDidChange)
-    ) {
+    if (!this.forceSyncAllModules && sourcesShaDidChange) {
       this.forceSyncAllModules = true;
+    }
+    if (patchIdsDidChange && !this.forceSyncAllModules) {
+      // A patch-id change on its own never changes what /sources/~ returns:
+      // the studio always reads it with apply_patches=false and folds the
+      // patch chain in client-side (getPatchedSource). So there is nothing to
+      // re-fetch — we only need to re-derive the patched view of the modules
+      // whose ordered patch chain actually moved.
+      //
+      // Forcing a full sync here (as we used to) meant that every keystroke
+      // which started a new patch made the server re-evaluate every module and
+      // made the client invalidate every module, which is why editing a single
+      // field felt slow.
+      const affected = this.getModulesAffectedByPatchIdChange(
+        previousGlobalServerSidePatchIds,
+        patchIds,
+      );
+      if (affected === "all") {
+        this.forceSyncAllModules = true;
+      } else {
+        for (const moduleFilePath of affected) {
+          this.invalidateSource(moduleFilePath);
+          this.requestModuleValidation(moduleFilePath);
+        }
+      }
     }
     return this.sync(now);
   }
@@ -2448,13 +2470,20 @@ export class ValSyncEngine {
           this.schemas[moduleFilePath] = schema;
         }
       }
-      if (this.clientSideSchemaSha !== schemaRes.json.schemaSha) {
+      const schemaShaDidChange =
+        this.clientSideSchemaSha !== schemaRes.json.schemaSha;
+      if (schemaShaDidChange) {
         this.clientSideSchemaSha = schemaRes.json.schemaSha;
       }
 
       console.debug("Invalidating schema");
       this.resetSchemaError();
       this.invalidateSchema();
+      if (schemaShaDidChange) {
+        // The sources sync only re-validates modules whose source actually
+        // changed, so a new schema has to re-validate everything itself.
+        this.requestAllModuleValidation();
+      }
       return {
         status: "done",
       };
@@ -2666,6 +2695,64 @@ export class ValSyncEngine {
     return {
       status: "done",
     };
+  }
+
+  /**
+   * Given the previous and the next list of global (server side) patch ids,
+   * returns the modules whose ordered patch chain changed — i.e. the modules
+   * whose patched source could now be different.
+   *
+   * Returns "all" if we cannot map every patch id to a module, in which case
+   * the caller must fall back to syncing everything.
+   */
+  private getModulesAffectedByPatchIdChange(
+    previous: PatchId[] | null,
+    next: PatchId[],
+  ): "all" | ModuleFilePath[] {
+    if (previous === null) {
+      return "all";
+    }
+    const groupByModule = (
+      patchIds: PatchId[],
+    ): Map<ModuleFilePath, PatchId[]> | null => {
+      const byModule = new Map<ModuleFilePath, PatchId[]>();
+      for (const patchId of patchIds) {
+        const moduleFilePath = this.patchDataByPatchId[patchId]?.moduleFilePath;
+        if (!moduleFilePath) {
+          // We do not know which module this patch belongs to (syncPatches
+          // could not fetch it), so we cannot reason about what changed.
+          return null;
+        }
+        let patchIdsInModule = byModule.get(moduleFilePath);
+        if (!patchIdsInModule) {
+          patchIdsInModule = [];
+          byModule.set(moduleFilePath, patchIdsInModule);
+        }
+        patchIdsInModule.push(patchId);
+      }
+      return byModule;
+    };
+    const previousByModule = groupByModule(previous);
+    const nextByModule = groupByModule(next);
+    if (previousByModule === null || nextByModule === null) {
+      return "all";
+    }
+    const affected: ModuleFilePath[] = [];
+    const allModuleFilePaths = new Set([
+      ...previousByModule.keys(),
+      ...nextByModule.keys(),
+    ]);
+    for (const moduleFilePath of allModuleFilePaths) {
+      const previousPatchIds = previousByModule.get(moduleFilePath) || [];
+      const nextPatchIds = nextByModule.get(moduleFilePath) || [];
+      if (
+        previousPatchIds.length !== nextPatchIds.length ||
+        previousPatchIds.some((patchId, i) => patchId !== nextPatchIds[i])
+      ) {
+        affected.push(moduleFilePath);
+      }
+    }
+    return affected;
   }
 
   private getChangedModules(
@@ -2930,6 +3017,15 @@ export class ValSyncEngine {
               if (this.serverSources === null) {
                 this.serverSources = {};
               }
+              // A full sync returns every module, but typically only a few of
+              // them (often none) actually changed on disk. Invalidating the
+              // untouched ones would re-render every subscriber and re-run the
+              // validation worker for the whole project on every sync tick, so
+              // compare first and only invalidate what really moved.
+              const previousSource = this.serverSources[moduleFilePath];
+              const sourceDidChange =
+                previousSource === undefined ||
+                !deepEqual(previousSource, valModule.source);
               // With apply_patches=false on /sources/~, valModule.source is
               // the un-patched source. The patched view is computed by
               // getPatchedSource folding the known patch chain on top.
@@ -2939,30 +3035,46 @@ export class ValSyncEngine {
               if (this.renders === null) {
                 this.renders = {};
               }
-              this.renders[moduleFilePath] = valModule.render || null;
-              this.invalidateRenders(moduleFilePath);
-              // Drop any cached patched view for this module; the next read
-              // rebuilds from the fresh un-patched source.
-              if (this.patchedSourcesCache !== null) {
-                this.patchedSourcesCache = {
-                  ...this.patchedSourcesCache,
-                  [moduleFilePath]: undefined,
-                };
+              // Reference comparison is enough here: a render that actually
+              // came back from the server is always a fresh object, so this
+              // only skips the emit when the render stayed null (which it
+              // always is while apply_patches=false).
+              const previousRender = this.renders[moduleFilePath] ?? null;
+              const nextRender = valModule.render || null;
+              this.renders[moduleFilePath] = nextRender;
+              if (previousRender !== nextRender) {
+                this.invalidateRenders(moduleFilePath);
               }
-              console.debug("Invalidating source", moduleFilePath);
-              this.invalidateSource(moduleFilePath);
-              this.overlayEmitter?.(moduleFilePath, valModule.source);
-              this.invalidatePatchErrors(moduleFilePath);
-              if (valModule.patches?.errors) {
+              if (sourceDidChange) {
+                // Drop any cached patched view for this module; the next read
+                // rebuilds from the fresh un-patched source.
+                if (this.patchedSourcesCache !== null) {
+                  this.patchedSourcesCache = {
+                    ...this.patchedSourcesCache,
+                    [moduleFilePath]: undefined,
+                  };
+                }
+                console.debug("Invalidating source", moduleFilePath);
+                this.invalidateSource(moduleFilePath);
+                this.overlayEmitter?.(moduleFilePath, valModule.source);
+                // Validation always runs client-side via the worker now —
+                // /sources/~ is called with validate_sources=false.
+                this.requestModuleValidation(moduleFilePath);
+              }
+              const nextPatchErrors = valModule.patches?.errors;
+              if (nextPatchErrors) {
+                const patchErrorsDidChange = !deepEqual(
+                  this.errors.patchErrors?.[moduleFilePath] ?? null,
+                  nextPatchErrors,
+                );
                 if (this.errors.patchErrors === undefined) {
                   this.errors.patchErrors = {};
                 }
-                this.errors.patchErrors[moduleFilePath] = valModule.patches
-                  .errors as Record<PatchId, { message: string }>;
+                this.errors.patchErrors[moduleFilePath] = nextPatchErrors;
+                if (patchErrorsDidChange) {
+                  this.invalidatePatchErrors(moduleFilePath);
+                }
               }
-              // Validation always runs client-side via the worker now —
-              // /sources/~ is called with validate_sources=false.
-              this.requestModuleValidation(moduleFilePath);
               for (const syncedPatchId of valModule.patches?.applied || []) {
                 this.syncedServerSidePatchIds.push(syncedPatchId);
               }


### PR DESCRIPTION
Typing in a field made the studio re-fetch and invalidate **every** module roughly once per second, which is what made editing feel slow.

## The cause

In `ValSyncEngine.syncWithUpdatedStat`, any change to the server-side patch-id list set `forceSyncAllModules`. Per keystroke burst:

1. `addPatch` queues a pending op. Keystrokes only merge while the op is still queued, and the sync loop flushes every ~1s — so continuous typing mints a **new patch id roughly every second**.
2. The patch file lands on disk → the fs `/stat` long-poll breaks and returns a changed patch list.
3. `patchIdsDidChange` → `forceSyncAllModules` → `sync()` fetches `/sources/~` with **no path**, so the server re-evaluates every module in the project.
4. The response loop then ran `invalidateSource` + `requestModuleValidation` for every module unconditionally — re-rendering every subscriber and re-validating the whole project in the worker. (This is the `Invalidating source …` debug spam visible in the console while typing.)

That full re-sync was never needed: the studio always reads `/sources/~` with `apply_patches=false` and folds the patch chain in client-side via `getPatchedSource`, so **a patch-id change cannot change the sources that endpoint returns**.

## Changes

- **Patch-id changes no longer force a full sync.** New `getModulesAffectedByPatchIdChange` maps the previous/next patch-id lists back to their modules and returns only those whose ordered patch chain actually moved; those are invalidated locally with no network round-trip. If any patch id can't be mapped to a module (an unfetched foreign patch, a deleted patch), it still falls back to `"all"`.
- **Full syncs — still triggered by a sources-SHA change, e.g. publish or a disk edit — only invalidate modules that actually changed**, by comparing against the source already held instead of invalidating everything in the response.
- **`syncSchema` re-validates all modules when the schema SHA changes.** Previously the constant blanket re-validation masked this; with it gone, the schema path has to do it itself.
- Renders and patch errors get the same treatment — they only emit when the value actually changed.

No type assertions were needed for any of this.

## Testing

Added `editing one field does not invalidate every module` to `ValSyncEngine.test.ts`: three modules, edit one, assert across two stat cycles that only that module is re-fetched and invalidated. Confirmed it **fails on the unfixed code** (all three modules invalidated) and passes with the fix.

Full CI set green locally: `pnpm run lint`, `pnpm -w run format`, `pnpm test` (1066 tests), `pnpm run -r typecheck`, `pnpm run build`, and `cd examples/next && pnpm run build`.

## Follow-up (not in this PR)

After each patch flush there's still a `/sources/~` fetch scoped to the single edited module. It's now cheap on the client, but server-side `getSources()` still evaluates every module regardless of `path` (existing `TODO: currently sourcesRes contains ALL MODULES` in `ValServer.ts`). Strictly speaking that fetch is also redundant — it returns un-patched sources that didn't change, and only survives because it marks sync status done and reports applied patch ids. Removing it is a larger change than this fix warranted.

---
_Generated by [Claude Code](https://claude.ai/code/session_013c8ppabJvSCDwDxWzZ6FtQ)_