### PR TITLE
e2e against a mock content host: publishing, deployments, remote files, two editors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules/
 .next
+# The e2e suite's proxy-mode dev server, which needs a distDir of its own.
+.next-http
 dist
 tsconfig.tsbuildinfo
 .envrc

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 # next.js
 examples/next*/.next/
+examples/next*/.next-http/
 examples/next*/out/
 
 # production

--- a/architecture/quirks.md
+++ b/architecture/quirks.md
@@ -60,6 +60,46 @@ wherever the update budget ran out — typically a Radix ref callback, whose JS
 stack is pure Radix. Do not start there; census the fiber tree instead
 (see [stores.md](./stores.md#debugging-in-a-browser)).
 
+## Remote files and proxy mode
+
+**Two different functions answer "does this project use remote files", and they
+disagree.** `hasRemoteFileSchema` (server, gates whether `/save` demands remote
+credentials) only looks at `type: "file" | "image"` schemas, so it returns FALSE
+for `s.images({ remote: true })` — a record of metadata, not an image schema.
+`findRequiredRemoteFiles` (Studio, gates the `/remote/settings` fetch) has a
+`record` branch that checks `mediaType && remote`, so it returns TRUE for the same
+schema. A remote gallery therefore makes the Studio ask for remote settings while
+leaving publishing unguarded, and a remote _field_ guards publishing too.
+
+**One remote image or file field anywhere makes EVERY publish need remote
+credentials.** `/save` in `fs` mode calls `getIsRemoteRequired` over all schemas,
+and a single `true` switches the whole save into `upload-remote`, which needs an
+api key or a `.val/pat.json`. A local checkout has neither, so adding one
+`s.image().remote()` stops a project from publishing plain text. This is why the
+example app's remote gallery is opt-in (see `examples/next/val.modules.ts`).
+
+**Every commit failure reads "Unknown error".** `ValOpsHttp.commit` parses the
+error body with zod and then passes the _safeParse result_ — not the payload — to
+`getErrorMessageFromUnknownJson`, so the service's own message never survives.
+When a publish fails in proxy mode, read the content service's log, not the
+Studio's.
+
+**A remote upload and the commit that ships it key the same file differently.**
+The browser uploads bytes under the file path (the store splits the ref first),
+while `prepare` describes the file by its full remote ref. The content service is
+what reconciles them.
+
+**The `val_session` cookie is percent-encoded on the wire.** `initValServer`
+writes `encodeURIComponent(value)` into `Set-Cookie` and the read side decodes, so
+a hand-made session cookie has to be encoded too — an HMAC signature is base64 and
+routinely contains `+` and `/`. Sending it raw decodes to something else and reads
+as "you will need to login again".
+
+**The deployment UI is not mounted.** `DraftChanges` is the only component that
+renders `useDeployments()`, and nothing imports it as a component. Deployments and
+commits still arrive over the WebSocket and still land in provider state; there is
+just nothing on screen.
+
 ## Testing
 
 **`packages/ui` has no jsdom by default**, and importing a field component pulls in

--- a/e2e/http/config.ts
+++ b/e2e/http/config.ts
@@ -1,0 +1,46 @@
+/**
+ * The handful of values the mock content host, the proxy-mode app and the tests
+ * all have to agree on.
+ *
+ * In one file because they are agreed across process boundaries: the mock is
+ * started by `playwright.config.ts` with these in its environment, the app is
+ * started with the same ones in its `VAL_*` vars, and the tests sign session
+ * cookies with the same secret. A drift in any one of them shows up as an empty
+ * patch list or a 401, neither of which points back here.
+ *
+ * Ports are deliberately not the FS-mode ones (3456 / no mock): both apps run at
+ * once, so a run can compare the two modes without a restart.
+ */
+
+/** Where the fake content.val.build listens. */
+export const MOCK_CONTENT_PORT = 4567;
+
+/** Where the proxy-mode copy of `examples/next` listens. */
+export const HTTP_APP_PORT = 3457;
+
+/**
+ * The project's api key, as the app holds it and the mock checks it.
+ *
+ * The mock rejects anything else rather than merely requiring a key to be
+ * present: a mis-wired `VAL_API_KEY` is a real failure mode, and one that
+ * otherwise surfaces as "no changes" rather than as an error.
+ */
+export const MOCK_API_KEY = "mock-api-key";
+
+/**
+ * What `val_session` cookies are signed with.
+ *
+ * The tests mint their own instead of logging in — `http` mode refuses every
+ * request without a session, and the login flow is neither what these tests are
+ * for nor something a mock content host can stand in for.
+ */
+export const MOCK_SECRET = "mock-secret-for-e2e-only";
+
+/** Must match `val.config.ts`'s `project`, which the app sends on every call. */
+export const MOCK_PROJECT = "valbuild/val-examples-next";
+
+/** `VAL_GIT_COMMIT`: the commit the app believes it was built from. */
+export const MOCK_INITIAL_COMMIT = "mockcommit0";
+
+/** `val.config.ts`'s `root`, which the content host joins paths against. */
+export const MOCK_ROOT = "/examples/next";

--- a/e2e/http/deployments.spec.ts
+++ b/e2e/http/deployments.spec.ts
@@ -58,11 +58,17 @@ test.beforeEach(async () => {
 
 test.describe("events from the content service", () => {
   test("the Studio opens a socket to the content service", async ({ page }) => {
-    // `openHttpStudio` already waits for a subscriber, so this test is mostly a
+    // `openHttpStudio` already waits for the socket, so this test is mostly a
     // named place for the failure: if the socket does not come up, every other
-    // test in this file fails for a reason that looks like a missing event.
+    // test in this file fails for a reason that looks like a missing event. What
+    // it adds is the other end — the content service accepted the nonce and
+    // registered a subscriber, rather than closing the connection on it.
     await openHttpStudio(page);
-    expect((await mock.state()).subscribers).toBeGreaterThan(0);
+    await expect
+      .poll(async () => (await mock.state()).subscribers, {
+        message: "the content service did not accept the subscription",
+      })
+      .toBeGreaterThan(0);
   });
 
   test("a deployment announced by CI reaches the Studio", async ({ page }) => {

--- a/e2e/http/deployments.spec.ts
+++ b/e2e/http/deployments.spec.ts
@@ -1,0 +1,191 @@
+import { expect, test, type Page } from "@playwright/test";
+import {
+  mock,
+  openHttpStudio,
+  publishAll,
+  sessionCookie,
+  writePatch,
+} from "./httpMode";
+
+/**
+ * What arrives from outside the Studio: deployments, and commits nobody here made.
+ *
+ * These have no `fs`-mode equivalent at all. In proxy mode `/stat` answers
+ * `use-websocket`, the browser opens a socket to the content service itself, and
+ * everything that happens afterwards — a deployment starting, a deployment
+ * finishing, someone pushing a commit — arrives on it. Nothing an editor does
+ * produces one, which is why the mock has a control plane.
+ *
+ * ## What is asserted, and why it is not the UI
+ *
+ * The deployment banner is not reachable: `DraftChanges` — the only component
+ * that renders `useDeployments()` — is imported by nothing, so the Studio
+ * currently mounts no deployment UI at all. Asserting on it would mean asserting
+ * on a component the app does not render.
+ *
+ * So these tests assert the transport instead, which is the part that silently
+ * breaks: the message reaches the client and passes `WebSocketServerMessage`.
+ * That parse is a zod schema in `useStatus.ts` against JSON from a service in
+ * another repository, and when the two drift the whole feature stops working with
+ * one `console.error` and no other symptom. The `Could not parse` assertion is
+ * the point of these tests; the debug line only proves something arrived.
+ */
+
+test.use({
+  storageState: { cookies: [sessionCookie("ada")], origins: [] },
+});
+
+test.describe.configure({ mode: "serial" });
+
+/** Every console message, so a test can assert on what the socket did with one. */
+function collectConsole(page: Page): { type: string; text: string }[] {
+  const messages: { type: string; text: string }[] = [];
+  page.on("console", (message) =>
+    messages.push({ type: message.type(), text: message.text() }),
+  );
+  return messages;
+}
+
+function parseFailures(messages: readonly { text: string }[]): string[] {
+  return messages
+    .filter((message) => /Could not parse WebSocket message/.test(message.text))
+    .map((message) => message.text);
+}
+
+test.beforeEach(async () => {
+  await mock.reset();
+});
+
+test.describe("events from the content service", () => {
+  test("the Studio opens a socket to the content service", async ({ page }) => {
+    // `openHttpStudio` already waits for a subscriber, so this test is mostly a
+    // named place for the failure: if the socket does not come up, every other
+    // test in this file fails for a reason that looks like a missing event.
+    await openHttpStudio(page);
+    expect((await mock.state()).subscribers).toBeGreaterThan(0);
+  });
+
+  test("a deployment announced by CI reaches the Studio", async ({ page }) => {
+    const messages = collectConsole(page);
+    await openHttpStudio(page);
+
+    const announced = await mock.deployment({ deploymentState: "pending" });
+    expect(announced.deployment.commitSha).toBe("mockcommit0");
+
+    await expect
+      .poll(
+        () => messages.some((message) => message.text.startsWith("Deployment")),
+        { message: "the deployment never reached the browser" },
+      )
+      .toBe(true);
+    expect(parseFailures(messages)).toEqual([]);
+  });
+
+  /**
+   * A deployment moving from pending to success.
+   *
+   * Sent as a second message about the same `deploymentId`, which is how the real
+   * service reports progress, and what `mergeCommitsAndDeployments` keys on. The
+   * mock updates in place so the state it reports matches: two messages, one
+   * deployment.
+   */
+  test("a deployment that finishes updates in place", async ({ page }) => {
+    const messages = collectConsole(page);
+    await openHttpStudio(page);
+
+    const started = await mock.deployment({ deploymentState: "pending" });
+    await mock.deployment({
+      deploymentId: started.deployment.deploymentId,
+      deploymentState: "success",
+    });
+
+    await expect
+      .poll(
+        () =>
+          messages.filter((message) => message.text.startsWith("Deployment"))
+            .length,
+        { message: "both deployment messages never arrived" },
+      )
+      .toBeGreaterThanOrEqual(2);
+    expect(parseFailures(messages)).toEqual([]);
+
+    const state = await mock.state();
+    expect(state.deployments).toHaveLength(1);
+    expect(state.deployments[0].deploymentState).toBe("success");
+  });
+
+  /**
+   * Someone pushed a commit that did not come from this Studio.
+   *
+   * The build-on-a-new-commit case, from the Studio's side: a commit it did not
+   * make appears on the branch it is editing.
+   *
+   * Note what this cannot cover in a dev-server harness. `VAL_GIT_COMMIT` is read
+   * once at startup, so the app's own idea of which commit it serves cannot
+   * change while it runs — a real deploy replaces the process. The commit pushed
+   * here therefore deliberately carries the app's own sha: that is the state a
+   * finished build leaves behind, and it is the branch `observedCommitShas` keys
+   * on, without needing a restart.
+   */
+  test("a commit pushed outside the Studio reaches it", async ({ page }) => {
+    const messages = collectConsole(page);
+    await openHttpStudio(page);
+
+    await mock.pushCommit({
+      commitMessage: "A commit from CI",
+      creator: "profile-linus",
+    });
+
+    await expect
+      .poll(
+        () => messages.some((message) => message.text.startsWith("Commit")),
+        { message: "the pushed commit never reached the browser" },
+      )
+      .toBe(true);
+    expect(parseFailures(messages)).toEqual([]);
+    expect((await mock.state()).commits).toHaveLength(1);
+  });
+
+  /**
+   * The whole sequence, in the order it happens in production.
+   *
+   * Publish, CI builds and deploys, publish again. Worth running as one test
+   * rather than four because the failure it is looking for is order-dependent: a
+   * publish after a deployment has landed has to commit on top of the commit the
+   * deployment was for, not on top of the sha the app booted with.
+   */
+  test("publish, deploy, publish again", async ({ page }) => {
+    const messages = collectConsole(page);
+    await openHttpStudio(page);
+
+    await writePatch(page, "/content/authors.val.ts", [
+      { op: "replace", path: ["teddy", "name"], value: "Before the deploy" },
+    ]);
+    expect((await publishAll(page, "First")).status).toBe("published");
+    const firstCommit = (await mock.state()).commits[0].commitSha;
+
+    // CI picks it up, builds it, and deploys it.
+    const deployment = await mock.deployment({
+      commitSha: firstCommit,
+      deploymentState: "pending",
+    });
+    await mock.deployment({
+      deploymentId: deployment.deployment.deploymentId,
+      deploymentState: "success",
+    });
+
+    await writePatch(page, "/content/authors.val.ts", [
+      { op: "replace", path: ["teddy", "name"], value: "After the deploy" },
+    ]);
+    const second = await publishAll(page, "Second");
+    expect(second.status, second.message ?? "").toBe("published");
+
+    const state = await mock.state();
+    expect(state.commits).toHaveLength(2);
+    expect(state.commits[1].parentCommitSha).toBe(firstCommit);
+    expect(await mock.committedSource("/content/authors.val.ts")).toContain(
+      "After the deploy",
+    );
+    expect(parseFailures(messages)).toEqual([]);
+  });
+});

--- a/e2e/http/httpMode.ts
+++ b/e2e/http/httpMode.ts
@@ -23,16 +23,20 @@ const INTAKE_TIMEOUT = 60_000;
 
 const MOCK_BASE = `http://localhost:${MOCK_CONTENT_PORT}`;
 
-/**
- * The two people the mock knows about. Ids match its `/profiles` reply, because
- * the Studio shows the name that endpoint returns for the id in the session.
- */
-export const USERS = {
-  ada: { profileId: "profile-ada", fullName: "Ada Lovelace" },
-  linus: { profileId: "profile-linus", fullName: "Linus Pauling" },
-} as const;
+/** Which of the mock's two editors a test is acting as. */
+export type UserKey = "ada" | "linus";
 
-export type UserKey = keyof typeof USERS;
+/**
+ * The profile ids of the mock's two editors.
+ *
+ * These are the `sub` of the session cookie and the `authorId` on every patch, and
+ * they have to match the ids in the mock's `/profiles` reply — that is where the
+ * Studio gets the name it shows next to a change.
+ */
+export const USERS: Record<UserKey, { profileId: string }> = {
+  ada: { profileId: "profile-ada" },
+  linus: { profileId: "profile-linus" },
+};
 
 /**
  * A signed `val_session` cookie for one profile.
@@ -274,15 +278,6 @@ export const mock = {
     });
   },
 };
-
-/** Wait until the mock is holding `count` patches. */
-export async function expectPatchCount(count: number): Promise<void> {
-  await expect
-    .poll(async () => (await mock.state()).patches.length, {
-      message: `the content service never held ${count} patch(es)`,
-    })
-    .toBe(count);
-}
 
 // #endregion
 

--- a/e2e/http/httpMode.ts
+++ b/e2e/http/httpMode.ts
@@ -109,6 +109,22 @@ export async function openHttpStudio(
   page: Page,
   route = "/val",
 ): Promise<void> {
+  /**
+   * Proof that this page really is in proxy mode.
+   *
+   * The socket exists ONLY in `http` mode — `/stat` answers `use-websocket` there
+   * and long-polls in `fs` mode — so a socket to the content host is proof the
+   * app is talking to the content service. Without this a misconfigured server
+   * would run the whole suite against `fs` mode, passing while proving nothing.
+   *
+   * Watched on THIS page rather than by counting subscribers on the mock: a
+   * socket left open by a previous test would satisfy a count and this would then
+   * assert nothing. Registered before `goto`, because the socket opens during
+   * intake and a listener added afterwards can miss it.
+   */
+  const sockets: string[] = [];
+  page.on("websocket", (socket) => sockets.push(socket.url()));
+
   await page.goto(route);
   await expect
     .poll(
@@ -125,22 +141,12 @@ export async function openHttpStudio(
       },
     )
     .toBe(true);
-  /**
-   * And confirm it really is proxy mode.
-   *
-   * Asserted on the WebSocket rather than on the system, which exposes only a
-   * `setMode` and no getter: the socket exists ONLY in `http` mode — `/stat`
-   * answers `use-websocket` there and long-polls in `fs` mode — so a subscriber
-   * on the mock is proof the app is talking to the content service. Without this
-   * a misconfigured server would run the whole suite against `fs` mode, passing
-   * while proving nothing.
-   */
   await expect
-    .poll(async () => (await mock.state()).subscribers, {
+    .poll(() => sockets, {
       timeout: INTAKE_TIMEOUT,
-      message: "the Studio never subscribed to the content service",
+      message: "this page never opened a socket to the content service",
     })
-    .toBeGreaterThan(0);
+    .toContain(`ws://localhost:${MOCK_CONTENT_PORT}/ws`);
 }
 
 // #region the mock's control plane

--- a/e2e/http/httpMode.ts
+++ b/e2e/http/httpMode.ts
@@ -1,0 +1,392 @@
+import {
+  expect,
+  type Browser,
+  type BrowserContext,
+  type Page,
+} from "@playwright/test";
+import { encodeJwt, getExpire } from "../../packages/server/src/jwt";
+import {
+  HTTP_APP_PORT,
+  MOCK_CONTENT_PORT,
+  MOCK_PROJECT,
+  MOCK_ROOT,
+  MOCK_SECRET,
+} from "./config";
+
+/**
+ * Helpers for the proxy-mode suites: who is editing, and what the content
+ * service thinks happened.
+ */
+
+/** Long enough for `next dev` to compile the Studio route on the first test. */
+const INTAKE_TIMEOUT = 60_000;
+
+const MOCK_BASE = `http://localhost:${MOCK_CONTENT_PORT}`;
+
+/**
+ * The two people the mock knows about. Ids match its `/profiles` reply, because
+ * the Studio shows the name that endpoint returns for the id in the session.
+ */
+export const USERS = {
+  ada: { profileId: "profile-ada", fullName: "Ada Lovelace" },
+  linus: { profileId: "profile-linus", fullName: "Linus Pauling" },
+} as const;
+
+export type UserKey = keyof typeof USERS;
+
+/**
+ * A signed `val_session` cookie for one profile.
+ *
+ * Minted rather than obtained by logging in. `http` mode rejects every request
+ * without a session (`getAuth` returns an error unless the cookie decodes), so
+ * *something* has to produce one, and the login round-trip goes to
+ * admin.val.build — the one part of the product a content-host mock cannot stand
+ * in for, and the part that already works.
+ *
+ * The value is percent-encoded because that is how the real server sets it:
+ * `initValServer` writes `encodeURIComponent(cookie.value)` into `Set-Cookie`,
+ * and the read side decodes. An HMAC signature is base64, so it routinely
+ * contains `+` and `/`; sending it raw decodes to a different string and the
+ * session reads as invalid — which the Studio reports as "you will need to login
+ * again", pointing nowhere near the cause.
+ */
+export function sessionCookie(user: UserKey): {
+  name: string;
+  value: string;
+  domain: string;
+  path: string;
+  expires: number;
+  httpOnly: boolean;
+  secure: boolean;
+  sameSite: "Lax";
+} {
+  const [org, project] = MOCK_PROJECT.split("/");
+  const token = encodeJwt(
+    {
+      sub: USERS[user].profileId,
+      exp: getExpire(),
+      token: "mock-val-build-token",
+      org,
+      project,
+    },
+    MOCK_SECRET,
+  );
+  return {
+    name: "val_session",
+    value: encodeURIComponent(token),
+    domain: "localhost",
+    path: "/",
+    // The full shape, because these go through `storageState` as well as
+    // `addCookies`, and `storageState` requires every field.
+    expires: getExpire(),
+    httpOnly: true,
+    secure: false,
+    sameSite: "Lax",
+  };
+}
+
+/** A browser context already logged in as one of the two users. */
+export async function contextAs(
+  browser: Browser,
+  user: UserKey,
+): Promise<BrowserContext> {
+  const context = await browser.newContext({
+    baseURL: `http://localhost:${HTTP_APP_PORT}`,
+  });
+  await context.addCookies([sessionCookie(user)]);
+  return context;
+}
+
+/**
+ * Open the Studio and wait for it to take the project in.
+ *
+ * Same wait as the `fs` suites use, but it cannot be shared with them: this one
+ * has to tolerate the extra round-trip proxy mode makes before the first `/stat`
+ * resolves, and it asserts the mode it got — a test that silently ran against
+ * `fs` mode would pass while proving nothing.
+ */
+export async function openHttpStudio(
+  page: Page,
+  route = "/val",
+): Promise<void> {
+  await page.goto(route);
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          const bag = window as unknown as {
+            __VAL_STORES__?: { received: boolean };
+          };
+          return bag.__VAL_STORES__?.received === true;
+        }),
+      {
+        timeout: INTAKE_TIMEOUT,
+        message: "the store system never took the project in",
+      },
+    )
+    .toBe(true);
+  /**
+   * And confirm it really is proxy mode.
+   *
+   * Asserted on the WebSocket rather than on the system, which exposes only a
+   * `setMode` and no getter: the socket exists ONLY in `http` mode — `/stat`
+   * answers `use-websocket` there and long-polls in `fs` mode — so a subscriber
+   * on the mock is proof the app is talking to the content service. Without this
+   * a misconfigured server would run the whole suite against `fs` mode, passing
+   * while proving nothing.
+   */
+  await expect
+    .poll(async () => (await mock.state()).subscribers, {
+      timeout: INTAKE_TIMEOUT,
+      message: "the Studio never subscribed to the content service",
+    })
+    .toBeGreaterThan(0);
+}
+
+// #region the mock's control plane
+
+export type MockPatch = {
+  patchId: string;
+  path: string;
+  authorId: string | null;
+  applied: { commitSha: string } | null;
+  parentPatchId: string | null;
+};
+
+/**
+ * One uploaded file, and whether it was uploaded as a remote file.
+ *
+ * Reported separately from the patch it belongs to because the client uploads
+ * bytes before it saves the patch — so a test can see the upload without first
+ * waiting for the patch to exist.
+ */
+export type MockPatchFile = {
+  patchId: string;
+  filePath: string;
+  type: "file" | "image";
+  remote: boolean;
+  bytes: number;
+};
+
+export type MockCommit = {
+  commitSha: string;
+  parentCommitSha: string;
+  commitMessage: string | null;
+  branch: string;
+  creator: string;
+  createdAt: string;
+};
+
+export type MockDeployment = {
+  deploymentId: string;
+  commitSha: string;
+  deploymentState: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type MockState = {
+  patches: MockPatch[];
+  patchFiles: MockPatchFile[];
+  commits: MockCommit[];
+  deployments: MockDeployment[];
+  repoOverlay: string[];
+  remoteFiles: string[];
+  headCommitSha: string;
+  subscribers: number;
+};
+
+async function control<T>(
+  action: string,
+  init?: { method: "POST"; body?: unknown },
+): Promise<T> {
+  const res = await fetch(`${MOCK_BASE}/__test__/${action}`, {
+    method: init?.method ?? "GET",
+    ...(init?.body === undefined
+      ? {}
+      : {
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(init.body),
+        }),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `mock control plane ${action} failed: ${res.status} ${await res.text()}`,
+    );
+  }
+  return (await res.json()) as T;
+}
+
+/**
+ * Everything a test can ask of, or tell, the content service.
+ *
+ * `deployment` and `pushCommit` are the reason this exists: in production those
+ * come from CI, and the Studio only ever learns about them over the WebSocket it
+ * opened. There is no editor action that produces one, so a test that wants to
+ * see the Studio react has to be able to say it happened.
+ */
+export const mock = {
+  /** Forget every patch, commit, deployment and uploaded file. */
+  async reset(): Promise<void> {
+    await control("reset", { method: "POST" });
+  },
+
+  /** What the content service currently holds. */
+  state(): Promise<MockState> {
+    return control<MockState>("state");
+  },
+
+  /** The text a commit wrote for one module, or null if no commit touched it. */
+  async committedSource(moduleFilePath: string): Promise<string | null> {
+    const res = await control<{ content: string | null }>(
+      `committed-source?path=${encodeURIComponent(`${MOCK_ROOT}${moduleFilePath}`)}`,
+    );
+    return res.content;
+  },
+
+  /** Announce a deployment, or move an existing one to a new state. */
+  deployment(body: {
+    commitSha?: string;
+    deploymentId?: string;
+    deploymentState?: string;
+  }): Promise<{ deployment: MockDeployment }> {
+    return control<{ deployment: MockDeployment }>("deployment", {
+      method: "POST",
+      body,
+    });
+  },
+
+  /** Someone pushed a commit that did not come from the Studio. */
+  pushCommit(body?: {
+    commitMessage?: string;
+    creator?: string;
+    branch?: string;
+  }): Promise<{ commit: MockCommit }> {
+    return control<{ commit: MockCommit }>("commit", {
+      method: "POST",
+      body: body ?? {},
+    });
+  },
+};
+
+/** Wait until the mock is holding `count` patches. */
+export async function expectPatchCount(count: number): Promise<void> {
+  await expect
+    .poll(async () => (await mock.state()).patches.length, {
+      message: `the content service never held ${count} patch(es)`,
+    })
+    .toBe(count);
+}
+
+// #endregion
+
+// #region driving the store from the page
+
+/**
+ * The system handle the Studio exposes in dev.
+ *
+ * Typed here rather than imported: `packages/ui` is a browser bundle and these
+ * calls are strings evaluated inside the page, so the only contract that matters
+ * is the shape at runtime.
+ */
+type StoreBag = {
+  system: {
+    patchStore: {
+      allRecords(): { patchId: string; appliedAt?: unknown }[];
+      createPatch(
+        moduleFilePath: string,
+        patch: unknown[],
+      ): Promise<
+        | { status: "created"; record: { patchId: string } }
+        | { status: string; message: string }
+      >;
+    };
+    patchSync: { flush(): Promise<void> };
+    sourceStore: { peek(path: string): unknown };
+    discard(ids: string[]): Promise<{ status: string; message?: string }>;
+    publish(
+      patchIds: string[],
+      message?: string,
+    ): Promise<{ status: string; message?: string }>;
+  };
+};
+
+/**
+ * Make one edit and wait for the server to have it.
+ *
+ * Driven through the store rather than by typing, for the same reason the `fs`
+ * suites do it: this suite is about what happens between the store and the
+ * content service, and a text input in between only adds ways to fail that have
+ * nothing to do with that.
+ */
+export async function writePatch(
+  page: Page,
+  moduleFilePath: string,
+  patch: unknown[],
+): Promise<string> {
+  return page.evaluate(
+    async ({ mfp, ops }) => {
+      const bag = window as unknown as { __VAL_STORES__: StoreBag };
+      const system = bag.__VAL_STORES__.system;
+      const res = await system.patchStore.createPatch(mfp, ops);
+      // `in` rather than a status check: the failure branch types `status` as a
+      // plain `string`, which overlaps `"created"`, so TypeScript cannot narrow.
+      if (!("record" in res)) {
+        throw new Error(`createPatch failed: ${JSON.stringify(res)}`);
+      }
+      await system.patchSync.flush();
+      return res.record.patchId;
+    },
+    { mfp: moduleFilePath, ops: patch },
+  );
+}
+
+/** What the page currently shows at one source path. */
+export function peek(page: Page, sourcePath: string): Promise<unknown> {
+  return page.evaluate((path) => {
+    const bag = window as unknown as { __VAL_STORES__: StoreBag };
+    return bag.__VAL_STORES__.system.sourceStore.peek(path);
+  }, sourcePath);
+}
+
+/** How many patches the page's own store holds. */
+export function chainLength(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const bag = window as unknown as { __VAL_STORES__?: StoreBag };
+    return bag.__VAL_STORES__?.system.patchStore.allRecords().length ?? 0;
+  });
+}
+
+/**
+ * Publish everything the page currently holds, and return what the seam said.
+ *
+ * Driven through the system rather than by clicking Publish so a failure reads as
+ * a failure of the publish path, not of whatever the button was disabled by.
+ */
+export function publishAll(
+  page: Page,
+  message?: string,
+): Promise<{ status: string; message?: string }> {
+  return page.evaluate(async (commitMessage) => {
+    const bag = window as unknown as { __VAL_STORES__: StoreBag };
+    const system = bag.__VAL_STORES__.system;
+    const ids = system.patchStore.allRecords().map((record) => record.patchId);
+    return system.publish(ids, commitMessage);
+  }, message);
+}
+
+/** Throw away every patch the page holds. */
+export async function discardAll(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const bag = window as unknown as { __VAL_STORES__: StoreBag };
+    const system = bag.__VAL_STORES__.system;
+    const ids = system.patchStore.allRecords().map((record) => record.patchId);
+    if (ids.length === 0) return;
+    const res = await system.discard(ids);
+    if (res.status !== "discarded") {
+      throw new Error(`could not discard: ${res.message ?? res.status}`);
+    }
+  });
+}
+
+// #endregion

--- a/e2e/http/publish.spec.ts
+++ b/e2e/http/publish.spec.ts
@@ -1,0 +1,173 @@
+import { expect, test } from "@playwright/test";
+import {
+  discardAll,
+  mock,
+  openHttpStudio,
+  peek,
+  publishAll,
+  sessionCookie,
+  USERS,
+  writePatch,
+} from "./httpMode";
+
+/**
+ * Publishing, in the mode where publishing means a git commit.
+ *
+ * In `fs` mode a publish writes files and deletes the patches. In `http` mode it
+ * is an HTTP call that produces a commit, the patches come back marked applied
+ * rather than deleted, and the Studio then has to stop counting them as unsaved
+ * without losing the values they carry. That difference is `ValOpsHttp` plus
+ * `PatchStore`'s applied/published handling, and none of it had a test that ran
+ * against a server.
+ *
+ * The deployment half is here for the same reason: a deployment is something CI
+ * does, arriving over a WebSocket the browser opened. No editor action produces
+ * one, so the mock's control plane produces it instead.
+ */
+
+test.use({
+  storageState: { cookies: [sessionCookie("ada")], origins: [] },
+});
+
+test.describe.configure({ mode: "serial" });
+
+test.beforeEach(async () => {
+  await mock.reset();
+});
+
+test.describe("changes and publishing in http mode", () => {
+  test("a change reaches the content service, attributed to its author", async ({
+    page,
+  }) => {
+    await openHttpStudio(page);
+    const patchId = await writePatch(page, "/content/authors.val.ts", [
+      { op: "replace", path: ["teddy", "name"], value: "Ada was here" },
+    ]);
+
+    const state = await mock.state();
+    const saved = state.patches.find((patch) => patch.patchId === patchId);
+    expect(saved, "the patch never reached the content service").toBeTruthy();
+    expect(saved?.path).toBe("/content/authors.val.ts");
+    // The author is the session's profile id, not a placeholder. This is what
+    // the Studio shows next to a change and what a commit is credited to.
+    expect(saved?.authorId).toBe(USERS.ada.profileId);
+    // Nothing is applied until a publish.
+    expect(saved?.applied).toBeNull();
+  });
+
+  /**
+   * The whole publish, and the three things it has to leave behind.
+   *
+   * The commit is the obvious one. The other two are where the bugs live: the
+   * committed source has to contain the edited value (so the change actually
+   * shipped), and the patch has to be marked applied rather than deleted (so a
+   * second publish does not try to re-apply it, and so the Studio stops calling
+   * it unsaved).
+   */
+  test("publishing commits the change and marks the patch applied", async ({
+    page,
+  }) => {
+    await openHttpStudio(page);
+    const patchId = await writePatch(page, "/content/authors.val.ts", [
+      { op: "replace", path: ["teddy", "name"], value: "Published by Ada" },
+    ]);
+
+    const published = await publishAll(page, "A change from the e2e suite");
+    expect(published.status, published.message ?? "").toBe("published");
+
+    const state = await mock.state();
+    expect(state.commits).toHaveLength(1);
+    expect(state.commits[0].commitMessage).toBe("A change from the e2e suite");
+    expect(state.commits[0].creator).toBe(USERS.ada.profileId);
+    expect(state.commits[0].parentCommitSha).toBe("mockcommit0");
+
+    const saved = state.patches.find((patch) => patch.patchId === patchId);
+    expect(
+      saved?.applied?.commitSha,
+      "the patch was not marked applied by the commit",
+    ).toBe(state.commits[0].commitSha);
+
+    const committed = await mock.committedSource("/content/authors.val.ts");
+    expect(
+      committed,
+      "the commit carried no source for the module",
+    ).toBeTruthy();
+    expect(committed).toContain("Published by Ada");
+  });
+
+  /**
+   * A second cycle, on top of the first commit.
+   *
+   * This is the case a mock that always reads from disk gets wrong: the second
+   * publish prepares against the *committed* text, so if the content service
+   * forgot the first commit the second one would either fail to apply or silently
+   * drop the first change. Asserting both values are in the second commit is
+   * what proves the chain held.
+   */
+  test("a second change publishes on top of the first commit", async ({
+    page,
+  }) => {
+    await openHttpStudio(page);
+    await writePatch(page, "/content/authors.val.ts", [
+      { op: "replace", path: ["teddy", "name"], value: "First value" },
+    ]);
+    expect((await publishAll(page, "First publish")).status).toBe("published");
+
+    await writePatch(page, "/content/authors.val.ts", [
+      { op: "replace", path: ["freekh", "name"], value: "Second value" },
+    ]);
+    const second = await publishAll(page, "Second publish");
+    expect(second.status, second.message ?? "").toBe("published");
+
+    const state = await mock.state();
+    expect(state.commits).toHaveLength(2);
+    // Fast-forward: the second commit's parent is the first commit.
+    expect(state.commits[1].parentCommitSha).toBe(state.commits[0].commitSha);
+
+    const committed = await mock.committedSource("/content/authors.val.ts");
+    expect(
+      committed,
+      "the second commit lost the first commit's change",
+    ).toContain("First value");
+    expect(committed).toContain("Second value");
+  });
+
+  test("discarding removes the patch from the content service", async ({
+    page,
+  }) => {
+    await openHttpStudio(page);
+    const patchId = await writePatch(page, "/content/authors.val.ts", [
+      { op: "replace", path: ["teddy", "name"], value: "To be discarded" },
+    ]);
+    expect((await mock.state()).patches.map((p) => p.patchId)).toContain(
+      patchId,
+    );
+
+    await discardAll(page);
+    await expect
+      .poll(async () => (await mock.state()).patches.length, {
+        message: "the discarded patch is still on the content service",
+      })
+      .toBe(0);
+
+    // And the value is back to what the module ships with — a discard has to undo
+    // the edit locally, not merely forget the patch.
+    await expect
+      .poll(() => peek(page, '/content/authors.val.ts?p="teddy"."name"'))
+      .not.toBe("To be discarded");
+  });
+
+  /**
+   * A publish that has nothing to publish is not an error.
+   *
+   * Worth a line because the publish button's disabled state is derived, and a
+   * publish path that threw here would surface as a failure the editor caused by
+   * clicking a button they were allowed to click.
+   */
+  test("publishing with no changes is a no-op", async ({ page }) => {
+    await openHttpStudio(page);
+    const res = await publishAll(page);
+    expect(res.status).toBe("nothing-to-publish");
+    expect((await mock.state()).commits).toHaveLength(0);
+  });
+});

--- a/e2e/http/remoteFiles.spec.ts
+++ b/e2e/http/remoteFiles.spec.ts
@@ -71,6 +71,21 @@ test.beforeEach(async () => {
 
 test.describe("remote files", () => {
   /**
+   * The gallery is reachable from the nav, not only from its URL.
+   *
+   * Galleries have been missing from the Media section before — `enrichNavMenuData`
+   * rebuilt the nav without carrying `media` across — and a remote gallery is a
+   * separate branch of that listing. Asserted here because the rest of this file
+   * navigates straight to the module and would not notice.
+   */
+  test("is listed under Media", async ({ page }) => {
+    await openHttpStudio(page);
+    const studio = page.locator("#val-shadow-root");
+    await studio.getByRole("button", { name: "Media", exact: true }).click();
+    await expect(studio.getByTitle(MODULE)).toBeVisible();
+  });
+
+  /**
    * An upload, and the three things that make it remote rather than local.
    *
    * The ref is a URL on the remote host, not a repo path. The bytes reach the

--- a/e2e/http/remoteFiles.spec.ts
+++ b/e2e/http/remoteFiles.spec.ts
@@ -1,0 +1,221 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+import {
+  chainLength,
+  discardAll,
+  mock,
+  openHttpStudio,
+  publishAll,
+  sessionCookie,
+} from "./httpMode";
+
+/**
+ * Remote files: uploaded to Val's file host rather than committed to the repo.
+ *
+ * This cannot be tested in `fs` mode at all. A remote upload needs
+ * `/remote/settings` to answer with a project id and a bucket, which comes from
+ * the content service; the ref the Studio builds encodes those, and the bytes go
+ * to the content host rather than to disk. Without a content service to talk to
+ * there is nothing to test.
+ *
+ * The fixture is `content/remoteImages.val.ts` — a gallery, deliberately, so
+ * that the example app can ship it. A single `s.image().remote()` field would
+ * make `hasRemoteFileSchema` true for the whole project and every `fs`-mode
+ * publish would then demand remote credentials a local checkout does not have.
+ * The upload path being exercised is the same one either way: `ModuleGallery`
+ * builds a remote ref with `createRemoteRef` and sends the bytes with
+ * `remote: true`.
+ */
+
+const MODULE = "/content/remoteImages.val.ts";
+const IMAGE = "e2e/fixtures/blue-8x8.png";
+const OTHER_IMAGE = "e2e/fixtures/green-8x8.png";
+
+test.use({
+  storageState: { cookies: [sessionCookie("ada")], origins: [] },
+});
+
+test.describe.configure({ mode: "serial" });
+
+/** The gallery's picker — never the AI chat's, which is the `multiple` one. */
+function picker(studio: Locator): Locator {
+  return studio.locator('input[type="file"]:not([multiple])');
+}
+
+/** Every `file` op path in the chain: where an upload decided to store itself. */
+function uploadedRefs(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const store = (
+      window as unknown as {
+        __VAL_STORES__: {
+          system: {
+            patchStore: {
+              allRecords(): { patch: { op: string; filePath?: string }[] }[];
+            };
+          };
+        };
+      }
+    ).__VAL_STORES__.system.patchStore;
+    return store
+      .allRecords()
+      .flatMap((record) =>
+        record.patch
+          .filter((op) => op.op === "file")
+          .map((op) => op.filePath ?? ""),
+      );
+  });
+}
+
+test.beforeEach(async () => {
+  await mock.reset();
+});
+
+test.describe("remote files", () => {
+  /**
+   * An upload, and the three things that make it remote rather than local.
+   *
+   * The ref is a URL on the remote host, not a repo path. The bytes reach the
+   * content service flagged `remote`. And the tile the editor sees comes back
+   * through `/api/val/files` with a patch id, because until the change is
+   * published there is no remote object to fetch — the file exists only inside
+   * the patch.
+   */
+  test("uploads to the content service, flagged remote, and the tile renders", async ({
+    page,
+  }) => {
+    await openHttpStudio(page, `/val/~${MODULE}`);
+    const studio = page.locator("#val-shadow-root");
+    await picker(studio).first().setInputFiles(IMAGE);
+
+    // A remote ref, not a repo path: `https://remote.val.build/file/p/...`, with
+    // the project, bucket and hashes the content service handed out.
+    const refs = await expect
+      .poll(() => uploadedRefs(page), { timeout: 30_000 })
+      .toHaveLength(1)
+      .then(() => uploadedRefs(page));
+    expect(refs[0]).toMatch(/^https:\/\/remote\.val\.build\/file\/p\//);
+    expect(refs[0], "the ref does not name the schema's directory").toContain(
+      "public/remote-images/blue-8x8_",
+    );
+
+    // The content service has the bytes, and they arrived as a remote upload.
+    await expect
+      .poll(async () => (await mock.state()).patchFiles.length, {
+        timeout: 30_000,
+        message: "the bytes never reached the content service",
+      })
+      .toBe(1);
+    const [uploaded] = (await mock.state()).patchFiles;
+    expect(uploaded.remote, "the upload was not flagged remote").toBe(true);
+    expect(uploaded.type).toBe("image");
+    expect(uploaded.bytes).toBeGreaterThan(0);
+
+    // And the editor can see it. Unpublished, so it can only come from the patch.
+    const tile = studio.locator('img[src*="blue-8x8_"]');
+    await expect(tile).toHaveCount(1);
+    await expect(tile).toHaveAttribute("src", /patch_id=/);
+    await expect
+      .poll(() => tile.evaluate((i) => (i as HTMLImageElement).naturalWidth), {
+        timeout: 20_000,
+        message: "the uploaded remote tile did not decode",
+      })
+      .toBe(8);
+  });
+
+  /**
+   * Publishing moves the bytes out to remote storage rather than into the repo.
+   *
+   * The distinction the whole feature exists for: a committed remote image must
+   * NOT appear in the commit's files, or the repository grows by every image ever
+   * uploaded, which is the problem remote files solve.
+   */
+  test("publishing moves the file to remote storage, not into the commit", async ({
+    page,
+  }) => {
+    await openHttpStudio(page, `/val/~${MODULE}`);
+    const studio = page.locator("#val-shadow-root");
+    await picker(studio).first().setInputFiles(IMAGE);
+    await expect
+      .poll(() => uploadedRefs(page), { timeout: 30_000 })
+      .toHaveLength(1);
+
+    const published = await publishAll(page, "Adding a remote image");
+    expect(published.status, published.message ?? "").toBe("published");
+
+    const state = await mock.state();
+    expect(state.commits).toHaveLength(1);
+    expect(
+      state.remoteFiles,
+      "the file was not moved to remote storage",
+    ).toHaveLength(1);
+    expect(state.remoteFiles[0]).toContain("public/remote-images/blue-8x8_");
+    // The commit carries the module's source, and no image bytes.
+    const committed = await mock.committedSource(MODULE);
+    expect(
+      committed,
+      "the commit carried no source for the gallery",
+    ).toBeTruthy();
+    expect(committed).toContain("public/remote-images/blue-8x8_");
+    expect(
+      state.repoOverlay.filter((filePath) =>
+        filePath.includes("remote-images"),
+      ),
+      "an image ended up in the repo despite being remote",
+    ).toEqual([]);
+  });
+
+  /**
+   * Deleting a remote entry.
+   *
+   * A gallery delete is a `remove` op plus a `file` op with a null value — the
+   * shape that tells the server to forget the bytes as well as the record. Done
+   * on a freshly uploaded entry rather than a committed one because that is the
+   * case the editor hits: upload, look at it, change their mind.
+   */
+  test("deletes a remote entry it just uploaded", async ({ page }) => {
+    await openHttpStudio(page, `/val/~${MODULE}`);
+    const studio = page.locator("#val-shadow-root");
+    await picker(studio).first().setInputFiles(OTHER_IMAGE);
+
+    const tile = studio.locator('img[src*="green-8x8_"]');
+    await expect(tile).toHaveCount(1);
+    await expect
+      .poll(() => tile.evaluate((i) => (i as HTMLImageElement).naturalWidth), {
+        timeout: 20_000,
+      })
+      .toBe(8);
+
+    // Delete lives in the file's properties dialog, behind a click on the tile —
+    // and it stays disabled until the reference scan has finished, because
+    // deleting a file something still points at is the mistake it guards.
+    await tile.click();
+    const remove = studio.getByRole("button", { name: "Delete", exact: true });
+    await expect(remove).toBeEnabled({ timeout: 30_000 });
+    await remove.click();
+
+    await expect(tile, "the deleted tile is still on screen").toHaveCount(0);
+    // The record is gone from the module the editor is looking at.
+    await expect
+      .poll(() =>
+        page.evaluate((mfp) => {
+          const peek = (
+            window as unknown as {
+              __VAL_STORES__: {
+                system: {
+                  sourceStore: {
+                    peek(p: string): { status: string; data?: unknown };
+                  };
+                };
+              };
+            }
+          ).__VAL_STORES__.system.sourceStore.peek(mfp);
+          return peek.status === "ready"
+            ? JSON.stringify(peek.data)
+            : peek.status;
+        }, MODULE),
+      )
+      .not.toContain("green-8x8_");
+
+    await discardAll(page);
+    await expect.poll(() => chainLength(page)).toBe(0);
+  });
+});

--- a/e2e/http/users.spec.ts
+++ b/e2e/http/users.spec.ts
@@ -1,0 +1,230 @@
+import { expect, test } from "@playwright/test";
+import {
+  chainLength,
+  contextAs,
+  mock,
+  openHttpStudio,
+  publishAll,
+  USERS,
+  writePatch,
+} from "./httpMode";
+
+/**
+ * Two editors, at once.
+ *
+ * `fs` mode has one writer by construction — a directory on a laptop — so
+ * everything about more than one person editing is `http`-mode-only: patches
+ * carry an author, the chain is single-writer and linear so a second editor's
+ * write has to name the first one's patch as its parent, and each Studio learns
+ * about the other's changes over its own WebSocket.
+ *
+ * Each user gets their own browser context because the session is a cookie: the
+ * same context is the same person, and two people is two contexts.
+ */
+
+test.describe.configure({ mode: "serial" });
+
+test.beforeEach(async () => {
+  await mock.reset();
+});
+
+test.describe("two editors at once", () => {
+  /**
+   * The chain stays linear across two editors, and each change keeps its author.
+   *
+   * Deliberately asserted on the end state rather than on the mechanism. Whether
+   * the second editor's write appends cleanly or is refused with a 409 and
+   * retried depends on whether their socket delivered the first patch first, and
+   * that is a race — but the result must not be: both patches present, one chain,
+   * each credited to the person who made it.
+   */
+  test("two editors produce one linear chain, each change attributed", async ({
+    browser,
+  }) => {
+    const adaContext = await contextAs(browser, "ada");
+    const linusContext = await contextAs(browser, "linus");
+    const ada = await adaContext.newPage();
+    const linus = await linusContext.newPage();
+    try {
+      await openHttpStudio(ada);
+      await openHttpStudio(linus);
+
+      const adaPatch = await writePatch(ada, "/content/authors.val.ts", [
+        { op: "replace", path: ["teddy", "name"], value: "Ada's edit" },
+      ]);
+      const linusPatch = await writePatch(linus, "/content/authors.val.ts", [
+        { op: "replace", path: ["freekh", "name"], value: "Linus's edit" },
+      ]);
+
+      const state = await mock.state();
+      const byId = new Map(
+        state.patches.map((patch) => [patch.patchId, patch]),
+      );
+      expect(byId.get(adaPatch)?.authorId).toBe(USERS.ada.profileId);
+      expect(byId.get(linusPatch)?.authorId).toBe(USERS.linus.profileId);
+
+      // One chain: exactly one patch has no parent, and every other patch's
+      // parent is a patch that exists.
+      const roots = state.patches.filter(
+        (patch) => patch.parentPatchId === null,
+      );
+      expect(roots, "the chain is not rooted at a single patch").toHaveLength(
+        1,
+      );
+      for (const patch of state.patches) {
+        if (patch.parentPatchId !== null) {
+          expect(
+            byId.has(patch.parentPatchId),
+            `patch ${patch.patchId} names a parent that does not exist`,
+          ).toBe(true);
+        }
+      }
+    } finally {
+      await adaContext.close();
+      await linusContext.close();
+    }
+  });
+
+  /**
+   * One editor's change reaches the other's Studio.
+   *
+   * Over the WebSocket, and only over it: `/stat`'s long-poll interval in proxy
+   * mode is twenty minutes, so nothing else could deliver this inside a test. If
+   * the socket stops working, this is the test that says so.
+   */
+  test("a change made by one editor arrives in the other's Studio", async ({
+    browser,
+  }) => {
+    const adaContext = await contextAs(browser, "ada");
+    const linusContext = await contextAs(browser, "linus");
+    const ada = await adaContext.newPage();
+    const linus = await linusContext.newPage();
+    try {
+      await openHttpStudio(ada);
+      await openHttpStudio(linus);
+      expect(await chainLength(linus)).toBe(0);
+
+      await writePatch(ada, "/content/authors.val.ts", [
+        { op: "replace", path: ["teddy", "name"], value: "Ada typed this" },
+      ]);
+
+      await expect
+        .poll(() => chainLength(linus), {
+          message: "the other editor's Studio never learned about the change",
+        })
+        .toBe(1);
+    } finally {
+      await adaContext.close();
+      await linusContext.close();
+    }
+  });
+
+  /**
+   * Publishing takes everyone's changes, credited to whoever pressed the button.
+   *
+   * That is the real contract and the surprising half of it: the commit has one
+   * committer, but the patches in it can have several authors. A publish that
+   * silently dropped the other editor's patch would look like a successful
+   * publish to both of them.
+   */
+  test("publishing commits both editors' changes, credited to the publisher", async ({
+    browser,
+  }) => {
+    const adaContext = await contextAs(browser, "ada");
+    const linusContext = await contextAs(browser, "linus");
+    const ada = await adaContext.newPage();
+    const linus = await linusContext.newPage();
+    try {
+      await openHttpStudio(ada);
+      await openHttpStudio(linus);
+
+      await writePatch(ada, "/content/authors.val.ts", [
+        { op: "replace", path: ["teddy", "name"], value: "From Ada" },
+      ]);
+      await writePatch(linus, "/content/authors.val.ts", [
+        { op: "replace", path: ["freekh", "name"], value: "From Linus" },
+      ]);
+
+      // Linus publishes. Wait until his Studio holds both patches, or he would
+      // publish only his own and the test would prove nothing.
+      await expect.poll(() => chainLength(linus)).toBe(2);
+      const published = await publishAll(linus, "Published by Linus");
+      expect(published.status, published.message ?? "").toBe("published");
+
+      const state = await mock.state();
+      expect(state.commits).toHaveLength(1);
+      expect(state.commits[0].creator).toBe(USERS.linus.profileId);
+      for (const patch of state.patches) {
+        expect(
+          patch.applied?.commitSha,
+          `patch ${patch.patchId} by ${patch.authorId} was not in the commit`,
+        ).toBe(state.commits[0].commitSha);
+      }
+      const committed = await mock.committedSource("/content/authors.val.ts");
+      expect(committed).toContain("From Ada");
+      expect(committed).toContain("From Linus");
+    } finally {
+      await adaContext.close();
+      await linusContext.close();
+    }
+  });
+
+  /**
+   * A change one editor discards disappears from the other's Studio too.
+   *
+   * The inverse of the arrival test, and the one that catches a store which adds
+   * foreign patches but never removes them — the state that makes the publish
+   * button think there is something to publish forever.
+   */
+  test("a change one editor discards leaves the other's Studio", async ({
+    browser,
+  }) => {
+    const adaContext = await contextAs(browser, "ada");
+    const linusContext = await contextAs(browser, "linus");
+    const ada = await adaContext.newPage();
+    const linus = await linusContext.newPage();
+    try {
+      await openHttpStudio(ada);
+      await openHttpStudio(linus);
+
+      await writePatch(ada, "/content/authors.val.ts", [
+        { op: "replace", path: ["teddy", "name"], value: "Briefly" },
+      ]);
+      await expect.poll(() => chainLength(linus)).toBe(1);
+
+      await ada.evaluate(async () => {
+        const bag = window as unknown as {
+          __VAL_STORES__: {
+            system: {
+              patchStore: { allRecords(): { patchId: string }[] };
+              discard(
+                ids: string[],
+              ): Promise<{ status: string; message?: string }>;
+            };
+          };
+        };
+        const system = bag.__VAL_STORES__.system;
+        const ids = system.patchStore
+          .allRecords()
+          .map((record) => record.patchId);
+        const res = await system.discard(ids);
+        if (res.status !== "discarded") {
+          throw new Error(`could not discard: ${res.message ?? res.status}`);
+        }
+      });
+
+      await expect
+        .poll(async () => (await mock.state()).patches.length)
+        .toBe(0);
+      await expect
+        .poll(() => chainLength(linus), {
+          message:
+            "the other editor's Studio still holds a patch that was discarded",
+        })
+        .toBe(0);
+    } finally {
+      await adaContext.close();
+      await linusContext.close();
+    }
+  });
+});

--- a/e2e/mock-content-host/server.ts
+++ b/e2e/mock-content-host/server.ts
@@ -298,6 +298,18 @@ function headPatchId(): string | null {
   return last;
 }
 
+/**
+ * Tell every subscriber what the chain is now.
+ *
+ * The WHOLE chain, not the ids that just changed: `useStatus` handles a `patches`
+ * message by REPLACING `stat.data.patches` with what the message carries, so
+ * sending only the new id would announce that every other patch had vanished.
+ * Anything that adds to or removes from the chain has to call this.
+ */
+function broadcastChain(): void {
+  broadcast({ type: "patches", patches: [...state.patches.keys()] });
+}
+
 function broadcast(message: unknown): void {
   const payload = JSON.stringify(message);
   for (const socket of sockets) {
@@ -453,7 +465,7 @@ const savePatch: Handler = async (req, res) => {
     parentPatchId: body.parentPatchId ?? null,
     applied: null,
   });
-  broadcast({ type: "patches", patches: [body.patchId] });
+  broadcastChain();
   json(res, 200, { patchId: body.patchId });
 };
 
@@ -465,6 +477,7 @@ const deletePatches: Handler = async (req, res) => {
     state.patches.delete(patchId);
     state.patchFiles.delete(patchId);
   }
+  broadcastChain();
   // Every id comes back as deleted, including ones that were already gone: a
   // patch someone else removed first is absent either way, and reporting that
   // as a failure would make an ordinary discard look broken.
@@ -684,6 +697,9 @@ const commit: Handler = async (req, res) => {
   state.commits.push(record);
   state.headCommitSha = commitSha;
   broadcast({ type: "commit", commit: record });
+  // The patches are still in the chain, now applied. Announced so a second
+  // editor's Studio learns they were published rather than still pending.
+  broadcastChain();
   json(res, 200, {
     updatedFiles: Object.keys(body.patchedSourceFiles ?? {}),
     commit: commitSha,
@@ -814,7 +830,13 @@ const controlPlane: Handler = async (req, res, url) => {
       json(res, 400, { message: "path is required" });
       return;
     }
-    json(res, 200, { content: state.repoOverlay.get(key) ?? null });
+    const overlaid = state.repoOverlay.get(key);
+    json(res, 200, {
+      // Text only: this endpoint exists for asserting on committed source, and
+      // an image's bytes are stored base64 — handing those back as `content`
+      // would be neither readable nor safe to compare.
+      content: overlaid && overlaid.encoding === "utf8" ? overlaid.value : null,
+    });
     return;
   }
   if (action === "deployment" && req.method === "POST") {

--- a/e2e/mock-content-host/server.ts
+++ b/e2e/mock-content-host/server.ts
@@ -163,8 +163,17 @@ type State = {
    * `null` means the commit deleted the file. Read back by `PUT /files` with
    * `location: "repo"`, so a second publish prepares against the first one's
    * result rather than against whatever is on disk.
+   *
+   * The encoding travels with the value because a commit carries two different
+   * kinds of file: source text, which arrives as a string, and image bytes, which
+   * arrive as base64. Storing both as "a string" and reading both back as UTF-8
+   * silently corrupts every byte outside ASCII — so the bytes are kept as base64
+   * and only decoded on the way out.
    */
-  repoOverlay: Map<string, string | null>;
+  repoOverlay: Map<
+    string,
+    { encoding: "utf8" | "base64"; value: string } | null
+  >;
   /** Bytes of files a commit moved out to remote storage, keyed by remote ref. */
   remoteFiles: Map<string, string>;
   /** Nonces handed out by `presigned-auth-nonce` and `websocket/nonces`. */
@@ -190,6 +199,16 @@ let state = emptyState();
 
 /** Every subscribed browser. Written to by the control plane and by commits. */
 const sockets = new Set<WebSocket>();
+
+/**
+ * The `Origin` of the request each response belongs to.
+ *
+ * A side table rather than a property hung off the response, so that
+ * `corsHeaders` can reflect the caller's origin back without a cast: the browser
+ * sends credentials with its uploads, and `Access-Control-Allow-Origin: *` is not
+ * allowed to be combined with `Allow-Credentials`.
+ */
+const requestOrigins = new WeakMap<ServerResponse, string>();
 
 // #endregion
 
@@ -221,7 +240,7 @@ function json(res: ServerResponse, status: number, body: unknown): void {
  * what the Studio shows for that is a stuck progress bar, not an error.
  */
 function corsHeaders(res: ServerResponse): Record<string, string> {
-  const origin = (res as ServerResponse & { __origin?: string }).__origin;
+  const origin = requestOrigins.get(res);
   return {
     "Access-Control-Allow-Origin": origin ?? "*",
     "Access-Control-Allow-Credentials": "true",
@@ -327,7 +346,13 @@ async function readRepoFile(
     if (overlaid === null) {
       return { error: `File was deleted by a commit: ${key}` };
     }
-    return { value: Buffer.from(overlaid, "utf-8").toString("base64") };
+    // A repo read answers with plain base64, whatever the value was stored as.
+    return {
+      value:
+        overlaid.encoding === "base64"
+          ? overlaid.value
+          : Buffer.from(overlaid.value, "utf-8").toString("base64"),
+    };
   }
   const onDisk = path.join(REPO_ROOT, key);
   try {
@@ -607,7 +632,10 @@ const commit: Handler = async (req, res) => {
   for (const [filePath, content] of Object.entries(
     body.patchedSourceFiles ?? {},
   )) {
-    state.repoOverlay.set(path.posix.join(body.root || "/", filePath), content);
+    state.repoOverlay.set(
+      path.posix.join(body.root || "/", filePath),
+      content === null ? null : { encoding: "utf8", value: content },
+    );
   }
   for (const [filePath, descriptor] of Object.entries(
     body.patchedBinaryFilesDescriptors ?? {},
@@ -630,10 +658,10 @@ const commit: Handler = async (req, res) => {
     if (descriptor.remote) {
       state.remoteFiles.set(filePath, base64);
     } else {
-      state.repoOverlay.set(
-        path.posix.join(body.root || "/", filePath),
-        Buffer.from(base64, "base64").toString("binary"),
-      );
+      state.repoOverlay.set(path.posix.join(body.root || "/", filePath), {
+        encoding: "base64",
+        value: base64,
+      });
     }
   }
   for (const patchIds of Object.values(body.appliedPatches ?? {})) {
@@ -852,7 +880,7 @@ const controlPlane: Handler = async (req, res, url) => {
 const server = createServer((req, res) => {
   const origin = req.headers.origin;
   if (typeof origin === "string") {
-    (res as ServerResponse & { __origin?: string }).__origin = origin;
+    requestOrigins.set(res, origin);
   }
   void handle(req, res).catch((err) => {
     console.error("[mock-content-host] unhandled error", err);

--- a/e2e/mock-content-host/server.ts
+++ b/e2e/mock-content-host/server.ts
@@ -1,0 +1,986 @@
+/**
+ * A fake content.val.build, for the tests that cannot run without one.
+ *
+ * ## Why this exists
+ *
+ * Everything else in `e2e/` drives the Studio in `fs` mode, where the "content
+ * host" is a directory on disk. That covers the editing surface, but it leaves a
+ * whole half of the product untested: in `http` mode (what a deployed app runs)
+ * `ValOpsHttp` is the only thing between the Studio and the content service, a
+ * publish becomes a git commit through an HTTP call, patches are marked applied
+ * rather than deleted, and deployment and build progress arrive over a WebSocket
+ * the browser opens itself. None of that has a filesystem equivalent, so none of
+ * it was covered.
+ *
+ * So: an in-memory content service, faithful to the wire protocol
+ * `packages/server/src/ValOpsHttp.ts` speaks, plus a `/__test__` control plane
+ * that lets a test say "a deployment just started" or "someone pushed a commit"
+ * — the two events the Studio reacts to that no editor action can produce.
+ *
+ * ## Why a separate process rather than request interception
+ *
+ * `page.route` cannot see any of this. The `ValOpsHttp` calls are made by the
+ * Next server, in its own process; only the direct file upload and the WebSocket
+ * are made by the browser. Intercepting in the page would mock two endpoints out
+ * of thirteen and leave the interesting ones untouched.
+ *
+ * ## Who calls what
+ *
+ * Next (`Authorization: Bearer <apiKey>`):
+ *   GET    /v1/{project}/applicable/patches
+ *   POST   /v1/{project}/patches
+ *   DELETE /v1/{project}/patches
+ *   GET    /v1/{project}/patches/{patchId}/files      (metadata)
+ *   PUT    /v1/{project}/files                        (read repo + patch files)
+ *   POST   /v1/{project}/commit
+ *   POST   /v1/{project}/commit-summary
+ *   POST   /v1/{project}/presigned-auth-nonce
+ *   POST   /v1/{project}/websocket/nonces
+ *   GET    /v1/{project}/settings
+ *   GET    /v1/{project}/profiles
+ *
+ * The browser, cross-origin, with `x-val-auth-nonce`:
+ *   POST   /v1/{project}/patches/{patchId}/files      (the bytes of an upload)
+ *   WS     /ws                                        (patches, commits, deployments)
+ *
+ * ## What it deliberately does not do
+ *
+ * No git. A commit records the source text it was handed in an overlay that
+ * `PUT /files` reads back, which is enough for a second publish to see the first
+ * one's result. The Studio's own sources still come from the modules the Next
+ * process imported at startup, exactly as in production between a commit and the
+ * deploy that follows it — so after a publish the page shows the pre-publish
+ * value until something reloads it. That divergence is real, not an artifact.
+ *
+ * No auth flow. `http` mode rejects any request without a session, so the tests
+ * mint the `val_session` cookie directly (see `e2e/httpMode.ts`). Login has its
+ * own coverage and is not what these tests are for.
+ */
+import { createHash, randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import path from "node:path";
+import { WebSocketServer, type WebSocket } from "ws";
+
+// #region config
+
+const PORT = Number(process.env.MOCK_CONTENT_PORT ?? 4567);
+const API_KEY = process.env.MOCK_CONTENT_API_KEY ?? "mock-api-key";
+const PROJECT =
+  process.env.MOCK_CONTENT_PROJECT ?? "valbuild/val-examples-next";
+const PUBLIC_PROJECT_ID =
+  process.env.MOCK_CONTENT_PUBLIC_PROJECT_ID ?? "mockproj";
+/** Where the repo is on disk, so `location: "repo"` reads can be served. */
+const REPO_ROOT = process.env.MOCK_CONTENT_REPO_ROOT ?? process.cwd();
+
+/**
+ * The people who can be editing.
+ *
+ * Fixed rather than generated: a test asserts on the name shown next to a
+ * change, and the profile id is also the `sub` of the session cookie it mints,
+ * so both ends have to agree on the list.
+ */
+const PROFILES = [
+  {
+    profileId: "profile-ada",
+    fullName: "Ada Lovelace",
+    email: "ada@example.com",
+    avatar: null,
+  },
+  {
+    profileId: "profile-linus",
+    fullName: "Linus Pauling",
+    email: "linus@example.com",
+    avatar: null,
+  },
+] as const;
+
+// #endregion
+
+// #region state
+
+type MockPatchFile = {
+  /** A base64 data URL, the shape `bufferFromDataUrl` expects. */
+  data: string;
+  type: "file" | "image";
+  metadata: unknown;
+  remote: boolean;
+};
+
+type MockPatch = {
+  patchId: string;
+  path: string;
+  patch: unknown;
+  authorId: string | null;
+  baseSha: string;
+  createdAt: string;
+  parentPatchId: string | null;
+  /** Set by a commit. The client reads this as `appliedAt`. */
+  applied: { commitSha: string } | null;
+};
+
+type MockCommit = {
+  commitSha: string;
+  clientCommitSha: string;
+  parentCommitSha: string;
+  commitMessage: string | null;
+  branch: string;
+  creator: string;
+  createdAt: string;
+};
+
+type MockDeployment = {
+  deploymentId: string;
+  commitSha: string;
+  deploymentState: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type State = {
+  /** Insertion-ordered: this is the patch chain. */
+  patches: Map<string, MockPatch>;
+  /**
+   * Uploaded bytes, keyed by patch id and then by file path.
+   *
+   * Kept apart from the patch records because the client uploads a patch's files
+   * BEFORE it saves the patch — so for a moment there are bytes belonging to a
+   * patch that does not exist yet. Holding them inside the patch map meant
+   * inventing a placeholder patch, and that placeholder then became the head of
+   * the chain (so the real save was refused as a conflict) and was handed out by
+   * `applicable/patches` with no ops (so `/save` crashed on it).
+   */
+  patchFiles: Map<string, Map<string, MockPatchFile>>;
+  commits: MockCommit[];
+  deployments: MockDeployment[];
+  /**
+   * Committed file content, layered over the working tree.
+   *
+   * `null` means the commit deleted the file. Read back by `PUT /files` with
+   * `location: "repo"`, so a second publish prepares against the first one's
+   * result rather than against whatever is on disk.
+   */
+  repoOverlay: Map<string, string | null>;
+  /** Bytes of files a commit moved out to remote storage, keyed by remote ref. */
+  remoteFiles: Map<string, string>;
+  /** Nonces handed out by `presigned-auth-nonce` and `websocket/nonces`. */
+  nonces: Set<string>;
+  /** The commit the mock considers current, i.e. what a new build would carry. */
+  headCommitSha: string;
+};
+
+function emptyState(): State {
+  return {
+    patches: new Map(),
+    patchFiles: new Map(),
+    commits: [],
+    deployments: [],
+    repoOverlay: new Map(),
+    remoteFiles: new Map(),
+    nonces: new Set(),
+    headCommitSha: process.env.MOCK_CONTENT_INITIAL_COMMIT ?? "mockcommit0",
+  };
+}
+
+let state = emptyState();
+
+/** Every subscribed browser. Written to by the control plane and by commits. */
+const sockets = new Set<WebSocket>();
+
+// #endregion
+
+// #region helpers
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function sha(input: string): string {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+function json(res: ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    "Content-Length": Buffer.byteLength(payload),
+    ...corsHeaders(res),
+  });
+  res.end(payload);
+}
+
+/**
+ * CORS, because the browser uploads patch files straight to this host.
+ *
+ * `x-val-auth-nonce` has to be allowed explicitly: it is not a CORS-safelisted
+ * header, so without it the preflight fails and the upload never happens — and
+ * what the Studio shows for that is a stuck progress bar, not an error.
+ */
+function corsHeaders(res: ServerResponse): Record<string, string> {
+  const origin = (res as ServerResponse & { __origin?: string }).__origin;
+  return {
+    "Access-Control-Allow-Origin": origin ?? "*",
+    "Access-Control-Allow-Credentials": "true",
+    "Access-Control-Allow-Headers":
+      "content-type, authorization, x-val-pat, x-val-auth-nonce",
+    "Access-Control-Allow-Methods": "GET, PUT, POST, DELETE, OPTIONS",
+  };
+}
+
+async function readBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+async function readJsonBody<T>(req: IncomingMessage): Promise<T | undefined> {
+  const raw = await readBody(req);
+  if (!raw) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Whether a request is allowed to talk to the content service.
+ *
+ * Checked against the configured key rather than merely required to be present:
+ * a wrongly wired `VAL_API_KEY` is a real failure mode, and one that otherwise
+ * shows up as an empty patch list.
+ */
+function authorized(req: IncomingMessage): boolean {
+  const auth = req.headers["authorization"];
+  if (typeof auth === "string" && auth === `Bearer ${API_KEY}`) {
+    return true;
+  }
+  if (typeof req.headers["x-val-pat"] === "string") {
+    return true;
+  }
+  const nonce = req.headers["x-val-auth-nonce"];
+  return typeof nonce === "string" && state.nonces.has(nonce);
+}
+
+/** The last patch in the chain, which is what a new patch must name as parent. */
+function headPatchId(): string | null {
+  let last: string | null = null;
+  for (const patchId of state.patches.keys()) {
+    last = patchId;
+  }
+  return last;
+}
+
+function broadcast(message: unknown): void {
+  const payload = JSON.stringify(message);
+  for (const socket of sockets) {
+    if (socket.readyState === socket.OPEN) {
+      socket.send(payload);
+    }
+  }
+}
+
+/**
+ * The path inside a remote ref, or null if this is not one.
+ *
+ * The two ends of a remote upload disagree about keys, and the content service is
+ * what reconciles them: the browser uploads bytes under the FILE PATH (the store
+ * splits the ref before sending), while `prepare` describes the file to commit by
+ * its full REF. So a commit that names
+ * `https://remote.val.build/file/p/{project}/b/{bucket}/v/{version}/h/{hash}/f/{fileHash}/p/public/x/y.png`
+ * has to find bytes stored under `/public/x/y.png`.
+ *
+ * The pattern mirrors `Internal.remote.splitRemoteRef`, duplicated rather than
+ * imported because `@valbuild/core` is not resolvable from the repository root
+ * and the mock is meant to run with nothing built.
+ */
+const REMOTE_REF =
+  /^https?:\/\/[^/]+\/file\/p\/[^/]+\/b\/[^/]+\/v\/[^/]+\/h\/[^/]+\/f\/[^/]+\/p\/(public\/.+)$/;
+
+function pathInRemoteRef(ref: string): string | null {
+  const match = ref.match(REMOTE_REF);
+  return match ? `/${match[1]}` : null;
+}
+
+/**
+ * Read a repo file: the overlay if a commit wrote it, otherwise the working tree.
+ *
+ * `root` comes from the request (`val.config`'s `root`, e.g. `/examples/next`)
+ * and `filePath` is module-relative, so the two have to be joined here rather
+ * than baked into `REPO_ROOT`.
+ */
+async function readRepoFile(
+  root: string,
+  filePath: string,
+): Promise<{ value: string } | { error: string }> {
+  const key = path.posix.join(root || "/", filePath);
+  const overlaid = state.repoOverlay.get(key);
+  if (overlaid !== undefined) {
+    if (overlaid === null) {
+      return { error: `File was deleted by a commit: ${key}` };
+    }
+    return { value: Buffer.from(overlaid, "utf-8").toString("base64") };
+  }
+  const onDisk = path.join(REPO_ROOT, key);
+  try {
+    const bytes = await readFile(onDisk);
+    return { value: bytes.toString("base64") };
+  } catch (err) {
+    return {
+      error: `Could not read ${key}: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+// #endregion
+
+// #region endpoints
+
+type Handler = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: URL,
+) => Promise<void> | void;
+
+/**
+ * `GET /v1/{project}/applicable/patches`
+ *
+ * The whole chain, in order, optionally filtered to `patch_id`s and optionally
+ * without the ops. Commits and deployments ride along on the same response —
+ * that is where `/stat` gets them from, and in turn where the Studio's
+ * deployment banner comes from.
+ */
+const getApplicablePatches: Handler = (req, res, url) => {
+  const requested = url.searchParams.getAll("patch_id");
+  const excludeOps = url.searchParams.get("exclude_patch_ops") === "true";
+  const wanted = requested.length > 0 ? new Set(requested) : null;
+  const patches = [];
+  for (const patch of state.patches.values()) {
+    if (wanted && !wanted.has(patch.patchId)) {
+      continue;
+    }
+    patches.push({
+      path: patch.path,
+      patch: excludeOps ? null : patch.patch,
+      patchId: patch.patchId,
+      authorId: patch.authorId,
+      baseSha: patch.baseSha,
+      createdAt: patch.createdAt,
+      applied: patch.applied,
+    });
+  }
+  json(res, 200, {
+    patches,
+    commits: state.commits,
+    deployments: state.deployments,
+  });
+};
+
+/**
+ * `POST /v1/{project}/patches` — save one patch.
+ *
+ * The parent check is the real contract, not decoration: the chain is linear and
+ * single-writer, and a patch whose parent is no longer the head is a 409 the
+ * client is built to recover from. Two editors racing is the case that produces
+ * it, which is exactly one of the things these tests are for.
+ */
+const savePatch: Handler = async (req, res) => {
+  const body = await readJsonBody<{
+    path: string;
+    patch: unknown;
+    authorId: string | null;
+    patchId: string;
+    parentPatchId: string | null;
+    baseSha: string;
+  }>(req);
+  if (!body || typeof body.patchId !== "string") {
+    json(res, 400, { message: "Invalid save-patch body" });
+    return;
+  }
+  if (state.patches.has(body.patchId)) {
+    // Idempotent: the client retries a save it did not get an answer to.
+    json(res, 200, { patchId: body.patchId });
+    return;
+  }
+  const head = headPatchId();
+  if ((body.parentPatchId ?? null) !== head) {
+    res.writeHead(409, { "Content-Type": "text/plain", ...corsHeaders(res) });
+    res.end(
+      `Parent patch ${body.parentPatchId ?? "<head>"} is not the head of the chain (${head ?? "<empty>"})`,
+    );
+    return;
+  }
+  state.patches.set(body.patchId, {
+    patchId: body.patchId,
+    path: body.path,
+    patch: body.patch,
+    authorId: body.authorId ?? null,
+    baseSha: body.baseSha,
+    createdAt: nowIso(),
+    parentPatchId: body.parentPatchId ?? null,
+    applied: null,
+  });
+  broadcast({ type: "patches", patches: [body.patchId] });
+  json(res, 200, { patchId: body.patchId });
+};
+
+/** `DELETE /v1/{project}/patches` — what discard and the auto-delete path call. */
+const deletePatches: Handler = async (req, res) => {
+  const body = await readJsonBody<{ patchIds: string[] }>(req);
+  const ids = body?.patchIds ?? [];
+  for (const patchId of ids) {
+    state.patches.delete(patchId);
+    state.patchFiles.delete(patchId);
+  }
+  // Every id comes back as deleted, including ones that were already gone: a
+  // patch someone else removed first is absent either way, and reporting that
+  // as a failure would make an ordinary discard look broken.
+  json(res, 200, { deleted: ids });
+};
+
+/**
+ * `POST /v1/{project}/patches/{patchId}/files` — the bytes of an upload.
+ *
+ * Called by the browser directly in `http` mode (the Next server only proxies
+ * this for AI-generated images), so this is the one write path that arrives
+ * cross-origin with a nonce instead of the api key.
+ */
+const savePatchFile: Handler = async (req, res, url) => {
+  const patchId = url.pathname.split("/").at(-2);
+  const body = await readJsonBody<{
+    filePath: string;
+    data: string;
+    type: "file" | "image";
+    metadata: unknown;
+    remote?: boolean;
+  }>(req);
+  if (!patchId || !body || typeof body.filePath !== "string") {
+    json(res, 400, { message: "Invalid save-patch-file body" });
+    return;
+  }
+  // The patch itself may not exist yet — the client uploads bytes first and saves
+  // the patch afterwards — so this never touches the patch map.
+  let files = state.patchFiles.get(patchId);
+  if (!files) {
+    files = new Map();
+    state.patchFiles.set(patchId, files);
+  }
+  files.set(body.filePath, {
+    data: body.data,
+    type: body.type,
+    metadata: body.metadata,
+    remote: body.remote === true,
+  });
+  json(res, 200, { patchId, filePath: body.filePath });
+};
+
+/** `GET /v1/{project}/patches/{patchId}/files?file_path=&remote=` — metadata only. */
+const getPatchFileMetadata: Handler = (req, res, url) => {
+  const patchId = url.pathname.split("/").at(-2);
+  const filePath = url.searchParams.get("file_path");
+  if (!patchId || !filePath) {
+    json(res, 400, { message: "file_path is required" });
+    return;
+  }
+  const file = state.patchFiles.get(patchId)?.get(filePath);
+  if (!file) {
+    json(res, 404, { message: `No file ${filePath} in patch ${patchId}` });
+    return;
+  }
+  json(res, 200, { filePath, metadata: file.metadata, type: file.type });
+};
+
+/**
+ * `PUT /v1/{project}/files` — read files, from the repo or from a patch.
+ *
+ * PUT with a body because the request is a list of files; that is the real
+ * protocol, oddity included. Note the two encodings the caller expects: a repo
+ * file comes back as plain base64 and a patch file as the base64 data URL it was
+ * uploaded as.
+ */
+const getFiles: Handler = async (req, res) => {
+  const body = await readJsonBody<{
+    files: (
+      | {
+          filePath: string;
+          location: "patch";
+          patchId: string;
+          remote: boolean;
+        }
+      | { filePath: string; location: "repo"; root: string; commitSha: string }
+    )[];
+    root: string;
+  }>(req);
+  if (!body || !Array.isArray(body.files)) {
+    json(res, 400, { message: "Invalid files body" });
+    return;
+  }
+  const files = [];
+  const errors = [];
+  for (const requested of body.files) {
+    if (requested.location === "patch") {
+      const file = state.patchFiles
+        .get(requested.patchId)
+        ?.get(requested.filePath);
+      if (!file) {
+        errors.push({
+          filePath: requested.filePath,
+          location: "patch" as const,
+          patchId: requested.patchId,
+          remote: requested.remote,
+          message: `No file ${requested.filePath} in patch ${requested.patchId}`,
+        });
+        continue;
+      }
+      files.push({
+        filePath: requested.filePath,
+        location: "patch" as const,
+        patchId: requested.patchId,
+        remote: requested.remote,
+        value: file.data,
+      });
+      continue;
+    }
+    const read = await readRepoFile(
+      requested.root ?? body.root ?? "",
+      requested.filePath,
+    );
+    if ("error" in read) {
+      errors.push({
+        filePath: requested.filePath,
+        location: "repo" as const,
+        commitSha: requested.commitSha,
+        message: read.error,
+      });
+      continue;
+    }
+    files.push({
+      filePath: requested.filePath,
+      location: "repo" as const,
+      commitSha: requested.commitSha,
+      value: read.value,
+    });
+  }
+  json(res, 200, errors.length > 0 ? { files, errors } : { files });
+};
+
+/**
+ * `POST /v1/{project}/commit` — publish.
+ *
+ * Four things happen, and the tests depend on all of them: the source text lands
+ * in the overlay, uploaded binaries move from their patch into the repo (or into
+ * remote storage), the patches involved are marked applied rather than deleted,
+ * and a commit record appears — which is what turns into a row in the Studio's
+ * deployment list on the next `/stat`.
+ */
+const commit: Handler = async (req, res) => {
+  const body = await readJsonBody<{
+    patchedSourceFiles: Record<string, string | null>;
+    patchedBinaryFilesDescriptors: Record<
+      string,
+      { patchId: string; remote: boolean }
+    >;
+    appliedPatches: Record<string, string[]>;
+    root: string;
+    message: string;
+    committer: string;
+    existingBranch: string;
+    newBranch?: string;
+  }>(req);
+  if (!body) {
+    json(res, 400, { message: "Invalid commit body" });
+    return;
+  }
+  const parentCommitSha = state.headCommitSha;
+  const commitSha = sha(
+    `${parentCommitSha}:${JSON.stringify(body.patchedSourceFiles)}:${state.commits.length}`,
+  ).slice(0, 40);
+
+  for (const [filePath, content] of Object.entries(
+    body.patchedSourceFiles ?? {},
+  )) {
+    state.repoOverlay.set(path.posix.join(body.root || "/", filePath), content);
+  }
+  for (const [filePath, descriptor] of Object.entries(
+    body.patchedBinaryFilesDescriptors ?? {},
+  )) {
+    // A remote descriptor names the ref; the bytes were uploaded under the path
+    // inside it. See `pathInRemoteRef`.
+    const storedAs = pathInRemoteRef(filePath) ?? filePath;
+    const file = state.patchFiles.get(descriptor.patchId)?.get(storedAs);
+    if (!file) {
+      // Logged as well as returned: `ValOpsHttp.commit` runs its error body
+      // through `getErrorMessageFromUnknownJson` after zod has already wrapped
+      // it, so the caller only ever sees "Unknown error" and the reason has to
+      // be found here.
+      const message = `Commit references a file that was never uploaded: ${filePath} (looked for ${storedAs} in patch ${descriptor.patchId}). Uploaded for that patch: ${JSON.stringify([...(state.patchFiles.get(descriptor.patchId)?.keys() ?? [])])}`;
+      console.error(`[mock-content-host] ${message}`);
+      json(res, 400, { message });
+      return;
+    }
+    const base64 = file.data.slice(file.data.indexOf(",") + 1);
+    if (descriptor.remote) {
+      state.remoteFiles.set(filePath, base64);
+    } else {
+      state.repoOverlay.set(
+        path.posix.join(body.root || "/", filePath),
+        Buffer.from(base64, "base64").toString("binary"),
+      );
+    }
+  }
+  for (const patchIds of Object.values(body.appliedPatches ?? {})) {
+    for (const patchId of patchIds) {
+      const patch = state.patches.get(patchId);
+      if (patch) {
+        patch.applied = { commitSha };
+      }
+    }
+  }
+  const record: MockCommit = {
+    commitSha,
+    clientCommitSha: commitSha,
+    parentCommitSha,
+    commitMessage: body.message ?? null,
+    branch: body.newBranch || body.existingBranch,
+    creator: body.committer,
+    createdAt: nowIso(),
+  };
+  state.commits.push(record);
+  state.headCommitSha = commitSha;
+  broadcast({ type: "commit", commit: record });
+  json(res, 200, {
+    updatedFiles: Object.keys(body.patchedSourceFiles ?? {}),
+    commit: commitSha,
+    branch: record.branch,
+  });
+};
+
+/** `POST /v1/{project}/commit-summary` — the AI-written publish message. */
+const commitSummary: Handler = (req, res) => {
+  json(res, 200, { commitSummary: "Mock summary of the changes" });
+};
+
+/**
+ * `POST /v1/{project}/presigned-auth-nonce`
+ *
+ * What lets the browser upload without ever holding the api key. The nonce it
+ * hands back is the credential `savePatchFile` accepts.
+ */
+const presignedAuthNonce: Handler = (req, res) => {
+  const nonce = randomUUID();
+  state.nonces.add(nonce);
+  json(res, 200, {
+    nonce,
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+  });
+};
+
+/**
+ * `POST /v1/{project}/websocket/nonces`
+ *
+ * The reply decides where the browser opens its socket, so the url has to be one
+ * the browser can reach — this host, not an internal name.
+ */
+const websocketNonce: Handler = (req, res) => {
+  const nonce = randomUUID();
+  state.nonces.add(nonce);
+  json(res, 200, { nonce, url: `ws://localhost:${PORT}/ws` });
+};
+
+/** `GET /v1/{project}/settings` — where remote files are allowed to live. */
+const settings: Handler = (req, res) => {
+  json(res, 200, {
+    publicProjectId: PUBLIC_PROJECT_ID,
+    remoteFileBuckets: [{ bucket: "mock-bucket" }],
+  });
+};
+
+/** `GET /v1/{project}/profiles` — who the Studio shows next to a change. */
+const profiles: Handler = (req, res) => {
+  json(res, 200, { profiles: PROFILES });
+};
+
+/**
+ * `PUT /v1/{project}/remote/files/b/{bucket}/f/{hash}.{ext}`
+ *
+ * Only `fs` mode uploads this way (the content service does it itself at commit
+ * time in `http` mode), but it is here so a mixed-mode run does not 404.
+ */
+const putRemoteFile: Handler = async (req, res, url) => {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(chunk as Buffer);
+  }
+  state.remoteFiles.set(url.pathname, Buffer.concat(chunks).toString("base64"));
+  json(res, 200, { success: true });
+};
+
+// #endregion
+
+// #region control plane
+
+/**
+ * `/__test__/*` — the events no editor action can produce.
+ *
+ * Deployments and pushed commits come from CI in production. A test that wants
+ * to see the Studio react to one has to be able to say so, and this is where it
+ * says it. Everything here also pushes down the WebSocket, because that is how a
+ * running Studio finds out.
+ */
+const controlPlane: Handler = async (req, res, url) => {
+  const action = url.pathname.slice("/__test__/".length);
+  if (action === "reset" && req.method === "POST") {
+    state = emptyState();
+    json(res, 200, { ok: true });
+    return;
+  }
+  if (action === "state" && req.method === "GET") {
+    json(res, 200, {
+      patches: [...state.patches.values()].map((patch) => ({
+        patchId: patch.patchId,
+        path: patch.path,
+        authorId: patch.authorId,
+        applied: patch.applied,
+        parentPatchId: patch.parentPatchId,
+      })),
+      /**
+       * Every uploaded file, whatever state its patch is in.
+       *
+       * Top-level rather than nested under its patch so a test can assert on an
+       * upload without first waiting for the patch to be saved — and the `remote`
+       * flag is here because it is the only way to tell a remote upload from a
+       * local one: both arrive on the same endpoint with the same body.
+       */
+      patchFiles: [...state.patchFiles.entries()].flatMap(([patchId, files]) =>
+        [...files.entries()].map(([filePath, file]) => ({
+          patchId,
+          filePath,
+          type: file.type,
+          remote: file.remote,
+          bytes: Buffer.from(
+            file.data.slice(file.data.indexOf(",") + 1),
+            "base64",
+          ).byteLength,
+        })),
+      ),
+      commits: state.commits,
+      deployments: state.deployments,
+      repoOverlay: [...state.repoOverlay.keys()],
+      remoteFiles: [...state.remoteFiles.keys()],
+      headCommitSha: state.headCommitSha,
+      subscribers: sockets.size,
+    });
+    return;
+  }
+  if (action === "committed-source" && req.method === "GET") {
+    const key = url.searchParams.get("path");
+    if (!key) {
+      json(res, 400, { message: "path is required" });
+      return;
+    }
+    json(res, 200, { content: state.repoOverlay.get(key) ?? null });
+    return;
+  }
+  if (action === "deployment" && req.method === "POST") {
+    const body = await readJsonBody<{
+      commitSha?: string;
+      deploymentId?: string;
+      deploymentState?: string;
+    }>(req);
+    const deploymentId = body?.deploymentId ?? randomUUID();
+    const commitSha = body?.commitSha ?? state.headCommitSha;
+    const deploymentState = body?.deploymentState ?? "pending";
+    const existing = state.deployments.find(
+      (d) => d.deploymentId === deploymentId,
+    );
+    const record: MockDeployment = existing
+      ? Object.assign(existing, { deploymentState, updatedAt: nowIso() })
+      : {
+          deploymentId,
+          commitSha,
+          deploymentState,
+          createdAt: nowIso(),
+          updatedAt: nowIso(),
+        };
+    if (!existing) {
+      state.deployments.push(record);
+    }
+    broadcast({ type: "deployment", deployment: record });
+    json(res, 200, { deployment: record });
+    return;
+  }
+  if (action === "commit" && req.method === "POST") {
+    const body = await readJsonBody<{
+      commitMessage?: string;
+      creator?: string;
+      branch?: string;
+    }>(req);
+    const parentCommitSha = state.headCommitSha;
+    const commitSha = sha(
+      `push:${parentCommitSha}:${state.commits.length}`,
+    ).slice(0, 40);
+    const record: MockCommit = {
+      commitSha,
+      clientCommitSha: commitSha,
+      parentCommitSha,
+      commitMessage: body?.commitMessage ?? "A commit someone pushed",
+      branch: body?.branch ?? "main",
+      creator: body?.creator ?? "someone-else",
+      createdAt: nowIso(),
+    };
+    state.commits.push(record);
+    state.headCommitSha = commitSha;
+    broadcast({ type: "commit", commit: record });
+    json(res, 200, { commit: record });
+    return;
+  }
+  json(res, 404, { message: `Unknown control action: ${action}` });
+};
+
+// #endregion
+
+// #region routing
+
+const server = createServer((req, res) => {
+  const origin = req.headers.origin;
+  if (typeof origin === "string") {
+    (res as ServerResponse & { __origin?: string }).__origin = origin;
+  }
+  void handle(req, res).catch((err) => {
+    console.error("[mock-content-host] unhandled error", err);
+    if (!res.headersSent) {
+      json(res, 500, {
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  });
+});
+
+async function handle(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  const url = new URL(req.url ?? "/", `http://localhost:${PORT}`);
+  if (req.method === "OPTIONS") {
+    res.writeHead(204, corsHeaders(res));
+    res.end();
+    return;
+  }
+  if (url.pathname === "/__test__/ping") {
+    json(res, 200, { ok: true, project: PROJECT });
+    return;
+  }
+  if (url.pathname.startsWith("/__test__/")) {
+    await controlPlane(req, res, url);
+    return;
+  }
+  const prefix = `/v1/${PROJECT}`;
+  if (!url.pathname.startsWith(prefix)) {
+    json(res, 404, { message: `Not a route on this mock: ${url.pathname}` });
+    return;
+  }
+  if (!authorized(req)) {
+    json(res, 401, { message: "Unauthorized: bad or missing api key / nonce" });
+    return;
+  }
+  const rest = url.pathname.slice(prefix.length) || "/";
+  const route = `${req.method} ${rest}`;
+  // Patch-file routes carry the patch id in the path, so they are matched by
+  // shape rather than by an exact string.
+  if (/^\/patches\/[^/]+\/files$/.test(rest)) {
+    if (req.method === "POST") {
+      await savePatchFile(req, res, url);
+      return;
+    }
+    if (req.method === "GET") {
+      getPatchFileMetadata(req, res, url);
+      return;
+    }
+  }
+  if (req.method === "PUT" && rest.startsWith("/remote/files/")) {
+    await putRemoteFile(req, res, url);
+    return;
+  }
+  switch (route) {
+    case "GET /applicable/patches":
+      getApplicablePatches(req, res, url);
+      return;
+    case "POST /patches":
+      await savePatch(req, res, url);
+      return;
+    case "DELETE /patches":
+      await deletePatches(req, res, url);
+      return;
+    case "PUT /files":
+      await getFiles(req, res, url);
+      return;
+    case "POST /commit":
+      await commit(req, res, url);
+      return;
+    case "POST /commit-summary":
+      commitSummary(req, res, url);
+      return;
+    case "POST /presigned-auth-nonce":
+      presignedAuthNonce(req, res, url);
+      return;
+    case "POST /websocket/nonces":
+      websocketNonce(req, res, url);
+      return;
+    case "GET /settings":
+      settings(req, res, url);
+      return;
+    case "GET /profiles":
+      profiles(req, res, url);
+      return;
+    default:
+      json(res, 404, { message: `Unhandled content-host route: ${route}` });
+  }
+}
+
+/**
+ * The socket the Studio opens for itself.
+ *
+ * It sends one `subscribe` with the nonce from `/stat` and then only listens.
+ * The `subscribed` reply matters: without it the client sits waiting and its
+ * long-poll interval never lengthens.
+ */
+const wss = new WebSocketServer({ server, path: "/ws" });
+wss.on("connection", (socket) => {
+  socket.on("message", (raw) => {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw.toString());
+    } catch {
+      return;
+    }
+    const message = parsed as { type?: string; nonce?: string };
+    if (message.type !== "subscribe") {
+      return;
+    }
+    if (typeof message.nonce !== "string" || !state.nonces.has(message.nonce)) {
+      socket.close(1008, "Unknown nonce");
+      return;
+    }
+    sockets.add(socket);
+    socket.send(JSON.stringify({ type: "subscribed" }));
+  });
+  socket.on("close", () => {
+    sockets.delete(socket);
+  });
+});
+
+server.listen(PORT, () => {
+  console.log(
+    `[mock-content-host] listening on http://localhost:${PORT} for project ${PROJECT}`,
+  );
+});
+
+// #endregion

--- a/examples/next/content/remoteImages.val.ts
+++ b/examples/next/content/remoteImages.val.ts
@@ -12,6 +12,9 @@ import { s, c } from "../val.config";
  * ship in the example app without making `pnpm dev` unable to publish.
  *
  * Starts empty: the entries are whatever a test or a developer uploads.
+ *
+ * Registered only when `NEXT_PUBLIC_VAL_EXAMPLE_REMOTE_MEDIA` is `"true"` — see
+ * `val.modules.ts` for why it is opt-in.
  */
 export default c.define(
   "/content/remoteImages.val.ts",

--- a/examples/next/content/remoteImages.val.ts
+++ b/examples/next/content/remoteImages.val.ts
@@ -1,0 +1,20 @@
+import { s, c } from "../val.config";
+
+/**
+ * An images gallery whose files live on Val's remote host rather than in the repo.
+ *
+ * Here so the `http`-mode e2e suite has something to upload remotely, and it is a
+ * gallery rather than an `s.image().remote()` field on purpose: a single remote
+ * image or file schema anywhere in the project makes `hasRemoteFileSchema` true,
+ * and `/save` then demands remote credentials for EVERY publish — including
+ * publishes of plain text in `fs` mode, where a local checkout has no personal
+ * access token. A remote *gallery* does not trip that check, so this module can
+ * ship in the example app without making `pnpm dev` unable to publish.
+ *
+ * Starts empty: the entries are whatever a test or a developer uploads.
+ */
+export default c.define(
+  "/content/remoteImages.val.ts",
+  s.images({ remote: true, directory: "/public/remote-images" }),
+  {},
+);

--- a/examples/next/next.config.js
+++ b/examples/next/next.config.js
@@ -2,6 +2,11 @@ const withPreconstruct = require("@preconstruct/next");
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // So a second `next dev` can run against this same directory: the e2e suite
+  // starts one server in `fs` mode and one in `http` mode (proxy mode, talking to
+  // the mock content host), and two dev servers sharing `.next` corrupt each
+  // other's build output.
+  distDir: process.env.NEXT_DIST_DIR || ".next",
   images: {
     remotePatterns: [
       {

--- a/examples/next/tsconfig.json
+++ b/examples/next/tsconfig.json
@@ -24,6 +24,13 @@
       "_/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "//": "`.next-http/types` is the second dev server's generated types: the e2e suite runs one `next dev` in fs mode and one in proxy mode, and the second needs its own distDir. Listed here so `next dev` does not rewrite (and reformat) this file on every http-mode run.",
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next-http/types/**/*.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/examples/next/val.modules.ts
+++ b/examples/next/val.modules.ts
@@ -1,6 +1,26 @@
 import { modules } from "@valbuild/next";
 import { config } from "./val.config";
 
+/**
+ * Whether to include the remote-file example.
+ *
+ * Opt-in, because a remote schema is not free: the moment one exists anywhere in
+ * the project, the Studio starts asking `/remote/settings` for a project id and a
+ * bucket, and `/save` demands remote credentials for EVERY publish — including a
+ * publish of plain text. Both need a login this app does not have by default, so
+ * registering the module unconditionally would leave a plain `pnpm dev` logging
+ * failed requests and unable to publish anything.
+ *
+ * `NEXT_PUBLIC_` because both halves have to agree: the server needs the schema
+ * to validate and commit, and the Studio — which is handed `ValModules` in the
+ * browser — needs it to render the gallery at all. Only `NEXT_PUBLIC_*` reaches
+ * the client bundle. The `typeof` guard is for the CLI, which evaluates this file
+ * in a `node:vm` sandbox where `process` may not exist.
+ */
+const remoteMedia =
+  typeof process !== "undefined" &&
+  process.env.NEXT_PUBLIC_VAL_EXAMPLE_REMOTE_MEDIA === "true";
+
 export default modules(config, [
   { def: () => import("./content/authors.val") },
   { def: () => import("./app/blogs/[blog]/page.val") },
@@ -23,7 +43,8 @@ export default modules(config, [
   { def: () => import("./content/mediaFixtures.val") },
   { def: () => import("./content/fileGallery.val") },
   { def: () => import("./content/mediaFields.val") },
-  // A gallery backed by Val's remote file host. See content/remoteImages.val.ts
-  // for why this is a gallery and not a single remote image field.
-  { def: () => import("./content/remoteImages.val") },
+  // A gallery backed by Val's remote file host, when it is switched on. See
+  // `remoteMedia` above, and content/remoteImages.val.ts for why this is a
+  // gallery rather than a single remote image field.
+  ...(remoteMedia ? [{ def: () => import("./content/remoteImages.val") }] : []),
 ]);

--- a/examples/next/val.modules.ts
+++ b/examples/next/val.modules.ts
@@ -23,4 +23,7 @@ export default modules(config, [
   { def: () => import("./content/mediaFixtures.val") },
   { def: () => import("./content/fileGallery.val") },
   { def: () => import("./content/mediaFields.val") },
+  // A gallery backed by Val's remote file host. See content/remoteImages.val.ts
+  // for why this is a gallery and not a single remote image field.
+  { def: () => import("./content/remoteImages.val") },
 ]);

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@preconstruct/cli": "^2.8.12",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.0.9",
+    "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "^8.53.0",
     "@typescript-eslint/parser": "^8.53.0",
     "babel-jest": "^30.2.0",
@@ -44,7 +45,8 @@
     "globals": "^17.0.0",
     "jest": "30.2",
     "prettier": "^3.8.0",
-    "tsx": "^4.21.0"
+    "tsx": "^4.21.0",
+    "ws": "^8.21.3"
   },
   "preconstruct": {
     "packages": [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,13 @@
 import { defineConfig } from "@playwright/test";
 import { existsSync } from "node:fs";
+import {
+  MOCK_API_KEY,
+  MOCK_CONTENT_PORT,
+  MOCK_INITIAL_COMMIT,
+  MOCK_PROJECT,
+  MOCK_SECRET,
+  HTTP_APP_PORT,
+} from "./e2e/http/config";
 
 const PREINSTALLED_CHROMIUM =
   "/opt/pw-browsers/chromium-1194/chrome-linux/chrome";
@@ -23,6 +31,18 @@ const PREINSTALLED_CHROMIUM =
  *
  * `reuseExistingServer` so a developer with servers already up does not wait for
  * two more, and so a failing test can be re-run against the same processes.
+ *
+ * ## And two more, for `http` mode
+ *
+ * Everything under `e2e/http/` needs the app running in proxy mode against a
+ * content service, which `fs` mode has no equivalent of: publishing as a git
+ * commit, patches marked applied instead of deleted, deployment and build events
+ * arriving over a WebSocket. So a mock content host (`e2e/mock-content-host`) and
+ * a second `next dev` configured to talk to it come up alongside the other two.
+ *
+ * They start on every run rather than only when the `http` project is selected —
+ * Playwright's `webServer` is global, with no per-project form — but `next dev`
+ * compiles lazily, so an FS-only run pays for a process, not a build.
  */
 export default defineConfig({
   testDir: "./e2e",
@@ -45,6 +65,9 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
+      // The `fs`-mode suites. `e2e/http/` is excluded because those tests need
+      // the other app, on the other port.
+      testIgnore: "http/**",
       use: {
         launchOptions: {
           /**
@@ -56,6 +79,19 @@ export default defineConfig({
            * runner, and leaving it out made it unrunnable in the sandbox — so it
            * is used when it exists and Playwright resolves its own otherwise.
            */
+          ...(existsSync(PREINSTALLED_CHROMIUM)
+            ? { executablePath: PREINSTALLED_CHROMIUM }
+            : {}),
+          args: ["--no-sandbox", "--disable-dev-shm-usage"],
+        },
+      },
+    },
+    {
+      name: "chromium-http",
+      testMatch: "http/**/*.spec.ts",
+      use: {
+        baseURL: `http://localhost:${HTTP_APP_PORT}`,
+        launchOptions: {
           ...(existsSync(PREINSTALLED_CHROMIUM)
             ? { executablePath: PREINSTALLED_CHROMIUM }
             : {}),
@@ -79,6 +115,47 @@ export default defineConfig({
       reuseExistingServer: true,
       timeout: 180_000,
       cwd: "./examples/next",
+    },
+    {
+      // The fake content.val.build. Must be up before the app below: the app
+      // asks it for patches on the first `/stat`.
+      command: "pnpm exec tsx e2e/mock-content-host/server.ts",
+      url: `http://localhost:${MOCK_CONTENT_PORT}/__test__/ping`,
+      reuseExistingServer: true,
+      timeout: 60_000,
+      cwd: ".",
+      env: {
+        MOCK_CONTENT_PORT: String(MOCK_CONTENT_PORT),
+        MOCK_CONTENT_API_KEY: MOCK_API_KEY,
+        MOCK_CONTENT_PROJECT: MOCK_PROJECT,
+        MOCK_CONTENT_REPO_ROOT: process.cwd(),
+        MOCK_CONTENT_INITIAL_COMMIT: MOCK_INITIAL_COMMIT,
+      },
+    },
+    {
+      /**
+       * The same example app, in proxy mode.
+       *
+       * `initHandlerOptions` picks proxy mode from the environment alone —
+       * `VAL_API_KEY` and `VAL_SECRET` present means `http` — so this needs no
+       * product code and no second config file. `NEXT_DIST_DIR` keeps its build
+       * output away from the `fs`-mode server's.
+       */
+      command: `pnpm exec next dev -p ${HTTP_APP_PORT}`,
+      url: `http://localhost:${HTTP_APP_PORT}`,
+      reuseExistingServer: true,
+      timeout: 180_000,
+      cwd: "./examples/next",
+      env: {
+        NEXT_DIST_DIR: ".next-http",
+        VAL_API_KEY: MOCK_API_KEY,
+        VAL_SECRET: MOCK_SECRET,
+        VAL_PROJECT: MOCK_PROJECT,
+        VAL_GIT_COMMIT: MOCK_INITIAL_COMMIT,
+        VAL_GIT_BRANCH: "main",
+        VAL_CONTENT_URL: `http://localhost:${MOCK_CONTENT_PORT}`,
+        VAL_BUILD_URL: `http://localhost:${MOCK_CONTENT_PORT}`,
+      },
     },
   ],
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -148,6 +148,11 @@ export default defineConfig({
       cwd: "./examples/next",
       env: {
         NEXT_DIST_DIR: ".next-http",
+        // The remote-file example, which only this server registers: a remote
+        // schema makes the Studio ask for remote settings and makes every publish
+        // require remote credentials, so the fs-mode server has to stay without
+        // one. See examples/next/val.modules.ts.
+        NEXT_PUBLIC_VAL_EXAMPLE_REMOTE_MEDIA: "true",
         VAL_API_KEY: MOCK_API_KEY,
         VAL_SECRET: MOCK_SECRET,
         VAL_PROJECT: MOCK_PROJECT,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10095,18 +10095,6 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.19.0:
-    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   ws@8.21.3:
     resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
     engines: {node: '>=10.0.0'}
@@ -11859,7 +11847,7 @@ snapshots:
   '@jest/console@30.2.0':
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 20.10.0
+      '@types/node': 25.0.10
       chalk: 4.1.2
       jest-message-util: 30.2.0
       jest-util: 30.2.0
@@ -12014,7 +12002,7 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 20.10.0
+      '@types/node': 25.0.10
       jest-regex-util: 30.0.1
 
   '@jest/reporters@29.7.0':
@@ -12054,7 +12042,7 @@ snapshots:
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 20.10.0
+      '@types/node': 25.0.10
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit-x: 0.2.2
@@ -14076,7 +14064,7 @@ snapshots:
       util: 0.12.5
       util-deprecate: 1.0.2
       watchpack: 2.5.1
-      ws: 8.19.0
+      ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -14649,7 +14637,7 @@ snapshots:
 
   '@types/resolve@1.17.1':
     dependencies:
-      '@types/node': 20.10.0
+      '@types/node': 25.0.10
 
   '@types/resolve@1.20.2': {}
 
@@ -16425,7 +16413,7 @@ snapshots:
       eslint: 8.23.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@8.23.0))(eslint@8.23.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.23.0)(typescript@5.1.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@8.23.0))(eslint@8.23.0))(eslint@8.23.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.23.0)(typescript@5.1.3))(eslint-import-resolver-typescript@2.7.1)(eslint@8.23.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.23.0)
       eslint-plugin-react: 7.37.5(eslint@8.23.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.23.0)
@@ -16443,7 +16431,7 @@ snapshots:
       eslint: 8.32.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@8.32.0))(eslint@8.32.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.32.0)(typescript@5.1.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.32.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.32.0)(typescript@5.1.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@8.32.0))(eslint@8.32.0))(eslint@8.32.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.32.0)
       eslint-plugin-react: 7.37.5(eslint@8.32.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.32.0)
@@ -16470,7 +16458,7 @@ snapshots:
     dependencies:
       debug: 4.4.3
       eslint: 8.23.0
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.23.0)(typescript@5.1.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@8.23.0))(eslint@8.23.0))(eslint@8.23.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.23.0)(typescript@5.1.3))(eslint-import-resolver-typescript@2.7.1)(eslint@8.23.0)
       glob: 7.2.3
       is-glob: 4.0.3
       resolve: 1.22.11
@@ -16489,7 +16477,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.32.0)(typescript@5.1.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.32.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.32.0)(typescript@5.1.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@8.32.0))(eslint@8.32.0))(eslint@8.32.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -16515,7 +16503,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.23.0)(typescript@5.1.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@8.23.0))(eslint@8.23.0))(eslint@8.23.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.23.0)(typescript@5.1.3))(eslint-import-resolver-typescript@2.7.1)(eslint@8.23.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -16544,7 +16532,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.32.0)(typescript@5.1.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.32.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.32.0)(typescript@5.1.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@8.32.0))(eslint@8.32.0))(eslint@8.32.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -18138,7 +18126,7 @@ snapshots:
   jest-haste-map@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 20.10.0
+      '@types/node': 25.0.10
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -18297,7 +18285,7 @@ snapshots:
       '@jest/test-result': 30.2.0
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 20.10.0
+      '@types/node': 25.0.10
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
@@ -18353,7 +18341,7 @@ snapshots:
       '@jest/test-result': 30.2.0
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 20.10.0
+      '@types/node': 25.0.10
       chalk: 4.1.2
       cjs-module-lexer: 2.2.0
       collect-v8-coverage: 1.0.3
@@ -18434,7 +18422,7 @@ snapshots:
   jest-util@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 20.10.0
+      '@types/node': 25.0.10
       chalk: 4.1.2
       ci-info: 4.3.1
       graceful-fs: 4.2.11
@@ -18473,7 +18461,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 20.10.0
+      '@types/node': 25.0.10
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -18600,7 +18588,7 @@ snapshots:
       whatwg-encoding: 2.0.0
       whatwg-mimetype: 3.0.0
       whatwg-url: 11.0.0
-      ws: 8.19.0
+      ws: 8.21.3
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -21648,8 +21636,6 @@ snapshots:
   ws@6.2.3:
     dependencies:
       async-limiter: 1.0.1
-
-  ws@8.19.0: {}
 
   ws@8.21.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@types/node':
         specifier: ^25.0.9
         version: 25.0.10
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.53.0
         version: 8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
@@ -77,6 +80,9 @@ importers:
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
+      ws:
+        specifier: ^8.21.3
+        version: 8.21.3
 
   examples/next:
     dependencies:
@@ -4571,6 +4577,9 @@ packages:
 
   '@types/wrap-ansi@3.0.0':
     resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -10098,6 +10107,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
     engines: {node: '>=12'}
@@ -11838,7 +11859,7 @@ snapshots:
   '@jest/console@30.2.0':
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 25.0.10
+      '@types/node': 20.10.0
       chalk: 4.1.2
       jest-message-util: 30.2.0
       jest-util: 30.2.0
@@ -11993,7 +12014,7 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 25.0.10
+      '@types/node': 20.10.0
       jest-regex-util: 30.0.1
 
   '@jest/reporters@29.7.0':
@@ -12033,7 +12054,7 @@ snapshots:
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 25.0.10
+      '@types/node': 20.10.0
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit-x: 0.2.2
@@ -14628,7 +14649,7 @@ snapshots:
 
   '@types/resolve@1.17.1':
     dependencies:
-      '@types/node': 25.0.10
+      '@types/node': 20.10.0
 
   '@types/resolve@1.20.2': {}
 
@@ -14669,6 +14690,10 @@ snapshots:
   '@types/uuid@9.0.8': {}
 
   '@types/wrap-ansi@3.0.0': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.10.0
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -17897,7 +17922,7 @@ snapshots:
       '@jest/expect': 30.2.0
       '@jest/test-result': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 25.0.10
+      '@types/node': 20.10.0
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.1(babel-plugin-macros@3.1.0)
@@ -18087,7 +18112,7 @@ snapshots:
       '@jest/environment': 30.2.0
       '@jest/fake-timers': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 25.0.10
+      '@types/node': 20.10.0
       jest-mock: 30.2.0
       jest-util: 30.2.0
       jest-validate: 30.2.0
@@ -18113,7 +18138,7 @@ snapshots:
   jest-haste-map@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 25.0.10
+      '@types/node': 20.10.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -18272,7 +18297,7 @@ snapshots:
       '@jest/test-result': 30.2.0
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 25.0.10
+      '@types/node': 20.10.0
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
@@ -18328,7 +18353,7 @@ snapshots:
       '@jest/test-result': 30.2.0
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 25.0.10
+      '@types/node': 20.10.0
       chalk: 4.1.2
       cjs-module-lexer: 2.2.0
       collect-v8-coverage: 1.0.3
@@ -18409,7 +18434,7 @@ snapshots:
   jest-util@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 25.0.10
+      '@types/node': 20.10.0
       chalk: 4.1.2
       ci-info: 4.3.1
       graceful-fs: 4.2.11
@@ -18448,7 +18473,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 25.0.10
+      '@types/node': 20.10.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -18476,7 +18501,7 @@ snapshots:
 
   jest-worker@30.2.0:
     dependencies:
-      '@types/node': 25.0.10
+      '@types/node': 20.10.0
       '@ungap/structured-clone': 1.3.0
       jest-util: 30.2.0
       merge-stream: 2.0.0
@@ -21625,6 +21650,8 @@ snapshots:
       async-limiter: 1.0.1
 
   ws@8.19.0: {}
+
+  ws@8.21.3: {}
 
   xml-name-validator@4.0.0: {}
 


### PR DESCRIPTION
## What this is

An e2e suite that runs the example app in **proxy (`http`) mode** against a fake
content.val.build, so the half of the product a deployed app actually uses is
covered by tests.

Everything in `e2e/` until now drove the Studio in `fs` mode, where the "content
host" is a directory on disk. That left untested:

- `ValOpsHttp` — the only thing between the Studio and the content service
- publishing as a **git commit** through an HTTP call
- patches coming back **marked applied** rather than deleted
- **deployments and build commits** arriving over a WebSocket the browser opens itself
- **remote files** — which need a project id and a bucket from the content service, so they have no `fs`-mode equivalent at all
- **more than one editor** — `fs` mode is single-writer by construction

## How

`e2e/mock-content-host/server.ts` — an in-memory content service faithful to the
wire protocol `ValOpsHttp` speaks, plus a `/__test__` control plane for the events
no editor action can produce (a deployment starting, a deployment finishing, a
commit someone else pushed).

**No product code changed.** `initHandlerOptions` picks proxy mode from the
environment alone, so a second `next dev` with `VAL_API_KEY`, `VAL_SECRET` and
`VAL_CONTENT_URL` is the whole configuration. Playwright starts both, alongside the
existing two, and a `chromium-http` project runs `e2e/http/**` against it.

Request interception was not an option: the `ValOpsHttp` calls happen in the Next
process. Only the direct file upload and the WebSocket are made by the browser.

**Login is deliberately not covered** — it goes to admin.val.build, which a
content-host mock cannot stand in for, and it already works. `http` mode rejects
every request without a session, so the tests sign the `val_session` cookie
themselves. That is also what makes two editors testable: a session is a cookie, so
two people is two browser contexts.

## The 18 tests

**`publish.spec.ts`** — a change reaches the service attributed to its author; a
publish commits it and marks the patch applied; a second change commits on top of
the first commit (the case a mock that always read from disk would get wrong);
discard removes it; publishing nothing is a no-op.

**`deployments.spec.ts`** — the socket comes up and the service accepts the
subscription; a deployment arrives and parses; a deployment finishing updates in
place; a commit pushed outside the Studio arrives; publish → deploy → publish again
as one ordered sequence.

**`remoteFiles.spec.ts`** — the gallery is listed under Media; an upload carries a
ref on the remote host, is flagged remote, and renders from the patch; publishing
moves the bytes to remote storage and **not** into the commit; deleting an entry.

**`users.spec.ts`** — two editors keep one linear chain with per-change authors;
one editor's change arrives in the other's Studio over the socket; a publish takes
both editors' changes credited to whoever published; a discard by one leaves the
other's Studio.

## Two things this cannot reach, stated rather than papered over

**The deployment banner is not asserted**, because `DraftChanges` — the only
component that renders `useDeployments()` — is imported by nothing, so the Studio
mounts no deployment UI. These tests assert the transport instead, which is the
part that silently breaks: `WebSocketServerMessage` is a zod schema in `useStatus.ts`
against JSON from a service in another repo, and when the two drift the feature
dies with one `console.error` and no other symptom.

**`VAL_GIT_COMMIT` is read once at startup**, so the app's own idea of which commit
it serves cannot change while it runs — a real deploy replaces the process. The
build-on-a-new-commit test pushes a commit carrying the app's own sha, which is the
state a finished build leaves behind and the branch `observedCommitShas` keys on.

## The remote fixture is opt-in, and that is not a shortcut

`content/remoteImages.val.ts` is a gallery, not an `s.image().remote()` field, and
it is registered only when `NEXT_PUBLIC_VAL_EXAMPLE_REMOTE_MEDIA` is set. Both
choices are forced:

- one remote image or file **field** anywhere makes `hasRemoteFileSchema` true, and
  `/save` then demands remote credentials for **every** publish — including plain
  text in `fs` mode, where a local checkout has no PAT.
- a remote **gallery** does not trip that check, but it does trip
  `findRequiredRemoteFiles`, which starts a ten-attempt `/remote/settings` retry
  loop that 400s without a PAT. That is a console error on every Studio route —
  which the smoke suite asserts against, and which is how this was found.

So: gallery (so publishing still works), opt-in (so the console stays clean). The
upload path exercised is the same either way.

## Also

- `architecture/quirks.md` gains a "Remote files and proxy mode" section: the two
  disagreeing remote-file checks, the publish-wide credential requirement, commit
  errors always reading "Unknown error" (`ValOpsHttp.commit` passes zod's safeParse
  result rather than the payload to `getErrorMessageFromUnknownJson`), the
  upload/commit key mismatch, the percent-encoded session cookie, and the unmounted
  deployment UI.
- `.next-http` is the proxy-mode server's own distDir so two dev servers can share
  the directory; it is listed in `examples/next/tsconfig.json` so `next dev` stops
  rewriting that file on every run.
- `ws` as a root devDependency, for the mock's WebSocket.

No `packages/*` source changed, so there is no changeset.

## Verified

`pnpm run lint`, `pnpm -w run format`, `pnpm --filter example-next run typecheck`,
`pnpm run typecheck:e2e`, and the full Playwright suite — 49 passed, then the one
test added afterwards run separately (4 passed).

## One thing to apply by hand

The CI job could not be pushed — this token has no `workflow` scope, so
`.github/workflows/check.yml` is refused. The job, to add at the end of that file:

```yaml
  e2e:
    name: E2E
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v3
        with:
          persist-credentials: false
      - uses: actions/setup-node@v3
        with:
          node-version-file: ".nvmrc"
      - uses: pnpm/action-setup@v2
        with:
          version: 10
      - run: pnpm install --frozen-lockfile
      - run: pnpm exec playwright install --with-deps chromium
      # Starts four servers of its own (see playwright.config.ts): the Studio's
      # Vite dev server, the example app in fs mode, a mock content host, and the
      # example app again in proxy mode against that mock.
      - run: pnpm run test:e2e
      - uses: actions/upload-artifact@v4
        if: failure()
        with:
          name: playwright-report
          path: |
            playwright-report/
            test-results/
          retention-days: 7
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1uhmmkdc8148oqdVL23zX)_