### PR TITLE
Experiment: page on a canvas, fields at the side

### DIFF
--- a/packages/ui/spa/components/shell/canvas/CanvasChat.tsx
+++ b/packages/ui/spa/components/shell/canvas/CanvasChat.tsx
@@ -1,0 +1,149 @@
+import { useState } from "react";
+import { ArrowUp, Paperclip, Sparkles, X } from "lucide-react";
+import { cn } from "../../designSystem/cn";
+import { CanvasChatAttachment, CanvasChatMessage } from "./types";
+
+/**
+ * The assistant, with whatever you picked off the page attached to it.
+ *
+ * The attachment row above the input is the point: you select things on the
+ * canvas, they collect here as chips, and the message you write is about
+ * them. It saves describing in words the thing you are already pointing at.
+ */
+export function CanvasChat({
+  messages,
+  attachments,
+  onRemoveAttachment,
+  onSend,
+  suggestions,
+  className,
+}: {
+  messages: CanvasChatMessage[];
+  attachments: CanvasChatAttachment[];
+  onRemoveAttachment: (fieldId: string) => void;
+  onSend: (text: string) => void;
+  suggestions?: string[];
+  className?: string;
+}) {
+  const [draft, setDraft] = useState("");
+  const submit = () => {
+    const trimmed = draft.trim();
+    if (!trimmed) return;
+    onSend(trimmed);
+    setDraft("");
+  };
+  return (
+    <div className={cn("flex h-full flex-col bg-bg-float", className)}>
+      <div className="flex h-11 shrink-0 items-center gap-2 border-b border-border-float px-4">
+        <Sparkles size={13} className="text-fg-secondary-alt" />
+        <span className="text-[0.8125rem] font-semibold tracking-tight">
+          Assistant
+        </span>
+      </div>
+
+      <div className="min-h-0 flex-1 space-y-3 overflow-y-auto p-3">
+        {messages.map((message) => (
+          <div
+            key={message.id}
+            className={cn(
+              "flex",
+              message.role === "user" ? "justify-end" : "justify-start",
+            )}
+          >
+            <div className="max-w-[85%] space-y-1.5">
+              {message.attachments && message.attachments.length > 0 && (
+                <div className="flex flex-wrap justify-end gap-1">
+                  {message.attachments.map((attachment) => (
+                    <span
+                      key={attachment.fieldId}
+                      className="inline-flex items-center gap-1 rounded border border-border-float px-1.5 py-0.5 text-[0.625rem] text-fg-secondary-alt"
+                    >
+                      <Paperclip size={9} />
+                      {attachment.label}
+                    </span>
+                  ))}
+                </div>
+              )}
+              <p
+                className={cn(
+                  "text-xs leading-relaxed",
+                  message.role === "user" &&
+                    "rounded-lg rounded-br-sm bg-bg-float-raised px-2.5 py-1.5",
+                )}
+              >
+                {message.text}
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="shrink-0 space-y-2 border-t border-border-float p-3">
+        {attachments.length > 0 && (
+          <div className="flex flex-wrap items-center gap-1.5">
+            {attachments.map((attachment) => (
+              <span
+                key={attachment.fieldId}
+                className="inline-flex items-center gap-1 rounded-md border border-border-brand-primary bg-bg-surface py-0.5 pl-1.5 pr-0.5 text-[0.6875rem]"
+              >
+                <Paperclip size={10} className="text-fg-secondary-alt" />
+                {attachment.label}
+                <button
+                  type="button"
+                  onClick={() => onRemoveAttachment(attachment.fieldId)}
+                  aria-label={`Remove ${attachment.label}`}
+                  className="grid h-4 w-4 place-items-center rounded text-fg-secondary-alt hover:bg-bg-float-raised hover:text-fg-primary"
+                >
+                  <X size={10} />
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+        {suggestions && suggestions.length > 0 && attachments.length === 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {suggestions.map((suggestion) => (
+              <button
+                key={suggestion}
+                type="button"
+                onClick={() => onSend(suggestion)}
+                className="h-7 rounded-full border border-border-float px-2 text-[0.6875rem] text-fg-secondary hover:bg-bg-float-raised hover:text-fg-primary"
+              >
+                {suggestion}
+              </button>
+            ))}
+          </div>
+        )}
+        <div className="flex items-end gap-1.5 rounded-lg bg-bg-float-raised p-1.5">
+          <textarea
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && !event.shiftKey) {
+                event.preventDefault();
+                submit();
+              }
+            }}
+            rows={1}
+            placeholder={
+              attachments.length > 0
+                ? "What should change about these?"
+                : "Ask anything about this page…"
+            }
+            aria-label="Message the assistant"
+            className="max-h-24 min-w-0 flex-1 resize-none bg-transparent px-1.5 py-1 text-xs placeholder:text-fg-secondary-alt focus:outline-none"
+          />
+          <button
+            type="button"
+            onClick={submit}
+            disabled={draft.trim() === ""}
+            aria-label="Send"
+            className="grid h-7 w-7 shrink-0 place-items-center rounded-md border border-border-brand-primary bg-bg-brand-primary text-fg-brand-primary hover:bg-bg-brand-primary-hover disabled:border-border-float disabled:bg-bg-disabled disabled:text-fg-disabled"
+          >
+            <ArrowUp size={14} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/spa/components/shell/canvas/CanvasPage.tsx
+++ b/packages/ui/spa/components/shell/canvas/CanvasPage.tsx
@@ -1,0 +1,186 @@
+import { ReactNode } from "react";
+import { ImageIcon } from "lucide-react";
+import { cn } from "../../designSystem/cn";
+import { CanvasDevice, CanvasPageData } from "./types";
+
+/**
+ * The customer's page, rendered from the same field data the side panel edits.
+ *
+ * Every editable node carries `data-field-id`, which is how the selection
+ * layer finds it and how clicking the page maps back to a field. Nothing here
+ * uses Val's tokens: this is their design, and the canvas has to show it as
+ * they built it.
+ */
+export function CanvasPage({
+  page,
+  device,
+  selectedFieldId,
+  attachedFieldIds,
+  onSelectField,
+  isSelectMode,
+}: {
+  page: CanvasPageData;
+  device: CanvasDevice;
+  selectedFieldId: string | null;
+  attachedFieldIds: readonly string[];
+  onSelectField: (fieldId: string) => void;
+  /** In select mode every editable node advertises itself on hover. */
+  isSelectMode: boolean;
+}) {
+  const value = (id: string) => page.fields[id]?.value ?? "";
+  const narrow = device === "mobile";
+
+  const Editable = ({
+    id,
+    as: Tag = "div",
+    className,
+    children,
+  }: {
+    id: string;
+    as?: "div" | "h1" | "h2" | "p" | "span";
+    className?: string;
+    children: ReactNode;
+  }) => (
+    <Tag
+      data-field-id={id}
+      onClick={(event: React.MouseEvent) => {
+        event.stopPropagation();
+        onSelectField(id);
+      }}
+      className={cn(
+        "relative cursor-pointer transition-shadow",
+        isSelectMode &&
+          "hover:shadow-[0_0_0_2px_var(--bg-page-selection)] rounded-[2px]",
+        selectedFieldId === id &&
+          "shadow-[0_0_0_2px_var(--bg-page-selection)] rounded-[2px]",
+        attachedFieldIds.includes(id) &&
+          "shadow-[0_0_0_2px_var(--bg-page-selection)] rounded-[2px]",
+        className,
+      )}
+    >
+      {children}
+    </Tag>
+  );
+
+  return (
+    <div className="bg-[#fdf8f3] text-[#2b1a12] font-sans">
+      <header
+        className={cn(
+          "flex items-center gap-8 border-b border-[#e8d9c9]",
+          narrow ? "px-5 h-16" : "px-10 h-20",
+        )}
+      >
+        <span className="text-xl font-bold tracking-tight text-[#c2410c]">
+          Nordic Retail
+        </span>
+        {!narrow && (
+          <nav className="flex gap-6 text-sm">
+            {["Shop", "Stores", "Journal", "About"].map((item) => (
+              <span key={item}>{item}</span>
+            ))}
+          </nav>
+        )}
+      </header>
+
+      <section className={cn(narrow ? "px-5 py-10" : "px-10 py-16")}>
+        <Editable
+          id="eyebrow"
+          as="p"
+          className="mb-4 inline-block text-sm font-semibold uppercase tracking-[0.2em] text-[#c2410c]"
+        >
+          {value("eyebrow")}
+        </Editable>
+        <Editable
+          id="headline"
+          as="h1"
+          className={cn(
+            "mb-6 font-bold leading-[1.05] tracking-tight",
+            narrow ? "text-4xl" : "text-6xl max-w-2xl",
+          )}
+        >
+          {value("headline")}
+        </Editable>
+        <Editable
+          id="intro"
+          as="p"
+          className={cn(
+            "mb-8 leading-relaxed text-[#6b4f3f]",
+            narrow ? "text-base" : "text-lg max-w-xl",
+          )}
+        >
+          {value("intro")}
+        </Editable>
+        <Editable
+          id="ctaLabel"
+          as="span"
+          className="inline-block rounded-full bg-[#c2410c] px-6 py-3 text-sm font-medium text-white"
+        >
+          {value("ctaLabel")}
+        </Editable>
+      </section>
+
+      <section className={cn(narrow ? "px-5 pb-12" : "px-10 pb-20")}>
+        <div
+          className={cn("grid gap-5", narrow ? "grid-cols-1" : "grid-cols-3")}
+        >
+          {[1, 2, 3].map((n) => (
+            <div key={n}>
+              <Editable
+                id={`cat${n}Image`}
+                className="mb-3 grid aspect-[4/5] place-items-center rounded-lg bg-[#efe1d3] text-[#c9ab8e]"
+              >
+                <ImageIcon size={28} strokeWidth={1.25} />
+              </Editable>
+              <Editable id={`cat${n}Title`} as="p" className="font-medium">
+                {value(`cat${n}Title`)}
+              </Editable>
+              <Editable
+                id={`cat${n}Price`}
+                as="p"
+                className="text-sm text-[#6b4f3f]"
+              >
+                {value(`cat${n}Price`)}
+              </Editable>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section
+        className={cn("bg-[#f3e7da]", narrow ? "px-5 py-10" : "px-10 py-16")}
+      >
+        <Editable
+          id="storyTitle"
+          as="h2"
+          className={cn(
+            "mb-4 font-bold tracking-tight",
+            narrow ? "text-2xl" : "text-4xl",
+          )}
+        >
+          {value("storyTitle")}
+        </Editable>
+        <Editable
+          id="storyBody"
+          as="p"
+          className={cn(
+            "leading-relaxed text-[#6b4f3f]",
+            narrow ? "text-base" : "text-lg max-w-2xl",
+          )}
+        >
+          {value("storyBody")}
+        </Editable>
+      </section>
+
+      <footer
+        className={cn(
+          "border-t border-[#e8d9c9] text-sm text-[#6b4f3f]",
+          narrow ? "px-5 py-8" : "px-10 py-10",
+        )}
+      >
+        <Editable id="footerNote" as="span" className="inline-block">
+          {value("footerNote")}
+        </Editable>
+      </footer>
+    </div>
+  );
+}

--- a/packages/ui/spa/components/shell/canvas/CanvasToolbar.tsx
+++ b/packages/ui/spa/components/shell/canvas/CanvasToolbar.tsx
@@ -1,0 +1,123 @@
+import {
+  Maximize2,
+  Minus,
+  Monitor,
+  MousePointerSquareDashed,
+  Plus,
+  Smartphone,
+  Tablet,
+} from "lucide-react";
+import { cn } from "../../designSystem/cn";
+import { CanvasDevice } from "./types";
+
+const DEVICE_ICON: Record<CanvasDevice, typeof Monitor> = {
+  desktop: Monitor,
+  tablet: Tablet,
+  mobile: Smartphone,
+};
+
+/**
+ * The canvas's own controls: what width the page is shown at, how far it is
+ * zoomed, and whether clicking picks elements or pans.
+ *
+ * Floats over the canvas rather than sitting above it, so the canvas keeps
+ * the full height — the same reasoning as the shell's other bars.
+ */
+export function CanvasToolbar({
+  device,
+  onDeviceChange,
+  scale,
+  onZoomIn,
+  onZoomOut,
+  onFit,
+  isSelectMode,
+  onSelectModeChange,
+  className,
+}: {
+  device: CanvasDevice;
+  onDeviceChange: (device: CanvasDevice) => void;
+  scale: number;
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+  onFit: () => void;
+  isSelectMode: boolean;
+  onSelectModeChange: (value: boolean) => void;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-1 rounded-lg border border-border-float bg-bg-float p-1 shadow-lg",
+        className,
+      )}
+    >
+      <button
+        type="button"
+        aria-label="Select elements"
+        aria-pressed={isSelectMode}
+        onClick={() => onSelectModeChange(!isSelectMode)}
+        className={cn(
+          "grid h-7 w-7 place-items-center rounded-md",
+          isSelectMode
+            ? "bg-bg-float-raised text-fg-primary"
+            : "text-fg-secondary hover:bg-bg-float-raised hover:text-fg-primary",
+        )}
+      >
+        <MousePointerSquareDashed size={15} />
+      </button>
+      <Divider />
+      {(Object.keys(DEVICE_ICON) as CanvasDevice[]).map((option) => {
+        const Icon = DEVICE_ICON[option];
+        return (
+          <button
+            key={option}
+            type="button"
+            aria-label={`${option} width`}
+            aria-pressed={device === option}
+            onClick={() => onDeviceChange(option)}
+            className={cn(
+              "grid h-7 w-7 place-items-center rounded-md",
+              device === option
+                ? "bg-bg-float-raised text-fg-primary"
+                : "text-fg-secondary hover:bg-bg-float-raised hover:text-fg-primary",
+            )}
+          >
+            <Icon size={14} />
+          </button>
+        );
+      })}
+      <Divider />
+      <button
+        type="button"
+        aria-label="Zoom out"
+        onClick={onZoomOut}
+        className="grid h-7 w-7 place-items-center rounded-md text-fg-secondary hover:bg-bg-float-raised hover:text-fg-primary"
+      >
+        <Minus size={14} />
+      </button>
+      <span className="w-11 text-center text-[0.6875rem] tabular-nums text-fg-secondary">
+        {Math.round(scale * 100)}%
+      </span>
+      <button
+        type="button"
+        aria-label="Zoom in"
+        onClick={onZoomIn}
+        className="grid h-7 w-7 place-items-center rounded-md text-fg-secondary hover:bg-bg-float-raised hover:text-fg-primary"
+      >
+        <Plus size={14} />
+      </button>
+      <button
+        type="button"
+        aria-label="Fit page to screen"
+        onClick={onFit}
+        className="grid h-7 w-7 place-items-center rounded-md text-fg-secondary hover:bg-bg-float-raised hover:text-fg-primary"
+      >
+        <Maximize2 size={13} />
+      </button>
+    </div>
+  );
+}
+
+function Divider() {
+  return <span aria-hidden className="mx-0.5 h-5 w-px bg-border-float" />;
+}

--- a/packages/ui/spa/components/shell/canvas/CanvasView.tsx
+++ b/packages/ui/spa/components/shell/canvas/CanvasView.tsx
@@ -1,0 +1,372 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ArrowLeft, Layers, MessageSquare } from "lucide-react";
+import { cn } from "../../designSystem/cn";
+import { useShellBreakpoint } from "../useShellBreakpoint";
+import { CanvasChat } from "./CanvasChat";
+import { CanvasPage } from "./CanvasPage";
+import { CanvasToolbar } from "./CanvasToolbar";
+import { CanvasViewport, clampScale, fitTransform } from "./CanvasViewport";
+import { FieldsPanel } from "./FieldsPanel";
+import {
+  CANVAS_DEVICE_WIDTHS,
+  CanvasChatAttachment,
+  CanvasChatMessage,
+  CanvasDevice,
+  CanvasPageData,
+  CanvasPane,
+  CanvasTransform,
+} from "./types";
+
+export type CanvasViewProps = {
+  page: CanvasPageData;
+  initialChat?: CanvasChatMessage[];
+  onExit?: () => void;
+  /** Skips the entrance transition — for screenshots and for tests. */
+  skipTransition?: boolean;
+  /** Which pane a phone starts on. */
+  initialPane?: CanvasPane;
+  initialDevice?: CanvasDevice;
+  initialSelectedFieldId?: string | null;
+  initialAttachedFieldIds?: string[];
+  isDevMode?: boolean;
+};
+
+/** How far the canvas starts scaled down when it animates in. */
+const ENTER_SCALE = 0.96;
+
+/**
+ * The canvas view: the page on a pan/zoom canvas, its fields at the side, and
+ * the assistant holding whatever you picked off it.
+ *
+ * Entering scales and fades the whole view up from slightly small, which
+ * reads as stepping back from the page rather than as a new screen arriving.
+ * Leaving reverses it, so the way out is the way in.
+ *
+ * On a phone the two halves become panes that snap horizontally — chat on the
+ * left, canvas on the right — which is how Lovable does it, and it works
+ * because at that width you are only ever using one of them.
+ */
+export function CanvasView({
+  page: initialPage,
+  initialChat = [],
+  onExit,
+  skipTransition,
+  initialPane = "canvas",
+  initialDevice = "desktop",
+  initialSelectedFieldId = null,
+  initialAttachedFieldIds = [],
+  isDevMode,
+}: CanvasViewProps) {
+  const breakpoint = useShellBreakpoint();
+  const isPhone = breakpoint === "mobile";
+
+  const [page, setPage] = useState(initialPage);
+  const [device, setDevice] = useState<CanvasDevice>(initialDevice);
+  const [transform, setTransform] = useState<CanvasTransform>({
+    scale: 1,
+    x: 0,
+    y: 0,
+  });
+  const [selectedFieldId, setSelectedFieldId] = useState<string | null>(
+    initialSelectedFieldId,
+  );
+  const [attachedFieldIds, setAttachedFieldIds] = useState<string[]>(
+    initialAttachedFieldIds,
+  );
+  const [isSelectMode, setIsSelectMode] = useState(true);
+  const [chat, setChat] = useState<CanvasChatMessage[]>(initialChat);
+  const [pane, setPane] = useState<CanvasPane>(initialPane);
+  const [entered, setEntered] = useState(skipTransition === true);
+
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const pageRef = useRef<HTMLDivElement>(null);
+  const paneScrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (skipTransition) return;
+    // Next frame, so the browser has the pre-transition state to move from.
+    const raf = requestAnimationFrame(() => setEntered(true));
+    return () => cancelAnimationFrame(raf);
+  }, [skipTransition]);
+
+  const pageWidth = CANVAS_DEVICE_WIDTHS[device];
+
+  const fit = useCallback(() => {
+    const viewport = viewportRef.current?.getBoundingClientRect();
+    const height = pageRef.current?.offsetHeight;
+    if (!viewport || !height) return;
+    setTransform(
+      fitTransform(
+        { width: pageWidth, height },
+        { width: viewport.width, height: viewport.height },
+      ),
+    );
+  }, [pageWidth]);
+
+  // Fitting needs the page's laid-out height, which is not known for a frame
+  // or two after mount — measuring too early fits to a page a tenth of its
+  // real size. A ResizeObserver waits for the height to actually arrive, and
+  // the flag stops it re-fitting afterwards and fighting the user's zoom.
+  const [needsFit, setNeedsFit] = useState(true);
+  useEffect(() => {
+    if (!needsFit) return;
+    const pageEl = pageRef.current;
+    const viewportEl = viewportRef.current;
+    if (!pageEl || !viewportEl) return;
+    const attempt = () => {
+      if (pageEl.offsetHeight === 0 || viewportEl.clientHeight === 0) return;
+      fit();
+    };
+    const observer = new ResizeObserver(attempt);
+    observer.observe(pageEl);
+    observer.observe(viewportEl);
+    attempt();
+    return () => observer.disconnect();
+  }, [needsFit, fit]);
+
+  // A device switch changes the layout under the zoom, so it re-fits.
+  useEffect(() => setNeedsFit(true), [device]);
+
+  // The moment the user pans or zooms, the view is theirs and refitting would
+  // yank it back.
+  const setTransformByUser = useCallback((next: CanvasTransform) => {
+    setNeedsFit(false);
+    setTransform(next);
+  }, []);
+
+  // The phone's panes are a scroll container, so moving between them is a
+  // scroll — which keeps the swipe and the button doing the same thing.
+  useEffect(() => {
+    if (!isPhone) return;
+    const container = paneScrollRef.current;
+    if (!container) return;
+    container.scrollTo({
+      left: pane === "chat" ? 0 : container.clientWidth,
+      behavior: skipTransition ? "auto" : "smooth",
+    });
+  }, [pane, isPhone, skipTransition]);
+
+  const attachments = useMemo(
+    (): CanvasChatAttachment[] =>
+      attachedFieldIds
+        .map((id) => page.fields[id])
+        .filter((field) => field !== undefined)
+        .map((field) => ({ fieldId: field.id, label: field.label })),
+    [attachedFieldIds, page.fields],
+  );
+
+  const attachField = useCallback((fieldId: string) => {
+    setAttachedFieldIds((current) =>
+      current.includes(fieldId) ? current : [...current, fieldId],
+    );
+  }, []);
+
+  const selectField = useCallback(
+    (fieldId: string) => {
+      setSelectedFieldId(fieldId);
+      // Picking on the canvas is how you point at something for the
+      // assistant, so in select mode it also attaches.
+      if (isSelectMode) attachField(fieldId);
+    },
+    [isSelectMode, attachField],
+  );
+
+  const send = useCallback(
+    (text: string) => {
+      setChat((current) => [
+        ...current,
+        {
+          id: `local-${current.length}`,
+          role: "user",
+          text,
+          attachments: attachments.length > 0 ? attachments : undefined,
+        },
+      ]);
+      setAttachedFieldIds([]);
+    },
+    [attachments],
+  );
+
+  const canvas = (
+    <div className="relative h-full">
+      <CanvasViewport
+        ref={viewportRef}
+        pageWidth={pageWidth}
+        transform={transform}
+        onTransformChange={setTransformByUser}
+        className="h-full"
+      >
+        <div
+          ref={pageRef}
+          className="shadow-2xl"
+          onClick={() => setSelectedFieldId(null)}
+        >
+          <CanvasPage
+            page={page}
+            device={device}
+            selectedFieldId={selectedFieldId}
+            attachedFieldIds={attachedFieldIds}
+            onSelectField={selectField}
+            isSelectMode={isSelectMode}
+          />
+        </div>
+      </CanvasViewport>
+      <CanvasToolbar
+        className="absolute bottom-3 left-1/2 -translate-x-1/2"
+        device={device}
+        onDeviceChange={setDevice}
+        scale={transform.scale}
+        onZoomIn={() => {
+          setNeedsFit(false);
+          setTransform((t) => ({ ...t, scale: clampScale(t.scale * 1.2) }));
+        }}
+        onZoomOut={() => {
+          setNeedsFit(false);
+          setTransform((t) => ({ ...t, scale: clampScale(t.scale / 1.2) }));
+        }}
+        onFit={() => setNeedsFit(true)}
+        isSelectMode={isSelectMode}
+        onSelectModeChange={setIsSelectMode}
+      />
+    </div>
+  );
+
+  const fields = (
+    <FieldsPanel
+      page={page}
+      selectedFieldId={selectedFieldId}
+      onSelectField={setSelectedFieldId}
+      onChangeField={(fieldId, value) =>
+        setPage((current) => ({
+          ...current,
+          fields: {
+            ...current.fields,
+            [fieldId]: { ...current.fields[fieldId], value },
+          },
+        }))
+      }
+      onAttachField={attachField}
+      attachedFieldIds={attachedFieldIds}
+      isDevMode={isDevMode}
+    />
+  );
+
+  const assistant = (
+    <CanvasChat
+      messages={chat}
+      attachments={attachments}
+      onRemoveAttachment={(fieldId) =>
+        setAttachedFieldIds((current) => current.filter((id) => id !== fieldId))
+      }
+      onSend={send}
+      suggestions={["Improve this page", "Shorten the headline"]}
+    />
+  );
+
+  return (
+    <div
+      data-canvas-entered={entered}
+      style={{ height: "100svh" }}
+      className={cn(
+        "relative flex w-full flex-col overflow-hidden bg-bg-canvas text-fg-primary font-sans",
+        "transition-[opacity,transform] duration-300 ease-out",
+        entered ? "scale-100 opacity-100" : "opacity-0",
+      )}
+    >
+      {/* The pre-entry transform is inline because Tailwind has no scale-96. */}
+      <style>{`[data-canvas-entered="false"]{transform:scale(${ENTER_SCALE})}`}</style>
+
+      <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border-float bg-bg-float px-3">
+        <button
+          type="button"
+          onClick={onExit}
+          className="inline-flex h-8 items-center gap-1.5 rounded-md px-2 text-xs text-fg-secondary hover:bg-bg-float-raised hover:text-fg-primary"
+        >
+          <ArrowLeft size={14} />
+          Back to editor
+        </button>
+        <span className="mx-1 h-5 w-px bg-border-float" aria-hidden />
+        <span className="text-[0.8125rem] font-semibold tracking-tight">
+          {page.title}
+        </span>
+        <span className="font-mono text-[0.6875rem] text-fg-secondary-alt">
+          {page.urlPath}
+        </span>
+        {isPhone && (
+          <PaneToggle pane={pane} onChange={setPane} className="ml-auto" />
+        )}
+      </header>
+
+      {isPhone ? (
+        <div
+          ref={paneScrollRef}
+          className="flex min-h-0 flex-1 snap-x snap-mandatory overflow-x-auto overscroll-x-contain"
+        >
+          <div className="h-full w-full shrink-0 snap-start">{assistant}</div>
+          <div className="h-full w-full shrink-0 snap-start">{canvas}</div>
+        </div>
+      ) : (
+        <div className="flex min-h-0 flex-1">
+          <div className="w-[320px] shrink-0 border-r border-border-float">
+            {assistant}
+          </div>
+          <div className="min-w-0 flex-1">{canvas}</div>
+          <div className="w-[300px] shrink-0 border-l border-border-float">
+            {fields}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The phone's chat/canvas switch.
+ *
+ * A visible control as well as a swipe, because a pane you can only reach by
+ * guessing that it swipes is a pane most people never find.
+ */
+function PaneToggle({
+  pane,
+  onChange,
+  className,
+}: {
+  pane: CanvasPane;
+  onChange: (pane: CanvasPane) => void;
+  className?: string;
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Panes"
+      className={cn(
+        "flex gap-0.5 rounded-md bg-bg-float-raised p-0.5",
+        className,
+      )}
+    >
+      {(
+        [
+          ["chat", "Chat", MessageSquare],
+          ["canvas", "Canvas", Layers],
+        ] as const
+      ).map(([value, label, Icon]) => (
+        <button
+          key={value}
+          type="button"
+          role="tab"
+          aria-selected={pane === value}
+          onClick={() => onChange(value)}
+          className={cn(
+            "inline-flex h-7 items-center gap-1.5 rounded px-2 text-[0.6875rem]",
+            pane === value
+              ? "bg-bg-float font-medium text-fg-primary shadow-sm"
+              : "text-fg-secondary",
+          )}
+        >
+          <Icon size={12} />
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/packages/ui/spa/components/shell/canvas/CanvasView.tsx
+++ b/packages/ui/spa/components/shell/canvas/CanvasView.tsx
@@ -75,7 +75,14 @@ export function CanvasView({
   const breakpoint = useShellBreakpoint();
   const isPhone = breakpoint === "mobile";
   const reducedMotion = usePrefersReducedMotion();
-  /** Transition for the named properties, or none if motion is unwelcome. */
+  /**
+   * Transition for the named properties, or none if motion is unwelcome.
+   *
+   * Declared inline rather than with `transition-[…] duration-[…]` because a
+   * `duration-[320ms]` utility was measured losing to the duration that
+   * `transition-[…]` sets for itself, leaving the move at Tailwind's default
+   * 150ms. Inline, the timing is unambiguous.
+   */
   const ease = (properties: string[]) =>
     reducedMotion
       ? undefined
@@ -334,14 +341,15 @@ export function CanvasView({
       ) : (
         /*
          * Both arrangements are the same three regions; only their geometry
-         * changes. Absolutely positioned with px and percentage edges,
-         * because those interpolate — `grid-template-columns` will not
-         * animate between tracks that mix `fr` and `px`, it snaps.
+         * changes. The fields list travels from the middle of the screen to
+         * the right rail rather than one screen being swapped for another, so
+         * the list you were reading is still the list you are reading when it
+         * arrives.
          *
-         * The point of animating at all: the fields list travels from the
-         * middle of the screen to the right rail rather than one screen being
-         * swapped for another, so the list you were reading is still the list
-         * you are reading when it arrives.
+         * Absolutely positioned rather than a grid whose columns animate.
+         * Both work — `grid-template-columns` does interpolate across `fr`
+         * and `px` in Chromium, measured — but explicit edges keep the
+         * geometry readable next to the transition that drives it.
          */
         <div data-canvas-mode={mode} className="relative min-h-0 flex-1">
           <div

--- a/packages/ui/spa/components/shell/canvas/CanvasView.tsx
+++ b/packages/ui/spa/components/shell/canvas/CanvasView.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ArrowLeft, Layers, MessageSquare } from "lucide-react";
+import { ArrowLeft, Layers, ListTree, MessageSquare } from "lucide-react";
 import { cn } from "../../designSystem/cn";
 import { useShellBreakpoint } from "../useShellBreakpoint";
+import { usePrefersReducedMotion } from "./usePrefersReducedMotion";
 import { CanvasChat } from "./CanvasChat";
 import { CanvasPage } from "./CanvasPage";
 import { CanvasToolbar } from "./CanvasToolbar";
@@ -17,8 +18,13 @@ import {
   CanvasTransform,
 } from "./types";
 
+/** Which arrangement the workspace is in. */
+export type CanvasMode = "fields" | "canvas";
+
 export type CanvasViewProps = {
   page: CanvasPageData;
+  /** Arrangement to start in. */
+  initialMode?: CanvasMode;
   initialChat?: CanvasChatMessage[];
   onExit?: () => void;
   /** Skips the entrance transition — for screenshots and for tests. */
@@ -33,6 +39,14 @@ export type CanvasViewProps = {
 
 /** How far the canvas starts scaled down when it animates in. */
 const ENTER_SCALE = 0.96;
+/** Width of the assistant, and of the fields rail beside the canvas. */
+const CHAT_WIDTH = 320;
+const RAIL_WIDTH = 300;
+/** Width the fields list settles at when it is the whole workspace. */
+const FIELDS_COLUMN_WIDTH = 760;
+/** Long enough to follow the fields list across, short enough not to wait. */
+const MODE_MS = 320;
+const MODE_EASE = "cubic-bezier(0.4, 0, 0.2, 1)";
 
 /**
  * The canvas view: the page on a pan/zoom canvas, its fields at the side, and
@@ -48,6 +62,7 @@ const ENTER_SCALE = 0.96;
  */
 export function CanvasView({
   page: initialPage,
+  initialMode = "canvas",
   initialChat = [],
   onExit,
   skipTransition,
@@ -59,6 +74,12 @@ export function CanvasView({
 }: CanvasViewProps) {
   const breakpoint = useShellBreakpoint();
   const isPhone = breakpoint === "mobile";
+  const reducedMotion = usePrefersReducedMotion();
+  /** Transition for the named properties, or none if motion is unwelcome. */
+  const ease = (properties: string[]) =>
+    reducedMotion
+      ? undefined
+      : properties.map((p) => `${p} ${MODE_MS}ms ${MODE_EASE}`).join(", ");
 
   const [page, setPage] = useState(initialPage);
   const [device, setDevice] = useState<CanvasDevice>(initialDevice);
@@ -76,6 +97,7 @@ export function CanvasView({
   const [isSelectMode, setIsSelectMode] = useState(true);
   const [chat, setChat] = useState<CanvasChatMessage[]>(initialChat);
   const [pane, setPane] = useState<CanvasPane>(initialPane);
+  const [mode, setMode] = useState<CanvasMode>(initialMode);
   const [entered, setEntered] = useState(skipTransition === true);
 
   const viewportRef = useRef<HTMLDivElement>(null);
@@ -124,8 +146,9 @@ export function CanvasView({
     return () => observer.disconnect();
   }, [needsFit, fit]);
 
-  // A device switch changes the layout under the zoom, so it re-fits.
-  useEffect(() => setNeedsFit(true), [device]);
+  // A device switch changes the layout under the zoom, so it re-fits. So does
+  // arriving on the canvas, which has no width to fit into until it opens.
+  useEffect(() => setNeedsFit(true), [device, mode]);
 
   // The moment the user pans or zooms, the view is theirs and refitting would
   // yank it back.
@@ -292,6 +315,9 @@ export function CanvasView({
         <span className="font-mono text-[0.6875rem] text-fg-secondary-alt">
           {page.urlPath}
         </span>
+        {!isPhone && (
+          <ModeToggle mode={mode} onChange={setMode} className="ml-auto" />
+        )}
         {isPhone && (
           <PaneToggle pane={pane} onChange={setPane} className="ml-auto" />
         )}
@@ -306,16 +332,128 @@ export function CanvasView({
           <div className="h-full w-full shrink-0 snap-start">{canvas}</div>
         </div>
       ) : (
-        <div className="flex min-h-0 flex-1">
-          <div className="w-[320px] shrink-0 border-r border-border-float">
-            {assistant}
+        /*
+         * Both arrangements are the same three regions; only their geometry
+         * changes. Absolutely positioned with px and percentage edges,
+         * because those interpolate — `grid-template-columns` will not
+         * animate between tracks that mix `fr` and `px`, it snaps.
+         *
+         * The point of animating at all: the fields list travels from the
+         * middle of the screen to the right rail rather than one screen being
+         * swapped for another, so the list you were reading is still the list
+         * you are reading when it arrives.
+         */
+        <div data-canvas-mode={mode} className="relative min-h-0 flex-1">
+          <div
+            style={{
+              width: CHAT_WIDTH,
+              transition: ease(["transform", "opacity"]),
+            }}
+            className={cn(
+              "absolute inset-y-0 left-0 overflow-hidden border-r border-border-float",
+              mode === "canvas"
+                ? "translate-x-0 opacity-100"
+                : "-translate-x-full opacity-0",
+            )}
+          >
+            <div className="h-full" style={{ width: CHAT_WIDTH }}>
+              {assistant}
+            </div>
           </div>
-          <div className="min-w-0 flex-1">{canvas}</div>
-          <div className="w-[300px] shrink-0 border-l border-border-float">
+
+          {/* Scales up as it arrives, so it reads as the page being placed
+              behind the fields rather than sliding in from somewhere. */}
+          <div
+            style={{
+              left: mode === "canvas" ? CHAT_WIDTH : 0,
+              right: mode === "canvas" ? RAIL_WIDTH : 0,
+              transition: ease(["left", "right", "opacity", "transform"]),
+            }}
+            className={cn(
+              "absolute inset-y-0",
+              mode === "canvas"
+                ? "scale-100 opacity-100"
+                : "pointer-events-none scale-[0.97] opacity-0",
+            )}
+          >
+            {canvas}
+          </div>
+
+          {/* The constant. A rail on the canvas, a centred column without it —
+              same component, same scroll position, same selection. */}
+          <div
+            style={{
+              ...(mode === "canvas"
+                ? { left: `calc(100% - ${RAIL_WIDTH}px)`, width: RAIL_WIDTH }
+                : {
+                    left: `max(0px, calc(50% - ${FIELDS_COLUMN_WIDTH / 2}px))`,
+                    width: `min(${FIELDS_COLUMN_WIDTH}px, 100%)`,
+                  }),
+              transition: ease(["left", "width"]),
+            }}
+            className={cn(
+              "absolute inset-y-0",
+              mode === "canvas"
+                ? "border-l border-border-float"
+                : "border-l border-transparent",
+            )}
+          >
             {fields}
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+/**
+ * The way in and out of the canvas.
+ *
+ * Two labelled states rather than one button that toggles, so the control
+ * says where you are as well as where you can go — you can tell at a glance
+ * which arrangement you are in without having to remember what you pressed.
+ */
+function ModeToggle({
+  mode,
+  onChange,
+  className,
+}: {
+  mode: CanvasMode;
+  onChange: (mode: CanvasMode) => void;
+  className?: string;
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Workspace"
+      className={cn(
+        "flex gap-0.5 rounded-md bg-bg-float-raised p-0.5",
+        className,
+      )}
+    >
+      {(
+        [
+          ["fields", "Fields", ListTree],
+          ["canvas", "Canvas", Layers],
+        ] as const
+      ).map(([value, label, Icon]) => (
+        <button
+          key={value}
+          type="button"
+          role="tab"
+          aria-selected={mode === value}
+          onClick={() => onChange(value)}
+          className={cn(
+            "inline-flex h-7 items-center gap-1.5 rounded px-2.5 text-[0.6875rem]",
+            mode === value
+              ? "bg-bg-float font-medium text-fg-primary shadow-sm"
+              : "text-fg-secondary hover:text-fg-primary",
+          )}
+        >
+          <Icon size={12} />
+          {label}
+        </button>
+      ))}
     </div>
   );
 }

--- a/packages/ui/spa/components/shell/canvas/CanvasViewport.tsx
+++ b/packages/ui/spa/components/shell/canvas/CanvasViewport.tsx
@@ -1,0 +1,171 @@
+import {
+  forwardRef,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+  WheelEvent,
+} from "react";
+import { cn } from "../../designSystem/cn";
+import { CanvasTransform } from "./types";
+
+export const MIN_SCALE = 0.2;
+export const MAX_SCALE = 2;
+/** Room left around the page when fitting, so it does not touch the edges. */
+const FIT_PADDING = 48;
+
+export type CanvasViewportProps = {
+  /** Logical width of the page being shown, in CSS px. */
+  pageWidth: number;
+  transform: CanvasTransform;
+  onTransformChange: (transform: CanvasTransform) => void;
+  children: ReactNode;
+  className?: string;
+};
+
+/**
+ * A pan and zoom surface with the page inside it.
+ *
+ * The page keeps its own layout at its own width — the canvas only moves and
+ * scales it — so what you see is the page as the browser would lay it out,
+ * not a re-flow of it. That is the whole point of looking at it this way: a
+ * 1280px page stays a 1280px page while you zoom out to see all of it.
+ *
+ * Trackpad scroll pans, pinch or ctrl/cmd+scroll zooms, and dragging the
+ * background pans — the conventions from every design tool, so nobody has to
+ * learn this one.
+ */
+export const CanvasViewport = forwardRef<HTMLDivElement, CanvasViewportProps>(
+  function CanvasViewport(
+    { pageWidth, transform, onTransformChange, children, className },
+    forwardedRef,
+  ) {
+    const viewportRef = useRef<HTMLDivElement>(null);
+    // The parent measures this element to fit the page; the component needs it
+    // too, to zoom toward the pointer.
+    useImperativeHandle(
+      forwardedRef,
+      () => viewportRef.current as HTMLDivElement,
+    );
+    const [isPanning, setIsPanning] = useState(false);
+    const panOrigin = useRef<{ x: number; y: number } | null>(null);
+
+    const onWheel = useCallback(
+      (event: WheelEvent<HTMLDivElement>) => {
+        // ctrl/cmd + wheel is what a trackpad pinch reports as, so the two
+        // gestures land in the same branch.
+        if (event.ctrlKey || event.metaKey) {
+          const rect = viewportRef.current?.getBoundingClientRect();
+          if (!rect) return;
+          const next = clampScale(transform.scale * (1 - event.deltaY / 300));
+          // Zoom toward the pointer rather than the centre, so the thing under
+          // the cursor stays under the cursor.
+          const px = event.clientX - rect.left;
+          const py = event.clientY - rect.top;
+          const ratio = next / transform.scale;
+          onTransformChange({
+            scale: next,
+            x: px - (px - transform.x) * ratio,
+            y: py - (py - transform.y) * ratio,
+          });
+          return;
+        }
+        onTransformChange({
+          ...transform,
+          x: transform.x - event.deltaX,
+          y: transform.y - event.deltaY,
+        });
+      },
+      [transform, onTransformChange],
+    );
+
+    useEffect(() => {
+      if (!isPanning) return;
+      const onMove = (event: PointerEvent) => {
+        const origin = panOrigin.current;
+        if (!origin) return;
+        onTransformChange({
+          ...transform,
+          x: event.clientX - origin.x,
+          y: event.clientY - origin.y,
+        });
+      };
+      const onUp = () => {
+        setIsPanning(false);
+        panOrigin.current = null;
+      };
+      window.addEventListener("pointermove", onMove);
+      window.addEventListener("pointerup", onUp);
+      return () => {
+        window.removeEventListener("pointermove", onMove);
+        window.removeEventListener("pointerup", onUp);
+      };
+    }, [isPanning, transform, onTransformChange]);
+
+    return (
+      <div
+        ref={viewportRef}
+        onWheel={onWheel}
+        onPointerDown={(event) => {
+          // Only the background pans. A drag that starts on the page itself is
+          // a selection, not a pan.
+          if (event.target !== event.currentTarget) return;
+          panOrigin.current = {
+            x: event.clientX - transform.x,
+            y: event.clientY - transform.y,
+          };
+          setIsPanning(true);
+        }}
+        className={cn(
+          "relative overflow-hidden bg-bg-canvas",
+          // The dotted ground is what makes it read as a canvas rather than a
+          // page with margins.
+          "[background-image:radial-gradient(var(--border-float)_1px,transparent_1px)] [background-size:24px_24px]",
+          isPanning ? "cursor-grabbing" : "cursor-grab",
+          className,
+        )}
+      >
+        <div
+          style={{
+            width: pageWidth,
+            transform: `translate(${transform.x}px, ${transform.y}px) scale(${transform.scale})`,
+            transformOrigin: "0 0",
+          }}
+          className="absolute top-0 left-0 origin-top-left will-change-transform"
+        >
+          {children}
+        </div>
+      </div>
+    );
+  },
+);
+
+export function clampScale(scale: number): number {
+  return Math.min(MAX_SCALE, Math.max(MIN_SCALE, scale));
+}
+
+/**
+ * The transform that centres a page of this size in a viewport of that size.
+ *
+ * Exported so the toolbar's "fit" button and the initial state agree, and so
+ * it can be tested without a browser.
+ */
+export function fitTransform(
+  page: { width: number; height: number },
+  viewport: { width: number; height: number },
+): CanvasTransform {
+  const available = {
+    width: Math.max(1, viewport.width - FIT_PADDING * 2),
+    height: Math.max(1, viewport.height - FIT_PADDING * 2),
+  };
+  const scale = clampScale(
+    Math.min(available.width / page.width, available.height / page.height),
+  );
+  return {
+    scale,
+    x: (viewport.width - page.width * scale) / 2,
+    y: (viewport.height - page.height * scale) / 2,
+  };
+}

--- a/packages/ui/spa/components/shell/canvas/FieldsPanel.tsx
+++ b/packages/ui/spa/components/shell/canvas/FieldsPanel.tsx
@@ -1,0 +1,226 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Image as ImageIcon, Link2, Paperclip, Type } from "lucide-react";
+import { cn } from "../../designSystem/cn";
+import { PanelFilterInput } from "../PanelPrimitives";
+import { CanvasField, CanvasPageData } from "./types";
+
+/**
+ * Every editable field on the page, in one list at the side.
+ *
+ * This is the half of the experiment worth judging: instead of hunting across
+ * a page for the thing you want to change, the page's content is a list you
+ * can read top to bottom, filter, and work down. The canvas is then for
+ * seeing the result rather than for aiming at it.
+ *
+ * Selection is shared with the canvas in both directions — the selected
+ * field scrolls into view here when it is picked over there.
+ */
+export function FieldsPanel({
+  page,
+  selectedFieldId,
+  onSelectField,
+  onChangeField,
+  onAttachField,
+  attachedFieldIds,
+  isDevMode,
+}: {
+  page: CanvasPageData;
+  selectedFieldId: string | null;
+  onSelectField: (fieldId: string) => void;
+  onChangeField: (fieldId: string, value: string) => void;
+  /** Hand this field to the assistant as context. */
+  onAttachField: (fieldId: string) => void;
+  attachedFieldIds: readonly string[];
+  isDevMode?: boolean;
+}) {
+  const [query, setQuery] = useState("");
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const sections = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return page.sections
+      .map((section) => ({
+        ...section,
+        fields: section.fieldIds
+          .map((id) => page.fields[id])
+          .filter(
+            (field): field is CanvasField =>
+              field !== undefined &&
+              (q === "" ||
+                field.label.toLowerCase().includes(q) ||
+                field.value.toLowerCase().includes(q)),
+          ),
+      }))
+      .filter((section) => section.fields.length > 0);
+  }, [page, query]);
+
+  // Picking something on the canvas should bring its field into view here,
+  // otherwise the two halves drift apart the moment the list is long.
+  //
+  // Scrolled by hand rather than with `scrollIntoView`, which walks up and
+  // scrolls every scrollable ancestor — including the document, which drags
+  // the whole view out of position.
+  useEffect(() => {
+    if (!selectedFieldId) return;
+    const list = listRef.current;
+    const row = list?.querySelector<HTMLElement>(
+      `[data-field-row="${selectedFieldId}"]`,
+    );
+    if (!list || !row) return;
+    const top = row.offsetTop - list.offsetTop;
+    const bottom = top + row.offsetHeight;
+    if (top < list.scrollTop) {
+      list.scrollTo({ top, behavior: "smooth" });
+    } else if (bottom > list.scrollTop + list.clientHeight) {
+      list.scrollTo({
+        top: bottom - list.clientHeight,
+        behavior: "smooth",
+      });
+    }
+  }, [selectedFieldId]);
+
+  const fieldCount = Object.keys(page.fields).length;
+
+  return (
+    <div className="flex h-full flex-col bg-bg-float">
+      <div className="flex h-11 shrink-0 items-center gap-2 border-b border-border-float px-4">
+        <span className="text-[0.8125rem] font-semibold tracking-tight">
+          Fields
+        </span>
+        <span className="text-[0.6875rem] text-fg-secondary-alt tabular-nums">
+          {fieldCount}
+        </span>
+      </div>
+      <div className="shrink-0 border-b border-border-float px-3 py-2">
+        <PanelFilterInput
+          value={query}
+          onChange={setQuery}
+          placeholder="Filter fields…"
+        />
+      </div>
+      <div ref={listRef} className="min-h-0 flex-1 overflow-y-auto pb-4">
+        {sections.length === 0 && (
+          <p className="px-4 py-6 text-xs text-fg-secondary-alt">
+            No fields match this filter.
+          </p>
+        )}
+        {sections.map((section) => (
+          <section key={section.id}>
+            <h3 className="px-4 pb-1.5 pt-4 text-[0.6875rem] font-semibold uppercase tracking-wider text-fg-secondary-alt">
+              {section.name}
+            </h3>
+            {section.fields.map((field) => (
+              <FieldRow
+                key={field.id}
+                field={field}
+                selected={selectedFieldId === field.id}
+                attached={attachedFieldIds.includes(field.id)}
+                onSelect={() => onSelectField(field.id)}
+                onChange={(value) => onChangeField(field.id, value)}
+                onAttach={() => onAttachField(field.id)}
+                isDevMode={isDevMode}
+              />
+            ))}
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const FIELD_ICON: Record<CanvasField["type"], typeof Type> = {
+  string: Type,
+  text: Type,
+  richtext: Type,
+  image: ImageIcon,
+  link: Link2,
+};
+
+function FieldRow({
+  field,
+  selected,
+  attached,
+  onSelect,
+  onChange,
+  onAttach,
+  isDevMode,
+}: {
+  field: CanvasField;
+  selected: boolean;
+  attached: boolean;
+  onSelect: () => void;
+  onChange: (value: string) => void;
+  onAttach: () => void;
+  isDevMode?: boolean;
+}) {
+  const Icon = FIELD_ICON[field.type];
+  return (
+    <div
+      data-field-row={field.id}
+      onFocusCapture={onSelect}
+      onClick={onSelect}
+      className={cn(
+        "px-3 py-2 border-l-2 transition-colors",
+        selected
+          ? "border-bg-page-selection bg-bg-float-raised"
+          : "border-transparent hover:bg-bg-float-raised/60",
+      )}
+    >
+      <div className="mb-1.5 flex items-center gap-1.5">
+        <Icon size={12} className="shrink-0 text-fg-secondary-alt" />
+        <span className="text-[0.8125rem] font-medium">{field.label}</span>
+        {attached && (
+          <span
+            title="Attached to the assistant"
+            className="text-fg-secondary-alt"
+          >
+            <Paperclip size={11} />
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            onAttach();
+          }}
+          className="ml-auto rounded px-1.5 py-0.5 text-[0.625rem] text-fg-secondary-alt opacity-0 transition-opacity hover:bg-bg-float-raised hover:text-fg-primary focus:opacity-100 group-hover:opacity-100 [div:hover>div>&]:opacity-100"
+        >
+          Ask AI
+        </button>
+      </div>
+      {field.type === "image" ? (
+        <div className="flex items-center gap-2 rounded-md border border-border-float bg-bg-surface px-2 py-1.5">
+          <span className="grid h-8 w-8 shrink-0 place-items-center rounded bg-bg-float-raised text-fg-secondary-alt">
+            <ImageIcon size={13} />
+          </span>
+          <span className="truncate font-mono text-[0.6875rem] text-fg-secondary">
+            {field.value}
+          </span>
+        </div>
+      ) : field.type === "text" || field.type === "richtext" ? (
+        <textarea
+          value={field.value}
+          onChange={(event) => onChange(event.target.value)}
+          rows={3}
+          aria-label={field.label}
+          className="w-full resize-none rounded-md border border-border-float bg-bg-surface px-2 py-1.5 text-xs leading-relaxed focus:border-border-brand-primary focus:outline-none"
+        />
+      ) : (
+        <input
+          value={field.value}
+          onChange={(event) => onChange(event.target.value)}
+          aria-label={field.label}
+          className={cn(
+            "h-8 w-full rounded-md border border-border-float bg-bg-surface px-2 text-xs focus:border-border-brand-primary focus:outline-none",
+            field.type === "link" && "font-mono",
+          )}
+        />
+      )}
+      {isDevMode && (
+        <p className="mt-1 truncate font-mono text-[0.625rem] text-fg-secondary-alt">
+          {field.sourcePath}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/spa/components/shell/canvas/mockCanvasPage.ts
+++ b/packages/ui/spa/components/shell/canvas/mockCanvasPage.ts
@@ -1,0 +1,139 @@
+import { CanvasChatMessage, CanvasField, CanvasPageData } from "./types";
+
+/**
+ * A page to put on the canvas.
+ *
+ * Deliberately the same fictional shop as the overlay stories, so the two
+ * experiments can be compared against one design rather than two.
+ */
+
+function field(
+  id: string,
+  label: string,
+  type: CanvasField["type"],
+  value: string,
+  section: string,
+): CanvasField {
+  return {
+    id,
+    label,
+    type,
+    value,
+    section,
+    sourcePath: `/content/home.val.ts?p="${id}"`,
+  };
+}
+
+const FIELDS: CanvasField[] = [
+  field("eyebrow", "Eyebrow", "string", "Autumn 2026", "hero"),
+  field(
+    "headline",
+    "Headline",
+    "string",
+    "Clothes that outlast the season.",
+    "hero",
+  ),
+  field(
+    "intro",
+    "Intro",
+    "text",
+    "Made in Bergen from wool we can trace to the farm. Repaired free, for as long as you own it.",
+    "hero",
+  ),
+  field("ctaLabel", "Button label", "string", "Shop the collection", "hero"),
+  field("ctaHref", "Button link", "link", "/shop", "hero"),
+
+  field("cat1Title", "First category", "string", "Knitwear", "categories"),
+  field("cat1Price", "First price", "string", "From 1 490 kr", "categories"),
+  field(
+    "cat1Image",
+    "First image",
+    "image",
+    "/public/val/knitwear_a1b2c.jpg",
+    "categories",
+  ),
+  field("cat2Title", "Second category", "string", "Outerwear", "categories"),
+  field("cat2Price", "Second price", "string", "From 3 200 kr", "categories"),
+  field(
+    "cat2Image",
+    "Second image",
+    "image",
+    "/public/val/outerwear_d4e5f.jpg",
+    "categories",
+  ),
+  field("cat3Title", "Third category", "string", "Accessories", "categories"),
+  field("cat3Price", "Third price", "string", "From 390 kr", "categories"),
+  field(
+    "cat3Image",
+    "Third image",
+    "image",
+    "/public/val/accessories_g6h7i.jpg",
+    "categories",
+  ),
+
+  field(
+    "storyTitle",
+    "Story title",
+    "string",
+    "Repaired, not replaced",
+    "story",
+  ),
+  field(
+    "storyBody",
+    "Story body",
+    "richtext",
+    "Every garment comes with free repairs for as long as you own it. Bring it to any of our stores, or post it to us and we will send it back mended.",
+    "story",
+  ),
+  field("storyLink", "Story link", "link", "/repairs", "story"),
+
+  field(
+    "footerNote",
+    "Footer note",
+    "string",
+    "Made in Bergen since 1998",
+    "footer",
+  ),
+];
+
+export const mockCanvasPage: CanvasPageData = {
+  title: "Home",
+  urlPath: "/",
+  sections: [
+    {
+      id: "hero",
+      name: "Hero",
+      fieldIds: ["eyebrow", "headline", "intro", "ctaLabel", "ctaHref"],
+    },
+    {
+      id: "categories",
+      name: "Categories",
+      fieldIds: [
+        "cat1Title",
+        "cat1Price",
+        "cat1Image",
+        "cat2Title",
+        "cat2Price",
+        "cat2Image",
+        "cat3Title",
+        "cat3Price",
+        "cat3Image",
+      ],
+    },
+    {
+      id: "story",
+      name: "Story",
+      fieldIds: ["storyTitle", "storyBody", "storyLink"],
+    },
+    { id: "footer", name: "Footer", fieldIds: ["footerNote"] },
+  ],
+  fields: Object.fromEntries(FIELDS.map((f) => [f.id, f])),
+};
+
+export const mockCanvasChat: CanvasChatMessage[] = [
+  {
+    id: "c1",
+    role: "assistant",
+    text: "I can see the whole page. Pick anything on the canvas and I will work on it — or just tell me what you want changed.",
+  },
+];

--- a/packages/ui/spa/components/shell/canvas/stories/Canvas.stories.tsx
+++ b/packages/ui/spa/components/shell/canvas/stories/Canvas.stories.tsx
@@ -1,0 +1,169 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { CanvasView } from "../CanvasView";
+import { mockCanvasChat, mockCanvasPage } from "../mockCanvasPage";
+import { CanvasDevice, CanvasPane } from "../types";
+
+/**
+ * An experiment: what editing looks like if the page goes on a canvas.
+ *
+ * Three ideas are being tried together, and they are worth judging
+ * separately:
+ *
+ * 1. **The page on a pan/zoom canvas.** It keeps its own width and layout —
+ *    the canvas only moves and scales it — so a 1280px page stays a 1280px
+ *    page while you zoom out far enough to see all of it.
+ * 2. **Every field at the side.** Instead of hunting across the page for the
+ *    thing to change, the page's content is a list you read top to bottom and
+ *    can filter. The canvas becomes for seeing the result, not for aiming.
+ * 3. **Pick on the page, hand it to the assistant.** Selected elements
+ *    collect as chips above the chat input, so a message can be about the
+ *    thing you are pointing at rather than a description of it.
+ *
+ * On a phone the halves become panes that snap horizontally, chat left and
+ * canvas right, as Lovable does it.
+ *
+ * Nothing here is wired to real data.
+ */
+const meta: Meta<typeof CanvasHarness> = {
+  title: "Shell/Canvas (experiment)",
+  component: CanvasHarness,
+  parameters: { layout: "fullscreen", backgrounds: { disable: true } },
+  argTypes: {
+    theme: { control: "inline-radio", options: ["dark", "light"] },
+    device: {
+      control: "inline-radio",
+      options: ["desktop", "tablet", "mobile"],
+    },
+    pane: { control: "inline-radio", options: ["chat", "canvas"] },
+    selectedFieldId: {
+      control: "select",
+      options: [null, "headline", "intro", "cat1Image", "storyTitle"],
+    },
+    animate: {
+      control: "boolean",
+      description: "Play the entrance transition rather than starting settled",
+    },
+  },
+};
+export default meta;
+
+type HarnessProps = {
+  theme: "dark" | "light";
+  /** Width the page is rendered at inside the canvas. */
+  device: CanvasDevice;
+  pane: CanvasPane;
+  selectedFieldId: string | null;
+  attached: string[];
+  animate: boolean;
+  isDevMode: boolean;
+};
+
+function CanvasHarness({
+  theme,
+  device,
+  pane,
+  selectedFieldId,
+  attached,
+  animate,
+  isDevMode,
+}: HarnessProps) {
+  const [exited, setExited] = useState(false);
+  return (
+    <div data-mode={theme}>
+      {exited ? (
+        <div
+          style={{ height: "100svh" }}
+          className="grid place-items-center bg-bg-canvas text-fg-secondary"
+        >
+          <button
+            type="button"
+            onClick={() => setExited(false)}
+            className="rounded-md border border-border-float px-3 py-2 text-xs hover:bg-bg-float-raised"
+          >
+            Open the canvas again
+          </button>
+        </div>
+      ) : (
+        <CanvasView
+          key={`${device}-${pane}-${selectedFieldId}`}
+          page={mockCanvasPage}
+          initialChat={mockCanvasChat}
+          initialDevice={device}
+          initialPane={pane}
+          initialSelectedFieldId={selectedFieldId}
+          initialAttachedFieldIds={attached}
+          skipTransition={!animate}
+          isDevMode={isDevMode}
+          onExit={() => setExited(true)}
+        />
+      )}
+    </div>
+  );
+}
+
+type Story = StoryObj<typeof CanvasHarness>;
+
+const base: HarnessProps = {
+  theme: "dark",
+  device: "desktop",
+  pane: "canvas",
+  selectedFieldId: null,
+  attached: [],
+  animate: false,
+  isDevMode: false,
+};
+
+/** The whole idea in one screen: assistant, canvas, fields. */
+export const Default: Story = { args: base };
+
+/**
+ * A field selected. The canvas outlines it and the side panel scrolls to it —
+ * selection is shared, so the two halves never drift apart.
+ */
+export const FieldSelected: Story = {
+  args: { ...base, selectedFieldId: "headline" },
+};
+
+/**
+ * Two elements picked off the page and handed to the assistant. The chips
+ * above the input are what the next message will be about.
+ */
+export const AttachedToAssistant: Story = {
+  args: {
+    ...base,
+    selectedFieldId: "storyTitle",
+    attached: ["headline", "storyTitle"],
+  },
+};
+
+/** The page at tablet width, so the canvas is showing a different layout. */
+export const TabletWidth: Story = { args: { ...base, device: "tablet" } };
+
+/** The page at phone width — still on a desktop canvas. */
+export const MobileWidth: Story = { args: { ...base, device: "mobile" } };
+
+/** Source paths under every field. */
+export const DevMode: Story = {
+  args: { ...base, isDevMode: true, selectedFieldId: "intro" },
+};
+
+/** Light mode. */
+export const LightMode: Story = { args: { ...base, theme: "light" } };
+
+/**
+ * On a phone, the canvas pane. The toggle in the header moves between this
+ * and the chat; so does a horizontal swipe.
+ */
+export const PhoneCanvasPane: Story = { args: { ...base, pane: "canvas" } };
+
+/** On a phone, the chat pane, with elements already attached. */
+export const PhoneChatPane: Story = {
+  args: { ...base, pane: "chat", attached: ["headline", "cat1Image"] },
+};
+
+/**
+ * Plays the entrance: the view scales and fades up from slightly small, which
+ * reads as stepping back from the page rather than as a new screen arriving.
+ */
+export const Entering: Story = { args: { ...base, animate: true } };

--- a/packages/ui/spa/components/shell/canvas/stories/Canvas.stories.tsx
+++ b/packages/ui/spa/components/shell/canvas/stories/Canvas.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import { CanvasView } from "../CanvasView";
 import { mockCanvasChat, mockCanvasPage } from "../mockCanvasPage";
+import { CanvasMode } from "../CanvasView";
 import { CanvasDevice, CanvasPane } from "../types";
 
 /**
@@ -36,6 +37,11 @@ const meta: Meta<typeof CanvasHarness> = {
       options: ["desktop", "tablet", "mobile"],
     },
     pane: { control: "inline-radio", options: ["chat", "canvas"] },
+    mode: {
+      control: "inline-radio",
+      options: ["fields", "canvas"],
+      description: "Which arrangement to start in",
+    },
     selectedFieldId: {
       control: "select",
       options: [null, "headline", "intro", "cat1Image", "storyTitle"],
@@ -53,6 +59,7 @@ type HarnessProps = {
   /** Width the page is rendered at inside the canvas. */
   device: CanvasDevice;
   pane: CanvasPane;
+  mode: CanvasMode;
   selectedFieldId: string | null;
   attached: string[];
   animate: boolean;
@@ -63,6 +70,7 @@ function CanvasHarness({
   theme,
   device,
   pane,
+  mode,
   selectedFieldId,
   attached,
   animate,
@@ -86,11 +94,12 @@ function CanvasHarness({
         </div>
       ) : (
         <CanvasView
-          key={`${device}-${pane}-${selectedFieldId}`}
+          key={`${device}-${pane}-${mode}-${selectedFieldId}`}
           page={mockCanvasPage}
           initialChat={mockCanvasChat}
           initialDevice={device}
           initialPane={pane}
+          initialMode={mode}
           initialSelectedFieldId={selectedFieldId}
           initialAttachedFieldIds={attached}
           skipTransition={!animate}
@@ -108,6 +117,7 @@ const base: HarnessProps = {
   theme: "dark",
   device: "desktop",
   pane: "canvas",
+  mode: "canvas",
   selectedFieldId: null,
   attached: [],
   animate: false,
@@ -167,3 +177,74 @@ export const PhoneChatPane: Story = {
  * reads as stepping back from the page rather than as a new screen arriving.
  */
 export const Entering: Story = { args: { ...base, animate: true } };
+
+/**
+ * Fields mode: the list you were reading, as a comfortable centred column.
+ *
+ * This is where the round trip starts. Switching to Canvas keeps this list on
+ * screen and moves it to the right rail — nothing is swapped out, so there is
+ * no moment where you lose your place.
+ */
+export const FieldsMode: Story = { args: { ...base, mode: "fields" } };
+
+/** Fields mode, part-way down the list with a field open. */
+export const FieldsModeEditing: Story = {
+  args: { ...base, mode: "fields", selectedFieldId: "storyTitle" },
+};
+
+/** Fields mode in light. */
+export const FieldsModeLight: Story = {
+  args: { ...base, mode: "fields", theme: "light" },
+};
+
+/** Fields mode with source paths shown. */
+export const FieldsModeDev: Story = {
+  args: { ...base, mode: "fields", isDevMode: true },
+};
+
+/** An image field selected — the canvas outlines the picture, not the label. */
+export const ImageFieldSelected: Story = {
+  args: { ...base, selectedFieldId: "cat1Image" },
+};
+
+/** A rich text field: the side panel gives it room, the canvas shows it set. */
+export const RichTextSelected: Story = {
+  args: { ...base, selectedFieldId: "storyBody" },
+};
+
+/** One element attached, before anything has been asked about it. */
+export const OneAttachment: Story = {
+  args: { ...base, attached: ["headline"] },
+};
+
+/** Four attached — the chip row wraps rather than scrolling out of reach. */
+export const ManyAttachments: Story = {
+  args: {
+    ...base,
+    attached: ["eyebrow", "headline", "intro", "cat1Image"],
+    selectedFieldId: "intro",
+  },
+};
+
+/** Tablet width in light mode. */
+export const TabletLight: Story = {
+  args: { ...base, device: "tablet", theme: "light" },
+};
+
+/** Phone width with a field selected, so the outline is visible when small. */
+export const MobileWidthSelected: Story = {
+  args: { ...base, device: "mobile", selectedFieldId: "headline" },
+};
+
+/** Phone, chat pane, nothing attached yet — the suggestions show instead. */
+export const PhoneChatEmpty: Story = { args: { ...base, pane: "chat" } };
+
+/** Phone, canvas at phone width — the pairing you would actually use there. */
+export const PhoneCanvasMobileWidth: Story = {
+  args: { ...base, pane: "canvas", device: "mobile" },
+};
+
+/** Phone in light mode. */
+export const PhoneCanvasLight: Story = {
+  args: { ...base, pane: "canvas", device: "mobile", theme: "light" },
+};

--- a/packages/ui/spa/components/shell/canvas/types.ts
+++ b/packages/ui/spa/components/shell/canvas/types.ts
@@ -1,0 +1,81 @@
+/**
+ * Types for the canvas experiment.
+ *
+ * The idea under test: show the page itself on a pan/zoom canvas, and put
+ * every editable field on it into a panel at the side, so editing is a list
+ * you work down rather than a hunt across the page. Selection is shared —
+ * picking a field highlights it on the canvas, picking an element on the
+ * canvas scrolls to its field — and anything selected can be handed to the
+ * assistant as context.
+ */
+
+/** What kind of control a field gets in the side panel. */
+export type CanvasFieldType = "string" | "text" | "richtext" | "image" | "link";
+
+/** One editable field on the page. */
+export type CanvasField = {
+  id: string;
+  /** Label in the side panel, e.g. "Headline". */
+  label: string;
+  type: CanvasFieldType;
+  /** Current value. Images hold a file path. */
+  value: string;
+  /** The val source path, shown in dev mode. */
+  sourcePath: string;
+  /** Section this field belongs to, for grouping in the panel. */
+  section: string;
+};
+
+/** A group of fields, matching a section of the page. */
+export type CanvasSection = {
+  id: string;
+  name: string;
+  fieldIds: string[];
+};
+
+/** The page being displayed, as data the canvas and the panel both read. */
+export type CanvasPageData = {
+  title: string;
+  urlPath: string;
+  sections: CanvasSection[];
+  fields: Record<string, CanvasField>;
+};
+
+/** Widths the canvas can render the page at. */
+export type CanvasDevice = "desktop" | "tablet" | "mobile";
+
+export const CANVAS_DEVICE_WIDTHS: Record<CanvasDevice, number> = {
+  desktop: 1280,
+  tablet: 834,
+  mobile: 390,
+};
+
+/** Pan and zoom state. */
+export type CanvasTransform = {
+  /** 1 = 100%. */
+  scale: number;
+  x: number;
+  y: number;
+};
+
+/**
+ * An element the user picked on the canvas and handed to the assistant.
+ *
+ * Kept separate from the current selection: you attach several, then write a
+ * message about them, and the selection moves on in the meantime.
+ */
+export type CanvasChatAttachment = {
+  fieldId: string;
+  label: string;
+};
+
+export type CanvasChatMessage = {
+  id: string;
+  role: "user" | "assistant";
+  text: string;
+  /** Fields that were attached to this message when it was sent. */
+  attachments?: CanvasChatAttachment[];
+};
+
+/** Which pane a phone is showing. Chat sits left of the canvas, as in Lovable. */
+export type CanvasPane = "chat" | "canvas";

--- a/packages/ui/spa/components/shell/canvas/usePrefersReducedMotion.ts
+++ b/packages/ui/spa/components/shell/canvas/usePrefersReducedMotion.ts
@@ -4,9 +4,8 @@ import { useEffect, useState } from "react";
  * Whether the viewer has asked for less motion.
  *
  * Read in JS rather than left to a `motion-reduce:` class because the
- * transitions here are declared inline — Tailwind will not generate arbitrary
- * `transition-[left,width]` utilities, so the timing has to be set in the
- * style object, and the media query has to be checked the same way.
+ * transitions here are declared inline, so the media query that switches them
+ * off has to be checked the same way.
  */
 export function usePrefersReducedMotion(): boolean {
   const [reduced, setReduced] = useState(() =>

--- a/packages/ui/spa/components/shell/canvas/usePrefersReducedMotion.ts
+++ b/packages/ui/spa/components/shell/canvas/usePrefersReducedMotion.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Whether the viewer has asked for less motion.
+ *
+ * Read in JS rather than left to a `motion-reduce:` class because the
+ * transitions here are declared inline — Tailwind will not generate arbitrary
+ * `transition-[left,width]` utilities, so the timing has to be set in the
+ * style object, and the media query has to be checked the same way.
+ */
+export function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(() =>
+    typeof window === "undefined"
+      ? false
+      : window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  );
+  useEffect(() => {
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const onChange = () => setReduced(query.matches);
+    query.addEventListener("change", onChange);
+    return () => query.removeEventListener("change", onChange);
+  }, []);
+  return reduced;
+}


### PR DESCRIPTION
**An experiment.** Storybook only, wired to nothing, not proposed for merge as-is. Based on #488 rather than `main`, since it builds on the shell's tokens and primitives.

Storybook → **Shell / Canvas (experiment)**, 23 stories.

Four ideas tried together, and worth judging separately — any one could be worth keeping without the others.

## The round trip

What makes a mode switch jarring is that one screen is replaced by another and you have to find your place again. So the transition is built around a constant: **the fields list exists in both arrangements** — a comfortable 760px centred column on its own, a 300px rail beside the canvas — and switching *moves* it rather than replacing it. The canvas scales up behind it and the assistant slides in from the left, so nothing appears from nowhere.

Measured on the travelling element rather than judged by eye. The fields rail mid-flight:

| Frame | x | width |
| --- | --- | --- |
| fields | 420 | 760 |
| mid | 1065 | 423 |
| canvas | 1300 | 300 |
| mid, back | 655 | 637 |
| fields again | 420 | 760 |

After the full round trip the selected field is still `storyTitle` and the list is still scrolled to 449px. Reduced motion turns the movement off and keeps the states.

**Known limitation:** this round trip is *within* the canvas view — Fields mode and Canvas mode are two arrangements of one screen. The trip that matters is the shell's page editor → canvas → back, which needs a shared element across two views that do not currently share a component. Not done here.

## Fields mode

Every editable field on the page as one filterable list, grouped by section, typed per field. The idea: instead of hunting across a page for the thing to change, the page's content is a list you work down, and the canvas becomes for *seeing the result* rather than *aiming at it*.

**This needs a real project to judge.** The mock has 18 fields across 4 sections, which is comfortably below the size where a flat list stops being an improvement.

## The page on a pan/zoom canvas

The page keeps its own width and layout; the canvas only moves and scales it, so a 1280px page stays a 1280px page while you zoom out to see all of it. Trackpad scroll pans, pinch or ctrl/cmd+scroll zooms toward the pointer, dragging the background pans. A device switcher re-renders at tablet or phone width and refits.

## Selection, shared both ways

Picking a field outlines it on the canvas; picking an element on the canvas scrolls to its field. Selected elements can be handed to the assistant — they collect as chips above the chat input, and the placeholder becomes "What should change about these?".

## On a phone

Chat left, canvas right, snapping horizontally, with a toggle in the header *as well as* the swipe — a pane reachable only by guessing that it swipes is one most people never find.

## Correction — two bugs I reported that do not exist

This PR originally claimed two CSS bugs. **Both claims were wrong**, and one of them sent us after three more "bugs" in the existing UI that were never there. Corrected in 9a01a4d:

- **`h-[calc(100%-3rem)]` is fine.** Tailwind normalises the arbitrary value and emits `height: calc(100% - 3rem)` — verified by running the Tailwind CLI over the exact class. **There are no invalid `calc()` heights in `SearchResultsList.tsx` or `ToolsMenu.tsx`.**
- **`grid-template-columns` animates fine.** Measured across the mode switch it interpolates `0px 0px 900px` → `66.7px 0px 833.3px` → `320px 280px 300px`. Mixing `fr` and `px` tracks was not the problem.

**The single real cause was stale generated CSS.** The canvas directory was created while the dev server was already running, and the Tailwind watcher never picked up classes from the new directory — so nothing was generated for them, the height fell back to `auto` (hence a 1723px canvas in a 1000px window), and the transition properties did not exist. Restarting Storybook fixes it: a probe with the same classes computes 904px on a 952px parent and `transition-property: left, width`.

Worth knowing if you add a new directory under `spa/` and your styles seem to do nothing — restart the dev server before debugging the CSS.

The layout stays as absolutely positioned regions with inline transition timing because it is verified working, not because the alternative is broken. One observation does survive: a `duration-[320ms]` utility was measured losing to the duration `transition-[…]` sets for itself, leaving the move at Tailwind's default 150ms — a reason to keep the timing inline.

## Two real bugs that do stand

- **Fitting measured the page before it had a height.** The fit ran a frame after mount, when the page was a tenth of its final size, so it opened at 73% and off-centre. It now refits from a `ResizeObserver` until you pan or zoom, at which point the view is yours.
- **`scrollIntoView` scrolled the document.** The fields panel scrolls its own container by hand instead, because `scrollIntoView` walks up and scrolls *every* scrollable ancestor — which dragged the whole view out of position.

## Not done

- Nothing is wired to real data; the page is mock data both halves read.
- No shared element between the shell's editor and the canvas — see the round trip note above.
- No fields pane on phones; no keyboard navigation on the canvas, no multi-select, no undo.
- The motion is CSS. Nothing in the repo uses Framer Motion and this did not seem worth a dependency yet.

## Checks

`lint`, `format`, `typecheck` (all packages) and `test` (1723) green.