### PR TITLE
Studio: drop the validation-error pill, cap the Fix count at 9+

### DIFF
--- a/packages/ui/spa/components/publishButtonState.test.ts
+++ b/packages/ui/spa/components/publishButtonState.test.ts
@@ -61,6 +61,24 @@ describe("describePublishButton", () => {
     expect(state.reason).toContain("1 validation error to fix");
   });
 
+  test("past nine, the label stops counting", () => {
+    // The button is one width in every state: a three-digit count would widen
+    // it, and "how many exactly" stops being useful long before that.
+    expect(
+      describePublishButton(input({ validationErrorCount: 9 })).label,
+    ).toBe("Fix 9");
+    expect(
+      describePublishButton(input({ validationErrorCount: 10 })).label,
+    ).toBe("Fix 9+");
+    expect(
+      describePublishButton(input({ validationErrorCount: 137 })).label,
+    ).toBe("Fix 9+");
+    // The reason still names the real number — it has room for it.
+    expect(
+      describePublishButton(input({ validationErrorCount: 137 })).reason,
+    ).toContain("137 validation errors");
+  });
+
   test("both blockers are named, not just the first", () => {
     const state = describePublishButton(
       input({ validationErrorCount: 2, conflictingChangeCount: 1 }),

--- a/packages/ui/spa/components/publishButtonState.ts
+++ b/packages/ui/spa/components/publishButtonState.ts
@@ -95,9 +95,13 @@ export function describePublishButton(
     return {
       kind: "blocked",
       // The count, because it is the useful part and it fits: "Fix 3" is a
-      // number someone can go and work through.
+      // number someone can go and work through. Past 9 the exact number stops
+      // being one — and a fourth digit would push the button wider than the
+      // width every other state is sized to — so it caps at "Fix 9+".
       label:
-        validationErrorCount > 0 ? `Fix ${validationErrorCount}` : "Fix errors",
+        validationErrorCount > 0
+          ? `Fix ${validationErrorCount > 9 ? "9+" : validationErrorCount}`
+          : "Fix errors",
       description:
         validationErrorCount > 0
           ? "Show the validation errors"

--- a/packages/ui/spa/components/shell/Shell.tsx
+++ b/packages/ui/spa/components/shell/Shell.tsx
@@ -225,8 +225,6 @@ export type ShellProps = {
    */
   previewHref?: string;
   onSignOut?: () => void;
-  /** Open the full validation-errors view. Falls back to the utility panel. */
-  onShowErrors?: () => void;
   /**
    * Why the account could not be loaded, once the studio has stopped trying.
    *
@@ -340,7 +338,6 @@ export function Shell({
   onPreview,
   previewHref,
   onSignOut,
-  onShowErrors,
   accountError,
   aiUnavailable,
   aiEnabled = false,
@@ -714,8 +711,6 @@ export function Shell({
             ? "blocked"
             : publishState
         }
-        validationErrorCount={validationErrorCount}
-        onShowErrors={onShowErrors ?? (() => setOpenPanel("utility"))}
       />
 
       {breakpoint === "mobile" ? (

--- a/packages/ui/spa/components/shell/TopBar.tsx
+++ b/packages/ui/spa/components/shell/TopBar.tsx
@@ -60,12 +60,6 @@ export type TopBarProps = {
   pendingChanges: number;
   publishState?: PublishState;
   /**
-   * Number of validation errors across the project. Publishing with errors is
-   * blocked, so the count is surfaced next to the button that is blocked.
-   */
-  validationErrorCount?: number;
-  onShowErrors?: () => void;
-  /**
    * Set when the account could not be loaded, and the studio has stopped trying.
    *
    * This is the case where `user` is absent, so it also has to *put* a control
@@ -114,8 +108,6 @@ export function TopBar({
   publishSlot,
   pendingChanges,
   publishState = "idle",
-  validationErrorCount = 0,
-  onShowErrors,
   accountError,
   isLoading,
   aiEnabled = false,
@@ -158,12 +150,6 @@ export function TopBar({
               onToggleCanvas={onToggleCanvas}
               isCanvasOpen={isCanvasOpen}
             />
-            {validationErrorCount > 0 && onShowErrors && (
-              <ValidationErrorPill
-                count={validationErrorCount}
-                onClick={onShowErrors}
-              />
-            )}
             {publishSlot ?? (
               <PublishButton
                 pendingChanges={pendingChanges}
@@ -530,28 +516,6 @@ export function PublishButton({
       {publishState === "idle" && pendingChanges > 0 && (
         <span className="tabular-nums opacity-80">{pendingChanges}</span>
       )}
-    </button>
-  );
-}
-
-/** How many validation errors stand between here and a publish. */
-function ValidationErrorPill({
-  count,
-  onClick,
-}: {
-  count: number;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      title={`${count} validation ${count === 1 ? "error" : "errors"} — fix these before publishing`}
-      aria-label={`${count} validation ${count === 1 ? "error" : "errors"}`}
-      className="inline-flex items-center gap-1.5 h-8 px-2.5 rounded-md text-xs font-medium text-fg-error-on-surface border border-border-error-primary hover:bg-bg-error-secondary"
-    >
-      <AlertTriangle size={14} />
-      <span className="tabular-nums">{count}</span>
     </button>
   );
 }

--- a/packages/ui/spa/components/shell/ValShell.tsx
+++ b/packages/ui/spa/components/shell/ValShell.tsx
@@ -624,12 +624,6 @@ function ValShellBody({ state }: { state: ReturnType<typeof useShellData> }) {
     [validationErrors],
   );
 
-  const showErrors = useCallback(() => {
-    navigation.navigate(VAL_ERRORS_ROUTE, {
-      errorFields: allValidationErrorPaths,
-    });
-  }, [navigation, allValidationErrorPaths]);
-
   /** One module's errors, from the row in the utility panel. */
   const onSelectValidationError = useCallback(
     (error: ShellValidationError) => {
@@ -770,7 +764,6 @@ function ValShellBody({ state }: { state: ReturnType<typeof useShellData> }) {
       // Also as an href, so the menu item is a link that can be copied. The URL
       // enables preview and redirects, so it is worth sending to someone.
       previewHref={previewHref}
-      onShowErrors={showErrors}
       onSelectValidationError={onSelectValidationError}
       onCompare={showCompare}
       // Recent activity rows did nothing: the panel listed them and no handler


### PR DESCRIPTION
The top bar had two controls for the same thing: a red "Fix 3" publish button that navigates to the errors view, and an error-triangle pill immediately to its left that did exactly the same navigation. Now that the button itself is pressable and destructive, the pill is a second way to press the same control.

## Changes

**Removed `ValidationErrorPill`** (`packages/ui/spa/components/shell/TopBar.tsx`) along with the props that existed only to feed it — `validationErrorCount` and `onShowErrors` on `TopBar`, `onShowErrors` on `Shell`, and the now-dead `showErrors` callback in `ValShell`. `TopBar` still receives `publishState`, so its own fallback publish button (used where no `publishSlot` is passed) keeps rendering the blocked state.

**Capped the blocked label at `Fix 9+`** (`packages/ui/spa/components/publishButtonState.ts`). Past nine errors the exact number stops being useful, and a third digit would push the button past the width every other state is sized to. 1–9 read as before, and the tooltip reason still names the real count ("137 validation errors to fix."). Covered by a new case in `publishButtonState.test.ts`.

## Verification

All CI jobs run locally and green: `pnpm run lint`, `pnpm -w run format`, `pnpm run -r typecheck`, `pnpm test` (202 suites, 2328 tests), root `pnpm run build`, and `cd examples/next && pnpm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtTsAAEv3sHQP2uvxWtyUe

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtTsAAEv3sHQP2uvxWtyUe)_