### PR TITLE
Five ways a snapshot got overtaken: stat freshness, canvas catch-up, committed sources, uploads, and jsonValues entries

### DIFF
--- a/.changeset/adopt-committed-json-entries.md
+++ b/.changeset/adopt-committed-json-entries.md
@@ -1,0 +1,29 @@
+---
+"@valbuild/server": patch
+---
+
+Serve the `.jsonValues()` entry content a save has just written
+
+A `.jsonValues()` entry's committed content is resolved through the marker's own
+`import()` thunk, which resolves from the module registry rather than from disk.
+So after `/save` rewrote a `*.val.json`, the server kept answering with the
+content from before the publish — and unlike a module source there was nothing to
+re-extract, because the memoised source never held the entry content in the first
+place. It only corrected itself when the host rebuilt its module graph.
+
+Both readers saw it: a page rendering draft content, once the publish removed the
+patches there was nothing left to replay over the stale baseline; and the Studio,
+which reads `/json` with `apply_patches: false` on purpose because it applies
+patches itself.
+
+`prepare` already computes the new content but discarded it — the flush turns it
+into a flat path-keyed file map, and the entry key is not recoverable from a path
+(a marker does not carry its path at read time, and two different producers turn a
+key into a path). So it now reports `PreparedCommit.patchedJsonEntries`, keyed by
+module and entry key, recorded at each of the six op sites where the key is in
+scope. `adoptCommittedSources` takes the prepared commit and holds it;
+`getJsonEntries` consults it before the thunk, as the committed baseline, so
+pending patches still replay on top unchanged.
+
+Adopted only for a module whose source was also adopted, since the source is what
+decides which keys exist.

--- a/.changeset/stale-stat-published-patches.md
+++ b/.changeset/stale-stat-published-patches.md
@@ -1,4 +1,5 @@
 ---
+"@valbuild/core": patch
 "@valbuild/server": patch
 "@valbuild/ui": patch
 ---
@@ -52,3 +53,32 @@ on pre-publish content until the next keystroke put a patch back in the chain.
 The snapshot now also names the modules this session published into
 (`PatchStore.publishedModules()`), whose live source in the editor is the
 published value.
+
+## Committed content the server has just written
+
+`ValOps` memoises the sources and re-reads them by awaiting each module's `def` —
+the app's own `import()`, which resolves from the module registry rather than from
+disk. So after `/save` rewrites a `.val.ts`, invalidating the memo would return
+the pre-save content and store it as fresh; nothing replaced it until the host
+rebuilt its module graph. That is what a page rendering draft content falls back
+on once a publish has removed the patches, so it showed the content from before
+the publish.
+
+The save tells `ValOps` instead: `adoptCommittedSources` takes the analysis it
+just committed and adopts the sources it produced. The SHA fold moved out of
+`extractValModules` into `computeValModuleShas` so those SHAs can be recomputed
+over sources that did not come from evaluating the modules — the entries the fold
+ran over are kept, and replaying them unchanged reproduces the SHAs exactly, so
+only a module whose source actually moved changes anything.
+
+`baseSha` therefore moves on a publish in `fs` mode, for the first time within a
+server's lifetime. That is a signal the studio already knows how to read:
+`PatchStore.reconcileVanished` uses a moved base to tell "these patches were
+published" from "these were discarded", so a second studio watching a publish
+takes them out of its chain without reverting the published fields. `schemaSha`
+does not move, so nothing refetches `/schema`.
+
+Not covered: a `.jsonValues()` entry's content is not in the module source — the
+source holds markers and the content sits behind the marker's own `import()`
+thunk, which caches the same way. `architecture/quirks.md` records what closing
+that would take.

--- a/.changeset/stale-stat-published-patches.md
+++ b/.changeset/stale-stat-published-patches.md
@@ -82,3 +82,25 @@ Not covered: a `.jsonValues()` entry's content is not in the module source — t
 source holds markers and the content sits behind the marker's own `import()`
 thunk, which caches the same way. `architecture/quirks.md` records what closing
 that would take.
+
+## Replacing an image usually did not take
+
+The bytes of a patch's file are uploaded a round trip BEFORE the patch record
+that references them — the record's `file` op carries only a sha, so a record
+written first would point at nothing. That leaves `.val/patches/<patchId>/`
+holding `files/` and no `patch.json` until `PUT /patches` lands, which
+`readPatchStore` read as a patch whose contents were lost: repair removed the
+directory, took the uploaded bytes with it, and told the person editing their
+unpublished change had been thrown away. The image then 404ed from
+`?patch_id=...` and the replacement silently did not happen.
+
+The window is not passive. Writing into `.val/patches` is exactly what ends
+`getStat`'s long poll, so the upload summons the read that destroys it — which is
+why replacing an image worked only when the two requests happened to land close
+enough together.
+
+The upload now declares the window: `uploading.json` is written before the first
+byte, and a record-less directory carrying a fresh one is not a problem at all.
+`appendPatch` clears it once the record exists, and a marker older than an hour
+is an upload whose client never came back — swept as an orphan, and silently,
+because nothing ever referenced those bytes.

--- a/.changeset/stale-stat-published-patches.md
+++ b/.changeset/stale-stat-published-patches.md
@@ -1,0 +1,32 @@
+---
+"@valbuild/server": patch
+"@valbuild/ui": patch
+---
+
+Stop auto-save reporting published changes as changes that could not be loaded
+
+With auto-save on, the studio would show "N unpublished changes could not be
+loaded — the server listed them but did not send them" for changes that had just
+been published successfully.
+
+`/stat` long polls in `fs` mode: it reads the patch store, finds nothing changed,
+and waits for a file to move. It then answered with the list it read when the
+poll opened — and the write that ends most waits is the studio's own `/save`,
+which commits the patches and deletes them. So the response named patches that
+had stopped existing a polling interval earlier, the studio put those ids back in
+its chain, fetched them from a server that correctly no longer had them, and got
+an empty answer it reported as the server contradicting itself. Auto-save made it
+routine by publishing on every pause in typing.
+
+`getStat` now reads again before it answers, so the list describes the moment of
+the response rather than the moment of the wait. The studio no longer depends on
+that: it ignores an announcement of a patch it has already published, and gives
+an announced-but-undelivered id one more stat before reporting it — an
+announcement can be older than a delete, and only a stat issued after the delete
+can tell that from a server that cannot send what it has. The report for a server
+that really is announcing what it cannot deliver is unchanged, one stat later.
+
+Also fixes two timers the long poll left running behind every stat: the
+polling-interval fallback, which nothing cleared when another branch won the
+race, and the module-file poller, which rescheduled itself after the cleanup had
+already run.

--- a/.changeset/stale-stat-published-patches.md
+++ b/.changeset/stale-stat-published-patches.md
@@ -99,8 +99,16 @@ The window is not passive. Writing into `.val/patches` is exactly what ends
 why replacing an image worked only when the two requests happened to land close
 enough together.
 
-The upload now declares the window: `uploading.json` is written before the first
-byte, and a record-less directory carrying a fresh one is not a problem at all.
-`appendPatch` clears it once the record exists, and a marker older than an hour
-is an upload whose client never came back — swept as an orphan, and silently,
-because nothing ever referenced those bytes.
+So uploaded bytes are no longer in the store until they belong to something. They
+go to `.val/uploads/<patchId>/` — a sibling of the patches directory, so nothing
+reading the store lists it and moving into place is a rename — and `appendPatch`
+moves them in: record, then bytes, then log line, all under the lock. The record
+first is what makes "files but no `patch.json`" a state the store cannot produce;
+the log line last keeps the existing crash property; and the lock means repair,
+which re-reads under it, never sees the halfway state.
+
+Both readers of a patch's bytes accept either location, because the studio asks
+for the new image before the patch referencing it has been written. A staging
+directory whose `PUT` never arrived is swept after a day — a TTL that only
+governs garbage collection outside the store, where being wrong costs disk space
+rather than someone's upload.

--- a/.changeset/stale-stat-published-patches.md
+++ b/.changeset/stale-stat-published-patches.md
@@ -30,3 +30,25 @@ Also fixes two timers the long poll left running behind every stat: the
 polling-interval fallback, which nothing cleared when another branch won the
 race, and the module-file poller, which rescheduled itself after the cleanup had
 already run.
+
+## The canvas going stale after an auto-save
+
+Two defects in the same area, with the same cause: publishing rewrites the
+`.val.ts` files, `next dev` reloads the page on the change, and the studio was
+not set up to catch that new document up.
+
+The canvas relay carries changes, so a freshly loaded document is caught up once
+with a snapshot of what the editor holds. That snapshot was keyed on the reloads
+the STUDIO asked for, and a page that reloads itself announces the new document
+with another `ready` carrying the same `draftMode` — nothing the effect depended
+on changed, so it never re-ran. It is now keyed on the page announcing itself,
+which covers both.
+
+And the snapshot only named modules with a PENDING patch, which is the set a
+publish empties. So even when it did run it had nothing to send, and then said
+`sourcesSynced` — telling the page to render committed source. If that render
+came from a server that had not picked up the newly written file, the canvas sat
+on pre-publish content until the next keystroke put a patch back in the chain.
+The snapshot now also names the modules this session published into
+(`PatchStore.publishedModules()`), whose live source in the editor is the
+published value.

--- a/architecture/patch-store.md
+++ b/architecture/patch-store.md
@@ -13,6 +13,7 @@ applies to it.
     patches.repair.log        what repair has done, and when
     <patchId>/patch.json      one self-contained record per patch
     <patchId>/base.json       written when the patch is published
+    <patchId>/uploading.json  bytes are on the way, the record is not here yet
     <patchId>/files/…         binary payloads for this patch's file ops
 ```
 
@@ -101,6 +102,26 @@ directory: inert, and swept up by repair. The reverse order would leave the log
 naming a patch that is not there, which is the state that started all this. **If
 you touch the write path, keep that order.**
 
+**A patch carrying a file is written in TWO requests, bytes first, and the gap
+between them is declared.** The record's `file` op holds only a sha, so a record
+written before its bytes would point at nothing — the upload has to go first.
+That leaves `<patchId>/` holding `files/` and no `patch.json` for a round trip,
+which is neither of the two shapes above, and reading it as "a patch whose
+contents are lost" is wrong in the most expensive way: repair removes it, the
+bytes go, and the studio is told someone's work was thrown away. So
+`saveBase64EncodedBinaryFileFromPatch` writes `uploading.json` **before the first
+byte**, and `readPatchStore` skips a record-less directory that has a fresh one.
+
+This window is not rare and it is not passive. Writing into `.val/patches` is
+exactly what breaks `getStat`'s long poll, so **the upload summons the read that
+would destroy it** — which is why replacing an image worked only when the two
+requests happened to land close enough together.
+
+`appendPatch` removes the marker once the record exists, after the write for the
+same reason the log line comes last. A marker older than an hour is an upload
+whose client never came back: swept as an orphan, and silently, because nothing
+ever referenced those bytes.
+
 **A torn last line is discarded.** Appends are serialized by the lock, so an
 unterminated final line can only be a write that did not finish.
 
@@ -148,7 +169,9 @@ Directories are told apart by whether they hold a usable record. One that does
 not is an **unreadable patch**: work is gone, and it is reported. One that holds a
 perfectly good record the log does not name is a **crash leftover** — a record
 written before its log line — which nothing ever read, so nothing is lost and
-nobody is told.
+nobody is told. A third case is a record-less directory that says an upload is in
+flight: not a problem at all while the marker is fresh, an orphan once it is
+stale. See the write-path rule above.
 
 Repair only runs when something is wrong, so the healthy path — every stat poll —
 never touches the lock.

--- a/architecture/patch-store.md
+++ b/architecture/patch-store.md
@@ -83,6 +83,18 @@ published as stale (`publishedIds`), and gives an announced-but-undelivered id o
 more stat before reporting it (`notDeliveredOnce`). The server fix removes the
 routine case; the client fix is what makes the rest correct.
 
+**The base moves on a publish now.** `/save` hands the sources it just wrote to
+`ValOps.adoptCommittedSources`, which adopts them and re-folds the SHAs — because
+re-reading them cannot work: a module's content is read by awaiting its `def`,
+the app's own `import()`, which resolves from the module registry rather than the
+file that was just rewritten. So in `fs` mode `baseSha` changes within a server's
+lifetime for the first time, which is what `reconcileVanished` needs to tell a
+patch that was PUBLISHED from one that was discarded. `schemaSha` does not move —
+the fold leaves it alone when only sources change, so nothing refetches `/schema`.
+
+What that does NOT cover is `.jsonValues()` entry content: it is not in the
+source, which holds only markers. See `architecture/quirks.md`.
+
 **A crash can only ever leave a directory the log does not name.** `appendPatch`
 writes the record, then the log line. Interrupted, that leaves an unreferenced
 directory: inert, and swept up by repair. The reverse order would leave the log

--- a/architecture/patch-store.md
+++ b/architecture/patch-store.md
@@ -94,8 +94,10 @@ lifetime for the first time, which is what `reconcileVanished` needs to tell a
 patch that was PUBLISHED from one that was discarded. `schemaSha` does not move —
 the fold leaves it alone when only sources change, so nothing refetches `/schema`.
 
-What that does NOT cover is `.jsonValues()` entry content: it is not in the
-source, which holds only markers. See `architecture/quirks.md`.
+`.jsonValues()` entry content is adopted alongside it, by a separate route: it is
+not in the source at all, which holds only markers, so `prepare` reports it per
+entry key and `getJsonEntries` consults that before the marker's thunk. See
+`architecture/quirks.md`.
 
 **A crash can only ever leave a directory the log does not name.** `appendPatch`
 writes the record, then the log line. Interrupted, that leaves an unreferenced

--- a/architecture/patch-store.md
+++ b/architecture/patch-store.md
@@ -13,8 +13,9 @@ applies to it.
     patches.repair.log        what repair has done, and when
     <patchId>/patch.json      one self-contained record per patch
     <patchId>/base.json       written when the patch is published
-    <patchId>/uploading.json  bytes are on the way, the record is not here yet
     <patchId>/files/…         binary payloads for this patch's file ops
+.val/uploads/
+    <patchId>/files/…         uploaded bytes, until the patch record exists
 ```
 
 Two rules carry the whole design:
@@ -102,25 +103,34 @@ directory: inert, and swept up by repair. The reverse order would leave the log
 naming a patch that is not there, which is the state that started all this. **If
 you touch the write path, keep that order.**
 
-**A patch carrying a file is written in TWO requests, bytes first, and the gap
-between them is declared.** The record's `file` op holds only a sha, so a record
-written before its bytes would point at nothing — the upload has to go first.
-That leaves `<patchId>/` holding `files/` and no `patch.json` for a round trip,
-which is neither of the two shapes above, and reading it as "a patch whose
-contents are lost" is wrong in the most expensive way: repair removes it, the
-bytes go, and the studio is told someone's work was thrown away. So
-`saveBase64EncodedBinaryFileFromPatch` writes `uploading.json` **before the first
-byte**, and `readPatchStore` skips a record-less directory that has a fresh one.
+**Uploaded bytes are not in the store until they belong to something.** A patch
+carrying a file is written in TWO requests, bytes first: the record's `file` op
+holds only a sha, so a record written before its bytes would point at nothing.
+Uploading straight into `<patchId>/files/` left the directory holding files and
+no `patch.json` for a whole round trip — neither of the two shapes above — so
+`readPatchStore` read it as a patch whose contents were lost and repair removed
+it, bytes and all, telling the person editing their work had been thrown away.
 
-This window is not rare and it is not passive. Writing into `.val/patches` is
-exactly what breaks `getStat`'s long poll, so **the upload summons the read that
-would destroy it** — which is why replacing an image worked only when the two
-requests happened to land close enough together.
+That window was not rare and not passive: writing into `.val/patches` is exactly
+what breaks `getStat`'s long poll, so **the upload summoned the read that
+destroyed it**. Replacing an image worked only when the two requests happened to
+land close enough together.
 
-`appendPatch` removes the marker once the record exists, after the write for the
-same reason the log line comes last. A marker older than an hour is an upload
-whose client never came back: swept as an orphan, and silently, because nothing
-ever referenced those bytes.
+So uploads go to `.val/uploads/<patchId>/` — a sibling, so nothing reading the
+store lists it and moving into place is a rename — and `appendPatch` moves them
+in. **Record, then bytes, then log line**, all under the lock:
+
+- the record first, so a patch directory never exists without one, which is what
+  makes "files but no `patch.json`" a state this store cannot produce;
+- the log line last, for the reason above;
+- under the lock, so repair — which re-reads under it — never observes the
+  halfway state.
+
+Both readers of those bytes accept either location (`wherePatchFileIs`), because
+the studio asks for the new image before the patch referencing it is written. A
+staging directory whose `PUT` never arrived is swept after a day; that TTL only
+governs garbage collection **outside** the store, where being wrong costs disk
+space rather than someone's upload.
 
 **A torn last line is discarded.** Appends are serialized by the lock, so an
 unterminated final line can only be a write that did not finish.
@@ -169,9 +179,9 @@ Directories are told apart by whether they hold a usable record. One that does
 not is an **unreadable patch**: work is gone, and it is reported. One that holds a
 perfectly good record the log does not name is a **crash leftover** — a record
 written before its log line — which nothing ever read, so nothing is lost and
-nobody is told. A third case is a record-less directory that says an upload is in
-flight: not a problem at all while the marker is fresh, an orphan once it is
-stale. See the write-path rule above.
+nobody is told. There is no third case: uploaded bytes live outside the store
+until the record exists, so a record-less directory in `.val/patches` really is
+lost work. See the write-path rule above.
 
 Repair only runs when something is wrong, so the healthy path — every stat poll —
 never touches the lock.

--- a/architecture/patch-store.md
+++ b/architecture/patch-store.md
@@ -57,6 +57,32 @@ could break.**
 another is the bug; deriving both from one array is the fix. If you add a third
 caller, take it from there too.
 
+**And one answer per MOMENT.** `/stat` long polls: it reads, finds nothing
+changed, and waits up to `statPollingInterval` for a file to move. So "one read"
+is not enough on its own — the read has to be the one the answer is sent with.
+`getStat` reads the store again after the wait — the store only, because the
+shas and schemas come from `initSources`, which is memoised for the lifetime of
+the `ValOpsFS` instance and never invalidated. The reason is `/save`:
+
+- The write that ends most waits is the studio's own publish, which in `fs` mode
+  commits the patches and **deletes** them.
+- Answering with the list read before it names patches that stopped existing a
+  polling interval ago.
+- The studio then puts those ids back in its chain and fetches them from a server
+  that correctly no longer has them — "unpublished changes could not be loaded",
+  for changes that were just published. With auto-save on, that is every pause in
+  typing.
+
+`request-again` and `no-change` differ in why the wait ended, not in how current
+the answer has to be, so both re-read. **If you add a branch that returns after
+the wait, read again there too.**
+
+The studio does not rely on this. A snapshot protocol cannot promise its list was
+not overtaken, so `PatchStore` treats an announcement of a patch it has already
+published as stale (`publishedIds`), and gives an announced-but-undelivered id one
+more stat before reporting it (`notDeliveredOnce`). The server fix removes the
+routine case; the client fix is what makes the rest correct.
+
 **A crash can only ever leave a directory the log does not name.** `appendPatch`
 writes the record, then the log line. Interrupted, that leaves an unreferenced
 directory: inert, and swept up by repair. The reverse order would leave the log

--- a/architecture/quirks.md
+++ b/architecture/quirks.md
@@ -212,6 +212,15 @@ the server contradicting itself: the announcement may simply predate a delete.
 one more stat before reporting it. Auto-save is what made this loud, because it
 publishes on every pause in typing. See `architecture/patch-store.md`.
 
+**Writing into `.val/patches` wakes the stat that reads it.** `getStat` long
+polls on a watcher over the patches directory, so any write in there ends the
+poll and the next read happens immediately. That makes every "window" in the
+patch write path a window something actually looks into — which is how uploading
+an image, whose bytes land a round trip before the patch record that references
+them, came to summon the read that classified the half-written directory as lost
+work and deleted the bytes. `uploading.json` is what closes it; see
+[patch-store.md](./patch-store.md).
+
 **The server's committed sources do not come from disk.** `ValOps` memoises them,
 and re-reading means awaiting each module's `def` — the app's own `import()`,
 which resolves from the module registry. So a save that rewrites a `.val.ts`

