### PR TITLE
fix(ui): make the time picker clock icon follow the theme

### DIFF
--- a/packages/ui/spa/components/fields/DateTimeField.tsx
+++ b/packages/ui/spa/components/fields/DateTimeField.tsx
@@ -312,6 +312,10 @@ export function DateTimeFieldPure({
               type="time"
               step={1}
               disabled={readonly}
+              // The clock icon of a native time input is painted by the
+              // browser and follows `color-scheme`, not `color`: without this
+              // it stays dark and disappears against the dark theme surface.
+              className="[color-scheme:light] dark:[color-scheme:dark]"
               value={wall.time || "12:00:00"}
               onChange={(e) => {
                 const day =


### PR DESCRIPTION
## What

The time part of the `dateTime` field is a native `input[type="time"]`. Its clock icon is painted by the browser and follows `color-scheme`, **not** `color` — and nothing in the Val UI declares `color-scheme`, so the icon rendered dark and all but disappeared against the dark theme surface (`--bg-primary` is `#0c111d` in dark mode).

## Change

Pin `color-scheme` on that one input to the Val UI theme:

- `[color-scheme:light]` by default — explicit so a host page declaring `color-scheme: dark` on its root cannot bleed into the Val UI's light theme.
- `dark:[color-scheme:dark]` for dark mode. The `dark:` variant resolves to `[data-mode="dark"] *`, and the popover is portaled into the `ValPortalProvider` container which carries `data-mode`, so it matches there too.

## Verification

Rendered the native input in Chromium on a `#0c111d` surface, with and without `color-scheme: dark`: without it the clock icon is a near-invisible dark grey; with it the icon is white and legible.

Also confirmed the Tailwind build emits both utilities:

```
.\[color-scheme\:light\] { color-scheme: light }
.dark\:\[color-scheme\:dark\]:is([data-mode="dark"] *) { color-scheme: dark }
```

`pnpm run lint`, `pnpm --filter @valbuild/ui run typecheck` and `prettier --check` on the changed file all pass.