### PR TITLE
Require `directory` on s.images() and s.files()

### DIFF
--- a/.changeset/require-media-directory.md
+++ b/.changeset/require-media-directory.md
@@ -1,0 +1,25 @@
+---
+"@valbuild/core": minor
+---
+
+**Breaking:** `directory` is now required on `s.images()` and `s.files()`
+
+It used to default to `/public/val`. That default was silent and shared: two
+collections that had simply not said where they wanted their files landed in the
+same directory, which `images:check-unique-folder` then reports as a collision the
+author never chose. Where uploads go is not something to infer.
+
+```diff
+- s.images({ accept: "image/webp" })
++ s.images({ directory: "/public/val/images", accept: "image/webp" })
+
+- s.files({ accept: "application/pdf" })
++ s.files({ directory: "/public/val/documents", accept: "application/pdf" })
+```
+
+To keep the previous behaviour exactly, pass `directory: "/public/val"`.
+
+`s.images()` with no arguments no longer typechecks. Note also that the runtime
+fallback is gone along with the default, so a JavaScript caller that omits
+`directory` now serializes `directory: undefined` rather than `/public/val`;
+TypeScript callers cannot reach that.

--- a/architecture/media.md
+++ b/architecture/media.md
@@ -5,10 +5,15 @@
 `s.images()` / `s.files()` are **whole-module collections**. `s.image()` /
 `s.file()` are **fields**. They are not variants of each other.
 
-|       | collection (is the module)                     | field (lives at a path)                                      |
-| ----- | ---------------------------------------------- | ------------------------------------------------------------ |
-| image | `s.images({ directory, accept, alt, remote })` | `s.image({ directory, accept })` or `s.image(galleryModule)` |
-| file  | `s.files({ accept, directory, remote })`       | `s.file({ accept })`                                         |
+|       | collection (is the module)                        | field (lives at a path)                                      |
+| ----- | ------------------------------------------------- | ------------------------------------------------------------ |
+| image | `s.images({ directory, accept?, alt?, remote? })` | `s.image({ directory, accept })` or `s.image(galleryModule)` |
+| file  | `s.files({ directory, accept, remote? })`         | `s.file({ accept })`                                         |
+
+A collection's `directory` is **required**. It used to default to `/public/val`,
+which meant a gallery that had simply not said where it wanted its files shared a
+directory with every other one — and `images:check-unique-folder` (below) then
+failed on a collision the author never chose.
 
 This is why `s.images(galleryModule)` does not typecheck: `s.images()` _defines_ a
 collection, it does not reference one. A field backed by a gallery is