--- a/architecture/quirks.md
+++ b/architecture/quirks.md
@@ -212,6 +212,24 @@ the server contradicting itself: the announcement may simply predate a delete.
 one more stat before reporting it. Auto-save is what made this loud, because it
 publishes on every pause in typing. See `architecture/patch-store.md`.
 
+**The server's committed sources do not come from disk.** `ValOps` memoises them,
+and re-reading means awaiting each module's `def` — the app's own `import()`,
+which resolves from the module registry. So a save that rewrites a `.val.ts`
+cannot be picked up by invalidating the memo: the re-extraction returns the
+pre-save content and stores it as fresh. The save tells `ValOps` instead
+(`adoptCommittedSources`), which also re-folds the SHAs so `baseSha` moves — the
+first thing that moves it within a server's lifetime in `fs` mode, and the signal
+`PatchStore.reconcileVanished` needs to tell a publish from a discard.
+
+**A `.jsonValues()` entry is NOT covered by that, and is still stale after a
+publish.** Its content is not in the memoised source — the source holds markers,
+and the content sits behind the marker's own `import()` thunk, which caches the
+same way. So `getJsonEntry` keeps answering with the pre-publish entry content
+until the host re-evaluates, and a page rendering draft content sees it as soon as
+the publish removes the patches. Closing it means carrying the committed entry
+content out of `prepare` (which computes it, keyed by `*.val.json` path) into an
+adopted-entries map that `getJsonEntries` consults before the thunk. Not done.
+
 ## Testing
 
 **`packages/ui` has no jsdom by default**, and importing a field component pulls in

--- a/architecture/quirks.md
+++ b/architecture/quirks.md
@@ -218,7 +218,8 @@ poll and the next read happens immediately. That makes every "window" in the
 patch write path a window something actually looks into — which is how uploading
 an image, whose bytes land a round trip before the patch record that references
 them, came to summon the read that classified the half-written directory as lost
-work and deleted the bytes. `uploading.json` is what closes it; see
+work and deleted the bytes. Uploads now land in `.val/uploads/` and are moved in
+behind the record, so there is no half-written directory to read; see
 [patch-store.md](./patch-store.md).
 
 **The server's committed sources do not come from disk.** `ValOps` memoises them,

--- a/architecture/quirks.md
+++ b/architecture/quirks.md
@@ -231,14 +231,20 @@ pre-save content and stores it as fresh. The save tells `ValOps` instead
 first thing that moves it within a server's lifetime in `fs` mode, and the signal
 `PatchStore.reconcileVanished` needs to tell a publish from a discard.
 
-**A `.jsonValues()` entry is NOT covered by that, and is still stale after a
-publish.** Its content is not in the memoised source — the source holds markers,
-and the content sits behind the marker's own `import()` thunk, which caches the
-same way. So `getJsonEntry` keeps answering with the pre-publish entry content
-until the host re-evaluates, and a page rendering draft content sees it as soon as
-the publish removes the patches. Closing it means carrying the committed entry
-content out of `prepare` (which computes it, keyed by `*.val.json` path) into an
-adopted-entries map that `getJsonEntries` consults before the thunk. Not done.
+**A `.jsonValues()` entry needs its own adoption, for a sharper reason.** Its
+content is not in the memoised source at all — the source holds markers, and the
+content sits behind the marker's own `import()` thunk, which caches the same way.
+So there is nothing to re-extract: the memo was never holding it. `prepare` is the
+only thing that knows what an entry now holds, and it reports that as
+`PreparedCommit.patchedJsonEntries` — **keyed by entry key, not by file path**,
+because a marker does not carry its path at read time and two different producers
+turn a key into a path (`resolveEntryJsonPath`, and `getNewJsonEntryPaths` for an
+`add` or a move's destination). `getJsonEntries` consults the adopted map before
+the thunk, as the committed BASELINE, so pending patches still replay on top.
+
+Adopted only for a module whose source was also adopted: the source decides which
+keys exist, so taking one without the other would leave the content and the key
+set describing different moments.
 
 ## Testing
 

--- a/architecture/quirks.md
+++ b/architecture/quirks.md
@@ -203,6 +203,15 @@ two backwards and you either resurrect deleted edits as permanent failures, or
 wait forever on changes that will never arrive — the second of which is a real
 bug that shipped. See `architecture/patch-store.md`.
 
+**`/stat`'s patch list can be a polling interval old.** It long polls in `fs`
+mode, and it used to answer with the list it read when the poll _opened_ — so the
+response that arrives right after a publish still named the patches the publish
+committed and deleted. Announced-but-undelivered is therefore not, on its own,
+the server contradicting itself: the announcement may simply predate a delete.
+`getStat` now reads again before answering, and the studio still gives such an id
+one more stat before reporting it. Auto-save is what made this loud, because it
+publishes on every pause in typing. See `architecture/patch-store.md`.
+
 ## Testing
 
 **`packages/ui` has no jsdom by default**, and importing a field component pulls in

--- a/jest.config.js
+++ b/jest.config.js
@@ -21,4 +21,6 @@ module.exports = {
    * Run those with `pnpm run test:e2e`.
    */
   testPathIgnorePatterns: ["<rootDir>/e2e/", "/node_modules/"],
+  /** jsdom's missing web globals. See the file. */
+  setupFiles: ["<rootDir>/jest.setup.js"],
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,33 @@
+/**
+ * Fill in what jsdom does not have.
+ *
+ * These are part of the Node globals and of every browser, but jsdom does not
+ * install them. That is not an abstract gap here: importing
+ * `@valbuild/shared/internal` touches all of them at module scope — the richtext
+ * conversion builds a `TextEncoder`, and `ApiRoutes` names `ReadableStream` in a
+ * zod schema — so ANY jsdom suite that renders a component reaching shared code
+ * dies on the import, before a single test runs, with a stack pointing at
+ * richtext or at a route table rather than at anything the test is about.
+ *
+ * Assigned only when missing, because this file also runs for the node-env
+ * suites, where the real globals are already there.
+ */
+const { TextEncoder, TextDecoder } = require("util");
+const {
+  ReadableStream,
+  WritableStream,
+  TransformStream,
+} = require("stream/web");
+
+const missing = {
+  TextEncoder,
+  TextDecoder,
+  ReadableStream,
+  WritableStream,
+  TransformStream,
+};
+for (const [name, value] of Object.entries(missing)) {
+  if (typeof globalThis[name] === "undefined") {
+    globalThis[name] = value;
+  }
+}

--- a/packages/core/src/extractValModules.shas.test.ts
+++ b/packages/core/src/extractValModules.shas.test.ts
@@ -1,0 +1,131 @@
+import { initVal } from "./initVal";
+import {
+  computeValModuleShas,
+  extractValModules,
+  type ValModuleShaEntry,
+} from "./extractValModules";
+import type { ModuleFilePath } from "./val";
+import type { Source } from "./source";
+
+const { s, c, config } = initVal();
+
+/**
+ * The SHAs are a fold, and something other than extraction has to be able to
+ * reproduce it.
+ *
+ * The server promotes the sources it has just written to disk rather than
+ * re-evaluating the modules — a module `def` is the app's own `import()`, which
+ * resolves from the module registry and not from the file that was just
+ * rewritten, so re-extracting gets the OLD content back. Promoting means folding
+ * the SHAs again over entries the fold produced the first time, so that fold has
+ * to be replayable to the bit.
+ */
+const modules = () => ({
+  config,
+  modules: [
+    {
+      def: async () => ({
+        default: c.define("/a.val.ts", s.object({ title: s.string() }), {
+          title: "a",
+        }),
+      }),
+    },
+    {
+      def: async () => ({
+        default: c.define("/b.val.ts", s.object({ title: s.string() }), {
+          title: "b",
+        }),
+      }),
+    },
+  ],
+});
+
+const withSource = (
+  entries: readonly ValModuleShaEntry[],
+  path: string,
+  source: Source,
+): ValModuleShaEntry[] =>
+  entries.map((entry) =>
+    entry.path === (path as ModuleFilePath) ? { ...entry, source } : entry,
+  );
+
+describe("the module SHA fold", () => {
+  it("reproduces itself from the entries it recorded", async () => {
+    const extracted = await extractValModules(modules());
+
+    const again = computeValModuleShas(
+      config,
+      extracted.shaEntries,
+      extracted.moduleErrors,
+    );
+
+    expect(again).toEqual({
+      baseSha: extracted.baseSha,
+      schemaSha: extracted.schemaSha,
+      sourcesSha: extracted.sourcesSha,
+      configSha: extracted.configSha,
+    });
+  });
+
+  it("moves the source SHAs when one module's source moves, and nothing else", async () => {
+    const extracted = await extractValModules(modules());
+
+    const moved = computeValModuleShas(
+      config,
+      withSource(extracted.shaEntries, "/a.val.ts", { title: "published" }),
+      extracted.moduleErrors,
+    );
+
+    expect(moved.sourcesSha).not.toBe(extracted.sourcesSha);
+    expect(moved.baseSha).not.toBe(extracted.baseSha);
+    // The schemas did not move, and the client refetches `/schema` on this one.
+    expect(moved.schemaSha).toBe(extracted.schemaSha);
+    expect(moved.configSha).toBe(extracted.configSha);
+  });
+
+  /**
+   * The fold is ORDER-dependent, which is why the entries are a list and not a
+   * record keyed by path. A record would leave this to insertion order, which
+   * nothing in the type promises.
+   */
+  it("depends on the order the modules are folded in", async () => {
+    const extracted = await extractValModules(modules());
+
+    const reversed = computeValModuleShas(
+      config,
+      [...extracted.shaEntries].reverse(),
+      extracted.moduleErrors,
+    );
+
+    expect(reversed.sourcesSha).not.toBe(extracted.sourcesSha);
+  });
+
+  /**
+   * A module that fails to load changes the base SHA of every module folded in
+   * AFTER it and of none before, because the error array is mixed in as it
+   * stands at each step. `moduleErrorsAt` is what carries that, and getting it
+   * wrong would make a promotion look like a change on any project with a broken
+   * module.
+   */
+  it("mixes in only the errors collected before each module", async () => {
+    const broken = {
+      config,
+      modules: [
+        modules().modules[0],
+        { def: async () => Promise.reject(new Error("boom")) },
+        modules().modules[1],
+      ],
+    };
+    const extracted = await extractValModules(broken);
+    expect(extracted.moduleErrors).toHaveLength(1);
+    expect(extracted.shaEntries.map((entry) => entry.moduleErrorsAt)).toEqual([
+      0, 1,
+    ]);
+
+    // And the replay is still exact with the error in place.
+    expect(
+      computeValModuleShas(config, extracted.shaEntries, extracted.moduleErrors)
+        .baseSha,
+    ).toBe(extracted.baseSha);
+  });
+});

--- a/packages/core/src/extractValModules.ts
+++ b/packages/core/src/extractValModules.ts
@@ -20,6 +20,15 @@ export type ExtractedValModules = {
   sourcesSha: string;
   configSha: string;
   moduleErrors: ExtractedModuleError[];
+  /**
+   * What the SHAs above are a fold over, in order.
+   *
+   * Kept so they can be recomputed from a source that did NOT come from
+   * evaluating the modules — see {@link computeValModuleShas}. A record keyed by
+   * path could not do this: the fold is order-dependent, and the order is
+   * `val.modules`, which a record does not promise to preserve.
+   */
+  shaEntries: ValModuleShaEntry[];
 };
 
 // Lazily constructed: this module is also evaluated inside the `vm` sandbox
@@ -112,6 +121,93 @@ function collectObjectRecursive(
 }
 
 /**
+ * One module's contribution to the SHAs, in fold order.
+ *
+ * The SHAs are a FOLD, not a hash of a set: each module is mixed into the
+ * running value in `val.modules` order, so reproducing one means replaying the
+ * same modules with the same inputs in the same order. That is what this type
+ * is for — see {@link computeValModuleShas}.
+ */
+export type ValModuleShaEntry = {
+  path: ModuleFilePath;
+  source: Source;
+  serializedSchema: SerializedSchema;
+  /**
+   * How many module errors had been collected when this module was folded in.
+   *
+   * The base SHA mixes in the error array as it stood at each step, so a module
+   * that failed to load changes the hash of every module folded in AFTER it and
+   * of none before. Errors are only ever appended, so the state at step _i_ is
+   * the final array's first `moduleErrorsAt` entries — one number is enough to
+   * reproduce it exactly, and a per-step copy is not needed.
+   */
+  moduleErrorsAt: number;
+};
+
+export type ValModuleShas = {
+  baseSha: string;
+  schemaSha: string;
+  sourcesSha: string;
+  configSha: string;
+};
+
+/**
+ * The SHAs, from the entries they are a fold over.
+ *
+ * Split out from {@link extractValModules} because there are two ways to arrive
+ * at a set of sources. Extraction evaluates the modules; the server also
+ * PROMOTES the sources it has just written to disk, because re-evaluating gets
+ * it nothing — a module `def` is the app's own `import()`, which resolves from
+ * the module registry rather than from the file that was just rewritten. Both
+ * have to produce SHAs the other side can compare, so the fold has one
+ * implementation and both call it.
+ *
+ * Feeding back the entries a previous fold used, unchanged, reproduces its SHAs
+ * exactly. That is the property the promotion relies on: only the modules whose
+ * source actually moved change anything.
+ */
+export function computeValModuleShas(
+  config: ValModules["config"],
+  entries: readonly ValModuleShaEntry[],
+  moduleErrors: readonly ExtractedModuleError[],
+): ValModuleShas {
+  const configSha = hash(JSON.stringify(config));
+  let sourcesSha = "";
+  let baseSha = configSha;
+  // NOTE: schemaSha is deliberately NOT seeded with configSha. It is compared
+  // across bundles (the server extracts from the Node bundle, the editor SPA
+  // from the browser bundle) to detect that a new version has been deployed.
+  // The config contains values that are not part of the schema and that differ
+  // between those two bundles - most notably the documented
+  // `gitCommit: process.env.VERCEL_GIT_COMMIT_SHA` / `gitBranch`, which are
+  // server-only env vars and therefore `undefined` in the browser. Seeding with
+  // them made the two sides disagree on every production load.
+  let schemaSha = "";
+  for (const entry of entries) {
+    const { path, source, serializedSchema } = entry;
+    sourcesSha = hash(sourcesSha + JSON.stringify({ path, source }));
+    baseSha = hash(
+      baseSha +
+        JSON.stringify({
+          path,
+          schema: serializedSchema,
+          source,
+          modulesErrors: moduleErrors.slice(0, entry.moduleErrorsAt),
+        }),
+    );
+    // The PATH is part of the schema set, not just the schema: renaming a
+    // module while leaving its schema byte-identical still changes which paths
+    // exist, and an open client keyed its schema cache by the old path. Hashing
+    // the schema alone left this SHA unchanged, so with no commitSha to fall
+    // back on the client never refetched /schema.
+    schemaSha = hash(
+      schemaSha + JSON.stringify({ path, schema: serializedSchema }),
+    );
+  }
+  return { baseSha, schemaSha, sourcesSha, configSha };
+}
+
+/**
  * Extracts schemas and sources from a ValModules registry and computes the
  * deterministic SHAs that the server and client both use to detect changes.
  *
@@ -133,18 +229,15 @@ export async function extractValModules(
   const sources: Record<ModuleFilePath, Source> = {};
   const schemas: Record<ModuleFilePath, Schema<SelectorSource>> = {};
   const serializedSchemas: Record<ModuleFilePath, SerializedSchema> = {};
-  const configSha = hash(JSON.stringify(valModules.config));
-  let sourcesSha = "";
-  let baseSha = configSha;
-  // NOTE: schemaSha is deliberately NOT seeded with configSha. It is compared
-  // across bundles (the server extracts from the Node bundle, the editor SPA
-  // from the browser bundle) to detect that a new version has been deployed.
-  // The config contains values that are not part of the schema and that differ
-  // between those two bundles - most notably the documented
-  // `gitCommit: process.env.VERCEL_GIT_COMMIT_SHA` / `gitBranch`, which are
-  // server-only env vars and therefore `undefined` in the browser. Seeding with
-  // them made the two sides disagree on every production load.
-  let schemaSha = "";
+  /**
+   * What the fold below runs over, collected here rather than hashed inline.
+   *
+   * The hashing itself moved to `computeValModuleShas`, so the server can
+   * recompute these SHAs for sources it did not get by evaluating the modules.
+   * Collected in loop order, which is `val.modules` order, which is the order
+   * the fold is defined by.
+   */
+  const shaEntries: ValModuleShaEntry[] = [];
   for (let moduleIdx = 0; moduleIdx < valModules.modules.length; moduleIdx++) {
     const module = valModules.modules[moduleIdx];
     // NOTE: `at index N` refers to the module's position in the val.modules
@@ -222,33 +315,21 @@ export async function extractValModules(
     sources[pathM] = source;
     schemas[pathM] = schema;
     serializedSchemas[pathM] = serializedSchema;
-    sourcesSha = hash(sourcesSha + JSON.stringify({ path, source }));
-    baseSha = hash(
-      baseSha +
-        JSON.stringify({
-          path,
-          schema: serializedSchema,
-          source,
-          modulesErrors: moduleErrors,
-        }),
-    );
-    // The PATH is part of the schema set, not just the schema: renaming a
-    // module while leaving its schema byte-identical still changes which paths
-    // exist, and an open client keyed its schema cache by the old path. Hashing
-    // the schema alone left this SHA unchanged, so with no commitSha to fall
-    // back on the client never refetched /schema.
-    schemaSha = hash(
-      schemaSha + JSON.stringify({ path, schema: serializedSchema }),
-    );
+    shaEntries.push({
+      path: pathM,
+      source,
+      serializedSchema,
+      // The errors so far, which is what the base SHA used to mix in by hashing
+      // the live array at this point in the loop. See `moduleErrorsAt`.
+      moduleErrorsAt: moduleErrors.length,
+    });
   }
   return {
     sources,
     schemas,
     serializedSchemas,
-    baseSha,
-    schemaSha,
-    sourcesSha,
-    configSha,
+    ...computeValModuleShas(valModules.config, shaEntries, moduleErrors),
     moduleErrors,
+    shaEntries,
   };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,7 +2,10 @@ export { initVal, type ConfigDirectory } from "./initVal";
 export { modules, type ValModules } from "./modules";
 export {
   extractValModules,
+  computeValModuleShas,
   type ExtractedValModules,
+  type ValModuleShaEntry,
+  type ValModuleShas,
   type ExtractedModuleError,
 } from "./extractValModules";
 export type {

--- a/packages/server/src/ValOps.ts
+++ b/packages/server/src/ValOps.ts
@@ -20,7 +20,9 @@ import {
   ValidationError,
   ValidationErrors,
   extractValModules,
+  computeValModuleShas,
 } from "@valbuild/core";
+import type { ExtractedModuleError, ValModuleShaEntry } from "@valbuild/core";
 import { array, pipe, result } from "@valbuild/core/fp";
 import {
   JSONOps,
@@ -138,6 +140,22 @@ export abstract class ValOps {
   /** The sha256 / hash of schema + config - if this changes users needs to reload */
   private schemaSha: SchemaSha | null;
   private modulesErrors: ModulesError[] | null;
+  /**
+   * What the SHAs above are a fold over, so they can be recomputed.
+   *
+   * See {@link promoteCommittedSources}: the one thing that changes sources
+   * without re-evaluating the modules is a save, and it has to be able to move
+   * the SHAs with them.
+   */
+  private shaEntries: ValModuleShaEntry[] | null;
+  /**
+   * The extraction's OWN module errors, which are what the fold was given.
+   *
+   * Not the same list as {@link modulesErrors}: that one has the nested
+   * `.jsonValues()` errors concatenated on, and those were never part of the
+   * hash. Re-folding with the wrong list changes the base SHA for no reason.
+   */
+  private shaModuleErrors: ExtractedModuleError[] | null;
 
   constructor(
     private readonly valModules: ValModules,
@@ -150,6 +168,8 @@ export abstract class ValOps {
     this.sourcesSha = null;
     this.configSha = null;
     this.modulesErrors = null;
+    this.shaEntries = null;
+    this.shaModuleErrors = null;
   }
 
   // #region stat
@@ -240,6 +260,8 @@ export abstract class ValOps {
       this.sourcesSha = extracted.sourcesSha as SourcesSha;
       this.configSha = extracted.configSha as ConfigSha;
       this.modulesErrors = moduleErrors;
+      this.shaEntries = extracted.shaEntries;
+      this.shaModuleErrors = extracted.moduleErrors;
       return {
         baseSha: this.baseSha,
         schemaSha: this.schemaSha,
@@ -259,6 +281,128 @@ export abstract class ValOps {
       schemas: this.schemas,
       moduleErrors: this.modulesErrors,
     };
+  }
+
+  /**
+   * These patches are on disk now: adopt what they produced as the committed
+   * sources.
+   *
+   * The entry point for the mechanism {@link promoteCommittedSources} describes,
+   * and the only one — a caller hands over the analysis it just committed and
+   * this works out the rest, so the rule about which sources are adopted lives
+   * in one place rather than at each save site.
+   *
+   * A module whose patches could not be applied cleanly is left alone. `/save`
+   * refuses the whole commit before reaching here if `prepare` found errors, so
+   * this cannot normally fire — but adopting a partially patched source would
+   * put content in the memo that is not what was written, which is worse than
+   * being stale.
+   */
+  async adoptCommittedSources(
+    analysis: PatchAnalysis & OrderedPatches,
+  ): Promise<void> {
+    // Read BEFORE anything is promoted: this applies the chain to the sources as
+    // they stand, and promoting first would apply the same patches twice.
+    const { sources, errors } = await this.getSources(analysis);
+    const adopt: Sources = {};
+    for (const [moduleFilePathS, source] of Object.entries(sources)) {
+      const moduleFilePath = moduleFilePathS as ModuleFilePath;
+      if (errors[moduleFilePath] !== undefined) {
+        console.error(
+          "Val: not adopting the committed source of a module whose patches " +
+            "did not apply cleanly. Its content here stays as it was until the " +
+            "modules are re-evaluated.",
+          { moduleFilePath, errors: errors[moduleFilePath] },
+        );
+        continue;
+      }
+      adopt[moduleFilePath] = source;
+    }
+    this.promoteCommittedSources(adopt);
+  }
+
+  /**
+   * Adopt sources that have just been written to disk, and move the SHAs with
+   * them.
+   *
+   * ## Why this exists rather than an invalidation
+   *
+   * The obvious thing — throw the memo away after a save so the next read
+   * re-extracts — does not work, and quietly. `extractValModules` gets a
+   * module's content by awaiting its `def`, which is the app's own `import()`:
+   * that resolves from the MODULE REGISTRY, not from the file on disk. Right
+   * after `/save` rewrites a `.val.ts`, the registry still holds the module as
+   * it was evaluated before, so a re-extraction returns the pre-save content and
+   * stores it as fresh. What actually replaces it is the host rebuilding its
+   * module graph and constructing a new `ValOps` — which happens on its own
+   * schedule, and until it does, every read is stale.
+   *
+   * Stale reads here are not abstract: `getJsonEntry` resolves a
+   * `.jsonValues()` entry from the committed source and then replays pending
+   * patches over it, so once a publish has removed the patches, a page rendering
+   * draft content gets the committed value — the one this memo is holding from
+   * before the publish.
+   *
+   * So the save tells us instead. It has just computed what the new committed
+   * sources are, and that answer does not depend on anything being
+   * re-evaluated.
+   *
+   * ## And the SHAs move
+   *
+   * Deliberately, and this is the part with consequences. `baseSha` and
+   * `sourcesSha` identify the sources being served; leaving them still while the
+   * sources move would put a value other code compares against into
+   * disagreement with what it describes. Moving them means a `fs`-mode base SHA
+   * changes within a server's lifetime for the first time, which is a signal the
+   * studio already knows how to read: `PatchStore.reconcileVanished` uses a
+   * moved base to tell "these patches were published" from "these patches were
+   * discarded", and takes them out of the chain without reverting the fields —
+   * which is what a second tab watching a publish needs and could not get
+   * before.
+   *
+   * A module the fold does not know is ignored rather than appended: the fold's
+   * order is `val.modules`, and a path that is not in it has no position, so
+   * there is no honest answer for where its hash would go. It also cannot happen
+   * — a save only ever writes modules it read from here.
+   */
+  protected promoteCommittedSources(patched: Sources): void {
+    if (
+      this.sources === null ||
+      this.shaEntries === null ||
+      this.shaModuleErrors === null
+    ) {
+      // Nothing has been read yet, so there is no stale answer to correct and
+      // no fold to replay. The first read extracts, as it always would.
+      return;
+    }
+    const known = new Set(this.shaEntries.map((entry) => entry.path));
+    const adopt = Object.entries(patched).filter(
+      ([moduleFilePath, source]) =>
+        source !== undefined && known.has(moduleFilePath as ModuleFilePath),
+    ) as [ModuleFilePath, Source][];
+    if (adopt.length === 0) {
+      return;
+    }
+    const bySource = new Map<ModuleFilePath, Source>(adopt);
+    // A new object rather than a mutation: `getSources` hands this out, and a
+    // caller holding it must not have the ground move under it.
+    this.sources = { ...this.sources };
+    for (const [moduleFilePath, source] of adopt) {
+      this.sources[moduleFilePath] = source;
+    }
+    this.shaEntries = this.shaEntries.map((entry) => {
+      const source = bySource.get(entry.path);
+      return source === undefined ? entry : { ...entry, source };
+    });
+    const shas = computeValModuleShas(
+      this.valModules.config,
+      this.shaEntries,
+      this.shaModuleErrors,
+    );
+    this.baseSha = shas.baseSha as BaseSha;
+    this.schemaSha = shas.schemaSha as SchemaSha;
+    this.sourcesSha = shas.sourcesSha as SourcesSha;
+    this.configSha = shas.configSha as ConfigSha;
   }
 
   async init(): Promise<void> {

--- a/packages/server/src/ValOps.ts
+++ b/packages/server/src/ValOps.ts
@@ -156,6 +156,27 @@ export abstract class ValOps {
    * hash. Re-folding with the wrong list changes the base SHA for no reason.
    */
   private shaModuleErrors: ExtractedModuleError[] | null;
+  /**
+   * What a save has told us each `.jsonValues()` entry now holds.
+   *
+   * The entry twin of {@link sources}, and it has to be separate because an
+   * entry's content is not IN the source: the source holds a marker, and
+   * {@link getJsonEntries} resolves it by awaiting the marker's own `import()`.
+   * That resolves from the module registry, so after `/save` rewrites a
+   * `*.val.json` the thunk keeps answering with the content from before — and
+   * unlike a module source there is nothing to re-extract, because the memo was
+   * never holding the content in the first place.
+   *
+   * `null` for an entry the commit deleted.
+   *
+   * Never cleared: it describes what is on disk. A host rebuild makes a new
+   * instance, which is the right reset. Bounded by the project's entry count,
+   * holding only the latest content per key.
+   */
+  private adoptedJsonEntries = new Map<
+    ModuleFilePath,
+    Map<string, JSONValue | null>
+  >();
 
   constructor(
     private readonly valModules: ValModules,
@@ -300,6 +321,7 @@ export abstract class ValOps {
    */
   async adoptCommittedSources(
     analysis: PatchAnalysis & OrderedPatches,
+    preparedCommit: Pick<PreparedCommit, "patchedJsonEntries">,
   ): Promise<void> {
     // Read BEFORE anything is promoted: this applies the chain to the sources as
     // they stand, and promoting first would apply the same patches twice.
@@ -319,6 +341,30 @@ export abstract class ValOps {
       adopt[moduleFilePath] = source;
     }
     this.promoteCommittedSources(adopt);
+    /**
+     * And the `.jsonValues()` entry content, which the sources above do not
+     * carry — they hold markers. See {@link adoptedJsonEntries}.
+     *
+     * Only for a module whose source was adopted. The source is what frames an
+     * entry: it decides which keys exist at all, so adopting one without the
+     * other would leave the content and the key set describing different
+     * moments.
+     */
+    for (const [moduleFilePathS, entries] of Object.entries(
+      preparedCommit.patchedJsonEntries,
+    )) {
+      const moduleFilePath = moduleFilePathS as ModuleFilePath;
+      if (adopt[moduleFilePath] === undefined) {
+        continue;
+      }
+      const adopted =
+        this.adoptedJsonEntries.get(moduleFilePath) ??
+        new Map<string, JSONValue | null>();
+      for (const [entryKey, content] of Object.entries(entries)) {
+        adopted.set(entryKey, content);
+      }
+      this.adoptedJsonEntries.set(moduleFilePath, adopted);
+    }
   }
 
   /**
@@ -569,6 +615,31 @@ export abstract class ValOps {
         }
         if (marker === undefined) {
           return { entryKey, baseContent: undefined };
+        }
+        /**
+         * What a save told us this entry holds, ahead of the thunk.
+         *
+         * The thunk resolves from the module registry, so after `/save` rewrites
+         * a `*.val.json` it keeps answering with the content from before — and
+         * there is nothing to re-extract, because the committed content was
+         * never in the memoised source to begin with. See
+         * {@link adoptedJsonEntries}.
+         *
+         * `null` means the commit deleted the entry, which is reported the same
+         * way an absent key is. (Nearly unreachable — a `remove` also drops the
+         * thunk from the `.val.ts`, so the key is gone from `record` once the
+         * source is adopted — but the map says it, so this says it too.)
+         *
+         * The BASELINE only. Pending patches replay over it below exactly as
+         * they do over the thunk's answer.
+         */
+        const adopted = this.adoptedJsonEntries.get(moduleFilePath);
+        if (adopted !== undefined && adopted.has(entryKey)) {
+          const content = adopted.get(entryKey);
+          return {
+            entryKey,
+            baseContent: content === null ? undefined : content,
+          };
         }
         const thunk = Internal.getJsonImport(marker);
         if (!thunk) {
@@ -1385,6 +1456,13 @@ export abstract class ValOps {
           result: string | null;
           // Extra files to write/delete (jsonValues `*.val.json` entries).
           extraFiles: Record<string, string | null>;
+          /**
+           * The same entry content, keyed by ENTRY KEY. `null` = deleted.
+           *
+           * `extraFiles` is keyed by file path, which is not what a reader of an
+           * entry has to go on — see `jsonEntryContentsByKey`.
+           */
+          jsonEntries: Record<string, JSONValue | null>;
           appliedPatches: PatchId[];
           errors?: undefined;
         }
@@ -1432,6 +1510,22 @@ export abstract class ValOps {
 
       // jsonValues entry content, keyed by `*.val.json` path. `null` = delete.
       const jsonEntryContents = new Map<string, JSONValue | null>();
+      /**
+       * The same content, keyed by ENTRY KEY rather than by file path.
+       *
+       * The path is what gets written; the key is what a reader asks for, and it
+       * is dropped at the flush below. Reconstructing it afterwards is not on:
+       * TWO producers turn a key into a path — `resolveEntryJsonPath` and
+       * `getNewJsonEntryPaths`, the latter a locked convention for `add` and a
+       * move's destination — and a marker does not carry its path at read time
+       * (see `jsonEntryFiles.ts`). So it is recorded where the key is known.
+       *
+       * Read by `ValOps.adoptCommittedSources`, so a save can tell this instance
+       * what an entry now holds. Nothing else can: an entry's committed content
+       * is resolved through the marker's own `import()`, which caches, so the
+       * memo cannot be refreshed by re-reading.
+       */
+      const jsonEntryContentsByKey = new Map<string, JSONValue | null>();
       // Entries added in this commit → their new `*.val.json` path, so later
       // content ops in the same commit resolve to the freshly-created file.
       const entryKeyToJsonPath = new Map<string, string>();
@@ -1601,6 +1695,7 @@ export abstract class ValOps {
               tsSourceFile = insRes.value;
               tsChanged = true;
               jsonEntryContents.set(jsonPath, op.value);
+              jsonEntryContentsByKey.set(cls.entryKey, op.value);
               entryKeyToJsonPath.set(cls.entryKey, jsonPath);
             } else if (op.op === "remove") {
               const jsonPathRes = resolveEntryJsonPath(cls.entryKey);
@@ -1622,6 +1717,7 @@ export abstract class ValOps {
               tsSourceFile = remRes.value;
               tsChanged = true;
               jsonEntryContents.set(jsonPathRes.value, null);
+              jsonEntryContentsByKey.set(cls.entryKey, null);
             } else if (op.op === "replace") {
               const jsonPathRes = resolveEntryJsonPath(cls.entryKey);
               if (result.isErr(jsonPathRes)) {
@@ -1630,6 +1726,7 @@ export abstract class ValOps {
                 break;
               }
               jsonEntryContents.set(jsonPathRes.value, op.value);
+              jsonEntryContentsByKey.set(cls.entryKey, op.value);
             } else if (op.op === "move" || op.op === "copy") {
               // Rename (move) or duplicate (copy) a whole entry. The new entry
               // gets its own `*.val.json` written with the source entry's
@@ -1703,9 +1800,11 @@ export abstract class ValOps {
               tsSourceFile = insRes.value;
               tsChanged = true;
               jsonEntryContents.set(jsonPath, content);
+              jsonEntryContentsByKey.set(cls.entryKey, content);
               entryKeyToJsonPath.set(cls.entryKey, jsonPath);
               if (op.op === "move" && fromPathRes.value !== jsonPath) {
                 jsonEntryContents.set(fromPathRes.value, null);
+                jsonEntryContentsByKey.set(fromKey, null);
               }
             } else {
               errors.push({
@@ -1761,6 +1860,7 @@ export abstract class ValOps {
               break;
             }
             jsonEntryContents.set(jsonPath, applied.value);
+            jsonEntryContentsByKey.set(cls.entryKey, applied.value);
           }
         }
         if (patchHadError) {
@@ -1845,6 +1945,7 @@ export abstract class ValOps {
             appliedPatches,
             result: sourceFileText,
             extraFiles,
+            jsonEntries: Object.fromEntries(jsonEntryContentsByKey),
           };
         }
       }
@@ -1860,6 +1961,10 @@ export abstract class ValOps {
         errors,
       };
     };
+    const patchedJsonEntries: Record<
+      ModuleFilePath,
+      Record<string, JSONValue | null>
+    > = {};
     const allResults = await Promise.all(
       Object.entries(patchesByModule).map(([path, patches]) =>
         applySourceFilePatches(path as ModuleFilePath, patches),
@@ -1889,6 +1994,12 @@ export abstract class ValOps {
         }
         for (const [extraPath, data] of Object.entries(res.extraFiles)) {
           patchedSourceFiles[extraPath] = data;
+        }
+        // Kept per module and per entry key, not flattened into
+        // `patchedSourceFiles` beside the files: a reader of an entry has a
+        // module and a key, never a path. See `patchedJsonEntries`.
+        if (Object.keys(res.jsonEntries).length > 0) {
+          patchedJsonEntries[res.path] = res.jsonEntries;
         }
         appliedPatches[res.path] = res.appliedPatches ?? [];
       }
@@ -1937,6 +2048,7 @@ export abstract class ValOps {
       binaryFilePatchErrors,
       unappliablePatches,
       patchedSourceFiles,
+      patchedJsonEntries,
       previousSourceFiles,
       partiallyPatchedSourceFiles,
       patchedBinaryFilesDescriptors,
@@ -2172,6 +2284,23 @@ export type PreparedCommit = {
    * A null value signals that the file at that path should be deleted.
    */
   patchedSourceFiles: Record<string, string | null>;
+  /**
+   * The committed content of every `.jsonValues()` entry this commit changed,
+   * per module and entry key. `null` means the entry was deleted.
+   *
+   * Separate from {@link patchedSourceFiles} rather than folded into it, because
+   * that map is keyed by FILE PATH and a reader of an entry has a module and a
+   * key. A marker does not carry its path at read time, so the two are not
+   * interchangeable — see `jsonEntryFiles.ts`.
+   *
+   * Here for {@link ValOps.adoptCommittedSources}: an entry's committed content
+   * is resolved through the marker's own `import()`, which caches, so a save is
+   * the only thing that can tell the server what the entry now holds.
+   *
+   * Only modules whose patches applied cleanly appear; a module that errored
+   * contributes nothing, and `/save` refuses the commit anyway.
+   */
+  patchedJsonEntries: Record<ModuleFilePath, Record<string, JSONValue | null>>;
   /**
    * Previous source files that were patched
    */

--- a/packages/server/src/ValOpsFS.jsonValues.test.ts
+++ b/packages/server/src/ValOpsFS.jsonValues.test.ts
@@ -599,3 +599,194 @@ describe("ValOpsFS jsonValues commit flow", () => {
     expect(pc.hasErrors).toBe(true);
   });
 });
+
+/**
+ * What the server serves as an entry's COMMITTED content after a save has just
+ * written it.
+ *
+ * An entry's content is not in the module source — that holds a marker — so
+ * `getJsonEntries` resolves it by awaiting the marker's own `import()`. That
+ * caches, and unlike a module source there is nothing to re-extract, because the
+ * memo was never holding the content in the first place. So once a publish
+ * removes the patches, the committed baseline is the content from before the
+ * publish, and both readers see it: a page rendering draft content
+ * (`apply_patches: true`, with no patches left to replay) and the Studio, which
+ * asks with `apply_patches: false` on purpose.
+ *
+ * This fixture models the staleness faithfully: the entry thunks go through a
+ * `require` shim that caches by absolute path, so an entry resolved once keeps
+ * answering the same way no matter what is written to disk afterwards.
+ */
+describe("adopting the entry content a save has written", () => {
+  /** What `/save` does, in the order it does it. */
+  const publish = async (
+    ops: ValOpsFS,
+    patch: OrderedPatches["patches"][number]["patch"],
+    options?: { adopt?: boolean },
+  ): Promise<void> => {
+    await createPatch(ops, patch);
+    const patches = await ops.fetchPatches({ excludePatchOps: false });
+    const analysis = ops.analyzePatches(patches.patches);
+    const prepared = await ops.prepare({ ...analysis, ...patches });
+    expect(prepared.hasErrors).toBe(false);
+    const saved = await ops.saveOrUploadFiles(prepared, "skip-remote");
+    expect(saved.errors).toEqual({});
+    if (options?.adopt !== false) {
+      await ops.adoptCommittedSources({ ...analysis, ...patches }, prepared);
+    }
+    await ops.deletePatches(patches.patches.map((entry) => entry.patchId));
+  };
+
+  /**
+   * Resolve the entry BEFORE publishing, which is what a rendered page does.
+   *
+   * Load-bearing, not scene-setting: it is what puts the entry in the `require`
+   * cache, and therefore what makes the stale read reproducible at all. Publish
+   * first and the thunk resolves after the write, so the test passes with or
+   * without the adoption and asserts nothing.
+   */
+  const readFirst = async (ops: ValOpsFS, key: string): Promise<void> => {
+    const res = await ops.getJsonEntry(MODULE_PATH, key);
+    expect(res.status).toBe("success");
+  };
+
+  const entry = (ops: ValOpsFS, key: string) =>
+    ops.getJsonEntry(MODULE_PATH, key);
+
+  test("a content edit reads back as published", async () => {
+    const { ops } = setup();
+    await readFirst(ops, "/blog/hello");
+
+    await publish(ops, [
+      { op: "replace", path: ["/blog/hello", "title"], value: "Published!" },
+    ]);
+
+    expect(await ops.fetchPatches({ excludePatchOps: true })).toMatchObject({
+      patches: [],
+    });
+    expect(await entry(ops, "/blog/hello")).toEqual({
+      status: "success",
+      content: { title: "Published!", order: 1 },
+    });
+  });
+
+  /**
+   * The same run without the adoption, so what it is for is on the record rather
+   * than assumed: the file on disk is right and the answer is still the old one.
+   */
+  test("would answer with the pre-publish content without it", async () => {
+    const { ops, rootDir } = setup();
+    await readFirst(ops, "/blog/hello");
+
+    await publish(
+      ops,
+      [{ op: "replace", path: ["/blog/hello", "title"], value: "Published!" }],
+      { adopt: false },
+    );
+
+    expect(
+      JSON.parse(
+        fs.readFileSync(
+          path.join(rootDir, "/test/content/hello.val.json"),
+          "utf-8",
+        ),
+      ),
+    ).toEqual({ title: "Published!", order: 1 });
+    expect(await entry(ops, "/blog/hello")).toEqual({
+      status: "success",
+      content: { title: "Hello", order: 1 },
+    });
+  });
+
+  test("a whole-entry replace reads back as published", async () => {
+    const { ops } = setup();
+    await readFirst(ops, "/blog/hello");
+
+    await publish(ops, [
+      {
+        op: "replace",
+        path: ["/blog/hello"],
+        value: { title: "Whole", order: 9 },
+      },
+    ]);
+
+    expect(await entry(ops, "/blog/hello")).toEqual({
+      status: "success",
+      content: { title: "Whole", order: 9 },
+    });
+  });
+
+  test("an added entry reads back as published", async () => {
+    const { ops } = setup();
+    await readFirst(ops, "/blog/hello");
+
+    await publish(ops, [
+      { op: "add", path: ["/blog/new"], value: { title: "New", order: 3 } },
+    ]);
+
+    expect(await entry(ops, "/blog/new")).toEqual({
+      status: "success",
+      content: { title: "New", order: 3 },
+    });
+  });
+
+  test("a removed entry reads back as gone", async () => {
+    const { ops } = setup();
+    await readFirst(ops, "/blog/hello");
+
+    await publish(ops, [{ op: "remove", path: ["/blog/hello"] }]);
+
+    expect((await entry(ops, "/blog/hello")).status).toBe("not-found");
+    // The untouched entry is unaffected.
+    expect(await entry(ops, "/blog/world")).toEqual({
+      status: "success",
+      content: { title: "World", order: 2 },
+    });
+  });
+
+  test("a moved entry reads back at its new key and not its old one", async () => {
+    const { ops } = setup();
+    await readFirst(ops, "/blog/hello");
+
+    await publish(ops, [
+      { op: "move", from: ["/blog/hello"], path: ["/blog/renamed"] },
+    ]);
+
+    expect((await entry(ops, "/blog/hello")).status).toBe("not-found");
+    expect(await entry(ops, "/blog/renamed")).toEqual({
+      status: "success",
+      content: { title: "Hello", order: 1 },
+    });
+  });
+
+  /**
+   * The adopted value is the BASELINE, not the answer. A draft edit on top of a
+   * published entry has to keep working — that is the whole read path this is
+   * inside of.
+   */
+  test("a pending patch still applies on top of an adopted entry", async () => {
+    const { ops } = setup();
+    await readFirst(ops, "/blog/hello");
+    await publish(ops, [
+      { op: "replace", path: ["/blog/hello", "title"], value: "Published!" },
+    ]);
+
+    await createPatch(ops, [
+      { op: "replace", path: ["/blog/hello", "title"], value: "Draft again" },
+    ]);
+
+    expect(await entry(ops, "/blog/hello")).toEqual({
+      status: "success",
+      content: { title: "Draft again", order: 1 },
+    });
+    // And the committed baseline underneath it is the published content.
+    expect(
+      await ops.getJsonEntry(MODULE_PATH, "/blog/hello", {
+        applyPatches: false,
+      }),
+    ).toEqual({
+      status: "success",
+      content: { title: "Published!", order: 1 },
+    });
+  });
+});

--- a/packages/server/src/ValOpsFS.patchStore.test.ts
+++ b/packages/server/src/ValOpsFS.patchStore.test.ts
@@ -52,7 +52,14 @@ describe("ValOpsFS patch store", () => {
           },
         ],
       },
-      { config },
+      {
+        config,
+        // Short, so the long-poll test does not sit out a 20 second fallback.
+        // Every other test here uses shas that cannot match, so `getStat`
+        // answers before it ever reaches the wait.
+        statPollingInterval: 2000,
+        statFilePollingInterval: 25,
+      },
     );
   });
 
@@ -488,5 +495,70 @@ describe("ValOpsFS patch store", () => {
     expect(ids[0]).toBe("patch-0");
     expect(ids.slice(1).sort()).toEqual(["concurrent-a", "concurrent-b"]);
     expect(await announced()).toEqual(ids);
+  });
+
+  /**
+   * A long poll answers about the moment it ANSWERS.
+   *
+   * `getStat` reads the store, and if nothing has changed it waits — up to a
+   * whole polling interval — for a file to move. What usually moves the file is
+   * the studio's own `/save`, which in `fs` mode commits the patches and deletes
+   * them. Answering with the list read before the wait therefore names patches
+   * that no longer exist, and the studio then puts them back in its chain and
+   * fetches them from a server that correctly no longer has them: "unpublished
+   * changes could not be loaded", for changes that were published. With auto-save
+   * on that is every pause in typing.
+   */
+  describe("what a long poll answers with", () => {
+    it("names the patches the store holds now, not the ones it held when the poll opened", async () => {
+      const [patchId] = await createPatches(1);
+      // The params a client sends when it is up to date, so `getStat` finds
+      // nothing changed and waits.
+      const poll = ops.getStat({
+        baseSha: await ops.getBaseSha(),
+        schemaSha: await ops.getSchemaSha(),
+        sourcesSha: await ops.getSourcesSha(),
+        patches: [patchId],
+      });
+      // Let it get past its read and into the wait before anything moves.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // What `/save` does to a patch it has committed.
+      await ops.deletePatches([patchId]);
+
+      const stat = await poll;
+      if (stat.type === "error") {
+        throw new Error(`getStat failed: ${stat.error.message}`);
+      }
+      expect(stat.type).toBe("request-again");
+      expect(stat.patches).toEqual([]);
+    });
+
+    /**
+     * The other half: what it announces still comes out of the read
+     * `fetchPatches` delivers from, so the two cannot disagree at the moment of
+     * the answer either.
+     */
+    it("announces exactly what the fetch will deliver", async () => {
+      const created = await createPatches(2);
+      const poll = ops.getStat({
+        baseSha: await ops.getBaseSha(),
+        schemaSha: await ops.getSchemaSha(),
+        sourcesSha: await ops.getSourcesSha(),
+        patches: created,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      await ops.deletePatches([created[0]]);
+
+      const stat = await poll;
+      if (stat.type === "error") {
+        throw new Error(`getStat failed: ${stat.error.message}`);
+      }
+      const fetched = await ops.fetchPatches({ excludePatchOps: true });
+      expect(stat.patches).toEqual(
+        fetched.patches.map((patch) => patch.patchId),
+      );
+      expect(stat.patches).toEqual([created[1]]);
+    });
   });
 });

--- a/packages/server/src/ValOpsFS.patchStore.test.ts
+++ b/packages/server/src/ValOpsFS.patchStore.test.ts
@@ -95,9 +95,11 @@ describe("ValOpsFS patch store", () => {
     return created;
   };
 
-  const announced = async (): Promise<PatchId[]> => {
-    // Shas that cannot match, so getStat answers immediately with what it sees
-    // rather than long-polling for a change.
+  /** A whole stat answer, taken with shas that cannot match so it returns at once. */
+  const announcedStat = async (): Promise<{
+    baseSha: string;
+    patches: PatchId[];
+  }> => {
     const stat = await ops.getStat({
       baseSha: "never-matches" as BaseSha,
       schemaSha: "never-matches" as SchemaSha,
@@ -110,8 +112,11 @@ describe("ValOpsFS patch store", () => {
     if (stat.type !== "did-change") {
       throw new Error(`expected did-change, got ${stat.type}`);
     }
-    return stat.patches;
+    return { baseSha: stat.baseSha, patches: stat.patches };
   };
+
+  const announced = async (): Promise<PatchId[]> =>
+    (await announcedStat()).patches;
 
   /** What the next stat tells the studio it threw away. */
   const removedNotice = async (): Promise<
@@ -559,6 +564,122 @@ describe("ValOpsFS patch store", () => {
         fetched.patches.map((patch) => patch.patchId),
       );
       expect(stat.patches).toEqual([created[1]]);
+    });
+  });
+
+  /**
+   * What the server serves as COMMITTED content after it has just written it.
+   *
+   * The sources are memoised per `ValOps` instance, and the way they are re-read
+   * is by awaiting each module's `def` — in a real app the app's own `import()`,
+   * which resolves from the module registry rather than from the file on disk. So
+   * invalidating the memo after a save gets the PRE-SAVE content back and stores
+   * it as fresh. This suite's `def` models that exactly: it builds the module
+   * from a literal, so re-evaluating always answers `title: "start"` no matter
+   * what is on disk.
+   *
+   * It matters because committed content is what a page rendering DRAFT content
+   * falls back on once a publish has removed the patches. Stale there means the
+   * page shows what was there before the publish, with nothing left to correct
+   * it.
+   */
+  describe("adopting the sources a save has written", () => {
+    /** What `/save` does, in the order it does it. */
+    const publish = async (
+      title: string,
+      options?: { adopt?: boolean },
+    ): Promise<void> => {
+      await ops.createPatch(
+        MODULE_PATH,
+        [{ op: "replace", path: ["title"], value: title }],
+        crypto.randomUUID() as PatchId,
+        { type: "head", headBaseSha: await ops.getBaseSha() },
+        null,
+        null,
+      );
+      const patches = await ops.fetchPatches({ excludePatchOps: false });
+      const analysis = ops.analyzePatches(patches.patches);
+      const prepared = await ops.prepare({ ...analysis, ...patches });
+      expect(prepared.hasErrors).toBe(false);
+      const saved = await ops.saveOrUploadFiles(prepared, "skip-remote");
+      expect(saved.errors).toEqual({});
+      if (options?.adopt !== false) {
+        await ops.adoptCommittedSources({ ...analysis, ...patches });
+      }
+      await ops.deletePatches(patches.patches.map((entry) => entry.patchId));
+    };
+
+    const committedTitle = async (): Promise<unknown> => {
+      const { sources } = await ops.getSources();
+      const source = sources[MODULE_PATH];
+      if (source === null || typeof source !== "object") {
+        throw new Error(`expected an object, got ${JSON.stringify(source)}`);
+      }
+      return (source as Record<string, unknown>)["title"];
+    };
+
+    it("serves the published content once the patches are gone", async () => {
+      await publish("published");
+
+      expect(await ops.fetchPatches({ excludePatchOps: true })).toMatchObject({
+        patches: [],
+      });
+      expect(await committedTitle()).toBe("published");
+    });
+
+    /**
+     * The same run without the adoption, so what it is for is on the record: the
+     * file on disk is right and the answer is still the old one.
+     */
+    it("would answer with the pre-save content without it", async () => {
+      await publish("published", { adopt: false });
+
+      expect(
+        fs.readFileSync(path.join(rootDir, "test", "page.val.ts"), "utf-8"),
+      ).toContain("published");
+      expect(await committedTitle()).toBe("start");
+    });
+
+    it("moves the source shas with the sources, and leaves the schema sha alone", async () => {
+      const before = {
+        baseSha: await ops.getBaseSha(),
+        sourcesSha: await ops.getSourcesSha(),
+        schemaSha: await ops.getSchemaSha(),
+      };
+
+      await publish("published");
+
+      expect(await ops.getSourcesSha()).not.toBe(before.sourcesSha);
+      // The moved base is what tells a second studio "these were published, not
+      // discarded" — see `PatchStore.reconcileVanished`.
+      expect(await ops.getBaseSha()).not.toBe(before.baseSha);
+      // Nothing about the schemas moved, and the client refetches `/schema` on
+      // this one.
+      expect(await ops.getSchemaSha()).toBe(before.schemaSha);
+    });
+
+    it("leaves the shas alone when there is nothing to adopt", async () => {
+      const before = await ops.getBaseSha();
+
+      await ops.adoptCommittedSources({
+        ...ops.analyzePatches([]),
+        patches: [],
+      });
+
+      expect(await ops.getBaseSha()).toBe(before);
+    });
+
+    /**
+     * `/stat` answers with the SHAs, so a publish has to be visible there — that
+     * is the whole channel a second studio learns anything on.
+     */
+    it("shows up on the next stat", async () => {
+      const before = await announcedStat();
+      await publish("published");
+      const after = await announcedStat();
+
+      expect(after.baseSha).not.toBe(before.baseSha);
+      expect(after.patches).toEqual([]);
     });
   });
 });

--- a/packages/server/src/ValOpsFS.patchStore.test.ts
+++ b/packages/server/src/ValOpsFS.patchStore.test.ts
@@ -4,10 +4,35 @@ import path from "node:path";
 import { initVal, ModuleFilePath, PatchId } from "@valbuild/core";
 import { ParentRef } from "@valbuild/shared/internal";
 import { ValOpsFS } from "./ValOpsFS";
-import type { BaseSha, SchemaSha, SourcesSha } from "./ValOps";
-import { patchDir, patchesLogFile, patchUploadMarkerFile } from "./patchStore";
+import type { BaseSha, OpsMetadata, SchemaSha, SourcesSha } from "./ValOps";
+import {
+  patchDir,
+  patchesLogFile,
+  patchRecordFile,
+  patchUploadDir,
+} from "./patchStore";
 
 const { s, c, config } = initVal();
+
+/**
+ * The real thing, with one `protected` reader opened up.
+ *
+ * A subclass rather than a cast: reading a patch file's metadata is a genuine
+ * seam of this class, and a test is allowed to be one of its subclasses. `as any`
+ * would stop the signature being checked, which is the part worth keeping.
+ */
+class TestValOpsFS extends ValOpsFS {
+  readPatchFileMetadata(
+    filePath: string,
+    patchId: PatchId,
+  ): Promise<OpsMetadata<"image">> {
+    return this.getBase64EncodedBinaryFileMetadataFromPatch(
+      filePath,
+      "image",
+      patchId,
+    );
+  }
+}
 
 const MODULE_PATH = "/test/page.val.ts" as ModuleFilePath;
 
@@ -26,7 +51,7 @@ const MODULE_PATH = "/test/page.val.ts" as ModuleFilePath;
  */
 describe("ValOpsFS patch store", () => {
   let rootDir: string;
-  let ops: ValOpsFS;
+  let ops: TestValOpsFS;
 
   const patchesDir = (): string => path.join(rootDir, ".val", "patches");
 
@@ -37,7 +62,7 @@ describe("ValOpsFS patch store", () => {
       path.join(rootDir, "test", "page.val.ts"),
       `import { s, c } from "val.config";\n\nexport default c.define(\n  "${MODULE_PATH}",\n  s.object({ title: s.string() }),\n  { title: "start" },\n);\n`,
     );
-    ops = new ValOpsFS(
+    ops = new TestValOpsFS(
       "http://localhost:4000",
       rootDir,
       {
@@ -759,9 +784,11 @@ describe("ValOpsFS patch store", () => {
       const patchId = "upload-in-flight" as PatchId;
       await upload(patchId);
 
-      // The read the upload's own write woke up.
+      // The read the upload's own write used to wake up.
       expect(await announcedStat()).toMatchObject({ patches: [] });
 
+      // Served from staging, because the studio asks for the new image before
+      // the patch that references it has been written.
       expect(
         await ops.getBase64EncodedBinaryFileFromPatch(FILE_PATH, patchId),
       ).not.toBeNull();
@@ -788,55 +815,69 @@ describe("ValOpsFS patch store", () => {
     });
 
     /**
-     * The marker is spent once the record lands: a directory the log names is
-     * never classified by it, and leaving it behind would make the layout say
-     * something that is no longer true.
+     * The property the whole design rests on, asserted directly: there is no
+     * moment at which the store holds a patch directory without a record. The
+     * bytes are outside the store until they belong to something.
      */
-    it("stops declaring an upload once the record has landed", async () => {
+    it("does not put anything in the store before the record", async () => {
       const patchId = "upload-in-flight" as PatchId;
       await upload(patchId);
-      expect(fs.existsSync(patchUploadMarkerFile(patchesDir(), patchId))).toBe(
-        true,
-      );
 
+      expect(fs.existsSync(patchDir(patchesDir(), patchId))).toBe(false);
+      expect(fs.existsSync(patchUploadDir(patchesDir(), patchId))).toBe(true);
+    });
+
+    /**
+     * And the record comes first when they do move in, so an interrupted append
+     * leaves a directory the log does not name WITH a record — the benign half
+     * of a crash, swept silently — rather than the shape that gets reported as
+     * lost work.
+     */
+    it("moves them in behind the record, and empties the staging area", async () => {
+      const patchId = "upload-in-flight" as PatchId;
+      await upload(patchId);
       await writeRecord(patchId);
 
-      expect(fs.existsSync(patchUploadMarkerFile(patchesDir(), patchId))).toBe(
-        false,
-      );
+      expect(fs.existsSync(patchRecordFile(patchesDir(), patchId))).toBe(true);
+      expect(fs.existsSync(patchUploadDir(patchesDir(), patchId))).toBe(false);
     });
 
     /**
-     * An upload whose client never came back. Nothing ever referenced the bytes,
-     * so they are swept like any other orphan — and silently, for the same
-     * reason: there is no edit anyone could have seen.
+     * A delete that arrives before the record does — nothing has been moved in,
+     * so the bytes are still in staging and have to go from there.
      */
-    it("sweeps an upload that was abandoned, without reporting it", async () => {
-      const patchId = "abandoned" as PatchId;
+    it("takes staged bytes with it when the patch is deleted", async () => {
+      const patchId = "upload-in-flight" as PatchId;
       await upload(patchId);
-      // Backdated past the TTL, which is the only thing separating this from the
-      // in-flight case.
-      fs.writeFileSync(
-        patchUploadMarkerFile(patchesDir(), patchId),
-        JSON.stringify({
-          startedAt: new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString(),
-        }),
-      );
 
-      const stat = await announcedStat();
+      await ops.deletePatches([patchId]);
 
-      expect(stat.removed).toBeUndefined();
-      expect(fs.existsSync(patchDir(patchesDir(), patchId))).toBe(false);
+      expect(fs.existsSync(patchUploadDir(patchesDir(), patchId))).toBe(false);
     });
 
     /**
-     * A directory with neither a record nor an upload in progress is still an
-     * unreadable patch, and still reported. The distinction is the whole point:
-     * "no record yet, bytes on the way" is a normal moment in a two-request
-     * write, and "no record, and nothing says one is coming" is work that is
-     * gone.
+     * Both readers of those bytes, not just the one serving the image. A
+     * validation that ran in the window used to answer "Metadata file not found"
+     * for a file that was on disk.
      */
-    it("still reports a directory that is not an upload", async () => {
+    it("serves the metadata from staging too", async () => {
+      const patchId = "upload-in-flight" as PatchId;
+      await upload(patchId);
+
+      const res = await ops.readPatchFileMetadata(FILE_PATH, patchId);
+      if (res.errors !== undefined) {
+        throw new Error(`expected metadata, got ${JSON.stringify(res.errors)}`);
+      }
+      expect(res.metadata).toMatchObject({ mimeType: "image/png" });
+    });
+
+    /**
+     * And a directory in the store with no record is STILL reported as lost
+     * work, unchanged. That reading was never wrong — it was the upload putting
+     * the store into a shape the reading does not describe. With the bytes kept
+     * outside until they belong to something, there is nothing to soften.
+     */
+    it("still reports a record-less directory in the store", async () => {
       fs.mkdirSync(patchDir(patchesDir(), "junk" as PatchId), {
         recursive: true,
       });

--- a/packages/server/src/ValOpsFS.patchStore.test.ts
+++ b/packages/server/src/ValOpsFS.patchStore.test.ts
@@ -638,7 +638,7 @@ describe("ValOpsFS patch store", () => {
       const saved = await ops.saveOrUploadFiles(prepared, "skip-remote");
       expect(saved.errors).toEqual({});
       if (options?.adopt !== false) {
-        await ops.adoptCommittedSources({ ...analysis, ...patches });
+        await ops.adoptCommittedSources({ ...analysis, ...patches }, prepared);
       }
       await ops.deletePatches(patches.patches.map((entry) => entry.patchId));
     };
@@ -695,10 +695,10 @@ describe("ValOpsFS patch store", () => {
     it("leaves the shas alone when there is nothing to adopt", async () => {
       const before = await ops.getBaseSha();
 
-      await ops.adoptCommittedSources({
-        ...ops.analyzePatches([]),
-        patches: [],
-      });
+      await ops.adoptCommittedSources(
+        { ...ops.analyzePatches([]), patches: [] },
+        { patchedJsonEntries: {} },
+      );
 
       expect(await ops.getBaseSha()).toBe(before);
     });

--- a/packages/server/src/ValOpsFS.patchStore.test.ts
+++ b/packages/server/src/ValOpsFS.patchStore.test.ts
@@ -5,7 +5,7 @@ import { initVal, ModuleFilePath, PatchId } from "@valbuild/core";
 import { ParentRef } from "@valbuild/shared/internal";
 import { ValOpsFS } from "./ValOpsFS";
 import type { BaseSha, SchemaSha, SourcesSha } from "./ValOps";
-import { patchDir, patchesLogFile } from "./patchStore";
+import { patchDir, patchesLogFile, patchUploadMarkerFile } from "./patchStore";
 
 const { s, c, config } = initVal();
 
@@ -99,6 +99,11 @@ describe("ValOpsFS patch store", () => {
   const announcedStat = async (): Promise<{
     baseSha: string;
     patches: PatchId[];
+    /**
+     * Carried here as well, because the server DRAINS it on handover: taking one
+     * stat to read the patches and another to read the notice loses it.
+     */
+    removed?: { patchId: PatchId; reason: string }[];
   }> => {
     const stat = await ops.getStat({
       baseSha: "never-matches" as BaseSha,
@@ -112,7 +117,11 @@ describe("ValOpsFS patch store", () => {
     if (stat.type !== "did-change") {
       throw new Error(`expected did-change, got ${stat.type}`);
     }
-    return { baseSha: stat.baseSha, patches: stat.patches };
+    return {
+      baseSha: stat.baseSha,
+      patches: stat.patches,
+      removed: stat.removed,
+    };
   };
 
   const announced = async (): Promise<PatchId[]> =>
@@ -680,6 +689,165 @@ describe("ValOpsFS patch store", () => {
 
       expect(after.baseSha).not.toBe(before.baseSha);
       expect(after.patches).toEqual([]);
+    });
+  });
+
+  /**
+   * The window between a file upload and the patch record that will reference
+   * it.
+   *
+   * Replacing an image is TWO requests, in this order: the bytes go up first
+   * (`POST /upload/patches/:patchId/files`), and the patch that points at them
+   * is written after (`PUT /patches`) — the patch alone is useless, since its
+   * `file` op carries only a sha. So between them the store holds a directory
+   * with `files/` in it and no `patch.json`.
+   *
+   * Anything reading the store in that window used to classify that as an
+   * unreadable patch — "there is no .../patch.json" — and repair removed it and
+   * reported it as unpublished work thrown away. The bytes went with it, so the
+   * image 404ed from `?patch_id=...` and the replacement silently did not happen.
+   *
+   * And the read is not hypothetical: writing into the patches directory is
+   * exactly what breaks `getStat`'s long poll, so the upload itself summons the
+   * read that destroys it. Which is why replacing an image worked only when the
+   * two requests happened to land close enough together.
+   */
+  describe("a file uploaded before its patch record", () => {
+    const PNG =
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQAAAAA3bvkkAAAACklEQVR4AWNgAAAAAgABc3UBGAAAAABJRU5ErkJggg==";
+    const FILE_PATH = "/public/val/replaced_a1b2c.png";
+
+    /** The upload half, as `POST /upload/patches/:patchId/files` does it. */
+    const upload = async (patchId: PatchId) => {
+      const res = await ops.saveBase64EncodedBinaryFileFromPatch(
+        FILE_PATH,
+        { type: "head", headBaseSha: await ops.getBaseSha() },
+        patchId,
+        PNG,
+        "image",
+        { width: 1, height: 1, mimeType: "image/png" },
+      );
+      if ("error" in res && res.error !== undefined) {
+        throw new Error(`upload failed: ${res.error.message}`);
+      }
+    };
+
+    /** The patch half, as `PUT /patches` does it. */
+    const writeRecord = async (patchId: PatchId) => {
+      const res = await ops.createPatch(
+        MODULE_PATH,
+        [
+          {
+            op: "file",
+            path: ["image"],
+            filePath: FILE_PATH,
+            value: "sha256-placeholder",
+            remote: false,
+          },
+        ],
+        patchId,
+        { type: "head", headBaseSha: await ops.getBaseSha() },
+        null,
+        null,
+      );
+      if (res.kind !== "ok") {
+        throw new Error(`createPatch failed: ${JSON.stringify(res.error)}`);
+      }
+    };
+
+    it("survives a stat taken before the record lands", async () => {
+      const patchId = "upload-in-flight" as PatchId;
+      await upload(patchId);
+
+      // The read the upload's own write woke up.
+      expect(await announcedStat()).toMatchObject({ patches: [] });
+
+      expect(
+        await ops.getBase64EncodedBinaryFileFromPatch(FILE_PATH, patchId),
+      ).not.toBeNull();
+    });
+
+    it("is not reported as unpublished work that was thrown away", async () => {
+      const patchId = "upload-in-flight" as PatchId;
+      await upload(patchId);
+
+      // Nothing was lost, so the person editing must not be told anything was.
+      expect((await announcedStat()).removed).toBeUndefined();
+    });
+
+    it("is still there for the record that arrives after it", async () => {
+      const patchId = "upload-in-flight" as PatchId;
+      await upload(patchId);
+      await announcedStat();
+      await writeRecord(patchId);
+
+      expect(await announcedStat()).toMatchObject({ patches: [patchId] });
+      expect(
+        await ops.getBase64EncodedBinaryFileFromPatch(FILE_PATH, patchId),
+      ).not.toBeNull();
+    });
+
+    /**
+     * The marker is spent once the record lands: a directory the log names is
+     * never classified by it, and leaving it behind would make the layout say
+     * something that is no longer true.
+     */
+    it("stops declaring an upload once the record has landed", async () => {
+      const patchId = "upload-in-flight" as PatchId;
+      await upload(patchId);
+      expect(fs.existsSync(patchUploadMarkerFile(patchesDir(), patchId))).toBe(
+        true,
+      );
+
+      await writeRecord(patchId);
+
+      expect(fs.existsSync(patchUploadMarkerFile(patchesDir(), patchId))).toBe(
+        false,
+      );
+    });
+
+    /**
+     * An upload whose client never came back. Nothing ever referenced the bytes,
+     * so they are swept like any other orphan — and silently, for the same
+     * reason: there is no edit anyone could have seen.
+     */
+    it("sweeps an upload that was abandoned, without reporting it", async () => {
+      const patchId = "abandoned" as PatchId;
+      await upload(patchId);
+      // Backdated past the TTL, which is the only thing separating this from the
+      // in-flight case.
+      fs.writeFileSync(
+        patchUploadMarkerFile(patchesDir(), patchId),
+        JSON.stringify({
+          startedAt: new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString(),
+        }),
+      );
+
+      const stat = await announcedStat();
+
+      expect(stat.removed).toBeUndefined();
+      expect(fs.existsSync(patchDir(patchesDir(), patchId))).toBe(false);
+    });
+
+    /**
+     * A directory with neither a record nor an upload in progress is still an
+     * unreadable patch, and still reported. The distinction is the whole point:
+     * "no record yet, bytes on the way" is a normal moment in a two-request
+     * write, and "no record, and nothing says one is coming" is work that is
+     * gone.
+     */
+    it("still reports a directory that is not an upload", async () => {
+      fs.mkdirSync(patchDir(patchesDir(), "junk" as PatchId), {
+        recursive: true,
+      });
+      fs.writeFileSync(
+        path.join(patchDir(patchesDir(), "junk" as PatchId), "something.txt"),
+        "not a patch",
+      );
+
+      expect((await announcedStat()).removed).toMatchObject([
+        { patchId: "junk" },
+      ]);
     });
   });
 });

--- a/packages/server/src/ValOpsFS.ts
+++ b/packages/server/src/ValOpsFS.ts
@@ -47,7 +47,10 @@ import {
   patchBinaryFile,
   patchBinaryFileMetadata,
   patchDir,
-  markPatchUploading,
+  removeStagedUploads,
+  stagedPatchBinaryFile,
+  stagedPatchBinaryFileMetadata,
+  sweepStaleUploads,
   patchesLogFile,
   PATCH_REPAIR_LOG_FILE_NAME,
   PatchStoreEntry,
@@ -906,32 +909,41 @@ export class ValOpsFS extends ValOps {
     metadata: MetadataOfType<BinaryFileType> | undefined,
   ): Promise<WithGenericError<{ patchId: PatchId; filePath: string }>> {
     // Keyed by the patch's own id, so the parent is not needed and is not asked
-    // for. Uploads arrive before the patch record does — the record's `file` op
-    // carries only a sha, so it would otherwise point at nothing — which leaves
-    // the directory holding `files/` and no `patch.json` until `PUT /patches`
-    // lands.
+    // for.
     //
-    // That shape has to be DECLARED, or a read landing in the window takes it
-    // for a patch whose contents are lost and repair removes it, bytes and all.
-    // The window is not hypothetical: writing in here is what wakes `getStat`'s
-    // long poll, so the upload summons the read that would destroy it. See
-    // `markPatchUploading`.
+    // Written OUTSIDE the store, and moved in by `appendPatch` once the record
+    // exists. Uploads arrive before the patch record does — the record's `file`
+    // op carries only a sha, so it would otherwise point at nothing — and
+    // writing them straight into `<patchId>/files/` left a directory holding
+    // files and no `patch.json` for a whole round trip. Nothing can read that as
+    // anything but a patch whose contents are lost, so repair removed it, bytes
+    // and all, and the image 404ed.
+    //
+    // Staging is what makes that state unreachable rather than tolerated. See
+    // `uploadsDir`.
     const patchesDir = this.getPatchesDir();
-    if (data !== null) {
-      markPatchUploading(patchesDir, patchId);
-    }
-    const patchFilePath = patchBinaryFile(patchesDir, patchId, filePath);
-    const metadataFilePath = patchBinaryFileMetadata(
+    const patchFilePath = stagedPatchBinaryFile(patchesDir, patchId, filePath);
+    const metadataFilePath = stagedPatchBinaryFileMetadata(
       patchesDir,
       patchId,
       filePath,
     );
     try {
       if (data === null) {
+        // A delete is the other order — the record is written first — so the
+        // bytes are already in the store. Both locations, because a file staged
+        // and then removed before its record never got there.
+        this.host.deleteFile(patchBinaryFile(patchesDir, patchId, filePath));
+        this.host.deleteFile(
+          patchBinaryFileMetadata(patchesDir, patchId, filePath),
+        );
         this.host.deleteFile(patchFilePath);
         this.host.deleteFile(metadataFilePath);
         return { patchId, filePath };
       }
+      // Cheap, and this is the one path that creates staging directories, so it
+      // is where the ones nobody claimed get noticed.
+      sweepStaleUploads(patchesDir);
       const buffer = bufferFromDataUrl(data);
       if (!buffer) {
         return {
@@ -953,16 +965,34 @@ export class ValOpsFS extends ValOps {
     }
   }
 
+  /**
+   * Which of the two places a patch's file can be, if either.
+   *
+   * The bytes are in the store once the patch's record is, and in the staging
+   * area before that — see `uploadsDir`. Every reader has to accept both, and
+   * they decide it here rather than each on its own, so two readers of the same
+   * file cannot disagree about whether it exists.
+   */
+  private wherePatchFileIs(inStore: string, staged: string): string | null {
+    if (this.host.fileExists(inStore)) {
+      return inStore;
+    }
+    if (this.host.fileExists(staged)) {
+      return staged;
+    }
+    return null;
+  }
+
   protected override async getBase64EncodedBinaryFileMetadataFromPatch<
     T extends BinaryFileType,
   >(filePath: string, type: T, patchId: PatchId): Promise<OpsMetadata<T>> {
-    const metadataFilePath = patchBinaryFileMetadata(
-      this.getPatchesDir(),
-      patchId,
-      filePath,
+    const patchesDir = this.getPatchesDir();
+    const metadataFilePath = this.wherePatchFileIs(
+      patchBinaryFileMetadata(patchesDir, patchId, filePath),
+      stagedPatchBinaryFileMetadata(patchesDir, patchId, filePath),
     );
 
-    if (!this.host.fileExists(metadataFilePath)) {
+    if (metadataFilePath === null) {
       return {
         errors: [{ message: "Metadata file not found", filePath }],
       };
@@ -997,8 +1027,12 @@ export class ValOpsFS extends ValOps {
   ): Promise<Buffer | null> {
     // Straight from the id. This used to read and parse every patch on disk to
     // work out which directory the file was under, on every single image request.
-    const absPath = patchBinaryFile(this.getPatchesDir(), patchId, filePath);
-    if (!this.host.fileExists(absPath)) {
+    const patchesDir = this.getPatchesDir();
+    const absPath = this.wherePatchFileIs(
+      patchBinaryFile(patchesDir, patchId, filePath),
+      stagedPatchBinaryFile(patchesDir, patchId, filePath),
+    );
+    if (absPath === null) {
       return null;
     }
     return this.host.readBinaryFile(absPath);
@@ -1059,6 +1093,9 @@ export class ValOpsFS extends ValOps {
               recursive: true,
               force: true,
             });
+            // And anything this patch had staged but never moved in, which is
+            // the case where a delete arrives before the record does.
+            removeStagedUploads(patchesDir, patchId);
             deleted.push(patchId);
           } catch (err) {
             // Reported. This endpoint used to answer "deleted" unconditionally —

--- a/packages/server/src/ValOpsFS.ts
+++ b/packages/server/src/ValOpsFS.ts
@@ -47,6 +47,7 @@ import {
   patchBinaryFile,
   patchBinaryFileMetadata,
   patchDir,
+  markPatchUploading,
   patchesLogFile,
   PATCH_REPAIR_LOG_FILE_NAME,
   PatchStoreEntry,
@@ -905,10 +906,20 @@ export class ValOpsFS extends ValOps {
     metadata: MetadataOfType<BinaryFileType> | undefined,
   ): Promise<WithGenericError<{ patchId: PatchId; filePath: string }>> {
     // Keyed by the patch's own id, so the parent is not needed and is not asked
-    // for. Uploads arrive before the patch record does, which is fine: the
-    // directory sits there unreferenced until the log line that names it lands,
-    // and repair sweeps it up if that never happens.
+    // for. Uploads arrive before the patch record does — the record's `file` op
+    // carries only a sha, so it would otherwise point at nothing — which leaves
+    // the directory holding `files/` and no `patch.json` until `PUT /patches`
+    // lands.
+    //
+    // That shape has to be DECLARED, or a read landing in the window takes it
+    // for a patch whose contents are lost and repair removes it, bytes and all.
+    // The window is not hypothetical: writing in here is what wakes `getStat`'s
+    // long poll, so the upload summons the read that would destroy it. See
+    // `markPatchUploading`.
     const patchesDir = this.getPatchesDir();
+    if (data !== null) {
+      markPatchUploading(patchesDir, patchId);
+    }
     const patchFilePath = patchBinaryFile(patchesDir, patchId, filePath);
     const metadataFilePath = patchBinaryFileMetadata(
       patchesDir,

--- a/packages/server/src/ValOpsFS.ts
+++ b/packages/server/src/ValOpsFS.ts
@@ -283,16 +283,29 @@ export class ValOpsFS extends ValOps {
       const patches: PatchId[] = announceRes.entries.map(
         (entry) => entry.patchId,
       );
-      // Drained here, on the channel that always flows. A repair that removed
-      // everything leaves the studio nothing to fetch, so a notice riding on
-      // `GET /patches` would sit here unread.
-      const removed = this.removedPatchNotices.splice(
-        0,
-        this.removedPatchNotices.length,
-      );
-      const removedNotice: {
+      /**
+       * Drained on the channel that always flows.
+       *
+       * A repair that removed everything leaves the studio nothing to fetch, so
+       * a notice riding on `GET /patches` would sit here unread.
+       *
+       * Accumulating rather than assigning, because the long poll below drains
+       * again before it answers: a repair during the wait must not have to sit
+       * out another whole stat.
+       */
+      const removed: { patchId: PatchId; reason: string }[] = [];
+      const drainRemoved = (): {
         removed?: { patchId: PatchId; reason: string }[];
-      } = removed.length > 0 ? { removed } : {};
+      } => {
+        removed.push(
+          ...this.removedPatchNotices.splice(
+            0,
+            this.removedPatchNotices.length,
+          ),
+        );
+        return removed.length > 0 ? { removed } : {};
+      };
+      const removedNotice = drainRemoved();
       // something changed: return immediately
       const didChange =
         !params ||
@@ -394,6 +407,14 @@ export class ValOpsFS extends ValOps {
             if (Date.now() - start > interval) {
               console.warn("Val: polling interval of files exceeded");
             }
+            // Checked BEFORE rescheduling, as the patches-directory poller
+            // above does. Without it this walk goes on forever: the `finally`
+            // that ends the race clears the handle it can see, and a `go`
+            // already on the queue then schedules one nothing will ever clear —
+            // a leaked timer, re-stat-ing the whole project, per stat poll.
+            if (stopPolling) {
+              return;
+            }
             setHandle(setTimeout(() => go(resolve), interval));
           };
           if (stopPolling) {
@@ -408,6 +429,11 @@ export class ValOpsFS extends ValOps {
       const disableFilePolling = this.options?.disableFilePolling || false;
       let patchesDirHandle: NodeJS.Timeout;
       let valFilesIntervalHandle: NodeJS.Timeout;
+      // Held so the `finally` can clear it. A race the timeout LOSES still
+      // leaves its timer armed, and it is the long one — so every stat that
+      // returned on a file change kept the whole poll interval alive behind it,
+      // doing nothing but holding the event loop open.
+      let noChangeHandle: NodeJS.Timeout;
       const type = await Promise.race([
         // we poll the patches directory for changes since fs.watch does not work reliably on all system (in particular on WSL) and just checking the patches dir is relatively cheap
         disableFilePolling
@@ -473,12 +499,12 @@ export class ValOpsFS extends ValOps {
             },
           );
         }),
-        new Promise<"no-change">((resolve) =>
-          setTimeout(
+        new Promise<"no-change">((resolve) => {
+          noChangeHandle = setTimeout(
             () => resolve("no-change"),
             this.options?.statPollingInterval || 20000,
-          ),
-        ),
+          );
+        }),
       ]).finally(() => {
         if (fsWatcher) {
           fsWatcher.close();
@@ -486,14 +512,47 @@ export class ValOpsFS extends ValOps {
         stopPolling = true;
         clearInterval(patchesDirHandle);
         clearInterval(valFilesIntervalHandle);
+        clearTimeout(noChangeHandle);
       });
+      /**
+       * Read the store AGAIN, because `patches` above describes the moment this
+       * poll OPENED — up to a whole polling interval ago.
+       *
+       * That staleness is not a detail: what ends the wait is a write, and the
+       * write the studio does most is `/save`, which in `fs` mode commits the
+       * patches and DELETES them. Answering with the list read before it names
+       * patches that no longer exist, and the studio then puts those ids back in
+       * its chain and fetches them from a server that correctly no longer has
+       * them — "unpublished changes could not be loaded", for changes that were
+       * published a moment earlier. With auto-save on, that is every pause in
+       * typing.
+       *
+       * So a stat describes the moment it ANSWERS. `request-again` and
+       * `no-change` differ in why the wait ended, not in how current the answer
+       * has to be, so both come through here.
+       *
+       * The patch list is the only part that CAN have moved: the shas and the
+       * schemas come from `initSources`, which is memoised for the lifetime of
+       * this instance and never invalidated — a module change makes a new
+       * `ValOpsFS` rather than updating this one. Recomputing them would be a
+       * second full schema serialization per poll for a value that cannot have
+       * changed.
+       *
+       * A read error is returned as one rather than papered over with the list
+       * from the open: a patch store that cannot be read is what the error path
+       * is for, and the studio asks again.
+       */
+      const answerRes = await this.readStore();
+      if (answerRes.status === "error") {
+        return { type: "error", error: { message: answerRes.message } };
+      }
       return {
         type,
         baseSha: currentBaseSha,
         schemaSha: currentSchemaSha,
         sourcesSha: currentSourcesSha,
-        patches,
-        ...removedNotice,
+        patches: answerRes.entries.map((entry) => entry.patchId),
+        ...drainRemoved(),
         jsonEntriesSha: currentJsonEntriesSha,
       };
     } catch (err) {

--- a/packages/server/src/ValServer.ts
+++ b/packages/server/src/ValServer.ts
@@ -2013,7 +2013,10 @@ export const ValServer = (
            * the result of. See `ValOps.promoteCommittedSources` for why the SHAs
            * move with them.
            */
-          await serverOps.adoptCommittedSources({ ...analysis, ...patches });
+          await serverOps.adoptCommittedSources(
+            { ...analysis, ...patches },
+            preparedCommit,
+          );
           /*
            * Only what this request consumed.
            *

--- a/packages/server/src/ValServer.ts
+++ b/packages/server/src/ValServer.ts
@@ -1998,6 +1998,23 @@ export const ValServer = (
             };
           }
           /*
+           * The files on disk are the committed content now, so say so here too.
+           *
+           * Nothing else will: the sources are memoised per `ValOps` instance
+           * and are re-read by awaiting each module's `def`, which is the app's
+           * own `import()` — that resolves from the module registry, not from
+           * the file this save just rewrote. So until the host rebuilds its
+           * module graph, every read of committed content answers with what was
+           * there before the save. A page rendering draft content sees exactly
+           * that once the patches below are gone: `getJsonEntry` resolves the
+           * committed entry and has no patches left to replay over it.
+           *
+           * Before `deletePatches`, because it needs the patches it is adopting
+           * the result of. See `ValOps.promoteCommittedSources` for why the SHAs
+           * move with them.
+           */
+          await serverOps.adoptCommittedSources({ ...analysis, ...patches });
+          /*
            * Only what this request consumed.
            *
            * This used to be `deleteAllPatches()`, which renamed the whole store

--- a/packages/server/src/patchStore.ts
+++ b/packages/server/src/patchStore.ts
@@ -144,6 +144,111 @@ export function patchBaseFile(patchesDir: string, patchId: PatchId): string {
   return fsPath.join(patchDir(patchesDir, patchId), "base.json");
 }
 
+/**
+ * The marker that says "bytes are being uploaded for this patch, its record is
+ * coming".
+ *
+ * Writing a patch that carries a file is TWO requests, and the bytes go first:
+ * the patch's `file` op holds only a sha, so a record written before its file
+ * would point at nothing. That leaves the directory holding `files/` and no
+ * `patch.json` for as long as the round trip takes — a shape
+ * {@link readPatchStore} would otherwise read as a patch whose contents are
+ * lost, and repair would remove it and report someone's work as thrown away.
+ * The bytes went with it, which is how replacing an image came to fail most of
+ * the time.
+ *
+ * The upload cannot avoid the window, so it declares it instead. Written BEFORE
+ * the first byte, so there is no instant where the directory exists without an
+ * explanation.
+ */
+export function patchUploadMarkerFile(
+  patchesDir: string,
+  patchId: PatchId,
+): string {
+  return fsPath.join(patchDir(patchesDir, patchId), "uploading.json");
+}
+
+const FSPatchUpload = z.object({
+  /** When the upload began, for {@link UPLOAD_MARKER_TTL_MS}. */
+  startedAt: z.string(),
+});
+
+/**
+ * How long a declared upload is believed.
+ *
+ * Generous on purpose. Too short destroys a live upload, which is the bug this
+ * exists to fix; too long only leaves unreferenced bytes on disk a while longer,
+ * and nothing ever read them. A client that dies mid-upload is the only way to
+ * get a stale one.
+ */
+const UPLOAD_MARKER_TTL_MS = 60 * 60 * 1000;
+
+/**
+ * Declare an upload, before any of its bytes are written.
+ *
+ * A no-op once the record exists: there is no window left to explain, and
+ * {@link appendPatch} — the only thing that clears a marker — has already run,
+ * so one written now would sit in a live patch's directory forever describing a
+ * state that is over.
+ */
+export function markPatchUploading(
+  patchesDir: string,
+  patchId: PatchId,
+  now: Date = new Date(),
+): void {
+  if (fs.existsSync(patchRecordFile(patchesDir, patchId))) {
+    return;
+  }
+  const file = patchUploadMarkerFile(patchesDir, patchId);
+  fs.mkdirSync(fsPath.dirname(file), { recursive: true });
+  fs.writeFileSync(
+    file,
+    JSON.stringify({ startedAt: now.toISOString() } satisfies z.infer<
+      typeof FSPatchUpload
+    >),
+    "utf-8",
+  );
+}
+
+/**
+ * Is this directory an upload still in flight?
+ *
+ * `undefined` for "no marker at all", so the caller can tell a declared upload
+ * from a directory nothing explains — they get opposite handling.
+ */
+function readUploadMarker(
+  patchesDir: string,
+  name: string,
+  now: number,
+): { inFlight: boolean } | undefined {
+  const file = patchUploadMarkerFile(patchesDir, name as PatchId);
+  if (!fs.existsSync(file)) {
+    return undefined;
+  }
+  /**
+   * A marker whose contents cannot be used still says an upload was started
+   * here, so it never counts as work that is gone. Its AGE falls back to the
+   * file's mtime: assuming the worst instead would let one torn write of a
+   * forty-byte file cost a live upload its bytes, which is the whole failure
+   * this marker exists to prevent.
+   */
+  const res = readJsonFile(file, FSPatchUpload);
+  const startedAt =
+    res.error === undefined ? Date.parse(res.data.startedAt) : NaN;
+  if (!Number.isNaN(startedAt)) {
+    return { inFlight: now - startedAt < UPLOAD_MARKER_TTL_MS };
+  }
+  try {
+    return {
+      inFlight: now - fs.statSync(file).mtimeMs < UPLOAD_MARKER_TTL_MS,
+    };
+  } catch {
+    // It was there a moment ago. Something else is writing here, which is not a
+    // reason to delete anything.
+    return { inFlight: true };
+  }
+}
+
 export function patchBinaryFile(
   patchesDir: string,
   patchId: PatchId,
@@ -290,6 +395,7 @@ export function readPatchStore(patchesDir: string): ReadPatchStoreResult {
     });
   }
 
+  const now = Date.now();
   for (const name of dirNames) {
     if (named.has(name)) {
       continue;
@@ -299,6 +405,30 @@ export function readPatchStore(patchesDir: string): ReadPatchStoreResult {
     // leftover nothing ever read.
     const read = readPatchRecord(patchesDir, name);
     if (read.error !== undefined) {
+      /**
+       * Unless an upload said it was coming. See {@link patchUploadMarkerFile}:
+       * a patch carrying a file is written in two requests with the bytes first,
+       * so "files, no record" is a normal moment in that write and not work that
+       * is gone. Reported as lost, repair removed the bytes mid-upload and the
+       * replacement quietly failed.
+       *
+       * A stale marker is an upload whose client never came back. Nothing ever
+       * referenced those bytes — the log never named them and no record points
+       * at them — so they are swept like any other orphan, and silently, for the
+       * same reason.
+       */
+      const upload = readUploadMarker(patchesDir, name, now);
+      if (upload !== undefined) {
+        if (upload.inFlight) {
+          continue;
+        }
+        problems.push({
+          type: "orphan-directory",
+          name,
+          dir: fsPath.join(patchesDir, name),
+        });
+        continue;
+      }
       problems.push({
         type: "unreadable-patch",
         name,
@@ -410,6 +540,15 @@ export function appendPatch(
 ): PatchLogEntry {
   const patchId = record.patchId as PatchId;
   writePatchRecord(patchesDir, patchId, record);
+  // The record is the marker's whole purpose, so it is spent. Removed after the
+  // write rather than before: an interrupted append must never leave a directory
+  // with neither a record nor a reason to exist.
+  try {
+    fs.rmSync(patchUploadMarkerFile(patchesDir, patchId), { force: true });
+  } catch {
+    // Leaving it is harmless — a directory the log names is never classified by
+    // its marker — so this is not worth failing the write over.
+  }
   const entry: PatchLogEntry = {
     patchId,
     createdAt: record.createdAt,

--- a/packages/server/src/patchStore.ts
+++ b/packages/server/src/patchStore.ts
@@ -145,108 +145,59 @@ export function patchBaseFile(patchesDir: string, patchId: PatchId): string {
 }
 
 /**
- * The marker that says "bytes are being uploaded for this patch, its record is
- * coming".
+ * Where a patch's uploaded bytes wait for the record that will reference them.
  *
- * Writing a patch that carries a file is TWO requests, and the bytes go first:
- * the patch's `file` op holds only a sha, so a record written before its file
- * would point at nothing. That leaves the directory holding `files/` and no
- * `patch.json` for as long as the round trip takes — a shape
- * {@link readPatchStore} would otherwise read as a patch whose contents are
- * lost, and repair would remove it and report someone's work as thrown away.
- * The bytes went with it, which is how replacing an image came to fail most of
- * the time.
+ * ## Why they cannot simply be written into the patch directory
  *
- * The upload cannot avoid the window, so it declares it instead. Written BEFORE
- * the first byte, so there is no instant where the directory exists without an
- * explanation.
+ * A patch that carries a file is written in TWO requests, and the bytes go
+ * first: the record's `file` op holds only a sha, so a record written before its
+ * bytes would point at nothing. Uploading straight into `<patchId>/files/` left
+ * the directory holding files and no `patch.json` for the length of a round
+ * trip — which is neither of the two shapes this store allows, so
+ * {@link readPatchStore} read it as a patch whose contents were lost and repair
+ * removed it, bytes and all.
+ *
+ * And that window is not passive: writing into the patches directory is exactly
+ * what ends `getStat`'s long poll, so the upload summoned the read that
+ * destroyed it. Replacing an image worked only when the two requests happened to
+ * land close enough together.
+ *
+ * So the bytes are not in the store until they belong to something.
+ * {@link appendPatch} moves them in after writing the record, under the lock, so
+ * no reader ever sees a half-built patch directory — and the invariant that a
+ * directory either holds a usable record or is named by the log holds again,
+ * with nothing to tolerate and no ambiguous state to classify.
+ *
+ * A SIBLING of the patches directory, for two reasons: nothing that reads the
+ * store lists it, and it is on the same filesystem, so moving into place is a
+ * rename rather than a copy.
  */
-export function patchUploadMarkerFile(
-  patchesDir: string,
-  patchId: PatchId,
-): string {
-  return fsPath.join(patchDir(patchesDir, patchId), "uploading.json");
+export function uploadsDir(patchesDir: string): string {
+  return fsPath.join(fsPath.dirname(patchesDir), "uploads");
 }
 
-const FSPatchUpload = z.object({
-  /** When the upload began, for {@link UPLOAD_MARKER_TTL_MS}. */
-  startedAt: z.string(),
-});
-
-/**
- * How long a declared upload is believed.
- *
- * Generous on purpose. Too short destroys a live upload, which is the bug this
- * exists to fix; too long only leaves unreferenced bytes on disk a while longer,
- * and nothing ever read them. A client that dies mid-upload is the only way to
- * get a stale one.
- */
-const UPLOAD_MARKER_TTL_MS = 60 * 60 * 1000;
-
-/**
- * Declare an upload, before any of its bytes are written.
- *
- * A no-op once the record exists: there is no window left to explain, and
- * {@link appendPatch} — the only thing that clears a marker — has already run,
- * so one written now would sit in a live patch's directory forever describing a
- * state that is over.
- */
-export function markPatchUploading(
-  patchesDir: string,
-  patchId: PatchId,
-  now: Date = new Date(),
-): void {
-  if (fs.existsSync(patchRecordFile(patchesDir, patchId))) {
-    return;
-  }
-  const file = patchUploadMarkerFile(patchesDir, patchId);
-  fs.mkdirSync(fsPath.dirname(file), { recursive: true });
-  fs.writeFileSync(
-    file,
-    JSON.stringify({ startedAt: now.toISOString() } satisfies z.infer<
-      typeof FSPatchUpload
-    >),
-    "utf-8",
-  );
+/** Where one patch's uploads wait. See {@link uploadsDir}. */
+export function patchUploadDir(patchesDir: string, patchId: PatchId): string {
+  return fsPath.join(uploadsDir(patchesDir), patchId);
 }
 
 /**
- * Is this directory an upload still in flight?
+ * The binary layout, relative to whichever directory holds it.
  *
- * `undefined` for "no marker at all", so the caller can tell a declared upload
- * from a directory nothing explains — they get opposite handling.
+ * Shared by the patch directory and the staging directory so the two cannot
+ * drift — a move into place has to land the bytes exactly where a read expects
+ * them.
  */
-function readUploadMarker(
-  patchesDir: string,
-  name: string,
-  now: number,
-): { inFlight: boolean } | undefined {
-  const file = patchUploadMarkerFile(patchesDir, name as PatchId);
-  if (!fs.existsSync(file)) {
-    return undefined;
-  }
-  /**
-   * A marker whose contents cannot be used still says an upload was started
-   * here, so it never counts as work that is gone. Its AGE falls back to the
-   * file's mtime: assuming the worst instead would let one torn write of a
-   * forty-byte file cost a live upload its bytes, which is the whole failure
-   * this marker exists to prevent.
-   */
-  const res = readJsonFile(file, FSPatchUpload);
-  const startedAt =
-    res.error === undefined ? Date.parse(res.data.startedAt) : NaN;
-  if (!Number.isNaN(startedAt)) {
-    return { inFlight: now - startedAt < UPLOAD_MARKER_TTL_MS };
-  }
-  try {
-    return {
-      inFlight: now - fs.statSync(file).mtimeMs < UPLOAD_MARKER_TTL_MS,
-    };
-  } catch {
-    // It was there a moment ago. Something else is writing here, which is not a
-    // reason to delete anything.
-    return { inFlight: true };
-  }
+function binaryFilesDir(dir: string): string {
+  return fsPath.join(dir, "files");
+}
+
+function binaryFileIn(dir: string, filePath: string): string {
+  return fsPath.join(binaryFilesDir(dir), filePath, fsPath.basename(filePath));
+}
+
+function binaryFileMetadataIn(dir: string, filePath: string): string {
+  return fsPath.join(binaryFilesDir(dir), filePath, "metadata.json");
 }
 
 export function patchBinaryFile(
@@ -254,12 +205,7 @@ export function patchBinaryFile(
   patchId: PatchId,
   filePath: string,
 ): string {
-  return fsPath.join(
-    patchDir(patchesDir, patchId),
-    "files",
-    filePath,
-    fsPath.basename(filePath),
-  );
+  return binaryFileIn(patchDir(patchesDir, patchId), filePath);
 }
 
 export function patchBinaryFileMetadata(
@@ -267,12 +213,125 @@ export function patchBinaryFileMetadata(
   patchId: PatchId,
   filePath: string,
 ): string {
-  return fsPath.join(
-    patchDir(patchesDir, patchId),
-    "files",
-    filePath,
-    "metadata.json",
-  );
+  return binaryFileMetadataIn(patchDir(patchesDir, patchId), filePath);
+}
+
+/** The staged twin of {@link patchBinaryFile}. */
+export function stagedPatchBinaryFile(
+  patchesDir: string,
+  patchId: PatchId,
+  filePath: string,
+): string {
+  return binaryFileIn(patchUploadDir(patchesDir, patchId), filePath);
+}
+
+/** The staged twin of {@link patchBinaryFileMetadata}. */
+export function stagedPatchBinaryFileMetadata(
+  patchesDir: string,
+  patchId: PatchId,
+  filePath: string,
+): string {
+  return binaryFileMetadataIn(patchUploadDir(patchesDir, patchId), filePath);
+}
+
+/**
+ * Move a patch's staged uploads into the patch directory.
+ *
+ * Called by {@link appendPatch} between the record and the log line, so it runs
+ * under the lock and no reader can observe the halfway state.
+ *
+ * The whole `files` tree in one rename where it can be — the common case, since
+ * a patch's files only ever arrive before its record — and per file otherwise,
+ * for the case where something is already there.
+ */
+function moveStagedUploadsIn(patchesDir: string, patchId: PatchId): void {
+  const from = binaryFilesDir(patchUploadDir(patchesDir, patchId));
+  if (!fs.existsSync(from)) {
+    return;
+  }
+  const to = binaryFilesDir(patchDir(patchesDir, patchId));
+  if (!fs.existsSync(to)) {
+    fs.mkdirSync(fsPath.dirname(to), { recursive: true });
+    fs.renameSync(from, to);
+  } else {
+    moveTreeInto(from, to);
+  }
+  removeStagedUploads(patchesDir, patchId);
+}
+
+/** File-by-file, for when the destination already holds some of the tree. */
+function moveTreeInto(from: string, to: string): void {
+  for (const entry of fs.readdirSync(from, { withFileTypes: true })) {
+    const source = fsPath.join(from, entry.name);
+    const target = fsPath.join(to, entry.name);
+    if (entry.isDirectory()) {
+      fs.mkdirSync(target, { recursive: true });
+      moveTreeInto(source, target);
+      continue;
+    }
+    fs.mkdirSync(fsPath.dirname(target), { recursive: true });
+    fs.renameSync(source, target);
+  }
+}
+
+/** Drop a patch's staging directory, whatever is left of it. */
+export function removeStagedUploads(
+  patchesDir: string,
+  patchId: PatchId,
+): void {
+  try {
+    fs.rmSync(patchUploadDir(patchesDir, patchId), {
+      recursive: true,
+      force: true,
+    });
+  } catch {
+    // Hygiene, not correctness: nothing reads a staging directory that no patch
+    // claims, and the sweep below gets it eventually.
+  }
+}
+
+/**
+ * How long an upload nobody claimed is kept.
+ *
+ * Only garbage collection, which is why it can be a guess at all: these bytes
+ * are outside the store, so no reader can mistake them for a patch and nothing
+ * is lost by keeping them a while. The old marker-based attempt at this problem
+ * had a TTL deciding whether to delete something INSIDE the store, where being
+ * wrong meant destroying a live upload.
+ */
+const STALE_UPLOAD_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Drop staged uploads whose patch never arrived.
+ *
+ * A client that dies between the upload and the `PUT` leaves its bytes here.
+ * Nothing references them — no record points at them and the log never named
+ * them — so they are removed without a word.
+ */
+export function sweepStaleUploads(
+  patchesDir: string,
+  now: number = Date.now(),
+): void {
+  const dir = uploadsDir(patchesDir);
+  if (!fs.existsSync(dir)) {
+    return;
+  }
+  let names: string[];
+  try {
+    names = fs.readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const name of names) {
+    const staged = fsPath.join(dir, name);
+    try {
+      if (now - fs.statSync(staged).mtimeMs < STALE_UPLOAD_MS) continue;
+      fs.rmSync(staged, { recursive: true, force: true });
+    } catch {
+      // Someone else is writing here, or it is already gone. Either way it is
+      // not this pass's business.
+    }
+  }
 }
 
 /** Names that live in the patches directory but are not patches. */
@@ -395,7 +454,6 @@ export function readPatchStore(patchesDir: string): ReadPatchStoreResult {
     });
   }
 
-  const now = Date.now();
   for (const name of dirNames) {
     if (named.has(name)) {
       continue;
@@ -405,30 +463,6 @@ export function readPatchStore(patchesDir: string): ReadPatchStoreResult {
     // leftover nothing ever read.
     const read = readPatchRecord(patchesDir, name);
     if (read.error !== undefined) {
-      /**
-       * Unless an upload said it was coming. See {@link patchUploadMarkerFile}:
-       * a patch carrying a file is written in two requests with the bytes first,
-       * so "files, no record" is a normal moment in that write and not work that
-       * is gone. Reported as lost, repair removed the bytes mid-upload and the
-       * replacement quietly failed.
-       *
-       * A stale marker is an upload whose client never came back. Nothing ever
-       * referenced those bytes — the log never named them and no record points
-       * at them — so they are swept like any other orphan, and silently, for the
-       * same reason.
-       */
-      const upload = readUploadMarker(patchesDir, name, now);
-      if (upload !== undefined) {
-        if (upload.inFlight) {
-          continue;
-        }
-        problems.push({
-          type: "orphan-directory",
-          name,
-          dir: fsPath.join(patchesDir, name),
-        });
-        continue;
-      }
       problems.push({
         type: "unreadable-patch",
         name,
@@ -540,15 +574,18 @@ export function appendPatch(
 ): PatchLogEntry {
   const patchId = record.patchId as PatchId;
   writePatchRecord(patchesDir, patchId, record);
-  // The record is the marker's whole purpose, so it is spent. Removed after the
-  // write rather than before: an interrupted append must never leave a directory
-  // with neither a record nor a reason to exist.
-  try {
-    fs.rmSync(patchUploadMarkerFile(patchesDir, patchId), { force: true });
-  } catch {
-    // Leaving it is harmless — a directory the log names is never classified by
-    // its marker — so this is not worth failing the write over.
-  }
+  /*
+   * Then the bytes, then the log line — and the order is the whole point.
+   *
+   * The record goes first, so the directory never exists without one: that is
+   * what makes "files but no patch.json" a state this store cannot produce, and
+   * what lets a reader keep treating it as a patch whose contents are lost.
+   * The log line goes last, so an interrupted append leaves a directory the log
+   * does not name — the benign half of a crash, swept silently.
+   *
+   * See `uploadsDir`. Under the lock, like the rest of this function.
+   */
+  moveStagedUploadsIn(patchesDir, patchId);
   const entry: PatchLogEntry = {
     patchId,
     createdAt: record.createdAt,

--- a/packages/ui/spa/components/shell/canvas/CanvasFrame.tsx
+++ b/packages/ui/spa/components/shell/canvas/CanvasFrame.tsx
@@ -89,6 +89,23 @@ export function CanvasFrame({
   const frameRef = useRef<HTMLIFrameElement>(null);
   const [state, setState] = useState<FrameState>({ status: "waiting" });
   const [isEnabling, setIsEnabling] = useState(false);
+  /**
+   * Bumped every time the page announces itself.
+   *
+   * The catch-up snapshot below has to run once per DOCUMENT, and `reloadKey`
+   * only counts the reloads the studio asked for. A page reloads itself too —
+   * `next dev` does it when a `.val.ts` changes, which is exactly what
+   * publishing writes — and that new document arrives as another `ready` with
+   * the same `draftMode`, so nothing in `state` changes and the effect keyed on
+   * it did not re-run. The document then kept whatever the server rendered
+   * until the next keystroke happened to relay something, which with auto-save
+   * on is how the canvas came to sit on pre-publish content.
+   *
+   * A counter rather than a flag: `ready` is also posted when draft mode
+   * changes, and re-sending the snapshot then is harmless — it is the same
+   * sources again.
+   */
+  const [documentEpoch, setDocumentEpoch] = useState(0);
 
   // The URL the frame is actually given: the page, marked as a canvas load so
   // it renders itself without its own overlay.
@@ -126,6 +143,7 @@ export function CanvasFrame({
       const message = event.data;
       if (message.type === "ready") {
         setState({ status: "ready", draftMode: message.draftMode });
+        setDocumentEpoch((epoch) => epoch + 1);
         setIsEnabling(false);
       } else if (message.type === "elements") {
         onElements?.(message.elements);
@@ -214,8 +232,9 @@ export function CanvasFrame({
    * full of edits — then corrected itself on the next keystroke, which made it
    * look intermittent rather than like a missing step.
    *
-   * Keyed on the reload as well as on going live, because a reload is a new
-   * document with the same problem.
+   * Keyed on {@link documentEpoch} rather than on `reloadKey`: every new
+   * document has this problem, not only the ones the studio asked for, and the
+   * page announcing itself is the one signal that covers both.
    */
   const sendPendingSources = useValPendingSourceSnapshot();
   useEffect(() => {
@@ -233,7 +252,7 @@ export function CanvasFrame({
      * draft, and renders committed source for it immediately.
      */
     send({ val: VAL_CANVAS_MESSAGE, type: "sourcesSynced" });
-  }, [isLive, reloadKey, sendPendingSources, sendSourceUpdate, send]);
+  }, [isLive, documentEpoch, sendPendingSources, sendSourceUpdate, send]);
 
   const blocked =
     (state.status === "ready" && !state.draftMode) ||

--- a/packages/ui/spa/components/shell/canvas/canvasCatchUp.test.tsx
+++ b/packages/ui/spa/components/shell/canvas/canvasCatchUp.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, render } from "@testing-library/react";
+import {
+  VAL_CANVAS_MESSAGE,
+  type ValCanvasPageMessage,
+  type ValCanvasStudioMessage,
+} from "@valbuild/shared/internal";
+import { CanvasFrame } from "./CanvasFrame";
+
+/**
+ * Catching a new document up with what the editor holds.
+ *
+ * The relay into the canvas only carries a *change*, so a freshly loaded
+ * document is caught up once with a snapshot and then told that was all of it.
+ * Which document that runs for is the whole question, and it used to be keyed on
+ * `reloadKey` — the reloads the STUDIO asked for.
+ *
+ * A page also reloads itself: `next dev` does it when a `.val.ts` changes, and
+ * publishing rewrites those files. That new document announces itself with
+ * another `ready` carrying the same `draftMode`, so nothing the effect depended
+ * on changed and it never re-ran. The document kept whatever the server had
+ * rendered — which right after a publish can be the content from before it —
+ * until a keystroke happened to relay something. With auto-save on, a publish
+ * per pause in typing, that was the canvas going stale and coming back as you
+ * typed.
+ */
+describe("catching the canvas up", () => {
+  /** Every message the studio posted into the frame. */
+  let posted: ValCanvasStudioMessage[];
+  let frame: HTMLIFrameElement;
+
+  const renderFrame = () => {
+    const rendered = render(
+      <CanvasFrame
+        url="/"
+        width={800}
+        height={600}
+        reloadKey={0}
+        isPicking={false}
+        highlightedPath={null}
+        onRequestReload={() => {}}
+      />,
+    );
+    const found = rendered.container.querySelector("iframe");
+    if (found === null) {
+      throw new Error("the frame did not render");
+    }
+    frame = found;
+    posted = [];
+    const target = frame.contentWindow;
+    if (target === null) {
+      throw new Error("the frame has no content window");
+    }
+    jest
+      .spyOn(target, "postMessage")
+      .mockImplementation((message: unknown) =>
+        posted.push(message as ValCanvasStudioMessage),
+      );
+    return rendered;
+  };
+
+  /** The page announcing itself, as a new document does on mount. */
+  const announce = () => {
+    const message: ValCanvasPageMessage = {
+      val: VAL_CANVAS_MESSAGE,
+      type: "ready",
+      draftMode: true,
+      url: "http://localhost/",
+    };
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          source: frame.contentWindow,
+          data: message,
+        }),
+      );
+    });
+  };
+
+  const catchUps = () =>
+    posted.filter((message) => message.type === "sourcesSynced").length;
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("catches the first document up", () => {
+    renderFrame();
+    announce();
+    expect(catchUps()).toBe(1);
+  });
+
+  /**
+   * The regression. Two `ready` messages with the same `draftMode` are two
+   * documents, and the second one needs the snapshot as much as the first.
+   */
+  it("catches a document that reloaded itself up too", () => {
+    renderFrame();
+    announce();
+    announce();
+    expect(catchUps()).toBe(2);
+  });
+});

--- a/packages/ui/spa/stores/PatchStore.ts
+++ b/packages/ui/spa/stores/PatchStore.ts
@@ -239,6 +239,20 @@ export class PatchStore {
    */
   private publishedIds = new Set<PatchId>();
   /**
+   * Modules whose base this session moved by publishing into it.
+   *
+   * The question it answers is "where might the editor know something a fresh
+   * server render does not". A published module is exactly that: its value is on
+   * disk, but a page rendered from a server that has not picked the file up yet
+   * shows the content from before — and there is no pending patch left to relay,
+   * so nothing corrects it. See {@link publishedModules}.
+   *
+   * Recorded here rather than derived from {@link publishedIds}, because by the
+   * time anyone asks, `forgetPublished` has deleted the records those ids would
+   * have been looked up in.
+   */
+  private publishedModuleFilePaths = new Set<ModuleFilePath>();
+  /**
    * Bumped whenever the chain or its data changes.
    *
    * A monotonic counter rather than a hash, for the same reason the module
@@ -890,6 +904,26 @@ export class PatchStore {
     if (changed) this.bump();
   }
 
+  /**
+   * Modules this session has published into, in no particular order.
+   *
+   * For the canvas and the overlay: a page that renders one of these from the
+   * server can be showing the content from before the publish, and the chain has
+   * nothing left to say about it. The editor's live source does — it is the
+   * published value — so it is relayed alongside the pending ones.
+   *
+   * Never emptied within a session. The set is bounded by the modules someone
+   * edited, and re-sending a value the page already has costs one message and
+   * changes nothing on screen; forgetting one too early is a stale canvas with
+   * no way back.
+   *
+   * `http` mode never reaches this: a published patch stays in the chain there,
+   * so `allRecords()` already names its module.
+   */
+  publishedModules(): ModuleFilePath[] {
+    return [...this.publishedModuleFilePaths];
+  }
+
   markSaved(patchIds: readonly PatchId[]): void {
     const saved: PatchId[] = [];
     for (const patchId of patchIds) {
@@ -914,6 +948,12 @@ export class PatchStore {
     for (const patchId of patchIds) {
       if (!this.dataById.has(patchId) && !this.ordered.includes(patchId)) {
         continue;
+      }
+      // Before the record goes: it is the only thing that knows which module
+      // this shipped into. See `publishedModuleFilePaths`.
+      const moduleFilePath = this.dataById.get(patchId)?.moduleFilePath;
+      if (moduleFilePath !== undefined) {
+        this.publishedModuleFilePaths.add(moduleFilePath);
       }
       this.dataById.delete(patchId);
       this.originById.delete(patchId);

--- a/packages/ui/spa/stores/PatchStore.ts
+++ b/packages/ui/spa/stores/PatchStore.ts
@@ -184,6 +184,25 @@ export class PatchStore {
    */
   private verifying = new Set<PatchId>();
   /**
+   * Ids one fetch answered with neither a record nor an error.
+   *
+   * A stat is a SNAPSHOT, and in `fs` mode a stale one is routine: `/stat` long
+   * polls, so the patch list it returns was read when the poll opened and can be
+   * up to a whole polling interval old by the time it is answered. A publish or a
+   * discard inside that window leaves the response naming patches the server has
+   * already deleted — and a fetch for them then comes back empty, which looks
+   * exactly like the server contradicting itself.
+   *
+   * So one empty answer is not enough to report. The id leaves {@link fetching},
+   * a LATER stat re-announces it if it really is still pending, the fetch runs
+   * again, and only that second answer is evidence — because the confirmation
+   * that matters is a stat issued after the delete, which is the only thing that
+   * can tell a stale announcement from a wrong one.
+   *
+   * Cleared the moment the record arrives, or the id leaves the chain.
+   */
+  private notDeliveredOnce = new Set<PatchId>();
+  /**
    * Is a publish in flight? Injected, because only `createSystem` knows.
    *
    * `/save` in `fs` mode DELETES the patches it published, so a stat poll landing
@@ -328,14 +347,54 @@ export class PatchStore {
     baseMoved = false,
   ): Promise<void> {
     this.statSeen = true;
-    const announced = new Set(patchIds);
-    for (const patchId of patchIds) {
+    /**
+     * A stat older than our own publish is not evidence of anything.
+     *
+     * `/stat` long polls in `fs` mode: the patch list comes out of a read taken
+     * when the poll OPENED, and the response is sent when a file changes — which
+     * for a publish is the change the publish itself made. So the answer that
+     * arrives right after `/save` routinely names the patches `/save` has just
+     * committed and deleted, a whole polling interval after they stopped
+     * existing. Auto-save makes that the common case rather than a rarity: it
+     * publishes on every pause in typing.
+     *
+     * Taken at face value those ids go back into the chain — moving the head,
+     * unsettling it — and are then fetched from a server that correctly no longer
+     * has them, which is reported as unpublished changes that could not be
+     * loaded. Nothing is wrong: they are published, and their effect is in the
+     * base.
+     *
+     * {@link publishedIds} is what makes that recognisable, and it is why
+     * {@link forgetPublished} leaves the id in it. In `http` mode a published
+     * patch stays in the chain with its record, so the `dataById` test keeps this
+     * to the case it is about: an id this client published AND has forgotten.
+     */
+    const stale = new Set(
+      patchIds.filter(
+        (patchId) =>
+          this.publishedIds.has(patchId) && !this.dataById.has(patchId),
+      ),
+    );
+    if (stale.size > 0) {
+      console.debug(
+        "Val: ignoring published changes named by a stat that predates the " +
+          "publish.",
+        { patchIds: [...stale] },
+      );
+    }
+    /** What stat named, minus what it is too old to know about. */
+    const named =
+      stale.size > 0
+        ? patchIds.filter((patchId) => !stale.has(patchId))
+        : patchIds;
+    const announced = new Set(named);
+    for (const patchId of named) {
       if (!this.originById.has(patchId)) {
         this.originById.set(patchId, "external");
       }
     }
     const tail = this.ordered.filter((patchId) => !announced.has(patchId));
-    this.ordered = [...patchIds, ...tail];
+    this.ordered = [...named, ...tail];
     this.bump();
 
     /**
@@ -349,7 +408,7 @@ export class PatchStore {
       baseMoved,
     );
 
-    const missing = patchIds.filter(
+    const missing = named.filter(
       (patchId) => !this.dataById.has(patchId) && !this.fetching.has(patchId),
     );
     this.events.emit({ type: "patch:head", head: this.currentHead() });
@@ -374,12 +433,17 @@ export class PatchStore {
     const received: PatchId[] = [];
     for (const record of res.patches) {
       this.fetching.delete(record.patchId);
+      this.notDeliveredOnce.delete(record.patchId);
       this.dataById.set(record.patchId, record);
       received.push(record.patchId);
       this.bump();
     }
     for (const [patchId, message] of Object.entries(res.errors ?? {})) {
       this.fetching.delete(patchId as PatchId);
+      // An error is a definite answer, so the wait-and-confirm round that a
+      // silence gets does not apply: this is reported by `patch:fetch-failed`
+      // and the id is settled.
+      this.notDeliveredOnce.delete(patchId as PatchId);
       this.failedById.set(patchId as PatchId, message);
     }
     /*
@@ -400,6 +464,7 @@ export class PatchStore {
      * its own case.
      */
     const notDelivered: PatchId[] = [];
+    const inconclusive: PatchId[] = [];
     for (const patchId of missing) {
       if (
         this.fetching.delete(patchId) &&
@@ -407,18 +472,39 @@ export class PatchStore {
         // Re-read after the await rather than trusted from before it: a newer
         // stat may have stopped naming this id while the request was in flight,
         // and a patch someone else deleted mid-request is gone, not missing.
-        // (A delete that lands before the NEXT stat still reads as missing here.
-        // It costs one spurious report that clears itself on that stat, which is
-        // the right way round to be wrong: the alternative is the silence this
-        // whole change exists to remove.)
         this.ordered.includes(patchId)
       ) {
+        /*
+         * One empty answer is not a contradiction yet. See
+         * {@link notDeliveredOnce}: the announcement may simply be older than a
+         * delete — a publish or a discard, here or in another session — and the
+         * id is out of `fetching` now, so the next stat that still names it
+         * re-requests it. Only that answer is evidence.
+         *
+         * The cost of waiting is a report one stat later for a server that
+         * really is announcing what it cannot send; the chain stays unsettled in
+         * the meantime, so nothing on screen claims to be current. The cost of
+         * not waiting is a sticky error toast every time someone publishes.
+         */
+        if (!this.notDeliveredOnce.has(patchId)) {
+          this.notDeliveredOnce.add(patchId);
+          inconclusive.push(patchId);
+          continue;
+        }
         this.failedById.set(
           patchId,
           "The server said this change exists, but did not send it.",
         );
         notDelivered.push(patchId);
       }
+    }
+    if (inconclusive.length > 0) {
+      console.warn(
+        "Val: the server named these unpublished changes and did not send " +
+          "them. Asking again on the next stat before reporting it — an " +
+          "announcement can be older than a delete.",
+        { patchIds: inconclusive },
+      );
     }
     if (received.length > 0) {
       this.events.emit({ type: "patch:receive", patches: received });
@@ -837,6 +923,7 @@ export class PatchStore {
       this.creatorByPatchId.delete(patchId);
       this.sessionByPatchId.delete(patchId);
       this.fetching.delete(patchId);
+      this.notDeliveredOnce.delete(patchId);
       this.publishErrorById.delete(patchId);
       forgotten.push(patchId);
     }
@@ -877,6 +964,7 @@ export class PatchStore {
       this.creatorByPatchId.delete(patchId);
       this.sessionByPatchId.delete(patchId);
       this.fetching.delete(patchId);
+      this.notDeliveredOnce.delete(patchId);
       this.publishErrorById.delete(patchId);
       this.publishedIds.delete(patchId);
       dropped.push(patchId);

--- a/packages/ui/spa/stores/announcedNotDelivered.test.ts
+++ b/packages/ui/spa/stores/announcedNotDelivered.test.ts
@@ -1,6 +1,11 @@
 import { initVal } from "@valbuild/core";
 import type { PatchId } from "@valbuild/core";
-import { externalPatch, initTestSystem, patchIds } from "./testSystem";
+import {
+  externalPatch,
+  initTestSystem,
+  patchIds,
+  type TestSystem,
+} from "./testSystem";
 
 /** Let the fetch a stat kicked off actually come back. */
 const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
@@ -20,6 +25,14 @@ const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
  * "retry later", it is never again: no further request was ever made for them,
  * no error was ever raised, the chain never settled, and the studio sat on
  * "Loading unpublished changes…" for as long as the tab was open.
+ *
+ * The REPORT takes two stats, and that is not a softening of any of the above.
+ * An announcement can be older than a delete — `/stat` long polls, so its patch
+ * list is read when the poll opens and answered when a file changes, and the
+ * file that changes is usually the one `/save` just wrote — so one empty answer
+ * says nothing about whether the server is wrong. A stat issued after the delete
+ * does, and the id is out of `fetching` while we wait for it, which is the
+ * property the incident above was about. See `PatchStore.notDeliveredOnce`.
  */
 describe("changes the server announced and did not send", () => {
   const module = () => {
@@ -35,11 +48,22 @@ describe("changes the server announced and did not send", () => {
     return system;
   };
 
+  /**
+   * A second stat still naming the id, which is what turns an announcement that
+   * MIGHT be stale into a server contradicting itself. `simulateAnnouncedNotDelivered([])`
+   * adds nothing and re-sends the same list, which is exactly the next poll.
+   */
+  const confirm = async (server: TestSystem["server"]) => {
+    server.simulateAnnouncedNotDelivered([]);
+    await settle();
+  };
+
   it("settles the chain instead of waiting on them forever", async () => {
     const { patchStore, server, dispose } = await setup();
 
     server.simulateAnnouncedNotDelivered(["never-sent" as PatchId]);
     await settle();
+    await confirm(server);
 
     const head = await patchStore.getHead();
     // `-partial` is the waiting state, and it is the one that never ended.
@@ -52,6 +76,7 @@ describe("changes the server announced and did not send", () => {
 
     server.simulateAnnouncedNotDelivered(["never-sent" as PatchId]);
     await settle();
+    await confirm(server);
 
     const [error] = status.current().errors;
     expect(error?.message).toBe("An unpublished change could not be loaded.");
@@ -68,10 +93,30 @@ describe("changes the server announced and did not send", () => {
       "c" as PatchId,
     ]);
     await settle();
+    await confirm(server);
 
     expect(status.current().errors[0]?.message).toBe(
       "3 unpublished changes could not be loaded.",
     );
+    dispose();
+  });
+
+  /**
+   * One empty answer is not the report, and the reason is the shape of `/stat` in
+   * `fs` mode rather than caution for its own sake — see the file comment. The
+   * chain stays UNSETTLED meanwhile, so nothing on screen claims to be current
+   * while the question is still open.
+   */
+  it("waits for a second stat before saying anything", async () => {
+    const { patchStore, server, status, dispose } = await setup();
+
+    server.simulateAnnouncedNotDelivered(["never-sent" as PatchId]);
+    await settle();
+
+    expect(status.current().errors).toEqual([]);
+    // `-partial` is "still on its way", which is what it is: the id is out of
+    // `fetching`, so the next stat asks for it again.
+    expect((await patchStore.getHead()).type).toBe("external-partial");
     dispose();
   });
 
@@ -101,11 +146,13 @@ describe("changes the server announced and did not send", () => {
 
     server.simulateAnnouncedNotDelivered(["never-sent" as PatchId]);
     await settle();
-    server.simulateAnnouncedNotDelivered([]);
-    await settle();
+    await confirm(server);
+    await confirm(server);
+    await confirm(server);
 
-    // The id is settled as failed, so nothing asks for it again — which is what
-    // stops a permanent server fault becoming a permanent stream of toasts.
+    // A server that keeps announcing what it cannot send is asked on every stat
+    // and answers the same way every time. `StatusStore` de-duplicates by
+    // message, which is what stops a permanent fault becoming a stream of toasts.
     expect(status.current().errors).toHaveLength(1);
     dispose();
   });

--- a/packages/ui/spa/stores/autoSavePublish.test.ts
+++ b/packages/ui/spa/stores/autoSavePublish.test.ts
@@ -651,3 +651,78 @@ describe("a stat older than the publish it follows", () => {
     system.dispose();
   });
 });
+
+/**
+ * What the canvas has to be told about after a publish.
+ *
+ * The relay into a canvas document carries changes; a freshly loaded document is
+ * caught up with a snapshot of "every module the editor knows a newer value for
+ * than the page might". That used to mean modules with a PENDING patch, which is
+ * the set a publish empties — so the document loaded by the reload the publish
+ * itself caused was caught up with nothing, told that was all of it, and left
+ * rendering whatever the server gave it. Right after a publish that can be the
+ * content from before it, and nothing moved again until someone typed.
+ */
+describe("modules the editor stays authoritative about", () => {
+  it("names a module it published into, after the chain has emptied", async () => {
+    const { system } = makeSystem();
+    const first = await setTitle(system, "one");
+    await saved(system);
+    await system.publish([first], undefined, { exact: true });
+
+    // The chain is empty: nothing pending says this module was touched.
+    expect(system.patchStore.allRecords()).toEqual([]);
+    expect(system.patchStore.publishedModules()).toEqual(["/a.val.ts"]);
+    system.dispose();
+  });
+
+  it("says nothing about a module that was only saved", async () => {
+    const { system } = makeSystem();
+    await setTitle(system, "one");
+    await saved(system);
+
+    // Saved is not published: the patch is still in the chain, so the pending
+    // set already names this module and there is nothing to add.
+    expect(system.patchStore.publishedModules()).toEqual([]);
+    system.dispose();
+  });
+
+  it("names every module a publish spanned", async () => {
+    const { system } = makeSystem();
+    const first = await setTitle(system, "one");
+    const second = await edit(system, "/list.val.ts", [
+      { op: "add", path: ["items", "-"], value: "two" },
+    ]);
+    await saved(system);
+    await system.publish([first, second], undefined, { exact: true });
+
+    expect(system.patchStore.publishedModules().sort()).toEqual([
+      "/a.val.ts",
+      "/list.val.ts",
+    ]);
+    system.dispose();
+  });
+
+  /**
+   * Not emptied by anything, and that is the point: re-sending a value the page
+   * already has changes nothing on screen, while forgetting one too early is a
+   * stale canvas with no way back.
+   */
+  it("keeps naming it across a later publish", async () => {
+    const { system } = makeSystem();
+    const first = await setTitle(system, "one");
+    await saved(system);
+    await system.publish([first], undefined, { exact: true });
+    const second = await edit(system, "/list.val.ts", [
+      { op: "add", path: ["items", "-"], value: "two" },
+    ]);
+    await saved(system);
+    await system.publish([second], undefined, { exact: true });
+
+    expect(system.patchStore.publishedModules().sort()).toEqual([
+      "/a.val.ts",
+      "/list.val.ts",
+    ]);
+    system.dispose();
+  });
+});

--- a/packages/ui/spa/stores/autoSavePublish.test.ts
+++ b/packages/ui/spa/stores/autoSavePublish.test.ts
@@ -58,10 +58,14 @@ function makeSystem(options?: {
   publishOutcome?: Awaited<ReturnType<PublishPatches>>;
 }) {
   const publishes: PatchId[][] = [];
+  const fetched: PatchId[][] = [];
   const held: (() => void)[] = [];
   const modules = project();
   const system = createSystem({
-    fetchPatches: async () => ({ patches: [] }),
+    fetchPatches: async (patchIds) => {
+      fetched.push([...patchIds]);
+      return { patches: [] };
+    },
     fetchJsonEntry: async (moduleFilePath, key) => {
       // Genuinely async, like the real `GET /json`, so nothing can come to
       // depend on an entry being there synchronously.
@@ -91,7 +95,12 @@ function makeSystem(options?: {
   });
   system.host.receive(modules);
   system.stat.receiveStat({ patches: [], baseSha: "sha" });
-  return { system, publishes, releaseSaves: () => held.forEach((r) => r()) };
+  return {
+    system,
+    publishes,
+    fetched,
+    releaseSaves: () => held.forEach((r) => r()),
+  };
 }
 
 const edit = async (
@@ -570,5 +579,75 @@ describe("publishing in exact mode", () => {
       expect(starts).toBe(1);
       system.dispose();
     });
+  });
+});
+
+/**
+ * The stat that arrives right after `/save`, naming what `/save` just deleted.
+ *
+ * `/stat` long polls in `fs` mode: its patch list is read when the poll opens
+ * and the response is sent when a file changes — and the file that changes is
+ * the one the publish just wrote. So the answer routinely names the patches the
+ * publish committed and removed, a whole polling interval after they stopped
+ * existing.
+ *
+ * With auto-save on, that is every pause in typing, which is how this reached a
+ * user as "3 unpublished changes could not be loaded." for three changes that
+ * had been published a moment earlier. `ValOpsFS.getStat` now reads again before
+ * answering, so the stale list is not produced in the first place; this is the
+ * studio holding up its end regardless, because no snapshot protocol can promise
+ * the list was not overtaken.
+ */
+describe("a stat older than the publish it follows", () => {
+  it("ignores the patches it has already published", async () => {
+    const { system, fetched } = makeSystem();
+    const first = await setTitle(system, "one");
+    await saved(system);
+    expect(await system.publish([first], undefined, { exact: true })).toEqual({
+      status: "published",
+      patchIds: [first],
+    });
+
+    system.stat.receiveStat({ patches: [first], baseSha: "sha" });
+    await settle();
+
+    // Not reported, because nothing is wrong: the change is published and its
+    // effect is in the base.
+    expect(system.status.current().errors).toEqual([]);
+    // Not fetched either. Asking for it is what produces the empty answer that
+    // used to be read as the server contradicting itself.
+    expect(fetched).toEqual([]);
+    // And not back in the chain: re-adding it moves the head and unsettles it,
+    // which stops fields rendering while it is "on its way".
+    expect(system.patchStore.allRecords()).toEqual([]);
+    expect(await titleOf(system)).toBe("one");
+    system.dispose();
+  });
+
+  /**
+   * The value is the point. A published patch's effect lives in the base now, so
+   * anything that puts its id back in the chain has to be wrong in one direction
+   * or the other: dropped, and the field reverts; applied, and it lands twice.
+   */
+  it("does not apply a published patch a second time", async () => {
+    const { system } = makeSystem();
+    const first = await edit(system, "/list.val.ts", [
+      { op: "add", path: ["items", "-"], value: "two" },
+    ]);
+    await saved(system);
+    await system.publish([first], undefined, { exact: true });
+
+    system.stat.receiveStat({ patches: [first], baseSha: "sha" });
+    await settle();
+
+    const read = await system.sourceStore.get(
+      sp('/list.val.ts?p="items"'),
+      null,
+    );
+    if (read.status !== "resolved-head") {
+      throw new Error(`expected a value, got ${read.status}`);
+    }
+    expect(read.data).toEqual(["one", "two"]);
+    system.dispose();
   });
 });

--- a/packages/ui/spa/stores/patchFetchFailure.test.ts
+++ b/packages/ui/spa/stores/patchFetchFailure.test.ts
@@ -92,7 +92,7 @@ describe("a patch fetch that fails as a request", () => {
     system.dispose();
   });
 
-  it("reports an id stat named that the fetch did not return", async () => {
+  it("reports an id TWO stats named that the fetch did not return", async () => {
     /*
      * This case USED to assert silence, on the reading that an id absent from
      * the result is how a deleted patch is observed.
@@ -103,6 +103,11 @@ describe("a patch fetch that fails as a request", () => {
      * "still treats a change stat stopped naming as deleted" in
      * `announcedNotDelivered.test.ts`. Stat naming an id whose ops never arrive
      * is the opposite: the person is editing on top of content that is missing.
+     *
+     * What it takes TWO stats for is in `PatchStore.notDeliveredOnce`: the first
+     * announcement can simply be older than a delete, and a stat issued after
+     * the delete is the only thing that can tell that from a server that cannot
+     * send what it has.
      */
     const system = createSystem({
       fetchPatches: async () => ({ patches: [] }),
@@ -111,10 +116,38 @@ describe("a patch fetch that fails as a request", () => {
     system.host.receive([module()]);
     system.stat.receiveStat({ patches: ["gone" as PatchId], baseSha: "sha" });
     await settle();
+    expect(system.status.current().errors).toHaveLength(0);
+
+    system.stat.receiveStat({ patches: ["gone" as PatchId], baseSha: "sha" });
+    await settle();
     expect(system.status.current().errors).toHaveLength(1);
     expect(system.status.current().errors[0].message).toBe(
       "An unpublished change could not be loaded.",
     );
+    system.dispose();
+  });
+
+  /**
+   * The wait is not a silence with nothing behind it: the id is out of
+   * `fetching`, so the next stat that still names it asks again. That retry is
+   * the whole reason one empty answer can be treated as inconclusive.
+   */
+  it("asks again for an id the first fetch did not return", async () => {
+    const asked: PatchId[][] = [];
+    const system = createSystem({
+      fetchPatches: async (patchIds) => {
+        asked.push([...patchIds]);
+        return { patches: [] };
+      },
+      createPatchId: () => "unused" as PatchId,
+    });
+    system.host.receive([module()]);
+    system.stat.receiveStat({ patches: ["gone" as PatchId], baseSha: "sha" });
+    await settle();
+    system.stat.receiveStat({ patches: ["gone" as PatchId], baseSha: "sha" });
+    await settle();
+
+    expect(asked).toEqual([["gone"], ["gone"]]);
     system.dispose();
   });
 });

--- a/packages/ui/spa/stores/react/ValOverlayEmitter.tsx
+++ b/packages/ui/spa/stores/react/ValOverlayEmitter.tsx
@@ -106,7 +106,8 @@ export function useValSourceUpdates(
 }
 
 /**
- * Every module with unsaved work, as it stands right now.
+ * Every module the editor knows a newer value for than the page might, as it
+ * stands right now.
  *
  * The subscription above only fires on a *change*, which is the wrong shape for
  * something that has just started listening. A canvas frame gets its content
@@ -119,6 +120,17 @@ export function useValSourceUpdates(
  * Modules with a pending patch rather than everything the page reports: those
  * are exactly the ones whose content could disagree, the set is small, and it
  * does not need to know anything about the page.
+ *
+ * PLUS the modules this session has published into, which the pending set stops
+ * naming the moment the publish lands. That gap is what auto-save turned into a
+ * routine failure: publishing rewrites the `.val.ts` files, `next dev` reloads
+ * the page on the change, and the fresh document is caught up with a snapshot
+ * that now has nothing to send — followed by `sourcesSynced`, which tells the
+ * page to render committed source. If that render came from a server that had
+ * not picked the new file up, the canvas sat on pre-publish content until the
+ * next keystroke put a patch back in the chain. The editor's own source for a
+ * published module IS the published value, so sending it is both correct and
+ * idempotent.
  */
 export function useValPendingSourceSnapshot(): (
   onUpdate: (moduleFilePath: ModuleFilePath, source: unknown) => void,
@@ -133,6 +145,9 @@ export function useValPendingSourceSnapshot(): (
       const moduleFilePaths = new Set<ModuleFilePath>();
       for (const record of system.patchStore.allRecords()) {
         moduleFilePaths.add(record.moduleFilePath);
+      }
+      for (const moduleFilePath of system.patchStore.publishedModules()) {
+        moduleFilePaths.add(moduleFilePath);
       }
       for (const moduleFilePath of moduleFilePaths) {
         emitModuleSource(system, moduleFilePath, onUpdate);


### PR DESCRIPTION
Five failures with a common shape: something read a snapshot that had been overtaken, and nothing noticed.

## 1. Published changes reported as changes that could not be loaded

With auto-save on, the studio reported

> N unpublished changes could not be loaded.
> The server listed them but did not send them, so they are not shown. Reload before editing: anything you change now is written on top of content that is missing them.

for changes it had **just published successfully**.

`/stat` long polls in `fs` mode: it reads the patch store, finds nothing changed, and waits (up to `statPollingInterval`) for a file to move. It then answered with the patch list read when the poll *opened*. The write that ends most waits is the studio's own `/save`, which commits the patches and **deletes** them — so the response arriving right after a publish still named patches that had stopped existing a polling interval earlier. The studio took it at face value, put the ids back in its chain, fetched them from a server that correctly no longer had them, and read the empty answer as the server contradicting itself. Auto-save made it routine by publishing on every pause in typing; the count in the toast was the size of the last batch.

**Server — a stat describes the moment it answers.** `ValOpsFS.getStat` re-reads the patch store after the wait. `request-again` and `no-change` differ in why the wait ended, not in how current the answer has to be, so both go through it.

**Client — a snapshot protocol cannot promise its list was not overtaken**, so `PatchStore` no longer trusts one:

- An announcement of a patch this client has already published is ignored rather than put back in the chain (`publishedIds`, which `forgetPublished` deliberately leaves the id in). Re-adding it moved the head and unsettled the chain, then either dropped it — reverting a published field — or applied it twice.
- An announced-but-undelivered id gets one more stat before it is reported (`notDeliveredOnce`). The id leaves `fetching`, so the next stat that still names it re-requests it — the property the original 410/359 incident was about, preserved. Only the second answer is evidence, because the confirmation that matters is a stat issued *after* the delete.

**Two leaked timers in the long poll**, found because these are the first tests to enter that path: the polling-interval fallback was never cleared when another branch won the race, and the module-file poller rescheduled itself without checking `stopPolling`.

## 2. The canvas going stale after an auto-save

The canvas followed typing, then fell back to older content, then came back as soon as typing resumed.

Publishing rewrites the `.val.ts` files, `next dev` reloads the page on that change, and the studio was not set up to catch the new document up.

**The catch-up snapshot was not re-sent when the page reloaded itself.** It was keyed on `reloadKey` — the reloads the *studio* asks for. A page that reloads itself announces the new document with another `ready` carrying the same `draftMode`, so nothing in the deps changed and the snapshot never ran. It is now keyed on the page announcing itself.

**The snapshot named only modules with a pending patch** — exactly the set a publish empties. So even when it ran it had nothing to send, and then sent `sourcesSynced`, which tells the page to render committed source. It now also names the modules this session published into (`PatchStore.publishedModules()`): their live source in the editor *is* the published value, so relaying it is correct and idempotent.

## 3. Committed module content the server has just written

`ValOps` memoises the committed sources and re-reads them by awaiting each module's `def` — the app's own `import()`, which resolves from the **module registry**, not from disk. So invalidating the memo after a save does not work and does not say so: the re-extraction returns the pre-save content and stores it as fresh.

The save tells `ValOps` instead (`adoptCommittedSources`). To move the SHAs with the sources, the fold moved out of `extractValModules` into `computeValModuleShas`. The fold is order-dependent and mixes in the module-error list *as it stood at each step*, so the entries it ran over are kept alongside it — including a per-module error count, since errors are only appended and a prefix length reproduces that state exactly. Replaying them unchanged reproduces the SHAs to the bit, so only a module whose source actually moved changes anything.

**`baseSha` therefore moves on a publish in `fs` mode**, for the first time within a server's lifetime — a signal the studio already reads: `reconcileVanished` uses a moved base to tell "published" from "discarded", so a second studio watching a publish stops reverting the published fields. `schemaSha` does not move when only sources change. Nothing else keys on `baseSha` (it otherwise only feeds `parentRef`, which `fs` mode ignores).

## 4. Replacing an image usually did not take

A patch carrying a file is written in **two requests, bytes first**: the record's `file` op holds only a sha, so a record written before its bytes would point at nothing. Uploading straight into the patch's own `files/` directory left it holding files and no `patch.json` for a whole round trip — neither of the two shapes the store allows — so a read in that window classified it as a patch whose contents were lost, and repair removed it, bytes and all. What the studio showed was "the server removed these unpublished changes" plus a 404 for the image.

The window was not passive, which is why this failed most of the time rather than rarely: **writing into `.val/patches` is exactly what ends `getStat`'s long poll**, so the upload summoned the read that destroyed it.

So uploaded bytes are no longer in the store until they belong to something. They go to a per-patch directory under `.val/uploads/` — a sibling of the patches directory, so nothing reading the store lists it and moving into place is a rename — and `appendPatch` moves them in: **record, then bytes, then log line**, all under the lock the caller already holds.

- The record first, so a patch directory never exists without one. That is what makes "files but no `patch.json`" a state the store cannot produce.
- The log line last, so an interrupted append still leaves the benign half of a crash: a directory the log does not name, holding a good record.
- Under the lock, so repair — which re-reads under it — cannot observe the halfway state at all.

`readPatchStore` therefore goes back to what it said before: a record-less directory in the store is lost work, and is reported. That reading was never wrong; the upload was putting the store into a shape it does not describe. (An earlier commit here tolerated the window with an `uploading.json` marker instead. Keeping the bytes out of the store is the version with nothing to tolerate, and that commit is superseded.)

Both readers of a patch's bytes accept either location, decided in one place (`wherePatchFileIs`) — the image *and* its metadata, since a validation in that window otherwise reported a file that is on disk as missing.

## 5. `.jsonValues()` entry content after a publish

(3) does not reach an entry's content, for a sharper reason than the module case: the content is not in the memoised source at all. The source holds a marker, and `getJsonEntries` resolves it by awaiting the marker's own `import()`, which caches the same way. So there is nothing to re-extract — the memo was never holding it — and after `/save` rewrote a `*.val.json` the server kept answering with the pre-publish content until the host rebuilt its module graph.

Both readers saw it: a page rendering draft content, because once the publish removed the patches there was nothing left to replay over the stale baseline; and the Studio, which reads `/json` with `apply_patches: false` on purpose, because it applies patches itself.

`prepare` already computes the new content and threw it away. Its accumulator is keyed by `*.val.json` **path**, and the flush turns that into a flat path-keyed file map, from which the entry key is not recoverable — nor is reconstructing it an option, because a marker does not carry its path at read time and two different producers turn a key into a path (`resolveEntryJsonPath`, and `getNewJsonEntryPaths` for an `add` or a move's destination, which is a locked convention).

So it is recorded where the key **is** known: a second accumulator written beside each of the six op sites that change an entry, reported as `PreparedCommit.patchedJsonEntries` per module and entry key. Deliberately not the priming read inside `loadEntryContent`, which only establishes a baseline for a sub-op and whose closure has the path but not the key.

`adoptCommittedSources` takes the prepared commit and holds it; `getJsonEntries` consults it before the thunk, as the committed **baseline** only, so pending patches replay over it exactly as they did over the thunk's answer and draft edits are untouched. Adopted only for a module whose source was also adopted, because the source decides which keys exist — taking one without the other would leave the content and the key set describing different moments. The second argument is required rather than optional, so a future save path cannot silently skip entry adoption.

Not folded into any SHA: entry content was never in `sourcesSha`/`baseSha` (the client computes those from the module registry, which has no entry content), and entry changes are advertised separately through `jsonEntriesSha`.

## Tests

- `extractValModules.shas.test.ts` — the fold replays itself exactly from its recorded entries; moves the source SHAs and not the schema SHA when one source moves; depends on order; and mixes in only the errors collected before each module.
- `ValOpsFS.patchStore.test.ts` — a long poll answers with the patches the store holds now; the adoption serves the published content once the patches are gone, with the negative control (the same run without it answers with the pre-save content); and for uploads, that the patch's directory under `.val/patches` does **not** exist while its staging directory under `.val/uploads` does, that the record lands first and staging is emptied, that bytes and metadata are served from staging meanwhile, and that a record-less directory in the store is still reported.
- `ValOpsFS.jsonValues.test.ts` — publish-then-read for a content edit, a whole-entry replace, an `add`, a `remove` (reads as gone), and a `move` (old key gone, new key present); a pending patch still applies on top of an adopted entry, with the committed baseline underneath it published; plus the negative control. **These read the entry before publishing**, which is what puts it in the fixture's `require` cache and makes the stale read reproducible — publishing first resolves the thunk after the write and asserts nothing. Five of the seven fail with the adopted-entry lookup removed.
- `autoSavePublish.test.ts` — a stat older than the publish it follows is ignored; plus the `publishedModules()` contract.
- `patchFetchFailure.test.ts` / `announcedNotDelivered.test.ts` — the two-stat contract.
- `canvasCatchUp.test.tsx` — a second `ready` from a self-reloaded document is caught up too. Verified to fail against the old keying.

`jest.setup.js` is what lets a jsdom suite render a component reaching `@valbuild/shared/internal` at all: it touches `TextEncoder` and `ReadableStream` at module scope and jsdom installs neither.

`pnpm test` (2363 tests), `pnpm run lint`, `pnpm run format`, `pnpm run -r typecheck`, `pnpm run build`, `examples/next` build, and `val validate` through both `src/cli.ts` and `bin.js` all pass.

## Known remaining wart

`ValOpsFS.getStat` computes `jsonEntriesSha` when the long poll *opens* and returns it unrecomputed — (1) re-reads only the patch store there. So a `*.val.json` written during a wait ends the poll but is reported with the pre-write fingerprint, and the client learns of it on the round trip it issues immediately afterwards. Self-correcting in one round trip; recomputing the fingerprint per answer costs an `fs.statSync` per entry file, which is why it was left.

`architecture/patch-store.md` and `architecture/quirks.md` carry the stat-freshness, committed-sources, upload, and entry-adoption rules, since those docs are what CLAUDE.md points at before touching `ValOpsFS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nms3ddmnemWm2eGwjePkYj