--- a/packages/core/src/schema/files.test.ts
+++ b/packages/core/src/schema/files.test.ts
@@ -26,7 +26,10 @@ function filterCheckErrors(
 describe("FilesSchema", () => {
   describe("assert", () => {
     test("should return success if src is a valid files object", () => {
-      const schema = files({ accept: "application/pdf" });
+      const schema = files({
+        directory: "/public/val",
+        accept: "application/pdf",
+      });
       const src: Record<string, FilesEntryMetadata> = {
         "/public/val/document.pdf": {
           mimeType: "application/pdf",
@@ -39,13 +42,19 @@ describe("FilesSchema", () => {
     });
 
     test("should return error if src is null (non-nullable)", () => {
-      const schema = files({ accept: "application/pdf" });
+      const schema = files({
+        directory: "/public/val",
+        accept: "application/pdf",
+      });
       const result = schema["executeAssert"]("path" as SourcePath, null);
       expect(result.success).toEqual(false);
     });
 
     test("should return success if src is null (nullable)", () => {
-      const schema = files({ accept: "application/pdf" }).nullable();
+      const schema = files({
+        directory: "/public/val",
+        accept: "application/pdf",
+      }).nullable();
       expect(schema["executeAssert"]("path" as SourcePath, null)).toEqual({
         success: true,
         data: null,
@@ -53,13 +62,19 @@ describe("FilesSchema", () => {
     });
 
     test("should return error if src is not an object", () => {
-      const schema = files({ accept: "application/pdf" });
+      const schema = files({
+        directory: "/public/val",
+        accept: "application/pdf",
+      });
       const result = schema["executeAssert"]("path" as SourcePath, "test");
       expect(result.success).toEqual(false);
     });
 
     test("should return error if src is an array", () => {
-      const schema = files({ accept: "application/pdf" });
+      const schema = files({
+        directory: "/public/val",
+        accept: "application/pdf",
+      });
       const result = schema["executeAssert"]("path" as SourcePath, []);
       expect(result.success).toEqual(false);
     });
@@ -111,7 +126,10 @@ describe("FilesSchema", () => {
     });
 
     test("should validate mimeType against accept pattern", () => {
-      const schema = files({ accept: "application/pdf" });
+      const schema = files({
+        directory: "/public/val",
+        accept: "application/pdf",
+      });
       const src: Record<string, FilesEntryMetadata> = {
         "/public/val/document.docx": {
           mimeType:
@@ -131,7 +149,10 @@ describe("FilesSchema", () => {
     });
 
     test("should accept wildcard mimeType patterns", () => {
-      const schema = files({ accept: "application/*" });
+      const schema = files({
+        directory: "/public/val",
+        accept: "application/*",
+      });
       const src: Record<string, FilesEntryMetadata> = {
         "/public/val/document.pdf": {
           mimeType: "application/pdf",
@@ -149,7 +170,7 @@ describe("FilesSchema", () => {
     });
 
     test("should accept any mimeType with */*", () => {
-      const schema = files({ accept: "*/*" });
+      const schema = files({ directory: "/public/val", accept: "*/*" });
       const src: Record<string, FilesEntryMetadata> = {
         "/public/val/anything.xyz": {
           mimeType: "application/octet-stream",
@@ -167,7 +188,10 @@ describe("FilesSchema", () => {
     });
 
     test("should use default directory /public/val", () => {
-      const schema = files({ accept: "application/pdf" });
+      const schema = files({
+        directory: "/public/val",
+        accept: "application/pdf",
+      });
       const src: Record<string, FilesEntryMetadata> = {
         "/public/val/document.pdf": {
           mimeType: "application/pdf",
@@ -208,7 +232,10 @@ describe("FilesSchema", () => {
     });
 
     test("should validate mimeType is a string", () => {
-      const schema = files({ accept: "application/pdf" });
+      const schema = files({
+        directory: "/public/val",
+        accept: "application/pdf",
+      });
       const src = {
         "/public/val/document.pdf": {
           mimeType: 123,
@@ -224,7 +251,10 @@ describe("FilesSchema", () => {
 
   describe("serialization", () => {
     test("should serialize with correct type", () => {
-      const schema = files({ accept: "application/pdf" });
+      const schema = files({
+        directory: "/public/val",
+        accept: "application/pdf",
+      });
       const serialized = schema["executeSerialize"]();
       expect(serialized.type).toBe("record");
       expect((serialized as SerializedFilesSchema).mediaType).toBe("files");
@@ -244,13 +274,19 @@ describe("FilesSchema", () => {
     });
 
     test("should serialize remote flag", () => {
-      const schema = files({ accept: "application/pdf" }).remote();
+      const schema = files({
+        directory: "/public/val",
+        accept: "application/pdf",
+      }).remote();
       const serialized = schema["executeSerialize"]();
       expect(serialized.remote).toBe(true);
     });
 
     test("should serialize nullable flag", () => {
-      const schema = files({ accept: "application/pdf" }).nullable();
+      const schema = files({
+        directory: "/public/val",
+        accept: "application/pdf",
+      }).nullable();
       const serialized = schema["executeSerialize"]();
       expect(serialized.opt).toBe(true);
     });
@@ -258,13 +294,19 @@ describe("FilesSchema", () => {
 
   describe("remote", () => {
     test("should create remote variant", () => {
-      const schema = files({ accept: "application/pdf" });
+      const schema = files({
+        directory: "/public/val",
+        accept: "application/pdf",
+      });
       const remoteSchema = schema.remote();
       expect(remoteSchema["executeSerialize"]().remote).toBe(true);
     });
 
     test("should reject remote URLs when remote is not enabled", () => {
-      const schema = files({ accept: "application/pdf" });
+      const schema = files({
+        directory: "/public/val",
+        accept: "application/pdf",
+      });
       const src: Record<string, FilesEntryMetadata> = {
         "https://remote.val.build/file/p/proj123/b/01/v/1.0.0/h/abc123/f/def456/p/public/val/document.pdf":
           {
@@ -281,7 +323,10 @@ describe("FilesSchema", () => {
     });
 
     test("should accept remote URLs when remote is enabled", () => {
-      const schema = files({ accept: "application/pdf" }).remote();
+      const schema = files({
+        directory: "/public/val",
+        accept: "application/pdf",
+      }).remote();
       const src: Record<string, FilesEntryMetadata> = {
         "https://remote.val.build/file/p/proj123/b/01/v/1.0.0/h/abc123/f/def456/p/public/val/document.pdf":
           {
@@ -341,7 +386,10 @@ describe("FilesSchema", () => {
     });
 
     test("should reject invalid remote URLs", () => {
-      const schema = files({ accept: "application/pdf" }).remote();
+      const schema = files({
+        directory: "/public/val",
+        accept: "application/pdf",
+      }).remote();
       const src: Record<string, FilesEntryMetadata> = {
         "not-a-valid-url": {
           mimeType: "application/pdf",
@@ -376,7 +424,10 @@ describe("FilesSchema", () => {
     });
 
     test("should accept http URLs when remote is enabled", () => {
-      const schema = files({ accept: "application/pdf" }).remote();
+      const schema = files({
+        directory: "/public/val",
+        accept: "application/pdf",
+      }).remote();
       const src: Record<string, FilesEntryMetadata> = {
         "http://remote.val.build/file/p/proj123/b/01/v/1.0.0/h/abc123/f/def456/p/public/val/document.pdf":
           {
@@ -388,7 +439,10 @@ describe("FilesSchema", () => {
     });
 
     test("should reject non-Val remote URLs", () => {
-      const schema = files({ accept: "application/pdf" }).remote();
+      const schema = files({
+        directory: "/public/val",
+        accept: "application/pdf",
+      }).remote();
       const src: Record<string, FilesEntryMetadata> = {
         "https://example.com/document.pdf": {
           mimeType: "application/pdf",
@@ -492,7 +546,10 @@ describe("FilesSchema", () => {
 
   describe("custom validation", () => {
     test("should support custom validation function", () => {
-      const schema = files({ accept: "application/pdf" }).validate((src) => {
+      const schema = files({
+        directory: "/public/val",
+        accept: "application/pdf",
+      }).validate((src) => {
         if (Object.keys(src ?? {}).length === 0) {
           return "At least one file is required";
         }
@@ -511,7 +568,10 @@ describe("FilesSchema", () => {
 
   describe("accept patterns", () => {
     test("should accept comma-separated mime types", () => {
-      const schema = files({ accept: "application/pdf, application/msword" });
+      const schema = files({
+        directory: "/public/val",
+        accept: "application/pdf, application/msword",
+      });
       const src1: Record<string, FilesEntryMetadata> = {
         "/public/val/document.pdf": {
           mimeType: "application/pdf",
@@ -537,7 +597,10 @@ describe("FilesSchema", () => {
     });
 
     test("should reject mime types not in accept list", () => {
-      const schema = files({ accept: "application/pdf, application/msword" });
+      const schema = files({
+        directory: "/public/val",
+        accept: "application/pdf, application/msword",
+      });
       const src: Record<string, FilesEntryMetadata> = {
         "/public/val/document.txt": {
           mimeType: "text/plain",

--- a/packages/core/src/schema/files.ts
+++ b/packages/core/src/schema/files.ts
@@ -15,9 +15,13 @@ export type FilesOptions = {
   /**
    * The directory where files should be stored.
    * Must start with "/public" (e.g., "/public/val/files")
-   * @default "/public/val"
+   *
+   * Required, and deliberately so: it decides where every uploaded file in this
+   * collection lands, and it used to default to "/public/val" — which meant a
+   * collection that had simply not said where it wanted its files silently shared
+   * a directory with every other one.
    */
-  directory?: "/public" | `/public/${string}`;
+  directory: "/public" | `/public/${string}`;
   /**
    * Whether remote files are allowed
    * @default false
@@ -60,7 +64,7 @@ export const files = (
   Schema<string>,
   Record<string, FilesEntryMetadata>
 > => {
-  const directory = options.directory ?? "/public/val";
+  const directory = options.directory;
   const itemSchema = new ObjectSchema<FilesItemProps, FilesItemSrc>(
     { mimeType: new StringSchema({}, false) },
     false,

--- a/packages/core/src/schema/hasRemoteFileSchema.test.ts
+++ b/packages/core/src/schema/hasRemoteFileSchema.test.ts
@@ -281,35 +281,51 @@ describe("hasRemoteFileSchema", () => {
    */
   describe("media collections", () => {
     it("should return true for s.images({ remote: true })", () => {
-      expect(hasRemoteFileSchema(serialize(s.images({ remote: true })))).toBe(
-        true,
-      );
+      expect(
+        hasRemoteFileSchema(
+          serialize(s.images({ directory: "/public/val", remote: true })),
+        ),
+      ).toBe(true);
     });
 
     it("should return true for a remote s.files()", () => {
-      // `accept` is required on `s.files()` (unlike `s.images()`, whose options
-      // are all optional), so it is here to satisfy the type, not the test.
+      // `directory` and `accept` are both required by the type; neither is what
+      // this test is about.
       expect(
         hasRemoteFileSchema(
-          serialize(s.files({ accept: "application/pdf", remote: true })),
+          serialize(
+            s.files({
+              directory: "/public/val",
+              accept: "application/pdf",
+              remote: true,
+            }),
+          ),
         ),
       ).toBe(true);
     });
 
     it("should return false for a local s.images()", () => {
-      expect(hasRemoteFileSchema(serialize(s.images()))).toBe(false);
+      expect(
+        hasRemoteFileSchema(serialize(s.images({ directory: "/public/val" }))),
+      ).toBe(false);
     });
 
     it("should return false for a local s.files()", () => {
       expect(
-        hasRemoteFileSchema(serialize(s.files({ accept: "application/pdf" }))),
+        hasRemoteFileSchema(
+          serialize(
+            s.files({ directory: "/public/val", accept: "application/pdf" }),
+          ),
+        ),
       ).toBe(false);
     });
 
     it("should return false for s.images({ remote: false })", () => {
-      expect(hasRemoteFileSchema(serialize(s.images({ remote: false })))).toBe(
-        false,
-      );
+      expect(
+        hasRemoteFileSchema(
+          serialize(s.images({ directory: "/public/val", remote: false })),
+        ),
+      ).toBe(false);
     });
 
     it("should find a remote gallery nested in an object", () => {
@@ -318,7 +334,7 @@ describe("hasRemoteFileSchema", () => {
           serialize(
             s.object({
               title: s.string(),
-              gallery: s.images({ remote: true }),
+              gallery: s.images({ directory: "/public/val", remote: true }),
             }),
           ),
         ),
@@ -337,7 +353,7 @@ describe("hasRemoteFileSchema", () => {
               }),
               s.object({
                 type: s.literal("images"),
-                images: s.images({ remote: true }),
+                images: s.images({ directory: "/public/val", remote: true }),
               }),
             ),
           ),

--- a/packages/core/src/schema/images.test.ts
+++ b/packages/core/src/schema/images.test.ts
@@ -27,7 +27,7 @@ function filterCheckErrors(
 describe("ImagesSchema", () => {
   describe("assert", () => {
     test("should return success if src is a valid images object", () => {
-      const schema = images({ accept: "image/webp" });
+      const schema = images({ directory: "/public/val", accept: "image/webp" });
       const src: Record<string, ImagesEntryMetadata> = {
         "/public/val/test.webp": {
           width: 800,
@@ -43,13 +43,16 @@ describe("ImagesSchema", () => {
     });
 
     test("should return error if src is null (non-nullable)", () => {
-      const schema = images({ accept: "image/webp" });
+      const schema = images({ directory: "/public/val", accept: "image/webp" });
       const result = schema["executeAssert"]("path" as SourcePath, null);
       expect(result.success).toEqual(false);
     });
 
     test("should return success if src is null (nullable)", () => {
-      const schema = images({ accept: "image/webp" }).nullable();
+      const schema = images({
+        directory: "/public/val",
+        accept: "image/webp",
+      }).nullable();
       expect(schema["executeAssert"]("path" as SourcePath, null)).toEqual({
         success: true,
         data: null,
@@ -57,13 +60,13 @@ describe("ImagesSchema", () => {
     });
 
     test("should return error if src is not an object", () => {
-      const schema = images({ accept: "image/webp" });
+      const schema = images({ directory: "/public/val", accept: "image/webp" });
       const result = schema["executeAssert"]("path" as SourcePath, "test");
       expect(result.success).toEqual(false);
     });
 
     test("should return error if src is an array", () => {
-      const schema = images({ accept: "image/webp" });
+      const schema = images({ directory: "/public/val", accept: "image/webp" });
       const result = schema["executeAssert"]("path" as SourcePath, []);
       expect(result.success).toEqual(false);
     });
@@ -121,7 +124,7 @@ describe("ImagesSchema", () => {
     });
 
     test("should validate mimeType against accept pattern", () => {
-      const schema = images({ accept: "image/webp" });
+      const schema = images({ directory: "/public/val", accept: "image/webp" });
       const src: Record<string, ImagesEntryMetadata> = {
         "/public/val/test.png": {
           width: 800,
@@ -143,7 +146,7 @@ describe("ImagesSchema", () => {
     });
 
     test("should accept wildcard mimeType patterns", () => {
-      const schema = images({ accept: "image/*" });
+      const schema = images({ directory: "/public/val", accept: "image/*" });
       const src: Record<string, ImagesEntryMetadata> = {
         "/public/val/test.png": {
           width: 800,
@@ -164,7 +167,7 @@ describe("ImagesSchema", () => {
     });
 
     test("should validate required width and height", () => {
-      const schema = images({ accept: "image/webp" });
+      const schema = images({ directory: "/public/val", accept: "image/webp" });
       const src = {
         "/public/val/test.webp": {
           mimeType: "image/webp",
@@ -180,6 +183,7 @@ describe("ImagesSchema", () => {
 
     test("should validate alt with custom alt schema", () => {
       const schema = images({
+        directory: "/public/val",
         accept: "image/webp",
         alt: string().minLength(10),
       });
@@ -197,6 +201,7 @@ describe("ImagesSchema", () => {
 
     test("should allow null alt when using nullable alt schema", () => {
       const schema = images({
+        directory: "/public/val",
         accept: "image/webp",
         alt: string().nullable(),
       });
@@ -221,7 +226,7 @@ describe("ImagesSchema", () => {
     });
 
     test("should use default directory /public/val", () => {
-      const schema = images({ accept: "image/webp" });
+      const schema = images({ directory: "/public/val", accept: "image/webp" });
       const src: Record<string, ImagesEntryMetadata> = {
         "/public/val/test.webp": {
           width: 800,
@@ -243,7 +248,7 @@ describe("ImagesSchema", () => {
     });
 
     test("should validate hotspot if present", () => {
-      const schema = images({ accept: "image/webp" });
+      const schema = images({ directory: "/public/val", accept: "image/webp" });
       const src = {
         "/public/val/test.webp": {
           width: 800,
@@ -263,7 +268,7 @@ describe("ImagesSchema", () => {
 
   describe("serialization", () => {
     test("should serialize with correct type", () => {
-      const schema = images({ accept: "image/webp" });
+      const schema = images({ directory: "/public/val", accept: "image/webp" });
       const serialized = schema["executeSerialize"]();
       expect(serialized.type).toBe("record");
       expect((serialized as SerializedImagesSchema).mediaType).toBe("images");
@@ -283,13 +288,19 @@ describe("ImagesSchema", () => {
     });
 
     test("should serialize remote flag", () => {
-      const schema = images({ accept: "image/webp" }).remote();
+      const schema = images({
+        directory: "/public/val",
+        accept: "image/webp",
+      }).remote();
       const serialized = schema["executeSerialize"]();
       expect(serialized.remote).toBe(true);
     });
 
     test("should serialize nullable flag", () => {
-      const schema = images({ accept: "image/webp" }).nullable();
+      const schema = images({
+        directory: "/public/val",
+        accept: "image/webp",
+      }).nullable();
       const serialized = schema["executeSerialize"]();
       expect(serialized.opt).toBe(true);
     });
@@ -297,13 +308,13 @@ describe("ImagesSchema", () => {
 
   describe("remote", () => {
     test("should create remote variant", () => {
-      const schema = images({ accept: "image/webp" });
+      const schema = images({ directory: "/public/val", accept: "image/webp" });
       const remoteSchema = schema.remote();
       expect(remoteSchema["executeSerialize"]().remote).toBe(true);
     });
 
     test("should reject remote URLs when remote is not enabled", () => {
-      const schema = images({ accept: "image/webp" });
+      const schema = images({ directory: "/public/val", accept: "image/webp" });
       const src: Record<string, ImagesEntryMetadata> = {
         "https://remote.val.build/file/p/proj123/b/01/v/1.0.0/h/abc123/f/def456/p/public/val/image.webp":
           {
@@ -323,7 +334,10 @@ describe("ImagesSchema", () => {
     });
 
     test("should accept remote URLs when remote is enabled", () => {
-      const schema = images({ accept: "image/webp" }).remote();
+      const schema = images({
+        directory: "/public/val",
+        accept: "image/webp",
+      }).remote();
       const src: Record<string, ImagesEntryMetadata> = {
         "https://remote.val.build/file/p/proj123/b/01/v/1.0.0/h/abc123/f/def456/p/public/val/image.webp":
           {
@@ -395,7 +409,10 @@ describe("ImagesSchema", () => {
     });
 
     test("should reject invalid remote URLs", () => {
-      const schema = images({ accept: "image/webp" }).remote();
+      const schema = images({
+        directory: "/public/val",
+        accept: "image/webp",
+      }).remote();
       const src: Record<string, ImagesEntryMetadata> = {
         "not-a-valid-url": {
           width: 800,
@@ -436,7 +453,10 @@ describe("ImagesSchema", () => {
     });
 
     test("should accept http URLs when remote is enabled", () => {
-      const schema = images({ accept: "image/webp" }).remote();
+      const schema = images({
+        directory: "/public/val",
+        accept: "image/webp",
+      }).remote();
       const src: Record<string, ImagesEntryMetadata> = {
         "http://remote.val.build/file/p/proj123/b/01/v/1.0.0/h/abc123/f/def456/p/public/val/image.webp":
           {
@@ -451,7 +471,10 @@ describe("ImagesSchema", () => {
     });
 
     test("should reject non-Val remote URLs", () => {
-      const schema = images({ accept: "image/webp" }).remote();
+      const schema = images({
+        directory: "/public/val",
+        accept: "image/webp",
+      }).remote();
       const src: Record<string, ImagesEntryMetadata> = {
         "https://example.com/image.webp": {
           width: 800,
@@ -599,7 +622,7 @@ describe("ImagesSchema", () => {
 
   describe("defaults", () => {
     test("should default accept to image/* when options are omitted", () => {
-      const schema = images();
+      const schema = images({ directory: "/public/val" });
       const serialized = schema["executeSerialize"]();
       expect((serialized as SerializedImagesSchema).mediaType).toBe("images");
       expect(serialized.accept).toBe("image/*");
@@ -609,7 +632,9 @@ describe("ImagesSchema", () => {
     });
 
     test("should default accept to image/* when options are empty", () => {
-      const serialized = images({})["executeSerialize"]();
+      const serialized = images({ directory: "/public/val" })[
+        "executeSerialize"
+      ]();
       expect(serialized.accept).toBe("image/*");
       expect(serialized.directory).toBe("/public/val");
     });
@@ -623,12 +648,14 @@ describe("ImagesSchema", () => {
     });
 
     test("should default alt to a nullable string when options are omitted", () => {
-      const serialized = images()["executeSerialize"]();
+      const serialized = images({ directory: "/public/val" })[
+        "executeSerialize"
+      ]();
       expect(serialized.alt).toMatchObject({ type: "string", opt: true });
     });
 
     test("should accept any image mime type when options are omitted", () => {
-      const schema = images();
+      const schema = images({ directory: "/public/val" });
       const src: Record<string, ImagesEntryMetadata> = {
         "/public/val/test.png": {
           width: 800,
@@ -643,7 +670,7 @@ describe("ImagesSchema", () => {
     });
 
     test("should reject non-image mime types when options are omitted", () => {
-      const schema = images();
+      const schema = images({ directory: "/public/val" });
       const src = {
         "/public/val/test.pdf": {
           width: 800,
@@ -665,7 +692,7 @@ describe("ImagesSchema", () => {
     });
 
     test("should use the default /public/val directory when options are omitted", () => {
-      const schema = images();
+      const schema = images({ directory: "/public/val" });
       const src: Record<string, ImagesEntryMetadata> = {
         "/public/other/test.png": {
           width: 800,
@@ -684,7 +711,7 @@ describe("ImagesSchema", () => {
     });
 
     test("should not allow remote refs when options are omitted", () => {
-      const schema = images();
+      const schema = images({ directory: "/public/val" });
       const src: Record<string, ImagesEntryMetadata> = {
         "https://remote.val.build/file/p/proj123/b/01/v/1.0.0/h/abc123/f/def456/p/public/val/image.webp":
           {
@@ -706,7 +733,10 @@ describe("ImagesSchema", () => {
 
   describe("custom validation", () => {
     test("should support custom validation function", () => {
-      const schema = images({ accept: "image/webp" }).validate((src) => {
+      const schema = images({
+        directory: "/public/val",
+        accept: "image/webp",
+      }).validate((src) => {
         if (Object.keys(src ?? {}).length === 0) {
           return "At least one image is required";
         }

--- a/packages/core/src/schema/images.ts
+++ b/packages/core/src/schema/images.ts
@@ -25,9 +25,13 @@ export type ImagesOptions<Accept extends `image/${string}`> = {
   /**
    * The directory where images should be stored.
    * Must start with "/public" (e.g., "/public/val/images")
-   * @default "/public/val"
+   *
+   * Required, and deliberately so: it decides where every uploaded file in this
+   * collection lands, and it used to default to "/public/val" — which meant a
+   * gallery that had simply not said where it wanted its files silently shared a
+   * directory with every other one.
    */
-  directory?: "/public" | `/public/${string}`;
+  directory: "/public" | `/public/${string}`;
   /**
    * Alt text schema. Can be:
    * - s.string() for required alt text
@@ -75,8 +79,9 @@ type ImagesItemSrc = {
 /**
  * Define a collection of images.
  *
- * All options are optional: `s.images()` accepts any image type (`"image/*"`) in
- * the default `/public/val` directory, with nullable alt text and remote disabled.
+ * `directory` is required — it decides where uploads land, so it is not something
+ * to be inferred. The rest defaults: any image type (`"image/*"`), nullable alt
+ * text, remote disabled.
  *
  * @example
  * ```typescript
@@ -96,14 +101,14 @@ type ImagesItemSrc = {
  * ```
  */
 export const images = <Accept extends `image/${string}`>(
-  options?: ImagesOptions<Accept>,
+  options: ImagesOptions<Accept>,
 ): RecordSchema<
   ObjectSchema<ImagesItemProps, ImagesItemSrc>,
   Schema<string>,
   Record<string, ImagesEntryMetadata>
 > => {
-  const directory = options?.directory ?? "/public/val";
-  const altSchema = options?.alt ?? string().nullable();
+  const directory = options.directory;
+  const altSchema = options.alt ?? string().nullable();
   const itemSchema = new ObjectSchema(
     {
       width: new NumberSchema<number>(undefined, false),
@@ -115,9 +120,9 @@ export const images = <Accept extends `image/${string}`>(
   ) as ObjectSchema<ImagesItemProps, ImagesItemSrc>;
   return new RecordSchema(itemSchema, false, [], null, null, {
     type: "images",
-    accept: options?.accept ?? "image/*",
+    accept: options.accept ?? "image/*",
     directory,
-    remote: options?.remote ?? false,
+    remote: options.remote ?? false,
     altSchema,
   });
 };

--- a/packages/core/src/schema/jsonValues.test.ts
+++ b/packages/core/src/schema/jsonValues.test.ts
@@ -88,7 +88,9 @@ describe("c.json + .jsonValues()", () => {
   });
 
   test(".jsonValues() throws on image galleries", () => {
-    expect(() => images().jsonValues()).toThrow(/jsonValues/);
+    expect(() => images({ directory: "/public/val" }).jsonValues()).toThrow(
+      /jsonValues/,
+    );
   });
 
   describe("validation", () => {

--- a/packages/ui/spa/components/jsonValuesLoadRequirements.test.ts
+++ b/packages/ui/spa/components/jsonValuesLoadRequirements.test.ts
@@ -212,7 +212,11 @@ describe("jsonValuesLoadRequirements", () => {
   });
 
   test("file refs match the referenced gallery module", () => {
-    const gallery = c.define(GALLERY, s.images(), {});
+    const gallery = c.define(
+      GALLERY,
+      s.images({ directory: "/public/val" }),
+      {},
+    );
     const schemas = getSchemas([
       gallery,
       c.define(


### PR DESCRIPTION
`directory` was optional on both media collection factories, defaulting to `/public/val`.

That default was silent **and** shared. Two collections that had simply not said where they wanted their files both landed in `/public/val` — and `images:check-unique-folder` then reports a collision the author never chose. It is also the shape of the bug that started the media work in the first place: a gallery whose uploads went to `/public/val` while its schema named somewhere else.

Where uploads land is not something to infer, so it is now required.

```diff
- s.images({ accept: "image/webp" })
+ s.images({ directory: "/public/val/images", accept: "image/webp" })

- s.files({ accept: "application/pdf" })
+ s.files({ directory: "/public/val/documents", accept: "application/pdf" })
```

## Breaking, and what to do about it

`@valbuild/core` minor. `s.images()` with no arguments no longer typechecks. Passing `directory: "/public/val"` reproduces the old behaviour exactly.

The runtime `?? "/public/val"` fallbacks go with the default rather than lingering as unreachable code. One consequence worth stating: a **JavaScript** caller that omits `directory` now serializes `directory: undefined` rather than silently getting `/public/val`. TypeScript callers cannot reach that, and the schemas that matter live in typechecked `.val.ts` files.

## Scope

Nothing outside `packages/core`'s own tests needed changing — the example app, the CLI fixtures and the e2e specs all named their directory already. Every updated call site got `directory: "/public/val"`, i.e. the old default, so **no test expectation changed**.

One process note, since it shows in the branch's history: I first tried to update call sites by matching `s.images(` textually, and it rewrote docstrings and AI prompt strings as well. Reverted; the sites in this PR were found from the compiler's own (file, line, column), so only real code is touched.

## Verified

`pnpm run lint`, `pnpm -w run format`, `pnpm run -r typecheck`, `pnpm test` (1786 tests, 152 suites), and `val validate` against the example app (13 valid, same 2 pre-existing stale-metadata errors as before).

Stacked on [#492](https://github.com/valbuild/val/pull/492), which touches the same media/remote schema area.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1uhmmkdc8148oqdVL23zX)_