### PR TITLE
Split render into preview (dynamic) and render (static)

### DIFF
--- a/.changeset/preview-and-render-split.md
+++ b/.changeset/preview-and-render-split.md
@@ -48,9 +48,10 @@ re-merged with previews; `packages/core/src/render.ts` says so.
 
 Renamed, for consumers of the internals: `ReifiedRender` → `ReifiedPreview`,
 `ListArrayRender` / `ListRecordRender` → `ArrayPreview` / `RecordPreview`,
-`RenderScope` / `renderScope` → `PreviewScope` / `previewScope`. `CodeLanguage`
-is unchanged, and `CODE_LANGUAGES` is now exported as the list it is derived
-from.
+`RenderScope` / `renderScope` → `PreviewScope` / `previewScope`. `CodeRender` is
+gone — `StringRender` is the whole `.render()` input now, and it is what the
+serialized schema carries. `CodeLanguage` is unchanged, and `CODE_LANGUAGES` is
+newly exported as the list it is derived from.
 
 **Wire change:** `PUT /sources/~` returns `preview` per module where it returned
 `render`. It only ever carried container previews; a string's render now arrives

--- a/.changeset/preview-and-render-split.md
+++ b/.changeset/preview-and-render-split.md
@@ -1,0 +1,57 @@
+---
+"@valbuild/core": minor
+"@valbuild/server": minor
+"@valbuild/shared": minor
+"@valbuild/ui": minor
+---
+
+**Breaking:** `.render({ as: "list" })` is now `.preview()`
+
+`render` was two unrelated things. On `array` and `record` it took a `select`
+closure over source and produced the rows the Studio shows for a container's
+items — dynamic, expensive, and computed on demand for the paths that are on
+screen. On `string` it was a static layout hint with no closure and no dependency
+on source at all. They shared a name, a type, a pipeline, a store and a wire
+field, and the only thing they had in common was the word.
+
+They are now two concepts. A **preview** is what a container shows for its items;
+a **render** is how one field is laid out.
+
+```diff
+- s.array(s.object({ title: s.string() })).render({
+-   as: "list",
+-   select: ({ val }) => ({ title: val.title }),
+- })
++ s.array(s.object({ title: s.string() })).preview(({ val }) => ({
++   title: val.title,
++ }))
+
+- s.record(item).render({ as: "list", select: ({ key, val }) => ({ /* ... */ }) })
++ s.record(item).preview(({ key, val }) => ({ /* ... */ }))
+```
+
+`s.string().render({ as: "textarea" })` and `.render({ as: "code", language })`
+are unchanged.
+
+The `as: "list"` wrapper is gone: `list` was the only value, and how a preview is
+laid out is the editor's business, not the schema's. Preview data no longer
+carries `layout` either — `parent: "array" | "record"` was already the
+discriminant every consumer read.
+
+A string's render now lives in the SERIALIZED schema (`render?: { as: "textarea"
+} | { as: "code", language }` instead of `render?: true`), so the editor reads it
+straight off the schema it already has: no store, no host round-trip, and a
+module whose only render is a string layout hint is no longer sent to the host at
+all. This assumes a render stays static — deliberately, for simplicity. If one
+ever needs to depend on source it gets its own pipeline back rather than being
+re-merged with previews; `packages/core/src/render.ts` says so.
+
+Renamed, for consumers of the internals: `ReifiedRender` → `ReifiedPreview`,
+`ListArrayRender` / `ListRecordRender` → `ArrayPreview` / `RecordPreview`,
+`RenderScope` / `renderScope` → `PreviewScope` / `previewScope`. `CodeLanguage`
+is unchanged, and `CODE_LANGUAGES` is now exported as the list it is derived
+from.
+
+**Wire change:** `PUT /sources/~` returns `preview` per module where it returned
+`render`. It only ever carried container previews; a string's render now arrives
+with the schema instead.

--- a/architecture/known-issues.md
+++ b/architecture/known-issues.md
@@ -86,7 +86,7 @@ in `SerializedSchema` carries that today.
 
 **A line that fits on a line.** A primitive renders as itself. An object has to
 be summarised to one row before "moved from 4" can sit beside it, and the useful
-summary is schema-specific — `render({ select })` already exists for exactly this
+summary is schema-specific — `preview(select)` already exists for exactly this
 kind of question and would be the thing to reach for.
 
 Neither is hard, and both are guesses until someone has a case in front of them.

--- a/architecture/quirks.md
+++ b/architecture/quirks.md
@@ -67,6 +67,19 @@ on one render and runs more hooks on the next — "Rendered more hooks than duri
 the previous render", from inside `useMemo`, with nothing in the message about
 media. Compute hooks unconditionally and defensively; guard after.
 
+**An uncontrolled `defaultValue` can be masked by an async gate, and it will not
+stay masked.** `StringField`'s textarea worked for years while being
+uncontrolled, because the thing that decided it should BE a textarea arrived from
+the host a tick after the effect that fills `currentValue` — so by the time it
+mounted, the value was there. Making the layout synchronous (it is static schema
+config now, not something the host computes) removed that ordering, and the
+textarea started mounting at `null`. `.value` still looked right, because a
+textarea's value follows `defaultValue` while it is untouched — but
+`AutoGrowingTextarea` seeds its invisible sizing ghost from props exactly once,
+so the box rendered one line tall for any amount of text. If a field is
+uncontrolled, check what is actually keeping it correct before you change the
+timing around it. Pinned in `StringField.test.tsx`.
+
 **A context value built inline is a fresh object every render.** Harmless until
 something downstream takes it as a `useMemo`/effect dependency — then it is the
 whole subtree recomputing per keystroke. `FieldSourceOverrideContext` in the

--- a/docs/plans/jsonValues-walkthrough.md
+++ b/docs/plans/jsonValues-walkthrough.md
@@ -1,5 +1,11 @@
 # `.jsonValues()` manual walkthrough (V1–V20)
 
+> **2026-08-28:** `.render({ as: "list", select })` on a `record` or an `array` is
+> now `.preview(select)`. `render` still exists, but only as the static field
+> layout on `string` (`{ as: "textarea" | "code" }`). This document predates that
+> split and is left as the record of what was decided at the time; read every
+> `.render()` here as a preview.
+
 The verification checklist for `s.record(...).jsonValues()` / `s.router(...).jsonValues()`. The
 implementation tracker is [jsonValues.md](./jsonValues.md); this file is the part a person has to run.
 

--- a/docs/plans/jsonValues.md
+++ b/docs/plans/jsonValues.md
@@ -1,5 +1,11 @@
 # Implementation tracker: `.jsonValues()` — lazily-loaded JSON entries
 
+> **2026-08-28:** `.render({ as: "list", select })` on a `record` or an `array` is
+> now `.preview(select)`. `render` still exists, but only as the static field
+> layout on `string` (`{ as: "textarea" | "code" }`). This document predates that
+> split and is left as the record of what was decided at the time; read every
+> `.render()` here as a preview.
+
 > Living implementation plan for `s.record(...).jsonValues()` / `s.router(...).jsonValues()`.
 > The **design rationale + locked decisions** live in the approved design doc
 > (`~/.claude/plans/i-want-a-new-humming-zebra.md`). This file tracks **what's done /

--- a/docs/plans/syncStores.md
+++ b/docs/plans/syncStores.md
@@ -1,5 +1,11 @@
 # Implementation tracker: replace `ValSyncEngine` with event-driven stores
 
+> **2026-08-28:** `.render({ as: "list", select })` on a `record` or an `array` is
+> now `.preview(select)`. `render` still exists, but only as the static field
+> layout on `string` (`{ as: "textarea" | "code" }`). This document predates that
+> split and is left as the record of what was decided at the time; read every
+> `.render()` here as a preview.
+
 > Living implementation plan for retiring `packages/ui/spa/ValSyncEngine.ts` in
 > favour of small communicating stores. Keep the "Current state" block at the top up
 > to date after every work chunk, as `jsonValues.md` does.

--- a/examples/next/app/blogs/[blog]/page.val.ts
+++ b/examples/next/app/blogs/[blog]/page.val.ts
@@ -24,13 +24,10 @@ export default c.define(
       s.string().describe("The URL of the blog post"),
       blogSchema,
     )
-    .render({
-      as: "list",
-      select: ({ val }) => ({
-        title: val.title,
-        subtitle: val.author,
-      }),
-    }),
+    .preview(({ val }) => ({
+      title: val.title,
+      subtitle: val.author,
+    })),
   {
     "/blogs/blog2": {
       title: "Blog 2",

--- a/examples/next/app/notes/[note]/page.val.ts
+++ b/examples/next/app/notes/[note]/page.val.ts
@@ -24,10 +24,7 @@ export default c.define(
         body: s.string(),
       }),
     )
-    .render({
-      as: "list",
-      select: ({ val }) => ({ title: val.title, subtitle: val.body }),
-    }),
+    .preview(({ val }) => ({ title: val.title, subtitle: val.body })),
   {
     "/notes/first": {
       title: "First note",

--- a/examples/next/content/authors.val.ts
+++ b/examples/next/content/authors.val.ts
@@ -16,14 +16,11 @@ export const schema = s
       image: s.image(mediaVal).nullable(),
     }),
   )
-  .render({
-    as: "list",
-    select: ({ val }) => ({
-      title: val.name,
-      subtitle: val.birthdate,
-      image: val.image,
-    }),
-  });
+  .preview(({ val }) => ({
+    title: val.name,
+    subtitle: val.birthdate,
+    image: val.image,
+  }));
 
 export type Author = t.inferSchema<typeof schema>;
 export default c.define("/content/authors.val.ts", schema, {

--- a/examples/next/content/handbook.val.ts
+++ b/examples/next/content/handbook.val.ts
@@ -5,13 +5,13 @@ import authorsVal from "./authors.val";
 // Regenerate with a different size: pnpm handbook generate 4 3
 
 /**
- * A handbook: chapters of sections, with a `select` at BOTH array levels.
+ * A handbook: chapters of sections, with a `preview` at BOTH array levels.
  *
- * This is the shape the store benchmark exists to measure. Two nested `.render()`
- * calls mean an UNSCOPED render of one visible section has to walk every chapter
- * and every section and run the user's `select` closure for each — which is
+ * This is the shape the store benchmark exists to measure. Two nested
+ * `.preview()` calls mean an UNSCOPED preview of one visible section has to walk
+ * every chapter and every section and run the user's closure for each — which is
  * exactly the worst case `packages/ui/spa/stores/architecture.md` names, and the
- * reason `RenderScope` was added to `packages/core`.
+ * reason `PreviewScope` was added to `packages/core`.
  *
  * The rest of the shape is here so the other walks have real work too:
  * `s.richtext()` bodies for the validation walk, `s.keyOf(authorsVal)` and
@@ -34,15 +34,12 @@ export const handbookChapterSchema = s.object({
   slug: s.string().regexp(/^[a-z0-9-]+$/),
   summary: s.string().render({ as: "textarea" }),
   owner: s.keyOf(authorsVal),
-  sections: s.array(handbookSectionSchema).render({
-    as: "list",
-    select: ({ val }) => ({
-      title: val.heading,
-      // Deliberately reads INTO the richtext: a `select` that only returned a
-      // string would be cheap in a way a real one is not.
-      subtitle: firstText(val.body) ?? null,
-    }),
-  }),
+  sections: s.array(handbookSectionSchema).preview(({ val }) => ({
+    title: val.heading,
+    // Deliberately reads INTO the richtext: a preview that only returned a
+    // string would be cheap in a way a real one is not.
+    subtitle: firstText(val.body) ?? null,
+  })),
 });
 
 export type HandbookChapter = t.inferSchema<typeof handbookChapterSchema>;
@@ -67,13 +64,10 @@ function firstText(body: unknown): string | null {
 
 export default c.define(
   "/content/handbook.val.ts",
-  s.array(handbookChapterSchema).render({
-    as: "list",
-    select: ({ val }) => ({
-      title: val.title,
-      subtitle: `${val.sections.length} sections`,
-    }),
-  }),
+  s.array(handbookChapterSchema).preview(({ val }) => ({
+    title: val.title,
+    subtitle: `${val.sections.length} sections`,
+  })),
   [
     {
       title: "Onboarding",

--- a/examples/next/content/kb.val.ts
+++ b/examples/next/content/kb.val.ts
@@ -41,13 +41,10 @@ export default c.define(
   s
     .record(kbArticleSchema)
     .jsonValues()
-    .render({
-      as: "list",
-      select: ({ val }) => ({
-        title: val.title,
-        subtitle: val.body,
-      }),
-    }),
+    .preview(({ val }) => ({
+      title: val.title,
+      subtitle: val.body,
+    })),
   {
     "kb-000": c.json(() => import("./kb/entry-000.val.json")),
     "kb-001": c.json(() => import("./kb/entry-001.val.json")),

--- a/examples/next/scripts/handbook-fixture.mjs
+++ b/examples/next/scripts/handbook-fixture.mjs
@@ -226,13 +226,13 @@ import authorsVal from "./authors.val";
 // Regenerate with a different size: pnpm handbook generate ${chapterCount} ${sectionCount}
 
 /**
- * A handbook: chapters of sections, with a \`select\` at BOTH array levels.
+ * A handbook: chapters of sections, with a \`preview\` at BOTH array levels.
  *
- * This is the shape the store benchmark exists to measure. Two nested \`.render()\`
- * calls mean an UNSCOPED render of one visible section has to walk every chapter
- * and every section and run the user's \`select\` closure for each — which is
+ * This is the shape the store benchmark exists to measure. Two nested
+ * \`.preview()\` calls mean an UNSCOPED preview of one visible section has to walk
+ * every chapter and every section and run the user's closure for each — which is
  * exactly the worst case \`packages/ui/spa/stores/architecture.md\` names, and the
- * reason \`RenderScope\` was added to \`packages/core\`.
+ * reason \`PreviewScope\` was added to \`packages/core\`.
  *
  * The rest of the shape is here so the other walks have real work too:
  * \`s.richtext()\` bodies for the validation walk, \`s.keyOf(authorsVal)\` and
@@ -255,15 +255,12 @@ export const handbookChapterSchema = s.object({
   slug: s.string().regexp(/^[a-z0-9-]+$/),
   summary: s.string().render({ as: "textarea" }),
   owner: s.keyOf(authorsVal),
-  sections: s.array(handbookSectionSchema).render({
-    as: "list",
-    select: ({ val }) => ({
-      title: val.heading,
-      // Deliberately reads INTO the richtext: a \`select\` that only returned a
-      // string would be cheap in a way a real one is not.
-      subtitle: firstText(val.body) ?? null,
-    }),
-  }),
+  sections: s.array(handbookSectionSchema).preview(({ val }) => ({
+    title: val.heading,
+    // Deliberately reads INTO the richtext: a preview that only returned a
+    // string would be cheap in a way a real one is not.
+    subtitle: firstText(val.body) ?? null,
+  })),
 });
 
 export type HandbookChapter = t.inferSchema<typeof handbookChapterSchema>;
@@ -288,13 +285,10 @@ function firstText(body: unknown): string | null {
 
 export default c.define(
   "/content/handbook.val.ts",
-  s.array(handbookChapterSchema).render({
-    as: "list",
-    select: ({ val }) => ({
-      title: val.title,
-      subtitle: \`\${val.sections.length} sections\`,
-    }),
-  }),
+  s.array(handbookChapterSchema).preview(({ val }) => ({
+    title: val.title,
+    subtitle: \`\${val.sections.length} sections\`,
+  })),
   ${literal(chapters, 2)},
 );
 `;

--- a/examples/next/scripts/jsonvalues-fixtures.mjs
+++ b/examples/next/scripts/jsonvalues-fixtures.mjs
@@ -133,13 +133,10 @@ export default c.define(
   s
     .record(kbArticleSchema)
     .jsonValues()
-    .render({
-      as: "list",
-      select: ({ val }) => ({
-        title: val.title,
-        subtitle: val.body,
-      }),
-    }),
+    .preview(({ val }) => ({
+      title: val.title,
+      subtitle: val.body,
+    })),
   {
 ${entries.join("\n")}
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -163,14 +163,14 @@ export {
 export { type SerializedLiteralSchema, LiteralSchema } from "./schema/literal";
 export { deserializeSchema } from "./schema/deserialize";
 export {
-  type ListRecordRender,
-  type ListArrayRender,
-  type ReifiedRender,
-  type RenderScope,
-  type CodeLanguage,
-  type CodeRender,
-  renderScope,
-} from "./render";
+  type PreviewItem,
+  type RecordPreview,
+  type ArrayPreview,
+  type ReifiedPreview,
+  type PreviewScope,
+  previewScope,
+} from "./preview";
+export { type CodeLanguage, type StringRender, CODE_LANGUAGES } from "./render";
 export type { ValRouter, RouteValidationError } from "./router";
 export { getSourcePathFromRoute } from "./getSourcePathFromRoute";
 import { nextAppRouter, externalPageRouter } from "./router";

--- a/packages/core/src/preview.test.ts
+++ b/packages/core/src/preview.test.ts
@@ -1,4 +1,4 @@
-import { renderScope } from "./render";
+import { previewScope } from "./preview";
 import { array } from "./schema/array";
 import { object } from "./schema/object";
 import { record } from "./schema/record";
@@ -6,27 +6,27 @@ import { string } from "./schema/string";
 import { SourcePath } from "./val";
 
 /**
- * `RenderScope` is the mechanism that makes a render proportional to what is on
- * screen rather than to the project. The two questions it answers are easy to
- * conflate, and conflating them either renders too much (no saving) or renders a
- * list with rows missing (a broken screen), so both are pinned here.
+ * `PreviewScope` is the mechanism that makes a preview proportional to what is
+ * on screen rather than to the project. The two questions it answers are easy to
+ * conflate, and conflating them either previews too much (no saving) or previews
+ * a list with rows missing (a broken screen), so both are pinned here.
  */
-describe("renderScope", () => {
+describe("previewScope", () => {
   const sp = (path: string) => path as SourcePath;
 
   it("wants exactly the paths it was given", () => {
-    const scope = renderScope([sp('/a.val.ts?p="title"')]);
+    const scope = previewScope([sp('/a.val.ts?p="title"')]);
 
     expect(scope.wants(sp('/a.val.ts?p="title"'))).toBe(true);
     expect(scope.wants(sp('/a.val.ts?p="body"'))).toBe(false);
     // The container is not wanted: a request for a field inside it is not a
-    // request for the whole of it. This is the distinction that makes a list
-    // render windowed rather than complete.
+    // request for the whole of it. This is the distinction that makes a
+    // container's preview windowed rather than complete.
     expect(scope.wants(sp("/a.val.ts"))).toBe(false);
   });
 
   it("wants under both ancestors and descendants of a wanted path", () => {
-    const scope = renderScope([sp('/a.val.ts?p="rows".2."title"')]);
+    const scope = previewScope([sp('/a.val.ts?p="rows".2."title"')]);
 
     // Ancestors: recursion has to pass through them to reach what was asked for.
     expect(scope.wantsUnder(sp("/a.val.ts"))).toBe(true);
@@ -40,7 +40,7 @@ describe("renderScope", () => {
   });
 
   it("never crosses a module boundary", () => {
-    const scope = renderScope([sp('/a.val.ts?p="title"')]);
+    const scope = previewScope([sp('/a.val.ts?p="title"')]);
 
     expect(scope.wantsUnder(sp("/b.val.ts"))).toBe(false);
     expect(scope.wants(sp('/b.val.ts?p="title"'))).toBe(false);
@@ -49,17 +49,17 @@ describe("renderScope", () => {
   /**
    * The bug a string-prefix implementation has. `"title"` is a prefix of
    * `"titles"` as a STRING but not as a path, so `startsWith` would report the
-   * sibling as wanted and quietly render it.
+   * sibling as wanted and quietly preview it.
    */
   it("compares segments, not string prefixes", () => {
-    const scope = renderScope([sp('/a.val.ts?p="title"')]);
+    const scope = previewScope([sp('/a.val.ts?p="title"')]);
 
     expect(scope.wantsUnder(sp('/a.val.ts?p="titles"'))).toBe(false);
     expect(scope.wants(sp('/a.val.ts?p="titles"'))).toBe(false);
   });
 
   it("treats a key containing a dot as one segment", () => {
-    const scope = renderScope([sp('/a.val.ts?p="a.b"."c"')]);
+    const scope = previewScope([sp('/a.val.ts?p="a.b"."c"')]);
 
     expect(scope.wantsUnder(sp('/a.val.ts?p="a.b"'))).toBe(true);
     // `"a"` is not an ancestor of `"a.b"`: the dot is inside the key, not a
@@ -68,103 +68,97 @@ describe("renderScope", () => {
   });
 
   it("wants everything when the module root is asked for", () => {
-    const scope = renderScope(["/a.val.ts" as SourcePath]);
+    const scope = previewScope(["/a.val.ts" as SourcePath]);
 
     expect(scope.wants(sp("/a.val.ts"))).toBe(true);
     expect(scope.wantsUnder(sp('/a.val.ts?p="anything".3'))).toBe(true);
   });
 });
 
-describe("scoped executeRender", () => {
+describe("scoped executePreview", () => {
   const sp = (path: string) => path as SourcePath;
 
   function listSchema() {
     let calls = 0;
-    const schema = array(object({ name: string() })).render({
-      as: "list",
-      select: ({ val }) => {
-        calls++;
-        return { title: val.name };
-      },
+    const schema = array(object({ name: string() })).preview(({ val }) => {
+      calls++;
+      return { title: val.name };
     });
     return { schema, calls: () => calls };
   }
 
   const rows = [{ name: "Ada" }, { name: "Grace" }, { name: "Alan" }];
 
-  it("renders every row with no scope, as it always did", () => {
+  it("previews every row with no scope, as it always did", () => {
     const { schema, calls } = listSchema();
 
-    const res = schema["executeRender"](sp("/test.val.ts"), rows);
+    const res = schema["executePreview"](sp("/test.val.ts"), rows);
 
     expect(calls()).toBe(3);
     const at = res[sp("/test.val.ts")];
-    if (at?.status !== "success" || at.data.layout !== "list") {
-      throw new Error("expected a list render");
+    if (at?.status !== "success" || at.data.parent !== "array") {
+      throw new Error("expected an array preview");
     }
     expect(at.data.items.map(([index]) => index)).toEqual([0, 1, 2]);
   });
 
-  it("renders one row when only that row is wanted", () => {
+  it("previews one row when only that row is wanted", () => {
     const { schema, calls } = listSchema();
 
-    const res = schema["executeRender"](
+    const res = schema["executePreview"](
       sp("/test.val.ts"),
       rows,
-      renderScope([sp("/test.val.ts?p=1")]),
+      previewScope([sp("/test.val.ts?p=1")]),
     );
 
     expect(calls()).toBe(1);
     const at = res[sp("/test.val.ts")];
-    if (at?.status !== "success" || at.data.layout !== "list") {
-      throw new Error("expected a list render");
+    if (at?.status !== "success" || at.data.parent !== "array") {
+      throw new Error("expected an array preview");
     }
     expect(at.data.items).toEqual([
       [1, { title: "Grace", subtitle: undefined, image: undefined }],
     ]);
   });
 
-  it("renders every row when the list itself is wanted", () => {
+  it("previews every row when the list itself is wanted", () => {
     const { schema, calls } = listSchema();
 
-    const res = schema["executeRender"](
+    const res = schema["executePreview"](
       sp("/test.val.ts"),
       rows,
-      renderScope([sp("/test.val.ts")]),
+      previewScope([sp("/test.val.ts")]),
     );
 
     // A list VIEW asks for the container and needs all of it. Windowing here
     // would be a list with rows missing.
     expect(calls()).toBe(3);
     const at = res[sp("/test.val.ts")];
-    if (at?.status !== "success" || at.data.layout !== "list") {
-      throw new Error("expected a list render");
+    if (at?.status !== "success" || at.data.parent !== "array") {
+      throw new Error("expected an array preview");
     }
     expect(at.data.items.map(([index]) => index)).toEqual([0, 1, 2]);
   });
 
   /**
-   * A throwing `select` used to produce an error at the CONTAINER and no items
-   * at all, so one bad row took out the whole list. Now it is per row — matching
-   * what `record` already did — because windowing made the per-item loop the
-   * natural place for the try.
+   * A throwing preview closure used to produce an error at the CONTAINER and no
+   * items at all, so one bad row took out the whole list. Now it is per row —
+   * matching what `record` already did — because windowing made the per-item
+   * loop the natural place for the try.
    */
-  it("keeps the rows a throwing select did not touch", () => {
-    const schema = array(object({ name: string() })).render({
-      as: "list",
-      select: ({ val }) => {
-        if (val.name === "Grace") {
-          throw new Error("nope");
-        }
-        return { title: val.name };
-      },
+  it("keeps the rows a throwing preview did not touch", () => {
+    const schema = array(object({ name: string() })).preview(({ val }) => {
+      if (val.name === "Grace") {
+        throw new Error("nope");
+      }
+      return { title: val.name };
     });
 
-    const res = schema["executeRender"](sp("/test.val.ts"), rows);
+    const res = schema["executePreview"](sp("/test.val.ts"), rows);
 
     const at = res[sp("/test.val.ts")];
-    if (at?.status !== "success" || at.data.layout !== "list") {
-      throw new Error("expected a list render");
+    if (at?.status !== "success" || at.data.parent !== "array") {
+      throw new Error("expected an array preview");
     }
     expect(at.data.items.map(([index]) => index)).toEqual([0, 2]);
     expect(res[sp("/test.val.ts?p=1")]).toEqual({
@@ -175,33 +169,32 @@ describe("scoped executeRender", () => {
 
   it("windows a record to the wanted entry", () => {
     let calls = 0;
-    const schema = record(object({ name: string() })).render({
-      as: "list",
-      select: ({ key, val }) => {
+    const schema = record(object({ name: string() })).preview(
+      ({ key, val }) => {
         calls++;
         return { title: `${key}: ${val.name}` };
       },
-    });
+    );
     const src = { a: { name: "Ada" }, b: { name: "Grace" } };
 
-    const res = schema["executeRender"](
+    const res = schema["executePreview"](
       sp("/test.val.ts"),
       src,
-      renderScope([sp('/test.val.ts?p="b"')]),
+      previewScope([sp('/test.val.ts?p="b"')]),
     );
 
     expect(calls).toBe(1);
     const at = res[sp("/test.val.ts")];
-    if (at?.status !== "success" || at.data.layout !== "list") {
-      throw new Error("expected a list render");
+    if (at?.status !== "success" || at.data.parent !== "record") {
+      throw new Error("expected a record preview");
     }
     expect(at.data.items.map(([key]) => key)).toEqual(["b"]);
   });
 
   /**
    * The nested case, which is the one the whole exercise is for: `handboka` has
-   * `select` at two array levels, so an unscoped render of one visible section
-   * walks every chapter and every section.
+   * a `preview` at two array levels, so an unscoped preview of one visible
+   * section walks every chapter and every section.
    */
   it("prunes sibling subtrees in a nested list", () => {
     let outer = 0;
@@ -209,30 +202,24 @@ describe("scoped executeRender", () => {
     const schema = array(
       object({
         title: string(),
-        sections: array(object({ heading: string() })).render({
-          as: "list",
-          select: ({ val }) => {
-            inner++;
-            return { title: val.heading };
-          },
+        sections: array(object({ heading: string() })).preview(({ val }) => {
+          inner++;
+          return { title: val.heading };
         }),
       }),
-    ).render({
-      as: "list",
-      select: ({ val }) => {
-        outer++;
-        return { title: val.title };
-      },
+    ).preview(({ val }) => {
+      outer++;
+      return { title: val.title };
     });
     const src = [
       { title: "One", sections: [{ heading: "1.1" }, { heading: "1.2" }] },
       { title: "Two", sections: [{ heading: "2.1" }, { heading: "2.2" }] },
     ];
 
-    schema["executeRender"](
+    schema["executePreview"](
       sp("/test.val.ts"),
       src,
-      renderScope([sp('/test.val.ts?p=1."sections".0')]),
+      previewScope([sp('/test.val.ts?p=1."sections".0')]),
     );
 
     // One chapter of two, one section of two within it.

--- a/packages/core/src/preview.ts
+++ b/packages/core/src/preview.ts
@@ -1,0 +1,159 @@
+import { Schema } from "./schema";
+import { SelectorSource } from "./selector";
+import { ImageSource } from "./source/media";
+import { splitModuleFilePathAndModulePath, splitModulePath } from "./module";
+import { ModuleFilePath, SourcePath } from "./val";
+
+/**
+ * What a container shows for ONE of its items: the user's `preview` callback
+ * returns this, and the Studio draws a row from it.
+ *
+ * NB: {@link ArrayPreview} / {@link RecordPreview} name the DATA a container
+ * previews with. The Studio also has React components called `ArrayPreview` /
+ * `RecordPreview` (the fallback rendering of an array / record field, part of
+ * the `<Type>Preview` convention in `components/Preview.tsx`). They do not
+ * collide today because no file needs both - if one ever does, alias this type
+ * at the import rather than renaming that convention.
+ */
+export type PreviewItem = {
+  title: string;
+  subtitle?: string | null;
+  image?: ImageSource | null;
+};
+
+export type RecordPreview = {
+  parent: "record";
+  items: [key: string, value: PreviewItem][];
+};
+
+export type ArrayPreview = {
+  parent: "array";
+  /**
+   * The previewed items, each PAIRED WITH ITS INDEX - the same
+   * `[key, value][]` shape {@link RecordPreview} uses.
+   *
+   * Not a positionally-indexed array, and the reason is
+   * {@link PreviewScope}: a preview computed for a subset of paths carries only
+   * those items, so `items[i]` would silently read the wrong row. Carrying the
+   * index makes a windowed preview impossible to misread - a consumer looks its
+   * index up rather than trusting a position - and makes the array and record
+   * shapes symmetric.
+   */
+  items: [index: number, value: PreviewItem][];
+};
+
+/**
+ * Main preview type.
+ *
+ * Deliberately not exported: `parent` is the discriminant, and every consumer
+ * narrows on it rather than on the union as a whole. There is no `layout` here
+ * on purpose - how a preview is laid out is the editor's business, not the
+ * schema's.
+ */
+type PreviewTypes = RecordPreview | ArrayPreview;
+
+type WithStatus<T> =
+  | {
+      status: "error";
+      message: string;
+    }
+  | {
+      // TODO: loading doesn't really belong in core - however this is used in other places where it does make sense and we figured... Why not just add it here?
+      status: "loading";
+      data?: T;
+    }
+  | {
+      status: "success";
+      data: T;
+    };
+export type ReifiedPreview = Record<
+  SourcePath | ModuleFilePath,
+  WithStatus<PreviewTypes>
+>;
+
+/**
+ * Which paths a preview is being computed FOR.
+ *
+ * `executePreview` takes a whole module, so one request has always walked every
+ * node in it and run every `preview` closure - for `handboka`, with `preview` at
+ * two nested array levels, that is every chapter and every section to serve one
+ * visible row. A scope is what makes the walk proportional to what is being
+ * looked at instead of to the project.
+ *
+ * Two questions, because a container and its items need different answers:
+ *
+ * - {@link PreviewScope.wants} - is a preview AT this exact path wanted? A
+ *   container answers `true` here when the whole of it is being shown, and its
+ *   preview is then computed in full.
+ * - {@link PreviewScope.wantsUnder} - could anything at or below this path be
+ *   wanted? Recursion is pruned where this is `false`, and a container whose own
+ *   path is not wanted but which has wanted descendants previews a WINDOW: only
+ *   the items that were asked for. That is the case a single visible row is, and
+ *   it is why {@link ArrayPreview} carries indices.
+ *
+ * Absent scope means the whole module, which is what every existing caller
+ * passes and what every existing caller got.
+ */
+export type PreviewScope = {
+  wants(path: SourcePath | ModuleFilePath): boolean;
+  wantsUnder(path: SourcePath | ModuleFilePath): boolean;
+};
+
+/**
+ * A scope covering exactly `paths` and their subtrees.
+ *
+ * Compares SEGMENTS rather than string prefixes. A source path's module path is
+ * a quoted, dot-joined encoding (`?p="a".1."b"`), so `startsWith` gets the
+ * ancestor test wrong wherever a key is a prefix of a sibling key or contains a
+ * dot or a quote - `"title"` against `"titles"` being the cheapest example.
+ * Segments are parsed once here, not per comparison.
+ */
+export function previewScope(paths: readonly SourcePath[]): PreviewScope {
+  const wanted = paths.map((path) => {
+    const [moduleFilePath, modulePath] = splitModuleFilePathAndModulePath(path);
+    return {
+      moduleFilePath,
+      segments: modulePath === "" ? [] : splitModulePath(modulePath),
+    };
+  });
+  const parse = (path: SourcePath | ModuleFilePath) => {
+    const [moduleFilePath, modulePath] = splitModuleFilePathAndModulePath(path);
+    return {
+      moduleFilePath,
+      segments: modulePath === "" ? [] : splitModulePath(modulePath),
+    };
+  };
+  const isPrefix = (prefix: string[], of: string[]): boolean => {
+    if (prefix.length > of.length) return false;
+    for (let i = 0; i < prefix.length; i++) {
+      if (prefix[i] !== of[i]) return false;
+    }
+    return true;
+  };
+  return {
+    wants(path) {
+      const at = parse(path);
+      return wanted.some(
+        (entry) =>
+          entry.moduleFilePath === at.moduleFilePath &&
+          entry.segments.length === at.segments.length &&
+          isPrefix(entry.segments, at.segments),
+      );
+    },
+    wantsUnder(path) {
+      const at = parse(path);
+      return wanted.some(
+        (entry) =>
+          entry.moduleFilePath === at.moduleFilePath &&
+          // Either direction: a wanted path below `path` means recurse into it,
+          // and a wanted path ABOVE it means the whole subtree was asked for.
+          (isPrefix(at.segments, entry.segments) ||
+            isPrefix(entry.segments, at.segments)),
+      );
+    },
+  };
+}
+
+// TODO: improve this so that we do not get RawString and string, only string. Are there other things?
+export type PreviewSelector<T extends Schema<SelectorSource>> =
+  T extends Schema<infer S> ? S : never;

--- a/packages/core/src/render.ts
+++ b/packages/core/src/render.ts
@@ -1,186 +1,55 @@
-import { Schema } from "./schema";
-import { SelectorSource } from "./selector";
-import { ImageSource } from "./source/media";
-import { splitModuleFilePathAndModulePath, splitModulePath } from "./module";
-import { ModuleFilePath, SourcePath } from "./val";
+/**
+ * A RENDER is how one field is laid out in the editor: `s.string().render({ as:
+ * "textarea" })`, `.render({ as: "code", language })`.
+ *
+ * It is static configuration - plain data, with no closure behind it and no
+ * dependency on source - which is why it lives in the SERIALIZED schema
+ * (`SerializedStringSchema.render`) and is read straight off it where the field
+ * is drawn. There is no render pipeline, no store and no host round-trip.
+ *
+ * That "static" is an ASSUMPTION we are taking deliberately, for simplicity,
+ * not a law. A future render could plausibly want to depend on source - a
+ * layout that varies with the value, a callback of its own. If that day comes,
+ * the shape it needs back is `executePreview`'s, and the honest move is to give
+ * `render` its own execute/store pair again. It is NOT to re-merge the two:
+ * conflating them is what this file was split up to undo.
+ *
+ * The dynamic, source-dependent, demand-scoped thing - what a container shows
+ * for its items - is a PREVIEW. See `preview.ts`.
+ */
+/**
+ * The list is the declaration and {@link CodeLanguage} is derived from it, so
+ * that a validator elsewhere (`shared`'s zod schema) can enumerate the same
+ * languages without a second copy that drifts. Same shape as `COLOR_FORMATS`.
+ */
+export const CODE_LANGUAGES = [
+  "typescript",
+  "javascript",
+  "javascriptreact",
+  "typescriptreact",
+  "json",
+  "java",
+  "html",
+  "css",
+  "xml",
+  "markdown",
+  "sql",
+  "python",
+  "rust",
+  "php",
+  "go",
+  "cpp",
+  "sass",
+  "vue",
+  "angular",
+] as const;
 
-// TODO: we want to change layout -> as to be more consistent across the board
-export type ListRecordRender = {
-  layout: "list";
-  parent: "record";
-  items: [
-    key: string,
-    value: {
-      title: string;
-      subtitle?: string | null;
-      image?: ImageSource | null;
-    },
-  ][];
-};
-
-export type ListArrayRender = {
-  layout: "list";
-  parent: "array";
-  /**
-   * The rendered items, each PAIRED WITH ITS INDEX — the same
-   * `[key, value][]` shape {@link ListRecordRender} uses.
-   *
-   * Not a positionally-indexed array, and the reason is
-   * {@link RenderScope}: a render computed for a subset of paths carries only
-   * those items, so `items[i]` would silently read the wrong row. Carrying the
-   * index makes a windowed render impossible to misread — a consumer looks its
-   * index up rather than trusting a position — and makes the array and record
-   * shapes symmetric.
-   */
-  items: [
-    index: number,
-    value: {
-      title: string;
-      subtitle?: string | null;
-      image?: ImageSource | null;
-    },
-  ][];
-};
-
-export type TextareaRender = {
-  layout: "textarea";
-};
-
-export type CodeLanguage =
-  | "typescript"
-  | "javascript"
-  | "javascriptreact"
-  | "typescriptreact"
-  | "json"
-  | "java"
-  | "html"
-  | "css"
-  | "xml"
-  | "markdown"
-  | "sql"
-  | "python"
-  | "rust"
-  | "php"
-  | "go"
-  | "cpp"
-  | "sass"
-  | "vue"
-  | "angular";
-export type CodeRender = {
-  layout: "code";
-  language: CodeLanguage;
-};
-
-// Main render type:
-type RenderTypes =
-  | ListRecordRender
-  | ListArrayRender
-  | TextareaRender
-  | CodeRender;
-//
-
-type WithStatus<T> =
-  | {
-      status: "error";
-      message: string;
-    }
-  | {
-      // TODO: loading doesn't really belong in core - however this is used in other places where it does make sense and we figured... Why not just add it here?
-      status: "loading";
-      data?: T;
-    }
-  | {
-      status: "success";
-      data: T;
-    };
-export type ReifiedRender = Record<
-  SourcePath | ModuleFilePath,
-  WithStatus<RenderTypes>
->;
+export type CodeLanguage = (typeof CODE_LANGUAGES)[number];
 
 /**
- * Which paths a render is being computed FOR.
- *
- * `executeRender` takes a whole module, so one request has always walked every
- * node in it and run every `select` closure — for `handboka`, with `select` at
- * two nested array levels, that is every chapter and every section to serve one
- * visible row. A scope is what makes the walk proportional to what is being
- * looked at instead of to the project.
- *
- * Two questions, because a container and its items need different answers:
- *
- * - {@link RenderScope.wants} — is a render AT this exact path wanted? A
- *   container answers `true` here when the whole of it is being shown, and its
- *   list render is then computed in full.
- * - {@link RenderScope.wantsUnder} — could anything at or below this path be
- *   wanted? Recursion is pruned where this is `false`, and a container whose own
- *   path is not wanted but which has wanted descendants renders a WINDOW: only
- *   the items that were asked for. That is the case a single visible row is, and
- *   it is why {@link ListArrayRender} carries indices.
- *
- * Absent scope means the whole module, which is what every existing caller
- * passes and what every existing caller got.
+ * What `s.string().render(...)` takes, and what the serialized schema carries
+ * verbatim.
  */
-export type RenderScope = {
-  wants(path: SourcePath | ModuleFilePath): boolean;
-  wantsUnder(path: SourcePath | ModuleFilePath): boolean;
-};
-
-/**
- * A scope covering exactly `paths` and their subtrees.
- *
- * Compares SEGMENTS rather than string prefixes. A source path's module path is
- * a quoted, dot-joined encoding (`?p="a".1."b"`), so `startsWith` gets the
- * ancestor test wrong wherever a key is a prefix of a sibling key or contains a
- * dot or a quote — `"title"` against `"titles"` being the cheapest example.
- * Segments are parsed once here, not per comparison.
- */
-export function renderScope(paths: readonly SourcePath[]): RenderScope {
-  const wanted = paths.map((path) => {
-    const [moduleFilePath, modulePath] = splitModuleFilePathAndModulePath(path);
-    return {
-      moduleFilePath,
-      segments: modulePath === "" ? [] : splitModulePath(modulePath),
-    };
-  });
-  const parse = (path: SourcePath | ModuleFilePath) => {
-    const [moduleFilePath, modulePath] = splitModuleFilePathAndModulePath(path);
-    return {
-      moduleFilePath,
-      segments: modulePath === "" ? [] : splitModulePath(modulePath),
-    };
-  };
-  const isPrefix = (prefix: string[], of: string[]): boolean => {
-    if (prefix.length > of.length) return false;
-    for (let i = 0; i < prefix.length; i++) {
-      if (prefix[i] !== of[i]) return false;
-    }
-    return true;
-  };
-  return {
-    wants(path) {
-      const at = parse(path);
-      return wanted.some(
-        (entry) =>
-          entry.moduleFilePath === at.moduleFilePath &&
-          entry.segments.length === at.segments.length &&
-          isPrefix(entry.segments, at.segments),
-      );
-    },
-    wantsUnder(path) {
-      const at = parse(path);
-      return wanted.some(
-        (entry) =>
-          entry.moduleFilePath === at.moduleFilePath &&
-          // Either direction: a wanted path below `path` means recurse into it,
-          // and a wanted path ABOVE it means the whole subtree was asked for.
-          (isPrefix(at.segments, entry.segments) ||
-            isPrefix(entry.segments, at.segments)),
-      );
-    },
-  };
-}
-
-// TODO: improve this so that we do not get RawString and string, only string. Are there other things?
-export type RenderSelector<T extends Schema<SelectorSource>> =
-  T extends Schema<infer S> ? S : never;
+export type StringRender =
+  | { as: "textarea" }
+  | { as: "code"; language: CodeLanguage };

--- a/packages/core/src/schema/array.test.ts
+++ b/packages/core/src/schema/array.test.ts
@@ -19,21 +19,19 @@ describe("ArraySchema", () => {
       false,
     );
   });
-  test("render: list render is kept when chaining after render", () => {
-    const base = array(object({ name: string() })).render({
-      as: "list",
-      select: ({ val }) => ({ title: val.name }),
-    });
+  test("preview: preview is kept when chaining after preview", () => {
+    const base = array(object({ name: string() })).preview(({ val }) => ({
+      title: val.name,
+    }));
     const src = [{ name: "Ada" }];
     const expected = {
       "/test.val.ts": {
         status: "success",
         data: {
-          layout: "list",
           parent: "array",
-          // `[index, value]`, matching the record shape: a windowed render (see
-          // RenderScope) carries only the rows that were asked for, so the index
-          // travels with the item rather than being its position.
+          // `[index, value]`, matching the record shape: a windowed preview (see
+          // PreviewScope) carries only the rows that were asked for, so the
+          // index travels with the item rather than being its position.
           items: [[0, { title: "Ada", subtitle: undefined, image: undefined }]],
         },
       },
@@ -47,19 +45,16 @@ describe("ArraySchema", () => {
       base.validate(() => false),
     ]) {
       expect(
-        schema["executeRender"]("/test.val.ts" as SourcePath, src),
+        schema["executePreview"]("/test.val.ts" as SourcePath, src),
       ).toEqual(expected);
     }
   });
 
-  test("render: does not mutate the schema it was called on", () => {
+  test("preview: does not mutate the schema it was called on", () => {
     const base = array(object({ name: string() }));
-    base.render({
-      as: "list",
-      select: ({ val }) => ({ title: val.name }),
-    });
+    base.preview(({ val }) => ({ title: val.name }));
     expect(
-      base["executeRender"]("/test.val.ts" as SourcePath, [{ name: "Ada" }]),
+      base["executePreview"]("/test.val.ts" as SourcePath, [{ name: "Ada" }]),
     ).toEqual({});
   });
 });

--- a/packages/core/src/schema/array.ts
+++ b/packages/core/src/schema/array.ts
@@ -5,14 +5,14 @@ import {
   SerializedSchema,
 } from ".";
 import {
-  ListArrayRender,
-  RenderSelector,
-  ReifiedRender,
-  RenderScope,
-} from "../render";
+  ArrayPreview,
+  PreviewItem,
+  PreviewSelector,
+  ReifiedPreview,
+  PreviewScope,
+} from "../preview";
 import { SelectorSource } from "../selector";
 import { unsafeCreateSourcePath } from "../selector/SelectorProxy";
-import { ImageSource } from "../source/media";
 import { ModuleFilePath, SourcePath } from "../val";
 import {
   ValidationError,
@@ -24,29 +24,24 @@ export type SerializedArraySchema = {
   item: SerializedSchema;
   opt: boolean;
   /**
-   * Set when this schema declares a `render`.
+   * Set when this schema declares a `preview`.
    *
-   * The render itself cannot be serialized — `select` is a user closure — but
-   * whether one EXISTS can be, and that is worth carrying: it lets the non-host
-   * side skip asking the host to render a module that cannot produce one.
-   * Measured in a browser: mounting 260 fields across 141 modules spent ~2.3ms
-   * of 3.1ms calling `executeRender` on modules that returned nothing.
+   * The preview itself cannot be serialized — it is a user closure — but whether
+   * one EXISTS can be, and that is worth carrying: it lets the non-host side
+   * skip asking the host to preview a module that cannot produce one. Measured
+   * in a browser: mounting 260 fields across 141 modules spent ~2.3ms of 3.1ms
+   * calling `executePreview` on modules that returned nothing.
    */
-  render?: true;
+  preview?: true;
   customValidate?: boolean;
   readonly?: boolean;
   hidden?: boolean;
   description?: string;
 };
 
-type ArrayRenderInput<T extends Schema<SelectorSource>> = {
-  as: "list";
-  select: (input: { val: RenderSelector<T> }) => {
-    title: string;
-    subtitle?: string | null;
-    image?: ImageSource | null;
-  };
-};
+type ArrayPreviewInput<T extends Schema<SelectorSource>> = (input: {
+  val: PreviewSelector<T>;
+}) => PreviewItem;
 
 export class ArraySchema<
   T extends Schema<SelectorSource>,
@@ -61,7 +56,7 @@ export class ArraySchema<
     private readonly isReadonly: boolean = false,
     private readonly isHidden: boolean = false,
     private readonly description?: string,
-    private readonly renderInput: ArrayRenderInput<T> | null = null,
+    private readonly previewInput: ArrayPreviewInput<T> | null = null,
   ) {
     super();
   }
@@ -74,7 +69,7 @@ export class ArraySchema<
       this.isReadonly,
       this.isHidden,
       description ?? undefined,
-      this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -88,7 +83,7 @@ export class ArraySchema<
       this.isReadonly,
       this.isHidden,
       this.description,
-      this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -166,7 +161,7 @@ export class ArraySchema<
       this.isReadonly,
       this.isHidden,
       this.description,
-      this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -178,7 +173,7 @@ export class ArraySchema<
       true,
       this.isHidden,
       this.description,
-      this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -190,7 +185,7 @@ export class ArraySchema<
       this.isReadonly,
       true,
       this.description,
-      this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -210,7 +205,7 @@ export class ArraySchema<
       type: "array",
       item: this.item["executeSerialize"](),
       opt: this.opt,
-      render: this.renderInput ? true : undefined,
+      preview: this.previewInput ? true : undefined,
       customValidate:
         this.customValidateFunctions &&
         this.customValidateFunctions?.length > 0,
@@ -220,12 +215,12 @@ export class ArraySchema<
     };
   }
 
-  protected override executeRender(
+  protected override executePreview(
     sourcePath: SourcePath | ModuleFilePath,
     src: Src,
-    scope?: RenderScope,
-  ): ReifiedRender {
-    const res: ReifiedRender = {};
+    scope?: PreviewScope,
+  ): ReifiedPreview {
+    const res: ReifiedPreview = {};
     if (src === null) {
       return res;
     }
@@ -239,30 +234,24 @@ export class ArraySchema<
       if (scope !== undefined && !scope.wantsUnder(subPath)) {
         continue;
       }
-      const itemResult = this.item["executeRender"](subPath, itemSrc, scope);
+      const itemResult = this.item["executePreview"](subPath, itemSrc, scope);
       for (const keyS in itemResult) {
         const key = keyS as SourcePath | ModuleFilePath;
         res[key] = itemResult[key];
       }
     }
-    if (this.renderInput) {
-      const { select, as: layout } = this.renderInput;
-      if (layout !== "list") {
-        res[sourcePath] = {
-          status: "error",
-          message: "Unknown layout type: " + layout,
-        };
-      }
+    if (this.previewInput) {
+      const select = this.previewInput;
       // The whole list when the LIST is what is being shown; only the wanted
-      // rows when it is not. `select` is the user's closure and the real expense
-      // — a list view asks for the container and gets every row, a single field
-      // asks for its own path and costs one call.
+      // rows when it is not. The user's closure is the real expense — a list
+      // view asks for the container and gets every row, a single field asks for
+      // its own path and costs one call.
       // Non-null once, as a value, rather than a boolean the compiler cannot
       // tie back to `scope`: no scope and a scope that wants this exact path
       // both mean the whole list, and anything else is a window.
       const window =
         scope !== undefined && !scope.wants(sourcePath) ? scope : null;
-      const items: ListArrayRender["items"] = [];
+      const items: ArrayPreview["items"] = [];
       for (let index = 0; index < src.length; index++) {
         if (
           window !== null &&
@@ -270,10 +259,10 @@ export class ArraySchema<
         ) {
           continue;
         }
-        // Per ITEM, not per list, matching what `record` already does: `select`
-        // is user code, and one row whose data trips it up must not take out the
-        // whole list. Before scoping, one throwing row produced an error at the
-        // container and no items at all.
+        // Per ITEM, not per list, matching what `record` already does: the
+        // closure is user code, and one row whose data trips it up must not take
+        // out the whole list. Before scoping, one throwing row produced an error
+        // at the container and no items at all.
         try {
           // NB NB: display is actually defined by the user
           const { title, subtitle, image } = select({ val: src[index] });
@@ -288,7 +277,6 @@ export class ArraySchema<
       res[sourcePath] = {
         status: "success",
         data: {
-          layout: "list",
           parent: "array",
           items,
         },
@@ -297,7 +285,14 @@ export class ArraySchema<
     return res;
   }
 
-  render(input: ArrayRenderInput<T>): ArraySchema<T, Src> {
+  /**
+   * What the editor shows for each ITEM of this array: a title, and optionally a
+   * subtitle and an image.
+   *
+   * `select` is your own code over the item's source, so it is run on demand for
+   * the rows that are actually being looked at — see `PreviewScope`.
+   */
+  preview(select: ArrayPreviewInput<T>): ArraySchema<T, Src> {
     return new ArraySchema(
       this.item,
       this.opt,
@@ -305,7 +300,7 @@ export class ArraySchema<
       this.isReadonly,
       this.isHidden,
       this.description,
-      input,
+      select,
     );
   }
 }

--- a/packages/core/src/schema/boolean.ts
+++ b/packages/core/src/schema/boolean.ts
@@ -5,7 +5,7 @@ import {
   SchemaAssertResult,
   SerializedSchema,
 } from ".";
-import { ReifiedRender } from "../render";
+import { ReifiedPreview } from "../preview";
 import { ModuleFilePath, SourcePath } from "../val";
 import {
   ValidationError,
@@ -164,7 +164,7 @@ export class BooleanSchema<Src extends boolean | null> extends Schema<Src> {
     };
   }
 
-  protected executeRender(): ReifiedRender {
+  protected executePreview(): ReifiedPreview {
     return {};
   }
 }

--- a/packages/core/src/schema/color.ts
+++ b/packages/core/src/schema/color.ts
@@ -4,7 +4,7 @@ import {
   SchemaAssertResult,
   SerializedSchema,
 } from ".";
-import { ReifiedRender } from "../render";
+import { ReifiedPreview } from "../preview";
 import { SourcePath } from "../val";
 import {
   ColorFormat,
@@ -251,7 +251,7 @@ export class ColorSchema<Src extends string | null> extends Schema<Src> {
     };
   }
 
-  protected executeRender(): ReifiedRender {
+  protected executePreview(): ReifiedPreview {
     return {};
   }
 }

--- a/packages/core/src/schema/date.ts
+++ b/packages/core/src/schema/date.ts
@@ -4,7 +4,7 @@ import {
   SchemaAssertResult,
   SerializedSchema,
 } from ".";
-import { ReifiedRender } from "../render";
+import { ReifiedPreview } from "../preview";
 import { SourcePath } from "../val";
 import { RawString } from "./string";
 import {
@@ -246,7 +246,7 @@ export class DateSchema<Src extends string | null> extends Schema<Src> {
     };
   }
 
-  protected executeRender(): ReifiedRender {
+  protected executePreview(): ReifiedPreview {
     return {};
   }
 }

--- a/packages/core/src/schema/datetime.ts
+++ b/packages/core/src/schema/datetime.ts
@@ -4,7 +4,7 @@ import {
   SchemaAssertResult,
   SerializedSchema,
 } from ".";
-import { ReifiedRender } from "../render";
+import { ReifiedPreview } from "../preview";
 import { SourcePath } from "../val";
 import { RawString } from "./string";
 import {
@@ -282,7 +282,7 @@ export class DateTimeSchema<Src extends string | null> extends Schema<Src> {
     };
   }
 
-  protected executeRender(): ReifiedRender {
+  protected executePreview(): ReifiedPreview {
     return {};
   }
 }

--- a/packages/core/src/schema/deserialize.ts
+++ b/packages/core/src/schema/deserialize.ts
@@ -51,7 +51,10 @@ function deserializeSchemaImpl(
         serialized.opt,
         serialized.raw,
         [],
-        null,
+        // A render is static data, so it survives serialization and must be
+        // carried back: it is the schema's own configuration now, not something
+        // recomputed from an instance.
+        serialized.render ?? null,
         false,
         false,
         serialized.description,

--- a/packages/core/src/schema/file.ts
+++ b/packages/core/src/schema/file.ts
@@ -17,7 +17,7 @@ import {
   ValidationErrors,
 } from "./validation/ValidationError";
 import { Internal, ValModule } from "..";
-import { ReifiedRender } from "../render";
+import { ReifiedPreview } from "../preview";
 import { FilesEntryMetadata } from "./files";
 import { getSource } from "../module";
 
@@ -423,7 +423,7 @@ export class FileSchema<Src extends FileSource | null> extends Schema<Src> {
     };
   }
 
-  protected executeRender(): ReifiedRender {
+  protected executePreview(): ReifiedPreview {
     return {};
   }
 }

--- a/packages/core/src/schema/image.ts
+++ b/packages/core/src/schema/image.ts
@@ -15,7 +15,7 @@ import {
   ValidationErrors,
 } from "./validation/ValidationError";
 import { Internal, ValModule } from "..";
-import { ReifiedRender } from "../render";
+import { ReifiedPreview } from "../preview";
 import { ImagesEntryMetadata } from "./images";
 import { getSource } from "../module";
 
@@ -466,7 +466,7 @@ export class ImageSchema<Src extends ImageSource | null> extends Schema<Src> {
     };
   }
 
-  protected executeRender(): ReifiedRender {
+  protected executePreview(): ReifiedPreview {
     return {};
   }
 }

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -23,7 +23,7 @@ import {
 } from "./validation/ValidationError";
 import { FileSource } from "../source/media";
 import { GenericRichTextSourceNode, RichTextSource } from "../source/richtext";
-import { ReifiedRender, RenderScope } from "../render";
+import { ReifiedPreview, PreviewScope } from "../preview";
 // import { SerializedI18nSchema } from "./future/i18n";
 // import { SerializedOneOfSchema } from "./future/oneOf";
 
@@ -173,17 +173,17 @@ export abstract class Schema<Src extends SelectorSource> {
   abstract hidden(): Schema<Src>;
   protected abstract executeSerialize(): SerializedSchema;
   /**
-   * @param scope Which paths the caller needs a render for. Absent means the
+   * @param scope Which paths the caller needs a preview for. Absent means the
    * whole module, which is what every caller passed before scoping existed.
-   * See {@link RenderScope}: a container prunes recursion where nothing is
-   * wanted, and renders a WINDOW when its own path is not wanted but some of its
-   * items are — which is the single-visible-row case.
+   * See {@link PreviewScope}: a container prunes recursion where nothing is
+   * wanted, and previews a WINDOW when its own path is not wanted but some of
+   * its items are — which is the single-visible-row case.
    */
-  protected abstract executeRender(
+  protected abstract executePreview(
     sourcePath: SourcePath | ModuleFilePath,
     src: Src,
-    scope?: RenderScope,
-  ): ReifiedRender;
+    scope?: PreviewScope,
+  ): ReifiedPreview;
   // remote(): Src extends RemoteCompatibleSource
   //   ? Schema<RemoteSource<Src>>
   //   : never {

--- a/packages/core/src/schema/keyOf.ts
+++ b/packages/core/src/schema/keyOf.ts
@@ -14,7 +14,7 @@ import {
   ValidationErrors,
 } from "./validation/ValidationError";
 import { RawString } from "./string";
-import { ReifiedRender } from "../render";
+import { ReifiedPreview } from "../preview";
 import { ObjectSchema } from "./object";
 import { RecordSchema } from "./record";
 
@@ -378,7 +378,7 @@ export class KeyOfSchema<
     } satisfies SerializedKeyOfSchema;
   }
 
-  protected executeRender(): ReifiedRender {
+  protected executePreview(): ReifiedPreview {
     return {};
   }
 }

--- a/packages/core/src/schema/literal.ts
+++ b/packages/core/src/schema/literal.ts
@@ -4,7 +4,7 @@ import {
   SchemaAssertResult,
   SerializedSchema,
 } from ".";
-import { ReifiedRender } from "../render";
+import { ReifiedPreview } from "../preview";
 import { SourcePath } from "../val";
 import {
   ValidationError,
@@ -194,7 +194,7 @@ export class LiteralSchema<Src extends string | null> extends Schema<Src> {
     };
   }
 
-  protected executeRender(): ReifiedRender {
+  protected executePreview(): ReifiedPreview {
     return {};
   }
 }

--- a/packages/core/src/schema/number.ts
+++ b/packages/core/src/schema/number.ts
@@ -4,7 +4,7 @@ import {
   SchemaAssertResult,
   SerializedSchema,
 } from ".";
-import { ReifiedRender } from "../render";
+import { ReifiedPreview } from "../preview";
 import { SourcePath } from "../val";
 import {
   ValidationError,
@@ -232,7 +232,7 @@ export class NumberSchema<Src extends number | null> extends Schema<Src> {
     };
   }
 
-  protected executeRender(): ReifiedRender {
+  protected executePreview(): ReifiedPreview {
     return {};
   }
 }

--- a/packages/core/src/schema/object.ts
+++ b/packages/core/src/schema/object.ts
@@ -7,7 +7,7 @@ import {
   SelectorOfSchema,
   SerializedSchema,
 } from ".";
-import { ReifiedRender, RenderScope } from "../render";
+import { ReifiedPreview, PreviewScope } from "../preview";
 import { SelectorSource } from "../selector";
 import {
   createValPathOfItem,
@@ -285,12 +285,12 @@ export class ObjectSchema<
     };
   }
 
-  protected executeRender(
+  protected executePreview(
     sourcePath: SourcePath | ModuleFilePath,
     src: Src,
-    scope?: RenderScope,
-  ): ReifiedRender {
-    const res: ReifiedRender = {};
+    scope?: PreviewScope,
+  ): ReifiedPreview {
+    const res: ReifiedPreview = {};
     if (src === null) {
       return res;
     }
@@ -300,13 +300,13 @@ export class ObjectSchema<
         continue;
       }
       const subPath = unsafeCreateSourcePath(sourcePath, key);
-      // An object produces no render of its own, so it is pure recursion — and
+      // An object produces no preview of its own, so it is pure recursion — and
       // pruning it is the whole contribution: a field deep in one branch stops
-      // paying for every sibling branch's renders.
+      // paying for every sibling branch's previews.
       if (scope !== undefined && !scope.wantsUnder(subPath)) {
         continue;
       }
-      const itemResult = this.items[key]["executeRender"](
+      const itemResult = this.items[key]["executePreview"](
         subPath,
         itemSrc,
         scope,

--- a/packages/core/src/schema/record.test.ts
+++ b/packages/core/src/schema/record.test.ts
@@ -15,7 +15,7 @@ describe("RecordSchema", () => {
     });
   });
 
-  test("record: nested renders", () => {
+  test("record: nested previews", () => {
     const schema = record(
       object({
         title: string(),
@@ -23,22 +23,16 @@ describe("RecordSchema", () => {
           object({
             baz: string().nullable(),
           }),
-        ).render({
-          as: "list",
-          select: ({ val }) => {
-            return {
-              title: val.baz || "No baz",
-            };
-          },
+        ).preview(({ val }) => {
+          return {
+            title: val.baz || "No baz",
+          };
         }),
       }).nullable(),
-    ).render({
-      as: "list",
-      select: ({ val }) => {
-        return {
-          title: val?.title || "No item",
-        };
-      },
+    ).preview(({ val }) => {
+      return {
+        title: val?.title || "No item",
+      };
     });
     const src = {
       "upper-key": {
@@ -51,12 +45,11 @@ describe("RecordSchema", () => {
       },
       "nullable-key": null,
     };
-    const res = schema["executeRender"]("/test.val.ts" as SourcePath, src);
+    const res = schema["executePreview"]("/test.val.ts" as SourcePath, src);
     expect(res).toStrictEqual({
       '/test.val.ts?p="upper-key"."bar"': {
         status: "success",
         data: {
-          layout: "list",
           parent: "record",
           items: [
             ["test1", { title: "baz", subtitle: undefined, image: undefined }],
@@ -66,7 +59,6 @@ describe("RecordSchema", () => {
       "/test.val.ts": {
         status: "success",
         data: {
-          layout: "list",
           parent: "record",
           items: [
             [
@@ -83,18 +75,15 @@ describe("RecordSchema", () => {
     });
   });
 
-  test("render: a partially loaded .jsonValues() record renders its loaded keys", () => {
+  test("preview: a partially loaded .jsonValues() record previews its loaded keys", () => {
     // Un-loaded entries are opaque `{_type:"json"}` markers. They must be skipped
-    // rather than fed to the user's `select` — and the result must still cover the
+    // rather than fed to the user's closure — and the result must still cover the
     // keys that ARE loaded, which is what makes a windowed list work: the caller
-    // renders a placeholder for the keys missing from `items`.
+    // shows a placeholder for the keys missing from `items`.
     const schema = record(object({ title: string() }))
       .jsonValues()
-      .render({
-        as: "list",
-        select: ({ val }) => ({ title: val.title }),
-      });
-    const res = schema["executeRender"](
+      .preview(({ val }) => ({ title: val.title }));
+    const res = schema["executePreview"](
       "/test.val.ts" as SourcePath,
       {
         loaded: { title: "Loaded" },
@@ -105,7 +94,6 @@ describe("RecordSchema", () => {
     expect(res["/test.val.ts" as SourcePath]).toStrictEqual({
       status: "success",
       data: {
-        layout: "list",
         parent: "record",
         items: [
           [
@@ -117,26 +105,22 @@ describe("RecordSchema", () => {
     });
   });
 
-  test("render: one key whose select throws is one error, not a dead render", () => {
-    const schema = record(object({ title: string() })).render({
-      as: "list",
-      select: ({ val }) => {
-        if (val.title === "boom") {
-          throw new Error("user select blew up");
-        }
-        return { title: val.title };
-      },
+  test("preview: one key whose closure throws is one error, not a dead preview", () => {
+    const schema = record(object({ title: string() })).preview(({ val }) => {
+      if (val.title === "boom") {
+        throw new Error("user select blew up");
+      }
+      return { title: val.title };
     });
-    const res = schema["executeRender"]("/test.val.ts" as SourcePath, {
+    const res = schema["executePreview"]("/test.val.ts" as SourcePath, {
       ok: { title: "fine" },
       bad: { title: "boom" },
     });
 
-    // The record still renders, with the surviving key...
+    // The record still previews, with the surviving key...
     expect(res["/test.val.ts" as SourcePath]).toStrictEqual({
       status: "success",
       data: {
-        layout: "list",
         parent: "record",
         items: [
           ["ok", { title: "fine", subtitle: undefined, image: undefined }],
@@ -610,17 +594,16 @@ describe("RecordSchema", () => {
       expect(reserialized.key?.type).toBe(serialized.key?.type);
     }
   });
-  test("record: list render is kept when chaining after render", () => {
-    const base = record(object({ name: string() })).render({
-      as: "list",
-      select: ({ key, val }) => ({ title: val.name, subtitle: key }),
-    });
+  test("record: preview is kept when chaining after preview", () => {
+    const base = record(object({ name: string() })).preview(({ key, val }) => ({
+      title: val.name,
+      subtitle: key,
+    }));
     const src = { ada: { name: "Ada" } };
     const expected = {
       "/test.val.ts": {
         status: "success",
         data: {
-          layout: "list",
           parent: "record",
           items: [["ada", { title: "Ada", subtitle: "ada", image: undefined }]],
         },
@@ -636,19 +619,16 @@ describe("RecordSchema", () => {
       base.router(nextAppRouter),
     ]) {
       expect(
-        schema["executeRender"]("/test.val.ts" as SourcePath, src),
+        schema["executePreview"]("/test.val.ts" as SourcePath, src),
       ).toEqual(expected);
     }
   });
 
-  test("record: render does not mutate the schema it was called on", () => {
+  test("record: preview does not mutate the schema it was called on", () => {
     const base = record(object({ name: string() }));
-    base.render({
-      as: "list",
-      select: ({ val }) => ({ title: val.name }),
-    });
+    base.preview(({ val }) => ({ title: val.name }));
     expect(
-      base["executeRender"]("/test.val.ts" as SourcePath, {
+      base["executePreview"]("/test.val.ts" as SourcePath, {
         ada: { name: "Ada" },
       }),
     ).toEqual({});

--- a/packages/core/src/schema/record.ts
+++ b/packages/core/src/schema/record.ts
@@ -6,11 +6,12 @@ import {
   SerializedSchema,
 } from ".";
 import {
-  ListRecordRender,
-  RenderSelector,
-  ReifiedRender,
-  RenderScope,
-} from "../render";
+  RecordPreview,
+  PreviewItem,
+  PreviewSelector,
+  ReifiedPreview,
+  PreviewScope,
+} from "../preview";
 import { splitModuleFilePathAndModulePath } from "../module";
 import { ValRouter } from "../router";
 import { SelectorSource } from "../selector";
@@ -18,7 +19,6 @@ import {
   createValPathOfItem,
   unsafeCreateSourcePath,
 } from "../selector/SelectorProxy";
-import { ImageSource } from "../source/media";
 import { JsonOf, JsonSource, isJson } from "../source/json";
 import { ModuleFilePath, SourcePath } from "../val";
 import {
@@ -40,8 +40,8 @@ export type SerializedRecordSchema = {
   item: SerializedSchema;
   key?: SerializedSchema;
   opt: boolean;
-  /** Set when this schema declares a `render`. See `SerializedArraySchema`. */
-  render?: true;
+  /** Set when this schema declares a `preview`. See `SerializedArraySchema`. */
+  preview?: true;
   router?: string;
   customValidate?: boolean;
   // Optional media collection marker for files/images that are backed by a record
@@ -79,14 +79,10 @@ export type JsonValuesRecordSrc<
   JsonSource<JsonOf<SelectorOfSchema<T>>> | SelectorOfSchema<T>
 >;
 
-type RecordRenderInput<T extends Schema<SelectorSource>> = {
-  layout: "list";
-  select: (input: { key: string; val: RenderSelector<T> }) => {
-    title: string;
-    subtitle?: string | null;
-    image?: ImageSource | null;
-  };
-};
+type RecordPreviewInput<T extends Schema<SelectorSource>> = (input: {
+  key: string;
+  val: PreviewSelector<T>;
+}) => PreviewItem;
 
 export class RecordSchema<
   T extends Schema<SelectorSource>,
@@ -108,7 +104,7 @@ export class RecordSchema<
     private readonly description?: string,
     /** When true, entry values are lazily loaded {@link JsonSource} thunks. */
     private readonly isJsonValues: boolean = false,
-    private readonly renderInput: RecordRenderInput<T> | null = null,
+    private readonly previewInput: RecordPreviewInput<T> | null = null,
   ) {
     super();
   }
@@ -125,7 +121,7 @@ export class RecordSchema<
       this.isHidden,
       description ?? undefined,
       this.isJsonValues,
-      this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -143,7 +139,7 @@ export class RecordSchema<
       this.isHidden,
       this.description,
       this.isJsonValues,
-      this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -589,7 +585,7 @@ export class RecordSchema<
       this.isHidden,
       this.description,
       this.isJsonValues,
-      this.renderInput,
+      this.previewInput,
     ) as RecordSchema<T, K, Src | null>;
   }
 
@@ -605,7 +601,7 @@ export class RecordSchema<
       this.isHidden,
       this.description,
       this.isJsonValues,
-      this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -621,7 +617,7 @@ export class RecordSchema<
       true,
       this.description,
       this.isJsonValues,
-      this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -637,7 +633,7 @@ export class RecordSchema<
       this.isHidden,
       this.description,
       this.isJsonValues,
-      this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -653,7 +649,7 @@ export class RecordSchema<
       this.isHidden,
       this.description,
       this.isJsonValues,
-      this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -698,7 +694,7 @@ export class RecordSchema<
       this.isHidden,
       this.description,
       true,
-      this.renderInput,
+      this.previewInput,
     ) as RecordSchema<T, K, JsonValuesRecordSrc<T, K>>;
   }
 
@@ -781,7 +777,7 @@ export class RecordSchema<
       item: this.item["executeSerialize"](),
       key: this.keySchema?.["executeSerialize"](),
       opt: this.opt,
-      render: this.renderInput ? true : undefined,
+      preview: this.previewInput ? true : undefined,
       router: this.currentRouter?.getRouterId(),
       customValidate:
         this.customValidateFunctions &&
@@ -816,12 +812,12 @@ export class RecordSchema<
     return this.item["executeValidate"](path, content);
   }
 
-  protected override executeRender(
+  protected override executePreview(
     sourcePath: SourcePath | ModuleFilePath,
     src: Src,
-    scope?: RenderScope,
-  ): ReifiedRender {
-    const res: ReifiedRender = {};
+    scope?: PreviewScope,
+  ): ReifiedPreview {
+    const res: ReifiedPreview = {};
     if (src === null) {
       return res;
     }
@@ -832,34 +828,28 @@ export class RecordSchema<
       }
       if (isJson(itemSrc)) {
         // An un-loaded `.jsonValues()` entry: an opaque marker, not the item this
-        // schema describes. Skipping it is what makes rendering a partially
+        // schema describes. Skipping it is what makes previewing a partially
         // loaded record work — the result comes out covering exactly the loaded
-        // keys, and the caller renders a placeholder for the rest.
+        // keys, and the caller shows a placeholder for the rest.
         continue;
       }
       const subPath = unsafeCreateSourcePath(sourcePath, key);
       if (scope !== undefined && !scope.wantsUnder(subPath)) {
         continue;
       }
-      const itemResult = this.item["executeRender"](subPath, itemSrc, scope);
+      const itemResult = this.item["executePreview"](subPath, itemSrc, scope);
       for (const keyS in itemResult) {
         const key = keyS as SourcePath | ModuleFilePath;
         res[key] = itemResult[key];
       }
     }
-    if (this.renderInput) {
-      const { select: prepare, layout: layout } = this.renderInput;
-      if (layout !== "list") {
-        res[sourcePath] = {
-          status: "error",
-          message: "Unknown layout type: " + layout,
-        };
-      }
+    if (this.previewInput) {
+      const prepare = this.previewInput;
       // See the same block in `array`: the whole record when the record is what
       // is being shown, only the wanted entries when it is not.
       const window =
         scope !== undefined && !scope.wants(sourcePath) ? scope : null;
-      const items: ListRecordRender["items"] = [];
+      const items: RecordPreview["items"] = [];
       for (const [key, val] of Object.entries(src)) {
         if (isJson(val)) {
           continue; // as above: nothing to select from an un-loaded entry
@@ -870,7 +860,7 @@ export class RecordSchema<
         ) {
           continue;
         }
-        // Per KEY, not per record: `select` is user code, and one entry whose
+        // Per KEY, not per record: the closure is user code, and one entry whose
         // data trips it up must not take out the whole list.
         try {
           // NB NB: display is actually defined by the user
@@ -889,7 +879,6 @@ export class RecordSchema<
       res[sourcePath] = {
         status: "success",
         data: {
-          layout: "list",
           parent: "record",
           items,
         },
@@ -898,14 +887,15 @@ export class RecordSchema<
     return res;
   }
 
-  render(input: {
-    as: "list";
-    select: (input: { key: string; val: RenderSelector<T> }) => {
-      title: string;
-      subtitle?: string | null;
-      image?: ImageSource | null;
-    };
-  }): RecordSchema<T, K, Src> {
+  /**
+   * What the editor shows for each ENTRY of this record: a title, and optionally
+   * a subtitle and an image.
+   *
+   * `select` is your own code over the entry's key and source, so it is run on
+   * demand for the entries that are actually being looked at — see
+   * `PreviewScope`.
+   */
+  preview(select: RecordPreviewInput<T>): RecordSchema<T, K, Src> {
     return new RecordSchema(
       this.item,
       this.opt,
@@ -917,10 +907,7 @@ export class RecordSchema<
       this.isHidden,
       this.description,
       this.isJsonValues,
-      {
-        layout: input.as,
-        select: input.select,
-      },
+      select,
     );
   }
 }

--- a/packages/core/src/schema/richtext.ts
+++ b/packages/core/src/schema/richtext.ts
@@ -5,7 +5,7 @@ import {
   SchemaAssertResult,
   SerializedSchema,
 } from ".";
-import { ReifiedRender } from "../render";
+import { ReifiedPreview } from "../preview";
 import { unsafeCreateSourcePath } from "../selector/SelectorProxy";
 import { ImageSource } from "../source/media";
 import {
@@ -735,7 +735,7 @@ export class RichTextSchema<
     };
   }
 
-  protected executeRender(): ReifiedRender {
+  protected executePreview(): ReifiedPreview {
     return {};
   }
 }

--- a/packages/core/src/schema/route.ts
+++ b/packages/core/src/schema/route.ts
@@ -1,6 +1,6 @@
 import { Schema, SchemaAssertResult, SerializedSchema } from ".";
 import { SourcePath } from "../val";
-import { ReifiedRender } from "../render";
+import { ReifiedPreview } from "../preview";
 import {
   ValidationError,
   ValidationErrors,
@@ -247,7 +247,7 @@ export class RouteSchema<Src extends string | null> extends Schema<Src> {
     };
   }
 
-  protected executeRender(): ReifiedRender {
+  protected executePreview(): ReifiedPreview {
     return {};
   }
 }

--- a/packages/core/src/schema/string.test.ts
+++ b/packages/core/src/schema/string.test.ts
@@ -1,19 +1,85 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import { SourcePath } from "../val";
-import { number } from "./number";
+import { deserializeSchema } from "./deserialize";
+import { string } from "./string";
 
-describe("NumberSchema", () => {
-  test("assert: should return true if src is a number", () => {
-    const schema = number().nullable();
-    expect(schema["executeAssert"]("foo" as SourcePath, 1)).toEqual({
-      success: true,
-      data: 1,
+describe("StringSchema", () => {
+  /**
+   * A render is static configuration that lives in the SERIALIZED schema — the
+   * editor reads it from there rather than from a pipeline. So what
+   * `executeSerialize` produces is the whole contract, not a marker.
+   */
+  test("render: serializes whole, not as a marker", () => {
+    expect(
+      string().render({ as: "textarea" })["executeSerialize"](),
+    ).toMatchObject({
+      type: "string",
+      render: { as: "textarea" },
+    });
+    expect(
+      string()
+        .render({ as: "code", language: "typescript" })
+        ["executeSerialize"](),
+    ).toMatchObject({
+      type: "string",
+      render: { as: "code", language: "typescript" },
     });
   });
-  test("assert: should return false if src is a string", () => {
-    const schema = number();
-    expect(
-      schema["executeAssert"]("foo" as SourcePath, "1" as any).success,
-    ).toEqual(false);
+
+  test("render: absent when none is declared", () => {
+    expect(string()["executeSerialize"]()).toMatchObject({ render: undefined });
+  });
+
+  /**
+   * The guard `array` and `record` have had since a render could be dropped by
+   * chaining, which `string` never had despite threading `renderInput` through
+   * ten builders. It matters more now: a dropped render is no longer a missing
+   * textarea in the Studio, it is a serialized schema that is wrong.
+   */
+  test("render: survives every chained builder", () => {
+    const base = string().render({ as: "code", language: "json" });
+    for (const schema of [
+      base,
+      base.minLength(1),
+      base.maxLength(10),
+      base.regexp(/x/),
+      base.validate(() => false),
+      base.nullable(),
+      base.readonly(),
+      base.hidden(),
+      base.raw(),
+      base.describe("Some description"),
+    ]) {
+      expect(schema["executeSerialize"]()).toMatchObject({
+        render: { as: "code", language: "json" },
+      });
+    }
+  });
+
+  test("render: does not mutate the schema it was called on", () => {
+    const base = string();
+    base.render({ as: "textarea" });
+    expect(base["executeSerialize"]()).toMatchObject({ render: undefined });
+  });
+
+  /**
+   * Round-tripping is what makes the serialized schema the source of truth: a
+   * deserialized schema has no instance behind it, so anything it drops here is
+   * gone for good.
+   */
+  test("render: round-trips through deserializeSchema", () => {
+    for (const base of [
+      string().render({ as: "textarea" }),
+      string().render({ as: "code", language: "typescript" }),
+      string(),
+    ]) {
+      const serialized = base["executeSerialize"]();
+      expect(deserializeSchema(serialized)["executeSerialize"]()).toStrictEqual(
+        serialized,
+      );
+    }
+  });
+
+  /** A string has no items, so it has nothing to preview. */
+  test("preview: a string never previews, render or not", () => {
+    expect(string().render({ as: "textarea" })["executePreview"]()).toEqual({});
   });
 });

--- a/packages/core/src/schema/string.ts
+++ b/packages/core/src/schema/string.ts
@@ -1,7 +1,7 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { Schema, SchemaAssertResult, SerializedSchema } from ".";
-import { CodeLanguage, ReifiedRender, RenderScope } from "../render";
-import { ModuleFilePath, SourcePath } from "../val";
+import { ReifiedPreview } from "../preview";
+import { StringRender } from "../render";
+import { SourcePath } from "../val";
 import {
   ValidationError,
   ValidationErrors,
@@ -16,8 +16,16 @@ type StringOptions = {
 
 export type SerializedStringSchema = {
   type: "string";
-  /** Set when this schema declares a `render`. See `SerializedArraySchema`. */
-  render?: true;
+  /**
+   * How this field is laid out in the editor, carried WHOLE rather than as a
+   * marker.
+   *
+   * A render is static configuration — no closure, no dependency on source — so
+   * unlike a `preview` it serializes in full, and the editor reads it straight
+   * off the schema it already has. See `render.ts` for what that assumption
+   * buys, and what to do if a render ever needs to stop being static.
+   */
+  render?: StringRender;
   options?: {
     maxLength?: number;
     minLength?: number;
@@ -47,10 +55,7 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
     private readonly customValidateFunctions: ((
       src: Src,
     ) => false | string)[] = [],
-    private readonly renderInput:
-      | { as: "textarea" }
-      | { as: "code"; language: CodeLanguage }
-      | null = null,
+    private readonly renderInput: StringRender | null = null,
     private readonly isReadonly: boolean = false,
     private readonly isHidden: boolean = false,
     private readonly description?: string,
@@ -290,7 +295,7 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
   protected executeSerialize(): SerializedSchema {
     return {
       type: "string",
-      render: this.renderInput ? true : undefined,
+      render: this.renderInput ?? undefined,
       options: {
         maxLength: this.options?.maxLength,
         minLength: this.options?.minLength,
@@ -314,9 +319,14 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
     };
   }
 
-  render(
-    input: { as: "textarea" } | { as: "code"; language: CodeLanguage },
-  ): StringSchema<Src> {
+  /**
+   * How this field is laid out in the editor: a textarea, or a code editor for
+   * the given language.
+   *
+   * Static configuration, not a callback — see `render.ts`. What a CONTAINER
+   * shows for its items is a `preview`, which is a different thing entirely.
+   */
+  render(input: StringRender): StringSchema<Src> {
     return new StringSchema<Src>(
       this.options,
       this.opt,
@@ -329,36 +339,12 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
     );
   }
 
-  protected executeRender(
-    sourcePath: SourcePath | ModuleFilePath,
-    src: Src,
-    // Accepted and unused: a string's render is a static layout hint
-    // (`{as:"textarea"}` / `{as:"code",language}`) with no closure behind it, so
-    // there is nothing a scope could prune. Declared so the signature is uniform
-    // across every schema rather than something a reader has to check.
-    _scope?: RenderScope,
-  ): ReifiedRender {
-    if (this.renderInput) {
-      if (this.renderInput.as === "code") {
-        return {
-          [sourcePath]: {
-            status: "success" as const,
-            data: {
-              layout: this.renderInput.as,
-              language: this.renderInput.language,
-            },
-          },
-        };
-      }
-      return {
-        [sourcePath]: {
-          status: "success" as const,
-          data: {
-            layout: this.renderInput.as,
-          },
-        },
-      };
-    }
+  /**
+   * Nothing: a string has no items, so there is nothing to preview. Its layout
+   * is a `render`, which travels in the serialized schema instead of through
+   * this pipeline.
+   */
+  protected executePreview(): ReifiedPreview {
     return {};
   }
 }

--- a/packages/core/src/schema/union.test.ts
+++ b/packages/core/src/schema/union.test.ts
@@ -57,7 +57,7 @@ describe("UnionSchema", () => {
     expect(res.success).toEqual(false);
   });
 
-  test("render union object schema", () => {
+  test("preview union object schema", () => {
     const schema = union(
       "type",
       object({
@@ -66,20 +66,17 @@ describe("UnionSchema", () => {
           object({
             value: string(),
           }),
-        ).render({
-          as: "list",
-          select: ({ val }) => {
-            return {
-              title: val.value,
-            };
-          },
+        ).preview(({ val }) => {
+          return {
+            title: val.value,
+          };
         }),
       }),
       object({ type: literal("value2"), innerString: string() }),
     );
 
     expect(
-      schema["executeRender"]("/test.foo.val.ts" as ModuleFilePath, {
+      schema["executePreview"]("/test.foo.val.ts" as ModuleFilePath, {
         type: "value1",
         innerObject: {
           record1: { value: "test value 1" },
@@ -90,7 +87,6 @@ describe("UnionSchema", () => {
       '/test.foo.val.ts?p="innerObject"': {
         status: "success",
         data: {
-          layout: "list",
           parent: "record",
           items: [
             [

--- a/packages/core/src/schema/union.ts
+++ b/packages/core/src/schema/union.ts
@@ -6,7 +6,7 @@ import {
   SchemaAssertResult,
   SerializedSchema,
 } from ".";
-import { ReifiedRender, RenderScope } from "../render";
+import { ReifiedPreview, PreviewScope } from "../preview";
 import {
   createValPathOfItem,
   unsafeCreateSourcePath,
@@ -621,12 +621,12 @@ export class UnionSchema<
     super();
   }
 
-  protected executeRender(
+  protected executePreview(
     sourcePath: SourcePath | ModuleFilePath,
     src: Src,
-    scope?: RenderScope,
-  ): ReifiedRender {
-    const res: ReifiedRender = {};
+    scope?: PreviewScope,
+  ): ReifiedPreview {
+    const res: ReifiedPreview = {};
     if (src === null) {
       return res;
     }
@@ -652,7 +652,7 @@ export class UnionSchema<
         },
       );
       if (thisSchema) {
-        const itemResult = thisSchema["executeRender"](sourcePath, src, scope);
+        const itemResult = thisSchema["executePreview"](sourcePath, src, scope);
         for (const keyS in itemResult) {
           const key = keyS as SourcePath | ModuleFilePath;
           res[key] = itemResult[key];

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -520,11 +520,12 @@ export default async function MyPage({ params }: { params:
 }
 ```
 
-### Custom render
+### Previews
 
-You can customize how records are displayed in the Val editor interface by using the `.render` method on `record`. This allows you to control how individual record items appear in the editor's preview.
-
-The only currently supported layout is `list`, which provides a customizable list view for record previews.
+A **preview** is what the Val editor shows for each ITEM of a container — the row
+you see in a list of records, or of array items. Declare one with `.preview()` on
+a `record` or an `array`, and return a `title`, and optionally a `subtitle` and an
+`image`.
 
 #### Example
 
@@ -532,18 +533,45 @@ The only currently supported layout is `list`, which provides a customizable lis
 const pagesSchema = s
   .record(s.object({ title: s.string(), image: s.image() }))
   .router(nextAppRouter)
-  .render({
-    layout: "list", // Use list layout for record preview
-    select({ key, val }) {
-      return {
-        // Capitalize the first letter of the key for display
-        title: key?.[0]?.toUpperCase() + key?.slice(1),
-        // Show the image from the record
-        image: val.image,
-      };
-    },
-  });
+  .preview(({ key, val }) => ({
+    // Capitalize the first letter of the key for display
+    title: key?.[0]?.toUpperCase() + key?.slice(1),
+    // Show the image from the record
+    image: val.image,
+  }));
 ```
+
+An array's preview gets the item alone, since there is no key:
+
+```ts
+const sectionsSchema = s
+  .array(s.object({ heading: s.string(), body: s.string() }))
+  .preview(({ val }) => ({ title: val.heading, subtitle: val.body }));
+```
+
+Your function is run on demand, for the rows actually on screen, so it is fine
+for it to read into the item's content.
+
+### Field rendering
+
+A **render** is how ONE field is laid out in the editor. It is static
+configuration rather than a function, and it is a different thing from a
+preview: a preview describes a container's items, a render describes a single
+field.
+
+```ts
+const articleSchema = s.object({
+  title: s.string(),
+  // A multi-line box instead of a single-line input
+  summary: s.string().render({ as: "textarea" }),
+  // A syntax-highlighted code editor
+  snippet: s.string().render({ as: "code", language: "typescript" }),
+});
+```
+
+`as: "code"` takes a `language` — `typescript`, `javascript`, `json`, `html`,
+`css`, `markdown`, `python`, `sql` and others; see `CodeLanguage` in
+`@valbuild/core` for the full list.
 
 ## RichText
 

--- a/packages/server/src/ValOps.ts
+++ b/packages/server/src/ValOps.ts
@@ -49,7 +49,7 @@ import ts from "typescript";
 import { ValSyntaxError, ValSyntaxErrorTree } from "./patch/ts/syntax";
 import sizeOf from "image-size";
 import { ParentPatchId } from "@valbuild/core";
-import type { ReifiedRender } from "@valbuild/core";
+import type { ReifiedPreview } from "@valbuild/core";
 import {
   ValCommit,
   ValDeployment,
@@ -578,28 +578,31 @@ export abstract class ValOps {
     };
   }
 
-  // #region getRenders
+  // #region getPreviews
   /**
-   * Reifies each module's render from its schema INSTANCE.
+   * Reifies each module's previews from its schema INSTANCE.
    *
-   * Kept even though the Studio also computes renders client-side: `select` is a
-   * user function that lives on the instance and is not part of the serialized
+   * Kept even though the Studio also computes previews client-side: a preview is
+   * a user function that lives on the instance and is not part of the serialized
    * schema, so a host app that does not render `<ValModulesClient>` has no
-   * instances in the browser and would otherwise get no renders at all. See
+   * instances in the browser and would otherwise get no previews at all. See
    * #470.
+   *
+   * A string's `render` needs none of this — it is static config that travels
+   * with the serialized schema.
    */
-  async getRenders(
+  async getPreviews(
     schemas: Schemas,
     sources: Sources,
   ): Promise<{
-    renders: Record<ModuleFilePath, ReifiedRender | null>;
+    previews: Record<ModuleFilePath, ReifiedPreview | null>;
   }> {
-    const renders: Record<ModuleFilePath, ReifiedRender | null> = {};
+    const previews: Record<ModuleFilePath, ReifiedPreview | null> = {};
     for (const [pathS, schema] of Object.entries(schemas)) {
       const path = pathS as ModuleFilePath;
-      renders[path] = schema["executeRender"](path, sources[path]);
+      previews[path] = schema["executePreview"](path, sources[path]);
     }
-    return { renders };
+    return { previews };
   }
 
   // #region getSources

--- a/packages/server/src/ValRouter.test.ts
+++ b/packages/server/src/ValRouter.test.ts
@@ -74,8 +74,8 @@ describe("ValRouter", () => {
   });
 
   // NOTE: the studio applies patches on the client and therefore requests
-  // sources with apply_patches=false. Renders must be returned either way:
-  // the select functions only exist on the server (they are not part of the
+  // sources with apply_patches=false. Previews must be returned either way:
+  // the preview functions only exist on the server (they are not part of the
   // serialized schema), so the client cannot compute them itself.
   const patchedAuthorName = "Fredrik Ekholdt (patched)";
   const patchedAuthorsSource = {
@@ -103,7 +103,7 @@ describe("ValRouter", () => {
       expectedBaseSource: authorsSource,
     },
   ])(
-    "/sources/~ returns renders (query: $query)",
+    "/sources/~ returns previews (query: $query)",
     async ({ query, expectedSource, expectedBaseSource }) => {
       // This case creates a real pending patch, and an fs-mode server stores
       // patches under `${process.cwd()}/.val`. Rooted at the repo that writes
@@ -115,7 +115,7 @@ describe("ValRouter", () => {
       const valRoot = fs.mkdtempSync(path.join(os.tmpdir(), "val-router-"));
       const cwdSpy = jest.spyOn(process, "cwd").mockReturnValue(valRoot);
       try {
-        await runRenderCase({ query, expectedSource, expectedBaseSource });
+        await runPreviewCase({ query, expectedSource, expectedBaseSource });
       } finally {
         cwdSpy.mockRestore();
         fs.rmSync(valRoot, { recursive: true, force: true });
@@ -123,7 +123,7 @@ describe("ValRouter", () => {
     },
   );
 
-  async function runRenderCase({
+  async function runPreviewCase({
     query,
     expectedSource,
     expectedBaseSource,
@@ -133,20 +133,17 @@ describe("ValRouter", () => {
     expectedBaseSource: typeof authorsSource | undefined;
   }) {
     {
-      const onRouteWithRender = createOnRoute(
+      const onRouteWithPreview = createOnRoute(
         c.define(
           "/content/authors.val.ts",
-          authorsSchema.render({
-            as: "list",
-            select: ({ val }) => ({
-              title: val.name,
-              subtitle: val.birthdate,
-            }),
-          }),
+          authorsSchema.preview(({ val }) => ({
+            title: val.name,
+            subtitle: val.birthdate,
+          })),
           authorsSource,
         ),
       );
-      const patchesRes = await onRouteWithRender(
+      const patchesRes = await onRouteWithPreview(
         fakeRequest({
           method: "GET",
           url: new URL("http://localhost:3000/api/val/patches"),
@@ -173,7 +170,7 @@ describe("ValRouter", () => {
       ) {
         throw new Error("Expected the patches response to carry a baseSha");
       }
-      const createPatchRes = await onRouteWithRender(
+      const createPatchRes = await onRouteWithPreview(
         fakeRequest({
           method: "PUT",
           url: new URL("http://localhost:3000/api/val/patches"),
@@ -202,7 +199,7 @@ describe("ValRouter", () => {
         }),
       );
       expect(createPatchRes.status).toBe(200);
-      const serverRes = await onRouteWithRender(
+      const serverRes = await onRouteWithPreview(
         fakeRequest({
           method: "PUT",
           url: new URL(
@@ -221,7 +218,7 @@ describe("ValRouter", () => {
       const json = serverRes.json as unknown as {
         modules: Record<
           string,
-          { source?: unknown; baseSource?: unknown; render?: unknown }
+          { source?: unknown; baseSource?: unknown; preview?: unknown }
         >;
       };
       expect(json.modules["/content/authors.val.ts"]?.source).toEqual(
@@ -230,11 +227,10 @@ describe("ValRouter", () => {
       expect(json.modules["/content/authors.val.ts"]?.baseSource).toEqual(
         expectedBaseSource,
       );
-      expect(json.modules["/content/authors.val.ts"]?.render).toEqual({
+      expect(json.modules["/content/authors.val.ts"]?.preview).toEqual({
         "/content/authors.val.ts": {
           status: "success",
           data: {
-            layout: "list",
             parent: "record",
             items: Object.entries(patchedAuthorsSource).map(([key, author]) => [
               key,

--- a/packages/server/src/ValServer.ts
+++ b/packages/server/src/ValServer.ts
@@ -15,7 +15,7 @@ import {
   SelectorSource,
   hasRemoteFileSchema,
 } from "@valbuild/core";
-import { ReifiedRender } from "@valbuild/core";
+import { ReifiedPreview } from "@valbuild/core";
 import {
   Api,
   ParentRef,
@@ -1513,11 +1513,11 @@ export const ValServer = (
         // The studio client always passes false: it owns patch application
         // and validation, and treats /sources/~ as a pure un-patched read.
         const applyPatches = query.apply_patches !== false;
-        // NOTE: renders are computed here even when the client applies patches
-        // itself: the render select functions live on the Schema instances and
-        // are not part of the serialized schema, so the client cannot derive
-        // them. They are computed on the patched sources, so that previews
-        // (list titles / subtitles / images) reflect the patches that apply.
+        // NOTE: previews are computed here even when the client applies patches
+        // itself: the preview functions live on the Schema instances and are not
+        // part of the serialized schema, so the client cannot derive them. They
+        // are computed on the patched sources, so that previews (list titles /
+        // subtitles / images) reflect the patches that apply.
         let patchedSources = sourcesRes.sources;
         if ((patchOps.patches?.length ?? 0) > 0) {
           const onlyPatchedTreeModules = await serverOps.getSources({
@@ -1538,7 +1538,7 @@ export const ValServer = (
             };
           }
         }
-        const renderRes = await serverOps.getRenders(
+        const previewRes = await serverOps.getPreviews(
           schemasRes,
           patchedSources,
         );
@@ -1587,7 +1587,7 @@ export const ValServer = (
           {
             source: Json;
             baseSource?: Json;
-            render: ReifiedRender | null;
+            preview: ReifiedPreview | null;
             patches?: {
               applied: PatchId[];
               skipped?: PatchId[];
@@ -1631,7 +1631,7 @@ export const ValServer = (
                 applyPatches && hasPatches
                   ? unpatchedSources[moduleFilePath]
                   : undefined,
-              render: renderRes.renders[moduleFilePath] || null,
+              preview: previewRes.previews[moduleFilePath] || null,
               patches:
                 appliedPatches.length > 0 ||
                 skippedPatches.length > 0 ||

--- a/packages/shared/src/internal/ApiRoutes.ts
+++ b/packages/shared/src/internal/ApiRoutes.ts
@@ -889,7 +889,7 @@ export const Api = {
             modules: z.record(
               ModuleFilePath,
               z.object({
-                render: z.any().optional(), // TODO: improve this type
+                preview: z.any().optional(), // TODO: improve this type
                 source: z.any().optional(), //.optional(), // TODO: Json zod type
                 baseSource: z.any().optional(), // pre-patch source for compare view; only set when the server applies patches (apply_patches=true) and the module has pending patches
                 patches: z

--- a/packages/shared/src/internal/zod/SerializedSchema.ts
+++ b/packages/shared/src/internal/zod/SerializedSchema.ts
@@ -18,12 +18,21 @@ import {
   type SerializedDateTimeSchema as SerializedDateTimeSchemaT,
   type SerializedColorSchema as SerializedColorSchemaT,
   type SerializedImageSchema as SerializedImageSchemaT,
+  CODE_LANGUAGES,
 } from "@valbuild/core";
 import { SourcePath } from "./SourcePath";
 
 export const SerializedStringSchema: z.ZodType<SerializedStringSchemaT> =
   z.object({
     type: z.literal("string"),
+    // A render is static config, so unlike a `preview` it travels WHOLE — this
+    // is the field the editor reads the layout from. See `core/src/render.ts`.
+    render: z
+      .union([
+        z.object({ as: z.literal("textarea") }),
+        z.object({ as: z.literal("code"), language: z.enum(CODE_LANGUAGES) }),
+      ])
+      .optional(),
     options: z
       .object({
         maxLength: z.number().optional(),
@@ -90,6 +99,8 @@ export const SerializedArraySchema: z.ZodType<SerializedArraySchemaT> = z.lazy(
       type: z.literal("array"),
       item: SerializedSchema,
       opt: z.boolean(),
+      // Only whether a preview EXISTS: the closure itself cannot be serialized.
+      preview: z.literal(true).optional(),
       readonly: z.boolean().optional(),
       hidden: z.boolean().optional(),
     });
@@ -184,6 +195,8 @@ export const SerializedRecordSchema: z.ZodType<SerializedRecordSchemaT> =
         type: z.literal("record"),
         item: SerializedSchema,
         opt: z.boolean(),
+        // Only whether a preview EXISTS: the closure itself cannot be serialized.
+        preview: z.literal(true).optional(),
         // Optional gallery marker for files/images
         mediaType: z
           .union([z.literal("files"), z.literal("images")])

--- a/packages/ui/spa/bench/drivers.ts
+++ b/packages/ui/spa/bench/drivers.ts
@@ -20,7 +20,7 @@ import type { Revision } from "../stores/types";
  * method" did not exist. The engine's `getSourceSnapshot(module)` was per MODULE
  * and deep-cloned the whole module; `SourceStore.get(path, revision)` is per
  * PATH and clones nothing. The engine was EAGER — `addPatch` applied the patch
- * and kicked validation, renders and patch sets before returning — and the
+ * and kicked validation, previews and patch sets before returning — and the
  * stores are LAZY: a patch marks, and the following read computes.
  *
  * Timing `addPatch` against `createPatch` would therefore have been rigged in
@@ -31,7 +31,7 @@ import type { Revision } from "../stores/types";
  * **So the unit of measurement is a FIELD BECOMING READY.** Every scenario runs
  * from "the keystroke is issued" to "every mounted field has, in hand, the three
  * things it needs to paint: the source at its path, the validation errors for its
- * module, and the render at its path (where there is one)." That is what the user
+ * module, and the preview at its path (where there is one)." That is what the user
  * waits for, and nothing can win it by deferring work past the stopwatch.
  *
  * Two rules follow, and they still bind:
@@ -52,7 +52,7 @@ import type { Revision } from "../stores/types";
  */
 
 export type DriverReads = {
-  /** Fields that got source, validation and render. Guards against no-ops. */
+  /** Fields that got source, validation and preview. Guards against no-ops. */
   fieldsReady: number;
 };
 
@@ -167,7 +167,7 @@ async function readStoresField(
     revisions.set(path, read.revision);
   }
   await system.validationStore.validate(moduleFilePath);
-  await system.renderStore.get(path as SourcePath);
+  await system.previewStore.get(path as SourcePath);
   // `unchanged` counts as ready: it means the field already holds the right
   // value, which is the cheap path the protocol exists to provide. Excluding it
   // would charge the stores for their own optimisation.

--- a/packages/ui/spa/bench/generateProject.ts
+++ b/packages/ui/spa/bench/generateProject.ts
@@ -13,11 +13,11 @@ import { initVal, type SelectorSource, type ValModule } from "@valbuild/core";
  *
  * - **plain modules** — objects of strings with `minLength` validators, so schema
  *   validation has real work to do rather than returning `false` immediately;
- * - **list modules** — `s.array(...).render({ as: "list", select })`, where
- *   `select` is a user closure invoked per row. This is the expensive thing;
- * - **one nested list** — a list whose items each contain a list, both with
- *   `select`. This is the `handboka` shape, the worst case named throughout
- *   `architecture.md`, and the reason path-scoped renders were built.
+ * - **list modules** — `s.array(...).preview(select)`, where `select` is a user
+ *   closure invoked per row. This is the expensive thing;
+ * - **one nested list** — a list whose items each contain a list, both with a
+ *   `preview`. This is the `handboka` shape, the worst case named throughout
+ *   `architecture.md`, and the reason path-scoped previews were built.
  *
  * `select` is instrumented so a run can report how many times it ran. A duration
  * without that number cannot distinguish "faster" from "did less".
@@ -27,7 +27,7 @@ export type ProjectSize = {
   plainModules: number;
   /** Fields per plain module. */
   fieldsPerModule: number;
-  /** Modules that are a rendered list. */
+  /** Modules that are a previewed list. */
   listModules: number;
   /** Rows per list module. */
   rowsPerList: number;
@@ -156,7 +156,7 @@ export type GeneratedProject = {
   typedModule: string;
   /** Paths a UI would plausibly have mounted at once. */
   mountedPaths: string[];
-  /** A path inside the nested list, for the render worst case. */
+  /** A path inside the nested list, for the preview worst case. */
   nestedRowPath: string;
   nestedModule: string;
   moduleCount: number;
@@ -201,12 +201,9 @@ export function generateProject(size: ProjectSize): GeneratedProject {
         path,
         s
           .array(s.object({ title: s.string().minLength(2), body: s.string() }))
-          .render({
-            as: "list",
-            select: ({ val }) => {
-              selectCalls++;
-              return { title: val.title, subtitle: val.body };
-            },
+          .preview(({ val }) => {
+            selectCalls++;
+            return { title: val.title, subtitle: val.body };
           }),
         rows,
       ),
@@ -228,21 +225,15 @@ export function generateProject(size: ProjectSize): GeneratedProject {
             title: s.string().minLength(2),
             sections: s
               .array(s.object({ heading: s.string().minLength(2) }))
-              .render({
-                as: "list",
-                select: ({ val }) => {
-                  selectCalls++;
-                  return { title: val.heading };
-                },
+              .preview(({ val }) => {
+                selectCalls++;
+                return { title: val.heading };
               }),
           }),
         )
-        .render({
-          as: "list",
-          select: ({ val }) => {
-            selectCalls++;
-            return { title: val.title };
-          },
+        .preview(({ val }) => {
+          selectCalls++;
+          return { title: val.title };
         }),
       Array.from({ length: size.nestedChapters }, (_unused, chapter) => ({
         title: `chapter ${chapter}`,

--- a/packages/ui/spa/components/AutoGrowingTextarea.tsx
+++ b/packages/ui/spa/components/AutoGrowingTextarea.tsx
@@ -5,6 +5,11 @@ export function AutoGrowingTextarea(
   props: React.TextareaHTMLAttributes<HTMLTextAreaElement>,
 ) {
   const [text, setText] = useState(props.value || props.defaultValue || "");
+  // The invisible ghost below is what gives the box its height, so it has to
+  // follow a CONTROLLED value too: `text` only tracks typing, and a value that
+  // arrives (or changes) from outside would otherwise leave the box sized for
+  // the old one.
+  const ghost = props.value ?? text;
   const className =
     "flex rounded-md m-1 border border-border-primary bg-bg-primary px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50";
   return (
@@ -25,6 +30,10 @@ export function AutoGrowingTextarea(
         }}
       />
       <div
+        // A duplicate of the text, present only to give the grid cell its
+        // height: hidden from assistive technology so it is not read out twice.
+        aria-hidden="true"
+        data-testid="auto-growing-textarea-ghost"
         className={cn(
           "whitespace-pre-wrap invisible",
           className,
@@ -34,7 +43,7 @@ export function AutoGrowingTextarea(
           gridArea: "1 / 1 / 2 / 2",
         }}
       >
-        {text + " "}
+        {ghost + " "}
       </div>
     </div>
   );

--- a/packages/ui/spa/components/ComparePatchSets.stories.tsx
+++ b/packages/ui/spa/components/ComparePatchSets.stories.tsx
@@ -206,7 +206,7 @@ function StoryProviders({
 
 /**
  * Sets up an engine seeded with `mockData`, applies the supplied patches
- * (so server vs optimistic diverge), and previews the story with the engine.
+ * (so server vs optimistic diverge), and renders the story with the engine.
  */
 function StorySetup({
   mockData,

--- a/packages/ui/spa/components/ComparePatchSets.stories.tsx
+++ b/packages/ui/spa/components/ComparePatchSets.stories.tsx
@@ -4,7 +4,7 @@ import {
   Internal,
   Json,
   ModuleFilePath,
-  ReifiedRender,
+  ReifiedPreview,
   SerializedSchema,
 } from "@valbuild/core";
 import { ValClient } from "@valbuild/shared/internal";
@@ -63,7 +63,7 @@ function createMockData(
 ) {
   const schemas: Record<string, SerializedSchema> = {};
   const sources: Record<string, Json> = {};
-  const renders: Record<string, ReifiedRender> = {};
+  const previews: Record<string, ReifiedPreview> = {};
 
   for (const module of modules) {
     const moduleFilePath = Internal.getValPath(module);
@@ -74,13 +74,13 @@ function createMockData(
       const path = moduleFilePath as unknown as ModuleFilePath;
       schemas[path] = schema["executeSerialize"]();
       sources[path] = source;
-      renders[path] = schema["executeRender"](path, source);
+      previews[path] = schema["executePreview"](path, source);
     }
   }
   return {
     schemas: schemas as Record<ModuleFilePath, SerializedSchema>,
     sources: sources as Record<ModuleFilePath, Json>,
-    renders: renders as Record<ModuleFilePath, ReifiedRender>,
+    previews: previews as Record<ModuleFilePath, ReifiedPreview>,
   };
 }
 
@@ -142,14 +142,14 @@ function applyPatchesAndSerialize(
 type MockData = {
   schemas: Record<ModuleFilePath, SerializedSchema>;
   sources: Record<ModuleFilePath, Json>;
-  renders: Record<ModuleFilePath, ReifiedRender>;
+  previews: Record<ModuleFilePath, ReifiedPreview>;
 };
 
 function makeSystem(mockData: MockData): System {
   return createStorySystem({
     schemas: mockData.schemas,
     sources: mockData.sources,
-    renders: mockData.renders,
+    previews: mockData.previews,
   });
 }
 
@@ -206,7 +206,7 @@ function StoryProviders({
 
 /**
  * Sets up an engine seeded with `mockData`, applies the supplied patches
- * (so server vs optimistic diverge), and renders the story with the engine.
+ * (so server vs optimistic diverge), and previews the story with the engine.
  */
 function StorySetup({
   mockData,

--- a/packages/ui/spa/components/InlineField.stories.tsx
+++ b/packages/ui/spa/components/InlineField.stories.tsx
@@ -4,7 +4,7 @@ import {
   Internal,
   Json,
   ModuleFilePath,
-  ReifiedRender,
+  ReifiedPreview,
   SerializedSchema,
   SourcePath,
 } from "@valbuild/core";
@@ -56,7 +56,7 @@ function createMockData(
 ) {
   const schemas: Record<string, SerializedSchema> = {};
   const sources: Record<string, Json> = {};
-  const renders: Record<string, ReifiedRender> = {};
+  const previews: Record<string, ReifiedPreview> = {};
 
   for (const module of modules) {
     const moduleFilePath = Internal.getValPath(module);
@@ -67,13 +67,13 @@ function createMockData(
       const path = moduleFilePath as unknown as ModuleFilePath;
       schemas[path] = schema["executeSerialize"]();
       sources[path] = source;
-      renders[path] = schema["executeRender"](path, source);
+      previews[path] = schema["executePreview"](path, source);
     }
   }
   return {
     schemas: schemas as Record<ModuleFilePath, SerializedSchema>,
     sources: sources as Record<ModuleFilePath, Json>,
-    renders: renders as Record<ModuleFilePath, ReifiedRender>,
+    previews: previews as Record<ModuleFilePath, ReifiedPreview>,
   };
 }
 
@@ -85,7 +85,7 @@ function StoryProviders({
   mockData: {
     schemas: Record<ModuleFilePath, SerializedSchema>;
     sources: Record<ModuleFilePath, Json>;
-    renders: Record<ModuleFilePath, ReifiedRender>;
+    previews: Record<ModuleFilePath, ReifiedPreview>;
   };
 }) {
   const client = useMemo(() => createMockClient(), []);
@@ -94,7 +94,7 @@ function StoryProviders({
     return createStorySystem({
       schemas: mockData.schemas,
       sources: mockData.sources,
-      renders: mockData.renders,
+      previews: mockData.previews,
     });
   }, [client, mockData]);
 

--- a/packages/ui/spa/components/RefPreview.tsx
+++ b/packages/ui/spa/components/RefPreview.tsx
@@ -3,7 +3,12 @@ import { ListPreviewItem } from "./ListPreviewItem";
 import { Preview } from "./Preview";
 import { useRefPreview } from "./useRefPreview";
 
-export function PreviewWithRender({
+/**
+ * A container item's own preview — title, subtitle, image, as its schema's
+ * `preview` produced it — falling back to the generic {@link Preview} of the
+ * value when the container declares none.
+ */
+export function RefPreview({
   path,
   className,
   size,
@@ -12,14 +17,14 @@ export function PreviewWithRender({
   className?: string;
   size?: "compact";
 }) {
-  const render = useRefPreview(path);
+  const preview = useRefPreview(path);
 
-  if (render) {
+  if (preview) {
     return (
       <ListPreviewItem
-        title={render.title}
-        image={render.image ?? null}
-        subtitle={render.subtitle ?? null}
+        title={preview.title}
+        image={preview.image ?? null}
+        subtitle={preview.subtitle ?? null}
         className={className}
         size={size}
       />

--- a/packages/ui/spa/components/RichTextEditor/useRichTextEditorConfig.ts
+++ b/packages/ui/spa/components/RichTextEditor/useRichTextEditorConfig.ts
@@ -3,11 +3,10 @@ import {
   type SerializedRichTextOptions,
   type SerializedImageSchema,
   type ModuleFilePath,
-  type ListRecordRender,
   Internal,
 } from "@valbuild/core";
 import { useRoutesWithModulePaths } from "../useRoutesOf";
-import { useAllRenders } from "../ValFieldProvider";
+import { useAllPreviews } from "../ValFieldProvider";
 import { serializedRichTextOptionsToFeatures } from "./convertOptions";
 import type { EditorFeatures, EditorLinkCatalogItem } from "./types";
 
@@ -73,12 +72,12 @@ export function useRichTextEditorConfig(options?: SerializedRichTextOptions): {
   );
 
   const routesWithModulePaths = useRoutesWithModulePaths();
-  const allRenders = useAllRenders();
+  const allPreviews = useAllPreviews();
 
   const linkCatalog: EditorLinkCatalogItem[] | undefined = useMemo(() => {
     if (!isRouteLink) return undefined;
 
-    const renderItemsByModule = new Map<
+    const previewItemsByModule = new Map<
       ModuleFilePath,
       Map<string, { title: string; subtitle?: string | null; image?: string }>
     >();
@@ -90,23 +89,21 @@ export function useRichTextEditorConfig(options?: SerializedRichTextOptions): {
         return true;
       })
       .map(({ route, moduleFilePath }) => {
-        if (!renderItemsByModule.has(moduleFilePath)) {
+        if (!previewItemsByModule.has(moduleFilePath)) {
           const itemMap = new Map<
             string,
             { title: string; subtitle?: string | null; image?: string }
           >();
-          const renderAtModule = allRenders[moduleFilePath];
-          if (renderAtModule) {
-            const moduleRender = renderAtModule[moduleFilePath];
+          const previewAtModule = allPreviews[moduleFilePath];
+          if (previewAtModule) {
+            const modulePreview = previewAtModule[moduleFilePath];
             if (
-              moduleRender &&
-              "data" in moduleRender &&
-              moduleRender.data &&
-              moduleRender.data.layout === "list" &&
-              moduleRender.data.parent === "record"
+              modulePreview &&
+              "data" in modulePreview &&
+              modulePreview.data &&
+              modulePreview.data.parent === "record"
             ) {
-              const recordRender = moduleRender.data as ListRecordRender;
-              for (const [key, value] of recordRender.items) {
+              for (const [key, value] of modulePreview.data.items) {
                 itemMap.set(key, {
                   title: value.title,
                   subtitle: value.subtitle,
@@ -115,17 +112,19 @@ export function useRichTextEditorConfig(options?: SerializedRichTextOptions): {
               }
             }
           }
-          renderItemsByModule.set(moduleFilePath, itemMap);
+          previewItemsByModule.set(moduleFilePath, itemMap);
         }
 
-        const renderItem = renderItemsByModule.get(moduleFilePath)?.get(route);
+        const previewItem = previewItemsByModule
+          .get(moduleFilePath)
+          ?.get(route);
 
-        if (renderItem) {
+        if (previewItem) {
           return {
-            title: renderItem.title,
-            subtitle: renderItem.subtitle ?? moduleFilePath,
+            title: previewItem.title,
+            subtitle: previewItem.subtitle ?? moduleFilePath,
             href: route,
-            image: renderItem.image,
+            image: previewItem.image,
           };
         }
 
@@ -140,7 +139,7 @@ export function useRichTextEditorConfig(options?: SerializedRichTextOptions): {
     routesWithModulePaths,
     includePattern,
     excludePattern,
-    allRenders,
+    allPreviews,
   ]);
 
   const imageModulePath = useMemo((): ModuleFilePath | undefined => {

--- a/packages/ui/spa/components/Search/stories/Search.stories.tsx
+++ b/packages/ui/spa/components/Search/stories/Search.stories.tsx
@@ -3,11 +3,11 @@ import { useMemo, useState } from "react";
 import {
   type Json,
   ModuleFilePath,
-  ReifiedRender,
+  ReifiedPreview,
   SerializedSchema,
 } from "@valbuild/core";
 import { Search } from "../../Search";
-import { mockSchemas, mockSources, mockRenders } from "./mockData";
+import { mockSchemas, mockSources, mockPreviews } from "./mockData";
 import { createStorySystem } from "../../../stores/react/storySystem";
 import { ValSystemProvider } from "../../../stores/react/SystemContext";
 import { ValThemeProvider, Themes } from "../../ValThemeProvider";
@@ -38,11 +38,11 @@ function createMockClient(): ValClient {
 function SearchWithProviders({
   schemas = mockSchemas,
   sources = mockSources,
-  renders = mockRenders,
+  previews = mockPreviews,
 }: {
   schemas?: Record<ModuleFilePath, SerializedSchema | undefined>;
   sources?: Record<ModuleFilePath, Json | undefined>;
-  renders?: Record<ModuleFilePath, ReifiedRender | null>;
+  previews?: Record<ModuleFilePath, ReifiedPreview | null>;
 }) {
   const client = useMemo(() => createMockClient(), []);
   const [theme, setTheme] = useState<Themes | null>(null);
@@ -52,9 +52,9 @@ function SearchWithProviders({
     return createStorySystem({
       schemas: schemas,
       sources: sources,
-      renders: renders,
+      previews: previews,
     });
-  }, [client, schemas, sources, renders]);
+  }, [client, schemas, sources, previews]);
 
   // Mock getDirectFileUploadSettings callback
   const getDirectFileUploadSettings = useMemo(
@@ -155,7 +155,7 @@ export const EmptyState: Story = {
       <p className="mb-4 text-sm text-fg-secondary">
         Search with no data. Press Cmd+K (Mac) or Ctrl+K to activate search.
       </p>
-      <SearchWithProviders schemas={{}} sources={{}} renders={{}} />
+      <SearchWithProviders schemas={{}} sources={{}} previews={{}} />
     </div>
   ),
   name: "Empty State",

--- a/packages/ui/spa/components/Search/stories/SearchResultsList.stories.tsx
+++ b/packages/ui/spa/components/Search/stories/SearchResultsList.stories.tsx
@@ -3,13 +3,13 @@ import { useMemo, useState } from "react";
 import {
   Json,
   ModuleFilePath,
-  ReifiedRender,
+  ReifiedPreview,
   SerializedSchema,
   SourcePath,
 } from "@valbuild/core";
 import { SearchResultsList, type SearchResult } from "../../SearchResultsList";
 import { Command } from "../../designSystem/command";
-import { mockSchemas, mockSources, mockRenders } from "./mockData";
+import { mockSchemas, mockSources, mockPreviews } from "./mockData";
 import { createStorySystem } from "../../../stores/react/storySystem";
 import { ValSystemProvider } from "../../../stores/react/SystemContext";
 import { ValThemeProvider, Themes } from "../../ValThemeProvider";
@@ -112,12 +112,12 @@ function SearchResultsListWithProviders({
   results,
   schemas = mockSchemas,
   sources = mockSources,
-  renders = mockRenders,
+  previews = mockPreviews,
 }: {
   results: SearchResult[];
   schemas?: Record<ModuleFilePath, SerializedSchema | undefined>;
   sources?: Record<ModuleFilePath, Json | undefined>;
-  renders?: Record<ModuleFilePath, ReifiedRender | null>;
+  previews?: Record<ModuleFilePath, ReifiedPreview | null>;
 }) {
   const client = useMemo(() => createMockClient(), []);
   const [theme, setTheme] = useState<Themes | null>(null);
@@ -127,9 +127,9 @@ function SearchResultsListWithProviders({
     return createStorySystem({
       schemas: schemas,
       sources: sources,
-      renders: renders,
+      previews: previews,
     });
-  }, [client, schemas, sources, renders]);
+  }, [client, schemas, sources, previews]);
 
   // Mock getDirectFileUploadSettings callback
   const getDirectFileUploadSettings = useMemo(

--- a/packages/ui/spa/components/Search/stories/mockData.ts
+++ b/packages/ui/spa/components/Search/stories/mockData.ts
@@ -2,7 +2,7 @@ import {
   Internal,
   Json,
   ModuleFilePath,
-  ReifiedRender,
+  ReifiedPreview,
   Source,
   SerializedSchema,
   ValModule,
@@ -299,7 +299,7 @@ function createMockData() {
     },
   );
 
-  // Team members record with list view rendering
+  // Team members record with a list preview
   const team = c.define(
     "/content/team.val.ts",
     s
@@ -311,14 +311,11 @@ function createMockData() {
           email: s.string(),
         }),
       )
-      .render({
-        as: "list",
-        select({ val }) {
-          return {
-            title: val.name,
-            subtitle: val.position,
-          };
-        },
+      .preview(({ val }) => {
+        return {
+          title: val.name,
+          subtitle: val.position,
+        };
       }),
     {
       "team-1": {
@@ -342,7 +339,7 @@ function createMockData() {
     },
   );
 
-  // Product pages router with list view rendering
+  // Product pages router with a list preview
   const productPages = c.define(
     "/app/products/[product]/page.val.ts",
     s
@@ -355,14 +352,11 @@ function createMockData() {
         }),
       )
       .router(mockRouter)
-      .render({
-        as: "list",
-        select({ val }) {
-          return {
-            title: val.name,
-            subtitle: `$${val.price}`,
-          };
-        },
+      .preview(({ val }) => {
+        return {
+          title: val.name,
+          subtitle: `$${val.price}`,
+        };
       }),
     {
       "/products/product-1": {
@@ -414,7 +408,7 @@ function createMockData() {
     },
   );
 
-  // Configuration array with render methods
+  // Configuration array with renders on its string fields
   const config = c.define(
     "/content/config.val.ts",
     s
@@ -425,14 +419,11 @@ function createMockData() {
           description: s.string().render({ as: "textarea" }),
         }),
       )
-      .render({
-        as: "list",
-        select({ val }) {
-          return {
-            title: val.key,
-            subtitle: val.description,
-          };
-        },
+      .preview(({ val }) => {
+        return {
+          title: val.key,
+          subtitle: val.description,
+        };
       }),
     [
       {
@@ -477,7 +468,7 @@ function createMockData() {
   ];
   const schemas: Record<string, SerializedSchema> = {};
   const sources: Record<string, Source> = {};
-  const renders: Record<string, ReifiedRender> = {};
+  const previews: Record<string, ReifiedPreview> = {};
   for (const module of modules) {
     const moduleFilePath = Internal.getValPath(module);
     const schema = Internal.getSchema(module);
@@ -489,19 +480,19 @@ function createMockData() {
       const path = moduleFilePath as unknown as ModuleFilePath;
       schemas[path] = schema["executeSerialize"]();
       sources[path] = source;
-      renders[path] = schema["executeRender"](path, source);
+      previews[path] = schema["executePreview"](path, source);
     }
   }
 
   return {
     schemas: schemas as Record<ModuleFilePath, SerializedSchema>,
     sources: sources as Record<ModuleFilePath, Json>,
-    renders: renders as Record<ModuleFilePath, ReifiedRender>,
+    previews: previews as Record<ModuleFilePath, ReifiedPreview>,
   };
 }
 
 export const {
   schemas: mockSchemas,
   sources: mockSources,
-  renders: mockRenders,
+  previews: mockPreviews,
 } = createMockData();

--- a/packages/ui/spa/components/SearchItem.tsx
+++ b/packages/ui/spa/components/SearchItem.tsx
@@ -1,6 +1,6 @@
 import { SourcePath, Internal } from "@valbuild/core";
 import { Globe } from "lucide-react";
-import { PreviewWithRender } from "./PreviewWithRender";
+import { RefPreview } from "./RefPreview";
 import { useSchemaAtPath } from "./ValFieldProvider";
 import { NodeIcon } from "./NodeIcon";
 
@@ -38,7 +38,7 @@ export function SearchItem({
         {ItemIcon}
         <span>{formattedPath}</span>
       </div>
-      <PreviewWithRender path={path} size={size} />
+      <RefPreview path={path} size={size} />
     </div>
   );
 }

--- a/packages/ui/spa/components/SortableList.tsx
+++ b/packages/ui/spa/components/SortableList.tsx
@@ -26,8 +26,8 @@ import { DragEndEvent } from "@dnd-kit/core";
 import { CSS } from "@dnd-kit/utilities";
 import { Copy, EllipsisVertical, GripVertical, Trash2 } from "lucide-react";
 import { SourcePath, SerializedArraySchema } from "@valbuild/core";
-import type { ListArrayRender } from "@valbuild/core";
-import { PreviewWithRender } from "./PreviewWithRender";
+import type { ArrayPreview } from "@valbuild/core";
+import { RefPreview } from "./RefPreview";
 import { StringField } from "./fields/StringField";
 import { isParentError } from "../utils/isParentError";
 import { ErrorIndicator } from "./ErrorIndicator";
@@ -171,7 +171,7 @@ export function SortableContainer({
 
 export function SortableList({
   source,
-  render,
+  preview,
   schema,
   disabled,
   onClick,
@@ -182,7 +182,7 @@ export function SortableList({
   source: SourcePath[];
   path: SourcePath;
   disabled?: boolean;
-  render?: ListArrayRender;
+  preview?: ArrayPreview;
   schema: SerializedArraySchema;
   onMove: (from: number, to: number) => void;
   onClick: (path: SourcePath) => void;
@@ -190,16 +190,16 @@ export function SortableList({
   onDuplicate: (item: number) => void;
 }) {
   /**
-   * The render's items by index, built once per render of the list.
+   * The preview's items by index, built once per render of the list.
    *
-   * `items` is `[index, value][]` — a windowed render is a SHORTER array, so a
+   * `items` is `[index, value][]` — a windowed preview is a SHORTER array, so a
    * row has to be found by its index rather than read at a position. Doing that
    * with `find` per row is O(n) per row and therefore O(n²) for a full list,
    * which is the case with the most rows on screen.
    */
-  const renderByIndex = useMemo(
-    () => new Map(render?.items ?? []),
-    [render?.items],
+  const previewByIndex = useMemo(
+    () => new Map(preview?.items ?? []),
+    [preview?.items],
   );
   return (
     <SortableContainer
@@ -211,13 +211,12 @@ export function SortableList({
           id={id}
           schema={schema}
           disabled={disabled}
-          renderLayout={render?.layout}
-          render={
+          preview={
             /* id is 1-based because dnd kit didn't work with 0 based - surely we're doing something strange... (??) */
-            /* By index, not by position: a render computed for a subset of paths
+            /* By index, not by position: a preview computed for a subset of paths
                carries only those items, so items[n] would be a different row.
-               See ListArrayRender, and `renderByIndex` for why it is a Map. */
-            renderByIndex.get(id - 1)
+               See ArrayPreview, and `previewByIndex` for why it is a Map. */
+            previewByIndex.get(id - 1)
           }
           path={path}
           onClick={onClick}
@@ -246,15 +245,14 @@ export function SortableItemRow({
   path,
   schema,
   disabled,
-  render,
+  preview,
   onClick,
   onDelete,
   onDuplicate,
 }: {
   id: number;
   path: SourcePath;
-  renderLayout?: "list";
-  render?: ListArrayRender["items"][number][1];
+  preview?: ArrayPreview["items"][number][1];
   schema: SerializedArraySchema;
   disabled?: boolean;
   onClick: (path: SourcePath) => void;
@@ -307,7 +305,7 @@ export function SortableItemRow({
         <GripVertical />
       </button>
       {/** Changing this behavior means we need to change the getNavPath behavior */}
-      {!render && schema?.item?.type === "string" && (
+      {!preview && schema?.item?.type === "string" && (
         <div
           className={cn("flex-grow w-full", {
             "p-2 border border-bg-warning-secondary rounded-lg":
@@ -322,7 +320,7 @@ export function SortableItemRow({
           )}
         </div>
       )}
-      {(render || schema?.item?.type !== "string") && (
+      {(preview || schema?.item?.type !== "string") && (
         <button
           className={cn(
             "flex-grow",
@@ -339,7 +337,7 @@ export function SortableItemRow({
             onClick(path);
           }}
         >
-          <PreviewWithRender path={path} className="flex-grow p-4 w-full" />
+          <RefPreview path={path} className="flex-grow p-4 w-full" />
           {isTruncated && (
             <div
               className="absolute bottom-0 left-0 w-full bg-gradient-to-b via-50% from-transparent via-card/90 to-card"

--- a/packages/ui/spa/components/ValFieldProvider.tsx
+++ b/packages/ui/spa/components/ValFieldProvider.tsx
@@ -15,7 +15,7 @@ import {
   ModuleFilePath,
   ModulePath,
   PatchId,
-  ReifiedRender,
+  ReifiedPreview,
   SerializedSchema,
   SourcePath,
   ValConfig,
@@ -574,21 +574,28 @@ export function useValConfig() {
   return lastConfig.current;
 }
 
-/** `undefined` when the module has nothing to render at this path. */
-type RenderOverrideAtPathResult = ReifiedRender[SourcePath] | undefined;
+/** `undefined` when the module has nothing to preview at this path. */
+type PreviewAtPathResult = ReifiedPreview[SourcePath] | undefined;
 
-export function useRenderOverrideAtPath(
+/**
+ * The preview at a path — a container's rows, computed by the host on demand.
+ *
+ * NOT where a field's layout comes from: `s.string().render(...)` is static
+ * config carried by the serialized schema, so a field reads it off
+ * `useSchemaAtPath`. See `core/src/render.ts`.
+ */
+export function usePreviewAtPath(
   sourcePath: SourcePath | ModuleFilePath,
-): RenderOverrideAtPathResult {
+): PreviewAtPathResult {
   const val = useValSystem();
   const path = sourcePath as SourcePath;
   const initializedAt = useInitialized(val);
   /**
    * Registering interest IS the demand signal.
    *
-   * `RenderStore` listens for `source:listen` and computes a render for the
+   * `PreviewStore` listens for `source:listen` and computes a preview for the
    * paths that have listeners on them — which is what makes one visible row cost
-   * one `select` call instead of the whole module. So this hook subscribes even
+   * one closure call instead of the whole module. So this hook subscribes even
    * though it does not read source: mounting is the thing that asks.
    */
   const ownId = useId();
@@ -600,16 +607,16 @@ export function useRenderOverrideAtPath(
         ownId,
         onChange,
       );
-      const offResult = val.system.renderStore.events.on(
-        "render:result",
+      const offResult = val.system.previewStore.events.on(
+        "preview:result",
         onChange,
       );
-      const offInvalidate = val.system.renderStore.events.on(
-        "render:invalidate",
+      const offInvalidate = val.system.previewStore.events.on(
+        "preview:invalidate",
         onChange,
       );
-      const offError = val.system.renderStore.events.on(
-        "render:error",
+      const offError = val.system.previewStore.events.on(
+        "preview:error",
         onChange,
       );
       return () => {
@@ -622,7 +629,7 @@ export function useRenderOverrideAtPath(
     [val, path, ownId],
   );
   const getSnapshot = useCallback(
-    () => (val === null ? null : val.system.renderStore.peek(path)),
+    () => (val === null ? null : val.system.previewStore.peek(path)),
     [val, path],
   );
   const seen = useSyncExternalStore(
@@ -632,44 +639,44 @@ export function useRenderOverrideAtPath(
   );
 
   /**
-   * Compute a render this module does not have.
+   * Compute a preview this module does not have.
    *
-   * Only on `needs-render`, which is exactly the state that says asking would
-   * help. `no-render` means the schema declares none, and asking for it forever
-   * is the loop the store added `needs-render` to make impossible — the same
+   * Only on `needs-preview`, which is exactly the state that says asking would
+   * help. `no-preview` means the schema declares none, and asking for it forever
+   * is the loop the store added `needs-preview` to make impossible — the same
    * distinction, for the same reason, as `entry-missing` against `entry-failed`.
    */
   useEffect(() => {
-    if (val === null || seen === null || seen.status !== "needs-render") {
+    if (val === null || seen === null || seen.status !== "needs-preview") {
       return;
     }
-    void val.system.renderStore.get(path);
+    void val.system.previewStore.get(path);
   }, [val, path, seen]);
 
-  return useMemo<RenderOverrideAtPathResult>(() => {
+  return useMemo<PreviewAtPathResult>(() => {
     if (val === null || seen === null) {
       return undefined;
     }
-    if (initializedAt === null || seen.status === "needs-render") {
-      // Before intake, and while a render is owed, `loading` — with no data,
-      // because there is none yet. The engine returned the previous render's
+    if (initializedAt === null || seen.status === "needs-preview") {
+      // Before intake, and while a preview is owed, `loading` — with no data,
+      // because there is none yet. The engine returned the previous preview's
       // data here; it could, because it recomputed eagerly and therefore always
-      // had one. Nothing shows a stale render in the meantime, which is the
+      // had one. Nothing shows a stale preview in the meantime, which is the
       // honest reading of "not computed".
       return { status: "loading" };
     }
     switch (seen.status) {
-      case "rendered":
-        // Already a `WithStatus<RenderTypes>` — the store caches what the host
+      case "previewed":
+        // Already a `WithStatus<PreviewTypes>` — the store caches what the host
         // produced, statuses and all — so it is returned as it is rather than
         // wrapped again.
-        return seen.render;
+        return seen.preview;
       case "error":
         // `message`, not `error`: `WithStatus` in core names it that, and this
         // hook returns core's own shape rather than a translation of it.
         return { status: "error", message: seen.message };
-      case "no-render":
-      case "no-render-at-path":
+      case "no-preview":
+      case "no-preview-at-path":
         return undefined;
     }
   }, [val, seen, initializedAt]);
@@ -993,21 +1000,24 @@ export function useJsonEntriesProgress(): JsonEntriesProgress {
   }, [val, version]);
 }
 
-export function useAllRenders(): Record<ModuleFilePath, ReifiedRender | null> {
+export function useAllPreviews(): Record<
+  ModuleFilePath,
+  ReifiedPreview | null
+> {
   const val = useValSystem();
   const subscribe = useCallback(
     (onChange: () => void) => {
       if (val === null) return () => {};
-      const offResult = val.system.renderStore.events.on(
-        "render:result",
+      const offResult = val.system.previewStore.events.on(
+        "preview:result",
         onChange,
       );
-      const offInvalidate = val.system.renderStore.events.on(
-        "render:invalidate",
+      const offInvalidate = val.system.previewStore.events.on(
+        "preview:invalidate",
         onChange,
       );
-      const offError = val.system.renderStore.events.on(
-        "render:error",
+      const offError = val.system.previewStore.events.on(
+        "preview:error",
         onChange,
       );
       return () => {
@@ -1019,7 +1029,7 @@ export function useAllRenders(): Record<ModuleFilePath, ReifiedRender | null> {
     [val],
   );
   const getSnapshot = useCallback(
-    () => (val === null ? EMPTY_RENDERS : val.system.renderStore.all()),
+    () => (val === null ? EMPTY_PREVIEWS : val.system.previewStore.all()),
     [val],
   );
   return useSyncExternalStore(
@@ -1029,7 +1039,7 @@ export function useAllRenders(): Record<ModuleFilePath, ReifiedRender | null> {
   );
 }
 
-const EMPTY_RENDERS: Record<ModuleFilePath, ReifiedRender | null> = {};
+const EMPTY_PREVIEWS: Record<ModuleFilePath, ReifiedPreview | null> = {};
 
 /**
  * How far the `.jsonValues()` entry load has got. See

--- a/packages/ui/spa/components/ValidationErrors.stories.tsx
+++ b/packages/ui/spa/components/ValidationErrors.stories.tsx
@@ -4,7 +4,7 @@ import {
   Internal,
   Json,
   ModuleFilePath,
-  ReifiedRender,
+  ReifiedPreview,
   SerializedSchema,
   SourcePath,
   ValidationError,
@@ -42,7 +42,7 @@ function createMockClient(): ValClient {
 type MockData = {
   schemas: Record<ModuleFilePath, SerializedSchema>;
   sources: Record<ModuleFilePath, Json>;
-  renders: Record<ModuleFilePath, ReifiedRender>;
+  previews: Record<ModuleFilePath, ReifiedPreview>;
 };
 
 function createMockData(
@@ -50,7 +50,7 @@ function createMockData(
 ): MockData {
   const schemas: Record<string, SerializedSchema> = {};
   const sources: Record<string, Json> = {};
-  const renders: Record<string, ReifiedRender> = {};
+  const previews: Record<string, ReifiedPreview> = {};
   for (const module of modules) {
     const moduleFilePath = Internal.getValPath(module);
     const schema = Internal.getSchema(module);
@@ -59,13 +59,13 @@ function createMockData(
       const path = moduleFilePath as unknown as ModuleFilePath;
       schemas[path] = schema["executeSerialize"]();
       sources[path] = source;
-      renders[path] = schema["executeRender"](path, source);
+      previews[path] = schema["executePreview"](path, source);
     }
   }
   return {
     schemas: schemas as Record<ModuleFilePath, SerializedSchema>,
     sources: sources as Record<ModuleFilePath, Json>,
-    renders: renders as Record<ModuleFilePath, ReifiedRender>,
+    previews: previews as Record<ModuleFilePath, ReifiedPreview>,
   };
 }
 
@@ -73,7 +73,7 @@ function makeSystem(mockData: MockData): System {
   return createStorySystem({
     schemas: mockData.schemas,
     sources: mockData.sources,
-    renders: mockData.renders,
+    previews: mockData.previews,
   });
 }
 

--- a/packages/ui/spa/components/fields/ArrayFields.tsx
+++ b/packages/ui/spa/components/fields/ArrayFields.tsx
@@ -3,7 +3,7 @@ import {
   useAddPatch,
   useFieldCreatorId,
   useHasUnsavedFrom,
-  useRenderOverrideAtPath,
+  usePreviewAtPath,
   useSchemaAtPath,
   useShallowSourceAtPath,
   useSourceAtPath,
@@ -40,7 +40,7 @@ export function ArrayFields({
   const creatorId = useFieldCreatorId();
   const { navigate } = useNavigation();
   const schemaAtPath = useSchemaAtPath(path);
-  const renderAtPath = useRenderOverrideAtPath(path);
+  const previewAtPath = usePreviewAtPath(path);
   const shallowSourceAtPath = useShallowSourceAtPath(path, type, creatorId);
   const sourceAtPath = useSourceAtPath(path);
 
@@ -90,8 +90,8 @@ export function ArrayFields({
     );
   }
   const schema = schemaAtPath.data as SerializedArraySchema;
-  const renderAtPathData =
-    renderAtPath && "data" in renderAtPath ? renderAtPath.data : undefined;
+  const previewAtPathData =
+    previewAtPath && "data" in previewAtPath ? previewAtPath.data : undefined;
 
   /**
    * Is there an edit of ours the server has not acknowledged yet?
@@ -113,7 +113,7 @@ export function ArrayFields({
    * `SortableContainer` — rather than by disabling the control that caused it.
    */
   const savingOwnEdit =
-    renderAtPathData !== undefined &&
+    previewAtPathData !== undefined &&
     (hasUnsavedOwnEdit || shallowSourceAtPath.status === "loading");
   if (inline) {
     const sourcePaths = shallowSourceAtPath.data as SourcePath[] | null;
@@ -171,8 +171,8 @@ export function ArrayFields({
   }
   return (
     <div id={path} className="relative w-full">
-      {renderAtPath?.status === "error" && (
-        <PreviewError error={renderAtPath.message} path={path} />
+      {previewAtPath?.status === "error" && (
+        <PreviewError error={previewAtPath.message} path={path} />
       )}
       {savingOwnEdit && (
         // `pointer-events-none` is the whole point: it says something is in
@@ -233,11 +233,8 @@ export function ArrayFields({
           );
         }}
         schema={schema}
-        render={
-          renderAtPathData?.layout === "list" &&
-          renderAtPathData.parent === "array"
-            ? renderAtPathData
-            : undefined
+        preview={
+          previewAtPathData?.parent === "array" ? previewAtPathData : undefined
         }
         source={shallowSourceAtPath.data || []}
       />

--- a/packages/ui/spa/components/fields/KeyOfField.tsx
+++ b/packages/ui/spa/components/fields/KeyOfField.tsx
@@ -1,10 +1,5 @@
 import * as React from "react";
-import {
-  ImageSource,
-  Internal,
-  ListRecordRender,
-  SourcePath,
-} from "@valbuild/core";
+import { ImageSource, Internal, SourcePath } from "@valbuild/core";
 import { FieldLoading } from "../../components/FieldLoading";
 import { FieldNotFound } from "../../components/FieldNotFound";
 import { FieldSchemaError } from "../../components/FieldSchemaError";
@@ -13,7 +8,7 @@ import {
   useSchemaAtPath,
   useShallowSourceAtPath,
   useAddPatch,
-  useRenderOverrideAtPath,
+  usePreviewAtPath,
 } from "../ValFieldProvider";
 import { useValPortal } from "../ValPortalProvider";
 import { FieldSchemaMismatchError } from "../../components/FieldSchemaMismatchError";
@@ -173,7 +168,7 @@ export function KeyOfField({
     keyOf?.path,
     keyOf?.type as "record" | "object",
   );
-  const referencedRender = useRenderOverrideAtPath(
+  const referencedPreview = usePreviewAtPath(
     (keyOf?.path ?? path) as SourcePath,
   );
   const sourceAtPath = useShallowSourceAtPath(path, type);
@@ -267,7 +262,7 @@ export function KeyOfField({
       ? Object.keys(referencedSource.data)
       : undefined;
   const source = sourceAtPath.data as string | null;
-  const previews = buildKeyPreviews(referencedRender);
+  const previews = buildKeyPreviews(referencedPreview);
   const isLoading =
     schemaAtPath.status === "loading" ||
     keyOf === undefined ||
@@ -318,18 +313,17 @@ export function KeyOfField({
 }
 
 function buildKeyPreviews(
-  renderAtPath: ReturnType<typeof useRenderOverrideAtPath>,
+  previewAtPath: ReturnType<typeof usePreviewAtPath>,
 ): Record<string, KeyPreview> | undefined {
-  if (!renderAtPath || !("data" in renderAtPath) || !renderAtPath.data) {
+  if (!previewAtPath || !("data" in previewAtPath) || !previewAtPath.data) {
     return undefined;
   }
-  const renderData = renderAtPath.data;
-  if (renderData.layout !== "list" || renderData.parent !== "record") {
+  const previewData = previewAtPath.data;
+  if (previewData.parent !== "record") {
     return undefined;
   }
-  const recordRender = renderData as ListRecordRender;
   const out: Record<string, KeyPreview> = {};
-  for (const [key, value] of recordRender.items) {
+  for (const [key, value] of previewData.items) {
     out[key] = {
       title: value.title,
       subtitle: value.subtitle ?? null,

--- a/packages/ui/spa/components/fields/RecordFields.tsx
+++ b/packages/ui/spa/components/fields/RecordFields.tsx
@@ -1,7 +1,7 @@
 import { Internal, ModuleFilePath, SourcePath } from "@valbuild/core";
 import { useMemo } from "react";
 import {
-  useRenderOverrideAtPath,
+  usePreviewAtPath,
   useSchemaAtPath,
   useShallowSourceAtPath,
   useSourceAtPath,
@@ -22,7 +22,7 @@ import { FieldSchemaMismatchError } from "../../components/FieldSchemaMismatchEr
 import { FieldSourceError } from "../../components/FieldSourceError";
 import { useNavigation } from "../../components/ValRouter";
 import { PreviewLoading, PreviewNull } from "../../components/Preview";
-import { PreviewWithRender } from "../../components/PreviewWithRender";
+import { RefPreview } from "../../components/RefPreview";
 import type { ValidationError } from "@valbuild/core";
 import { isParentError } from "../../utils/isParentError";
 import { ErrorIndicator } from "../ErrorIndicator";
@@ -47,7 +47,7 @@ export function RecordFields({
   const type = "record";
   const validationErrors = useAllValidationErrors() || {};
   const schemaAtPath = useSchemaAtPath(path);
-  const renderAtPath = useRenderOverrideAtPath(path);
+  const previewAtPath = usePreviewAtPath(path);
   const sourceAtPath = useShallowSourceAtPath(path, type);
   if (schemaAtPath.status === "error") {
     return (
@@ -125,23 +125,22 @@ export function RecordFields({
     );
   }
 
-  const renderListAtPathData =
-    renderAtPath &&
-    "data" in renderAtPath &&
-    renderAtPath.data &&
-    renderAtPath.data.layout === "list" &&
-    renderAtPath.data.parent === "record"
-      ? renderAtPath.data
+  const previewAtPathData =
+    previewAtPath &&
+    "data" in previewAtPath &&
+    previewAtPath.data &&
+    previewAtPath.data.parent === "record"
+      ? previewAtPath.data
       : undefined;
   return (
     <div id={path}>
-      {renderAtPath?.status === "error" && (
-        <PreviewError error={renderAtPath.message} path={path} />
+      {previewAtPath?.status === "error" && (
+        <PreviewError error={previewAtPath.message} path={path} />
       )}
-      {renderListAtPathData && source && (
-        <ListRecordRenderComponent
+      {previewAtPathData && source && (
+        <RecordPreviewList
           path={path}
-          // The KEYS come from the source, not from the render's `items`: for a
+          // The KEYS come from the source, not from the preview's `items`: for a
           // `.jsonValues()` record `items` covers only the loaded entries, and a
           // list that rendered just those could never scroll far enough to load
           // the rest. Each row looks its own item up by key (resolveRefPreview),
@@ -150,7 +149,7 @@ export function RecordFields({
           jsonValues={schema.jsonValues === true}
         />
       )}
-      {!renderListAtPathData && source && (
+      {!previewAtPathData && source && (
         <RecordCardList
           path={path}
           keys={Object.keys(source)}
@@ -164,8 +163,8 @@ export function RecordFields({
 
 /** Row height estimate for the default card layout (`max-h-[170px]` + gap). */
 const CARD_ROW_HEIGHT = 186;
-/** Row height estimate for a `.render({layout:"list"})` row. */
-const RENDER_ROW_HEIGHT = 104;
+/** Row height estimate for a `.preview(...)` row. */
+const PREVIEW_ROW_HEIGHT = 104;
 
 function RecordCardList({
   path,
@@ -235,7 +234,7 @@ function RecordCardList({
                     height={96}
                   />
                 ) : (
-                  <PreviewWithRender path={sourcePathOfItem(path, key)} />
+                  <RefPreview path={sourcePathOfItem(path, key)} />
                 )}
               </div>
             </div>
@@ -298,7 +297,7 @@ function useJsonEntryRowStates(
   }, [jsonValues, data, val, moduleFilePath]);
 }
 
-function ListRecordRenderComponent({
+function RecordPreviewList({
   path,
   keys,
   jsonValues,
@@ -319,7 +318,7 @@ function ListRecordRenderComponent({
     <VirtualizedRecordList
       moduleFilePath={moduleFilePath}
       keys={keys}
-      estimatedRowHeight={RENDER_ROW_HEIGHT}
+      estimatedRowHeight={PREVIEW_ROW_HEIGHT}
       jsonValues={jsonValues}
       className="flex flex-col w-full"
       renderRow={(key) => {
@@ -354,7 +353,7 @@ function ListRecordRenderComponent({
                   height={72}
                 />
               ) : (
-                <PreviewWithRender path={sourcePathOfItem(path, key)} />
+                <RefPreview path={sourcePathOfItem(path, key)} />
               )}
             </button>
           </div>

--- a/packages/ui/spa/components/fields/RouteField.tsx
+++ b/packages/ui/spa/components/fields/RouteField.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import {
   ImageSource,
   Internal,
-  ListRecordRender,
   ModuleFilePath,
   ModulePath,
   SourcePath,
@@ -15,7 +14,7 @@ import {
   useSchemaAtPath,
   useShallowSourceAtPath,
   useAddPatch,
-  useAllRenders,
+  useAllPreviews,
 } from "../ValFieldProvider";
 import { useValPortal } from "../ValPortalProvider";
 import { FieldSchemaMismatchError } from "../../components/FieldSchemaMismatchError";
@@ -355,27 +354,26 @@ function toAvailableRoute(router: CreatableRouter): AvailableRoute {
 function useRouteSelectorRoutes(
   routesWithModulePaths: Array<{ route: string; moduleFilePath: string }>,
 ): RouteSelectorRoute[] {
-  const allRenders = useAllRenders();
+  const allPreviews = useAllPreviews();
   return React.useMemo(() => {
-    const renderItemsByModule = new Map<
+    const previewItemsByModule = new Map<
       string,
       Map<string, RouteSelectorRoute["preview"]>
     >();
     return routesWithModulePaths.map(({ route, moduleFilePath }) => {
-      if (!renderItemsByModule.has(moduleFilePath)) {
+      if (!previewItemsByModule.has(moduleFilePath)) {
         const itemMap = new Map<string, RouteSelectorRoute["preview"]>();
-        const renderAtModule = allRenders[moduleFilePath as ModuleFilePath];
-        if (renderAtModule) {
-          const moduleRender = renderAtModule[moduleFilePath as ModuleFilePath];
+        const previewAtModule = allPreviews[moduleFilePath as ModuleFilePath];
+        if (previewAtModule) {
+          const modulePreview =
+            previewAtModule[moduleFilePath as ModuleFilePath];
           if (
-            moduleRender &&
-            "data" in moduleRender &&
-            moduleRender.data &&
-            moduleRender.data.layout === "list" &&
-            moduleRender.data.parent === "record"
+            modulePreview &&
+            "data" in modulePreview &&
+            modulePreview.data &&
+            modulePreview.data.parent === "record"
           ) {
-            const recordRender = moduleRender.data as ListRecordRender;
-            for (const [key, value] of recordRender.items) {
+            for (const [key, value] of modulePreview.data.items) {
               itemMap.set(key, {
                 title: value.title,
                 subtitle: value.subtitle ?? null,
@@ -384,13 +382,13 @@ function useRouteSelectorRoutes(
             }
           }
         }
-        renderItemsByModule.set(moduleFilePath, itemMap);
+        previewItemsByModule.set(moduleFilePath, itemMap);
       }
       const preview =
-        renderItemsByModule.get(moduleFilePath)?.get(route) ?? null;
+        previewItemsByModule.get(moduleFilePath)?.get(route) ?? null;
       return { route, moduleFilePath, preview };
     });
-  }, [routesWithModulePaths, allRenders]);
+  }, [routesWithModulePaths, allPreviews]);
 }
 
 export function RouteField({

--- a/packages/ui/spa/components/fields/StringField.test.tsx
+++ b/packages/ui/spa/components/fields/StringField.test.tsx
@@ -1,0 +1,101 @@
+/** @jest-environment jsdom */
+// FIRST, and it must stay first: `StringField` pulls in the shared bundle, which
+// builds a `TextEncoder` at module scope.
+import "../../stores/react/testPolyfills";
+import { render, screen } from "@testing-library/react";
+import { SourcePath } from "@valbuild/core";
+
+/**
+ * A string field's LAYOUT comes off the serialized schema, synchronously.
+ *
+ * That is the point of the preview/render split: a `render` is static config, so
+ * there is nothing to wait for and no flash of a single-line input before the
+ * textarea. What is pinned here is the consequence that bit.
+ *
+ * The textarea used to be UNCONTROLLED (`defaultValue`), and it worked only
+ * because the layout arrived a tick AFTER the effect that fills `currentValue`,
+ * so it mounted with the text already in hand. `AutoGrowingTextarea` seeds its
+ * sizing ghost from props exactly once, at mount — so with the layout now
+ * synchronous, an uncontrolled textarea mounts at `null`, the ghost is seeded
+ * empty, and the box stays one line tall however long the text is. The
+ * `.value` assertion alone does NOT catch that (a textarea's value follows
+ * `defaultValue` while it is untouched); the ghost assertion does.
+ */
+const mockSchema = jest.fn();
+const mockSource = jest.fn();
+
+jest.mock("../ValFieldProvider", () => ({
+  __esModule: true,
+  useFieldCreatorId: () => "test",
+  useSchemaAtPath: () => mockSchema(),
+  useShallowSourceAtPath: () => mockSource(),
+  useAddPatch: () => ({ patchPath: [], addPatch: jest.fn() }),
+}));
+
+// `Preview` is the generic field dispatcher, so importing it drags in the whole
+// field tree (and, through `ValProvider`, a worker URL jest cannot parse). This
+// field only uses two leaf states from it.
+jest.mock("../../components/Preview", () => ({
+  __esModule: true,
+  PreviewLoading: () => <div data-testid="preview-loading" />,
+  PreviewNull: () => <div data-testid="preview-null" />,
+}));
+
+jest.mock("../CodeEditor", () => ({
+  __esModule: true,
+  CodeEditor: ({ language, value }: { language: string; value: string }) => (
+    <div data-testid="code-editor" data-language={language}>
+      {value}
+    </div>
+  ),
+}));
+
+import { StringField } from "./StringField";
+
+const PATH = '/content/page.val.ts?p="body"' as SourcePath;
+
+function mount(render: unknown, source: string) {
+  mockSchema.mockReturnValue({
+    status: "success",
+    data: { type: "string", opt: false, raw: false, render },
+  });
+  mockSource.mockReturnValue({ status: "success", data: source });
+  return render;
+}
+
+describe("StringField", () => {
+  test("a plain string is a single-line input carrying its value", () => {
+    mount(undefined, "Hello");
+    const { container } = render(<StringField path={PATH} />);
+    const input = container.querySelector("input");
+    expect(input).not.toBeNull();
+    expect(container.querySelector("textarea")).toBeNull();
+    expect(input!.value).toBe("Hello");
+  });
+
+  test("render textarea: a textarea, on the first frame, with its value in it", () => {
+    mount({ as: "textarea" }, "Multiline\ntext");
+    const { container } = render(<StringField path={PATH} />);
+    const textarea = container.querySelector("textarea");
+    expect(textarea).not.toBeNull();
+    expect(container.querySelector("input")).toBeNull();
+    expect(textarea!.value).toBe("Multiline\ntext");
+  });
+
+  /** The regression guard — see the note at the top of this file. */
+  test("render textarea: the auto-grow ghost is sized for the value", () => {
+    mount({ as: "textarea" }, "Multiline\ntext");
+    render(<StringField path={PATH} />);
+    expect(
+      screen.getByTestId("auto-growing-textarea-ghost").textContent,
+    ).toContain("Multiline\ntext");
+  });
+
+  test("render code: the code editor, with the language the schema names", () => {
+    mount({ as: "code", language: "typescript" }, "const a = 1;");
+    render(<StringField path={PATH} />);
+    const editor = screen.getByTestId("code-editor");
+    expect(editor.getAttribute("data-language")).toBe("typescript");
+    expect(editor.textContent).toBe("const a = 1;");
+  });
+});

--- a/packages/ui/spa/components/fields/StringField.tsx
+++ b/packages/ui/spa/components/fields/StringField.tsx
@@ -1,10 +1,9 @@
 import React from "react";
-import { CodeLanguage, SourcePath } from "@valbuild/core";
+import { SourcePath } from "@valbuild/core";
 import { Input } from "../designSystem/input";
 import {
   useAddPatch,
   useFieldCreatorId,
-  useRenderOverrideAtPath,
   useSchemaAtPath,
   useShallowSourceAtPath,
 } from "../ValFieldProvider";
@@ -71,24 +70,6 @@ export function StringField({
     // `write` is deliberately not a dependency: it is stable, and re-running
     // this when a pending edit changes is exactly what the guard prevents.
   }, [maybeSourceData, maybeClientSideOnly, write]);
-  const renderAtPath = useRenderOverrideAtPath(path);
-  const [renderAsTextarea, setRenderAsTextarea] = useState(false);
-  const [renderAsCodeLanguage, setRenderAsCodeLanguage] = useState<
-    CodeLanguage | false
-  >(false);
-  useEffect(() => {
-    if (renderAtPath && renderAtPath.status === "success") {
-      // Only change if render has indeed loaded (if not we will go from input to textarea and back which is bad)
-      if (renderAtPath.data.layout === "textarea") {
-        setRenderAsTextarea(true);
-      } else if (renderAtPath.data.layout === "code") {
-        setRenderAsCodeLanguage(renderAtPath.data.language);
-      } else {
-        setRenderAsTextarea(false);
-      }
-    }
-  }, [renderAtPath]);
-
   if (schemaAtPath.status === "error") {
     return (
       <FieldSchemaError path={path} error={schemaAtPath.error} type={type} />
@@ -124,14 +105,32 @@ export function StringField({
       />
     );
   }
+  /**
+   * The layout comes off the SCHEMA, synchronously.
+   *
+   * A render is static config — no closure, no dependency on source — so it
+   * travels in the serialized schema and there is nothing to wait for. That is
+   * what removes the old effect-driven dance here, which existed only because
+   * the layout used to arrive asynchronously from the host and the field would
+   * otherwise flip from input to textarea a tick later. (It also, silently, was
+   * the only reason the uncontrolled textarea below ever had a value — see
+   * `architecture/quirks.md`.) If a render ever stops being static, this read is
+   * the thing that has to change. See `core/src/render.ts`.
+   */
+  const render = schemaAtPath.data.render;
   let content: React.ReactNode;
-  if (renderAsTextarea) {
+  if (render?.as === "textarea") {
     content = (
       <div id={path}>
         <AutoGrowingTextarea
           className="pr-6 sm:pr-8 sm:w-[calc(100%-0.5rem)]"
           autoFocus={autoFocus}
-          defaultValue={currentValue || ""}
+          // Controlled, like the other two branches. `currentValue` is filled
+          // by an effect a commit AFTER the source arrives, so at mount it is
+          // still `null` — and the auto-grow ghost is seeded from props ONCE, so
+          // an uncontrolled `defaultValue` leaves the box sized for an empty
+          // string however long the text is. See `architecture/quirks.md`.
+          value={currentValue || ""}
           onChange={(ev) => {
             setCurrentValue(ev.target.value);
             write.push(ev.target.value);
@@ -140,11 +139,11 @@ export function StringField({
         />
       </div>
     );
-  } else if (renderAsCodeLanguage) {
+  } else if (render?.as === "code") {
     content = (
       <div id={path}>
         <CodeEditor
-          language={renderAsCodeLanguage}
+          language={render.language}
           value={currentValue || ""}
           autoFocus={autoFocus}
           onChange={(value) => {

--- a/packages/ui/spa/components/useRefPreview.ts
+++ b/packages/ui/spa/components/useRefPreview.ts
@@ -1,27 +1,15 @@
 import { useMemo } from "react";
-import {
-  ImageSource,
-  Internal,
-  ListArrayRender,
-  ListRecordRender,
-  SourcePath,
-} from "@valbuild/core";
+import { Internal, PreviewItem, SourcePath } from "@valbuild/core";
 import { useParent } from "../hooks/useParent";
-import { useRenderOverrideAtPath } from "./ValFieldProvider";
+import { usePreviewAtPath } from "./ValFieldProvider";
 
-export type RefPreview = {
-  title: string;
-  subtitle?: string | null;
-  image?: ImageSource | null;
-};
-
-export function useRefPreview(path: SourcePath): RefPreview | undefined {
+export function useRefPreview(path: SourcePath): PreviewItem | undefined {
   const { path: parentPath, schema: parentSchema } = useParent(path);
-  const renderAtPath = useRenderOverrideAtPath(parentPath);
+  const previewAtPath = usePreviewAtPath(parentPath);
 
   return useMemo(
-    () => resolveRefPreview(path, parentPath, parentSchema, renderAtPath),
-    [path, parentPath, parentSchema, renderAtPath],
+    () => resolveRefPreview(path, parentPath, parentSchema, previewAtPath),
+    [path, parentPath, parentSchema, previewAtPath],
   );
 }
 
@@ -29,19 +17,19 @@ export function resolveRefPreview(
   path: SourcePath,
   parentPath: SourcePath,
   parentSchema: ReturnType<typeof useParent>["schema"],
-  renderAtPath: ReturnType<typeof useRenderOverrideAtPath>,
-): RefPreview | undefined {
+  previewAtPath: ReturnType<typeof usePreviewAtPath>,
+): PreviewItem | undefined {
   if (
     parentPath === path ||
     !parentSchema ||
-    !renderAtPath ||
-    !("data" in renderAtPath) ||
-    !renderAtPath.data
+    !previewAtPath ||
+    !("data" in previewAtPath) ||
+    !previewAtPath.data
   ) {
     return undefined;
   }
 
-  const renderData = renderAtPath.data;
+  const previewData = previewAtPath.data;
   const [, modulePath] = Internal.splitModuleFilePathAndModulePath(path);
   if (!modulePath) {
     return undefined;
@@ -50,37 +38,30 @@ export function resolveRefPreview(
   const pathParts = Internal.splitModulePath(modulePath);
   const lastPart = pathParts[pathParts.length - 1];
 
-  if (
-    parentSchema.type === "array" &&
-    renderData.layout === "list" &&
-    renderData.parent === "array"
-  ) {
-    const arrayRender = renderData as ListArrayRender;
+  if (parentSchema.type === "array" && previewData.parent === "array") {
     let index: number;
     try {
       index = JSON.parse(lastPart);
     } catch {
       index = Number(lastPart);
     }
-    // By index, not by position: a windowed render carries only the items that
-    // were asked for. See ListArrayRender.
-    const item = arrayRender.items.find(([itemIndex]) => itemIndex === index);
+    // By index, not by position: a windowed preview carries only the items that
+    // were asked for. See ArrayPreview.
+    const item = previewData.items.find(([itemIndex]) => itemIndex === index);
     if (!Number.isNaN(index) && item) {
       return item[1];
     }
   } else if (
     parentSchema.type === "record" &&
-    renderData.layout === "list" &&
-    renderData.parent === "record"
+    previewData.parent === "record"
   ) {
-    const recordRender = renderData as ListRecordRender;
     let key: string;
     try {
       key = JSON.parse(lastPart);
     } catch {
       key = lastPart;
     }
-    const item = recordRender.items.find(([itemKey]) => itemKey === key);
+    const item = previewData.items.find(([itemKey]) => itemKey === key);
     if (item) {
       return item[1];
     }

--- a/packages/ui/spa/stores/HostStore.ts
+++ b/packages/ui/spa/stores/HostStore.ts
@@ -1,6 +1,6 @@
 import {
   Internal,
-  renderScope,
+  previewScope,
   type Json,
   type ModuleFilePath,
   type Schema,
@@ -15,7 +15,7 @@ import type { SystemEvent } from "./types";
 import type {
   HostBridge,
   HostCustomValidateResult,
-  HostRenderResult,
+  HostPreviewResult,
 } from "./bridges";
 import type { SchemaStore } from "./SchemaStore";
 import type { SourceStore } from "./SourceStore";
@@ -25,7 +25,7 @@ import { noopActivity, type ActivitySink } from "./activity";
  * REALM: host. Cannot ever move to a worker.
  *
  * The only place that holds real `Schema` INSTANCES — the objects carrying the
- * user's `select`, `render` and custom `validate` closures. Closures cannot be
+ * user's `preview` and custom `validate` closures. Closures cannot be
  * structured-cloned, so this store defines the edge of what can be threaded, and
  * everything that needs to execute one has to be on this side of it.
  *
@@ -37,7 +37,7 @@ import { noopActivity, type ActivitySink } from "./activity";
  *    SERIALIZED halves — serialized schema, JSON source — into the other
  *    stores. Nothing downstream can accidentally hold a closure.
  *
- * 2. **Execution.** It implements {@link HostBridge}, so the render and
+ * 2. **Execution.** It implements {@link HostBridge}, so the preview and
  *    validation stores can have the two things done that only an instance can
  *    do, without ever holding one.
  */
@@ -161,10 +161,10 @@ export class HostStore implements HostBridge {
     this.sourceStore.receive(sources);
   }
 
-  async render(
+  async preview(
     moduleFilePath: ModuleFilePath,
     only?: readonly SourcePath[],
-  ): Promise<HostRenderResult> {
+  ): Promise<HostPreviewResult> {
     const instance = this.instances[moduleFilePath];
     if (!instance) {
       return { status: "unknown-module" };
@@ -176,25 +176,25 @@ export class HostStore implements HostBridge {
       return { status: "unknown-module" };
     }
     try {
-      this.activity.work("host:execute-render", moduleFilePath);
+      this.activity.work("host:execute-preview", moduleFilePath);
       // An empty `only` is not "nothing": a caller with no paths to name wants
       // the module, which is what every caller before scoping got. Only a
       // non-empty list narrows anything.
       const scope =
         only !== undefined && only.length > 0
-          ? renderScope([...only])
+          ? previewScope([...only])
           : undefined;
       return {
-        status: "rendered",
-        render: instance["executeRender"](
+        status: "previewed",
+        preview: instance["executePreview"](
           moduleFilePath,
           source as SelectorSource,
           scope,
         ),
       };
     } catch (error) {
-      // A render is decoration. A schema whose render throws must not take the
-      // module's fields down with it — same rule as `computeRender` today.
+      // A preview is decoration. A schema whose preview throws must not take
+      // the module's fields down with it.
       return {
         status: "error",
         message: error instanceof Error ? error.message : String(error),
@@ -276,7 +276,7 @@ export class HostStore implements HostBridge {
     }
   }
 
-  /** For a render/validation store deciding whether asking is worth it. */
+  /** For a preview/validation store deciding whether asking is worth it. */
   has(moduleFilePath: ModuleFilePath): boolean {
     return this.instances[moduleFilePath] !== undefined;
   }

--- a/packages/ui/spa/stores/PreviewStore.ts
+++ b/packages/ui/spa/stores/PreviewStore.ts
@@ -1,4 +1,8 @@
-import type { ModuleFilePath, ReifiedRender, SourcePath } from "@valbuild/core";
+import type {
+  ModuleFilePath,
+  ReifiedPreview,
+  SourcePath,
+} from "@valbuild/core";
 import { Internal } from "@valbuild/core";
 import { StoreBus } from "./StoreBus";
 import type { SystemEvent } from "./types";
@@ -7,43 +11,43 @@ import type { SourceStore } from "./SourceStore";
 import type { SchemaStore } from "./SchemaStore";
 import { noopActivity, type ActivitySink } from "./activity";
 
-export type RenderRead =
-  | { status: "rendered"; render: NonNullable<ReifiedRender[SourcePath]> }
+export type PreviewRead =
+  | { status: "previewed"; preview: NonNullable<ReifiedPreview[SourcePath]> }
   /**
    * Nothing is computed for this module, and computing it might help.
    *
    * `peek` only. It exists because a caller that peeks has to know whether ASKING
    * would change the answer, and the first version of `peek` could not say: it
-   * returned `no-render` both for a module that declares no render and for one
+   * returned `no-preview` both for a module that declares no preview and for one
    * that simply has not been computed yet. A React hook reading that cannot
    * distinguish "there is nothing to show" from "ask and there will be", so it
-   * either never renders anything or asks forever. Exactly the same defect, and
+   * either never shows anything or asks forever. Exactly the same defect, and
    * the same fix, as `entry-missing` vs `entry-failed` in `SourceStore.peek`.
    *
    * `get` never returns it — `get` computes, so by the time it answers the
    * question is settled.
    */
-  | { status: "needs-render" }
+  | { status: "needs-preview" }
   /**
-   * The module rendered, but this path has no render of its own. Normal and
-   * common — most paths are not list/record/textarea/code nodes. Distinct from
-   * `no-render`, which is about the whole module.
+   * The module previewed, but this path has no preview of its own. Normal and
+   * common — only an array or a record that declares a `preview` has one.
+   * Distinct from `no-preview`, which is about the whole module.
    */
-  | { status: "no-render-at-path" }
-  /** The module declares no renders at all, or the host has no instance. */
-  | { status: "no-render" }
+  | { status: "no-preview-at-path" }
+  /** The module declares no previews at all, or the host has no instance. */
+  | { status: "no-preview" }
   | { status: "error"; message: string };
 
 /**
- * Are these the same whole-project render maps?
+ * Are these the same whole-project preview maps?
  *
- * Identity per module, for the same reason {@link sameRead} uses it: a render
+ * Identity per module, for the same reason {@link sameRead} uses it: a preview
  * that has not been recomputed is the same object out of the same cache entry,
  * so `===` is exact here rather than an approximation of equality.
  */
-function sameRenders(
-  a: Record<ModuleFilePath, ReifiedRender | null>,
-  b: Record<ModuleFilePath, ReifiedRender | null>,
+function samePreviews(
+  a: Record<ModuleFilePath, ReifiedPreview | null>,
+  b: Record<ModuleFilePath, ReifiedPreview | null>,
 ): boolean {
   const keys = Object.keys(a);
   if (keys.length !== Object.keys(b).length) {
@@ -58,15 +62,15 @@ function sameRenders(
 }
 
 /**
- * Is this the same render answer? Identity on the render, since an unchanged one
- * is the same object out of the same cache entry.
+ * Is this the same preview answer? Identity on the preview, since an unchanged
+ * one is the same object out of the same cache entry.
  */
-function sameRead(a: RenderRead, b: RenderRead): boolean {
+function sameRead(a: PreviewRead, b: PreviewRead): boolean {
   if (a.status !== b.status) {
     return false;
   }
-  if (a.status === "rendered" && b.status === "rendered") {
-    return a.render === b.render;
+  if (a.status === "previewed" && b.status === "previewed") {
+    return a.preview === b.preview;
   }
   if (a.status === "error" && b.status === "error") {
     return a.message === b.message;
@@ -79,62 +83,66 @@ function sameRead(a: RenderRead, b: RenderRead): boolean {
  *
  * ## Why it is a router and not a computer
  *
- * A render is produced by `executeRender`, which runs the user's `render({ as,
- * select })` closures. Only the host holds those. So this store owns everything
- * AROUND the render — the cache, the staleness, the events, the per-path lookup
- * — and asks the host for the render itself.
+ * A preview is produced by `executePreview`, which runs the user's `preview()`
+ * closures. Only the host holds those. So this store owns everything AROUND the
+ * preview — the cache, the staleness, the events, the per-path lookup — and asks
+ * the host for the preview itself.
+ *
+ * A string's `render` is NOT here and never was one of these: it is static
+ * config that travels with the serialized schema, so there is nothing to ask
+ * for. See `core/src/render.ts`.
  *
  * ## Per-path API, per-path execution
  *
- * Callers ask `get(path)`, and that path is now what gets rendered:
- * `executeRender` takes a `RenderScope`, so a listener on one row of a list runs
- * `select` for that row rather than for every row. A request for the CONTAINER
- * still renders all of it — a list view needs every row, and windowing there
- * would be a list with rows missing.
+ * Callers ask `get(path)`, and that path is now what gets previewed:
+ * `executePreview` takes a `PreviewScope`, so a listener on one row of a list
+ * runs the closure for that row rather than for every row. A request for the
+ * CONTAINER still previews all of it — a list view needs every row, and
+ * windowing there would be a list with rows missing.
  *
- * The worst case this was measured against: `handboka` has `select` at two nested
- * array levels, so an unscoped render of one visible section walked every chapter
- * and every section. Scoped, it walks one of each.
+ * The worst case this was measured against: `handboka` previews at two nested
+ * array levels, so an unscoped preview of one visible section walked every
+ * chapter and every section. Scoped, it walks one of each.
  *
  * ## What that costs this store
  *
  * Two things, both of which would be silent bugs if left out:
  *
- * - **The cache entry carries the scope it was computed at.** A render scoped to
- *   one row says nothing about another row, so serving it there is worse than a
+ * - **The cache entry carries the scope it was computed at.** A preview scoped
+ *   to one row says nothing about another row, so serving it there is worse than a
  *   miss — a miss is slow, that is wrong. Coverage is asked per CALLER and not
  *   as "is every listened path covered": folding those together makes one
  *   field's read pay for every other mounted field's, which is the fan-out this
  *   design exists to remove.
- * - **Concurrent readers of different paths must still cost one render.**
+ * - **Concurrent readers of different paths must still cost one preview.**
  *   Sharing an already-issued request cannot achieve that, because its scope was
  *   fixed when it was issued. See `refreshFor`.
  */
-export class RenderStore {
+export class PreviewStore {
   readonly events = new StoreBus<SystemEvent>();
 
   /**
-   * The cached render per module, WITH the scope it was computed for.
+   * The cached preview per module, WITH the scope it was computed for.
    *
-   * `scope: null` means the whole module. A scoped render answers for the paths
+   * `scope: null` means the whole module. A scoped preview answers for the paths
    * in its scope and for nothing else — so the scope is part of the cache entry,
-   * not a detail of how it was produced. Without it, a render computed for one
+   * not a detail of how it was produced. Without it, a preview computed for one
    * visible row would be served to a field on another row that it says nothing
    * about, which is worse than a cache miss: a miss is slow, this is wrong.
    */
-  private renders = new Map<
+  private previews = new Map<
     ModuleFilePath,
-    { render: ReifiedRender; scope: Set<SourcePath> | null }
+    { preview: ReifiedPreview; scope: Set<SourcePath> | null }
   >();
   private stale = new Set<ModuleFilePath>();
   /**
    * Memoised {@link peek} answers, so repeated peeks of one path are `===`.
    *
-   * Cleared per MODULE, because everything that can change a render — an
+   * Cleared per MODULE, because everything that can change a preview — an
    * invalidation, a recompute, an error — is a module-level event. Keyed by path
    * because that is what a caller asks about.
    */
-  private peeked = new Map<SourcePath, RenderRead>();
+  private peeked = new Map<SourcePath, PreviewRead>();
   /**
    * Deferred cache teardowns, per module. See the `source:unlisten` handler.
    * Cleared by {@link dispose} so a discarded system leaves no timers behind.
@@ -158,10 +166,10 @@ export class RenderStore {
     { scope: ReadonlySet<SourcePath> | null; request: Promise<void> }
   >();
   /**
-   * Reads that have asked but whose render has not gone out yet.
+   * Reads that have asked but whose preview has not gone out yet.
    *
    * The set of paths is mutable and shared with the pending request, so a reader
-   * arriving in the same turn widens the scope of the render that is about to be
+   * arriving in the same turn widens the scope of the preview that is about to be
    * issued instead of needing one of its own. See {@link refreshFor}.
    */
   private pendingReads = new Map<
@@ -172,7 +180,7 @@ export class RenderStore {
    * How many readers are registered on paths in each module.
    *
    * This is the demand signal, and it is the reason this store listens to the
-   * source store's registry rather than waiting to be called. A render is only
+   * source store's registry rather than waiting to be called. A preview is only
    * worth computing if someone is looking at it; a listener existing at a path
    * is the system's own record that someone is. `get()` cannot serve as that
    * signal — it is a caller choosing to pay, which a speculative or
@@ -181,7 +189,7 @@ export class RenderStore {
   private listenersByModule = new Map<ModuleFilePath, number>();
 
   /** The last {@link all} answer, reused when a fresh one is equal. */
-  private allRenders: Record<ModuleFilePath, ReifiedRender | null> | null =
+  private allPreviews: Record<ModuleFilePath, ReifiedPreview | null> | null =
     null;
 
   constructor(
@@ -192,13 +200,13 @@ export class RenderStore {
   ) {}
 
   /**
-   * A render is a function of (schema, source), so both invalidate it. Missing
-   * the schema half is how an HMR edit leaves a stale render on screen.
+   * A preview is a function of (schema, source), so both invalidate it. Missing
+   * the schema half is how an HMR edit leaves a stale preview on screen.
    */
   listenTo(): () => void {
-    // Demand arriving: a field mounted on a path in this module, so its render
+    // Demand arriving: a field mounted on a path in this module, so its preview
     // is now wanted. Computed at that point — which is the "user clicks to a
-    // path that needs a render" case — rather than when someone calls `get()`.
+    // path that needs a preview" case — rather than when someone calls `get()`.
     const offListen = this.sourceStore.events.on("source:listen", (event) => {
       const before = this.listenersByModule.get(event.moduleFilePath) ?? 0;
       this.listenersByModule.set(event.moduleFilePath, before + 1);
@@ -210,15 +218,15 @@ export class RenderStore {
         clearTimeout(pending);
         this.pendingForget.delete(event.moduleFilePath);
       }
-      // The FIRST field to look at a module is what makes it render. Later
+      // The FIRST field to look at a module is what makes it preview. Later
       // listeners deliberately do not trigger one, and that is the coalescing:
       // a commit mounting twenty rows would otherwise refresh twenty times at
-      // growing scope — strictly worse than the one whole-module render this
+      // growing scope — strictly worse than the one whole-module preview this
       // replaced. Their own reads cover them, and the first of those reads
-      // renders at the scope of everything mounted by then, so the twenty rows
-      // cost two renders rather than twenty.
+      // previews at the scope of everything mounted by then, so the twenty rows
+      // cost two previews rather than twenty.
       if (
-        this.renders.has(event.moduleFilePath) ||
+        this.previews.has(event.moduleFilePath) ||
         this.inFlight.has(event.moduleFilePath) ||
         this.pendingReads.has(event.moduleFilePath)
       ) {
@@ -228,17 +236,17 @@ export class RenderStore {
     });
     /**
      * Demand leaving. The cache is dropped once nobody is looking, so a module
-     * nobody has on screen cannot be re-rendered by a later change to it, and
-     * does not hold a render nobody will read.
+     * nobody has on screen cannot be recomputed by a later change to it, and
+     * does not hold a preview nobody will read.
      *
-     * DEFERRED BY A TICK, and that is the whole fix for a render loop.
+     * DEFERRED BY A TICK, and that is the whole fix for a re-render loop.
      *
      * "Nobody is looking" is not the same as "the count reached zero", because
      * React commits an unmount BEFORE the mount that replaces it. A virtualizer
      * scrolling one row out and another in therefore passes through zero even
      * though the module is still very much on screen. Dropping the cache there
-     * made the incoming row's read a cache MISS, which re-rendered the whole
-     * module, which produced new render objects, which re-rendered the rows,
+     * made the incoming row's read a cache MISS, which re-previewed the whole
+     * module, which produced new preview objects, which re-rendered the rows,
      * which moved the window again: 550 mount/unmount pairs on a 121-row record
      * and then "Maximum update depth exceeded".
      *
@@ -275,7 +283,7 @@ export class RenderStore {
             if ((this.listenersByModule.get(moduleFilePath) ?? 0) > 0) {
               return;
             }
-            this.renders.delete(moduleFilePath);
+            this.previews.delete(moduleFilePath);
             this.stale.delete(moduleFilePath);
             this.pendingReads.delete(moduleFilePath);
           }, 0),
@@ -310,8 +318,8 @@ export class RenderStore {
   }
 
   /**
-   * Bumped by every invalidation, so a render in flight can tell whether the
-   * world moved underneath it. See {@link render}.
+   * Bumped by every invalidation, so a preview in flight can tell whether the
+   * world moved underneath it. See {@link computePreview}.
    */
   private generation = 0;
 
@@ -319,21 +327,21 @@ export class RenderStore {
     this.generation++;
     const newlyStale = modules.filter(
       (moduleFilePath) =>
-        !this.stale.has(moduleFilePath) && this.renders.has(moduleFilePath),
+        !this.stale.has(moduleFilePath) && this.previews.has(moduleFilePath),
     );
     for (const moduleFilePath of modules) {
       this.stale.add(moduleFilePath);
     }
     // Only when something cached actually went stale. A keystroke in a module
-    // nobody has rendered is not news, and 40 keystrokes in one that has are
+    // nobody has previewed is not news, and 40 keystrokes in one that has are
     // one piece of news, not 40.
     if (newlyStale.length > 0) {
-      this.events.emit({ type: "render:invalidate", modules: newlyStale });
+      this.events.emit({ type: "preview:invalidate", modules: newlyStale });
     }
     // And that is ALL a change does. It deliberately does not recompute, not
     // even for a module someone is looking at: a burst of 40 keystrokes would
-    // then cost 40 whole-module renders, which is precisely the per-keystroke
-    // render cost this design exists to remove.
+    // then cost 40 whole-module previews, which is precisely the per-keystroke
+    // preview cost this design exists to remove.
     //
     // Nothing is lost by waiting, because the change already wakes the fields
     // on the affected paths (the source store dispatches to them in the same
@@ -343,45 +351,48 @@ export class RenderStore {
   }
 
   /**
-   * The render at one path, computing it (once, per module) if needed.
+   * The preview at one path, computing it (once, per module) if needed.
    *
    * Async because it may cross the host seam. Concurrent callers on the same
    * module share one in-flight request rather than each triggering their own
-   * `executeRender` over the whole module.
+   * `executePreview` over the whole module.
    */
-  async get(path: SourcePath): Promise<RenderRead> {
+  async get(path: SourcePath): Promise<PreviewRead> {
     const [moduleFilePath] = Internal.splitModuleFilePathAndModulePath(path);
     if (this.stale.has(moduleFilePath) || !this.covers(moduleFilePath, path)) {
-      this.activity.work("render:cache-miss", moduleFilePath);
+      this.activity.work("preview:cache-miss", moduleFilePath);
       await this.refreshFor(moduleFilePath, path);
     } else {
-      this.activity.work("render:cache-hit", moduleFilePath);
+      this.activity.work("preview:cache-hit", moduleFilePath);
     }
-    const entry = this.renders.get(moduleFilePath);
+    const entry = this.previews.get(moduleFilePath);
     if (entry === undefined) {
-      return { status: "no-render" };
+      return { status: "no-preview" };
     }
-    // `executeRender` keys every render by its exact `sourcePath`, and a module's
-    // own render lands under the bare module file path — that IS its source path,
+    // `executePreview` keys every preview by its exact `sourcePath`, and a
+    // module's own preview lands under the bare module file path — that IS its
+    // source path,
     // `joinModuleFilePathAndModulePath(mfp, "")` being `mfp`.
     //
     // The fallback is deliberate and load-bearing, which is worth saying because
-    // it reads like an over-broad default: a WINDOWED container render is keyed
+    // it reads like an over-broad default: a WINDOWED container preview is keyed
     // under the container, and a row asks about its OWN path and finds itself in
-    // that render's `items` (which carry their index — see `ListArrayRender`).
+    // that preview's `items` (which carry their index — see `ArrayPreview`).
+    // Only a container can be keyed at a container path, so the fallback cannot
+    // hand a field something that was never about it.
     // Scoping this to the module root breaks exactly that, and
     // `demandDriven.test.ts` says so in three tests.
     const at =
-      entry.render[path] ??
-      entry.render[moduleFilePath as string as SourcePath];
+      entry.preview[path] ??
+      entry.preview[moduleFilePath as string as SourcePath];
     if (at === undefined) {
-      return { status: "no-render-at-path" };
+      return { status: "no-preview-at-path" };
     }
-    return { status: "rendered", render: at };
+    return { status: "previewed", preview: at };
   }
 
   /**
-   * Does the cached render answer for this path?
+   * Does the cached preview answer for this path?
    *
    * Only about the one path, deliberately. A cache entry that covers the caller
    * but not some other mounted field is a HIT for this caller: that other field
@@ -390,20 +401,20 @@ export class RenderStore {
    * everyone else's, which is the fan-out this design exists to remove.
    */
   private covers(moduleFilePath: ModuleFilePath, path: SourcePath): boolean {
-    const entry = this.renders.get(moduleFilePath);
+    const entry = this.previews.get(moduleFilePath);
     if (entry === undefined) return false;
     return entry.scope === null || entry.scope.has(path);
   }
 
   /**
-   * Render for a reader at `forPath`, joining any request that has not yet gone
+   * Preview for a reader at `forPath`, joining any request that has not yet gone
    * out.
    *
    * The waiting is what makes N concurrent readers of N DIFFERENT paths cost one
-   * render rather than N. Sharing an already-issued request cannot do it: its
+   * preview rather than N. Sharing an already-issued request cannot do it: its
    * scope was fixed when it was issued, so a reader that joins late is either
    * served an answer that says nothing about its path, or has to start a second
-   * render. Collecting the asked-for paths first and issuing once covers both.
+   * preview. Collecting the asked-for paths first and issuing once covers both.
    *
    * The wait is a microtask, so it is free by contract — `get` is async
    * already — and it cannot outlive the caller's own turn.
@@ -416,7 +427,7 @@ export class RenderStore {
     if (pending !== undefined) {
       // Counted, because "N fields asking at once cost ONE host call" is a
       // claim this store makes and a test should be able to hold it to it.
-      this.activity.work("render:share-in-flight", moduleFilePath);
+      this.activity.work("preview:share-in-flight", moduleFilePath);
       pending.paths.add(forPath);
       return pending.request;
     }
@@ -424,25 +435,25 @@ export class RenderStore {
     const request = (async () => {
       // Yield once, so every reader in this turn is in `paths` before the scope
       // is fixed. Deliberately NOT done on the `source:listen` path: that one is
-      // dispatched synchronously from `addListener`, and "the render is ready
+      // dispatched synchronously from `addListener`, and "the preview is ready
       // when the mounting field first looks" is the whole promise of computing
       // on demand arriving — a field that mounts and reads in one turn must not
       // find it missing.
       await Promise.resolve();
       this.pendingReads.delete(moduleFilePath);
-      await this.render(moduleFilePath, paths);
+      await this.computePreview(moduleFilePath, paths);
     })();
     pending = { paths, request };
     this.pendingReads.set(moduleFilePath, pending);
     return request;
   }
 
-  /** Render at the scope of what is listened right now. The demand-arrival path. */
+  /** Preview at the scope of what is listened right now. The demand-arrival path. */
   private async refresh(moduleFilePath: ModuleFilePath): Promise<void> {
-    return this.render(moduleFilePath, new Set());
+    return this.computePreview(moduleFilePath, new Set());
   }
 
-  private async render(
+  private async computePreview(
     moduleFilePath: ModuleFilePath,
     alsoWanted: ReadonlySet<SourcePath>,
     /** Internal: set on the one retry, so sharing cannot recurse. */
@@ -454,16 +465,16 @@ export class RenderStore {
       const answersUs =
         inFlightScope === null ||
         [...alsoWanted].every((path) => inFlightScope.has(path));
-      this.activity.work("render:share-in-flight", moduleFilePath);
+      this.activity.work("preview:share-in-flight", moduleFilePath);
       await existing.request;
       if (answersUs) {
         return;
       }
       // It did not answer us. One retry, and that one issues unconditionally: a
-      // duplicate render costs time, whereas returning here would report
-      // `no-render-at-path` for a path that has a render, which is wrong. Bounded
+      // duplicate preview costs time, whereas returning here would report
+      // `no-preview-at-path` for a path that has a preview, which is wrong. Bounded
       // by the flag rather than by an argument about interleaving.
-      return this.render(moduleFilePath, alsoWanted, true);
+      return this.computePreview(moduleFilePath, alsoWanted, true);
     }
     // The scope is the listened paths, plus whoever is asking. Derived here and
     // not remembered: it is a question about now, and a stored answer could only
@@ -479,47 +490,47 @@ export class RenderStore {
     const startedAt = this.generation;
     const request: Promise<void> = (async () => {
       // Asked before crossing the host seam: a module whose schema declares no
-      // render cannot produce one, so the walk is pure cost. Cached as an empty
-      // render rather than skipped outright, so `get` and `peek` answer
-      // `no-render-at-path` exactly as they did when the host was asked and
+      // preview cannot produce one, so the walk is pure cost. Cached as an empty
+      // preview rather than skipped outright, so `get` and `peek` answer
+      // `no-preview-at-path` exactly as they did when the host was asked and
       // returned nothing.
-      const result = this.schemaStore.declaresRender(moduleFilePath)
-        ? await this.host.render(moduleFilePath, [...scope])
-        : { status: "rendered" as const, render: {} };
-      if (result.status === "rendered") {
+      const result = this.schemaStore.declaresPreview(moduleFilePath)
+        ? await this.host.preview(moduleFilePath, [...scope])
+        : { status: "previewed" as const, preview: {} };
+      if (result.status === "previewed") {
         // An empty scope is not a scope: with nothing listened and nobody
-        // asking, the host rendered the whole module, so that is what is cached.
-        this.renders.set(moduleFilePath, {
-          render: result.render,
+        // asking, the host previewed the whole module, so that is what is cached.
+        this.previews.set(moduleFilePath, {
+          preview: result.preview,
           scope: scope.size === 0 ? null : scope,
         });
         /**
-         * Only if nothing invalidated while the host was rendering.
+         * Only if nothing invalidated while the host was previewing.
          *
-         * `host.render` is awaited, so an edit can land mid-flight. Clearing
-         * `stale` unconditionally cached a render of the PRE-edit source and
+         * `host.preview` is awaited, so an edit can land mid-flight. Clearing
+         * `stale` unconditionally cached a preview of the PRE-edit source and
          * marked it fresh, and every field on those paths kept showing it — the
-         * reader only re-asks on `needs-render`. Cached anyway, because a stale
-         * render is better than none; just not marked fresh.
+         * reader only re-asks on `needs-preview`. Cached anyway, because a stale
+         * preview is better than none; just not marked fresh.
          */
         if (this.generation === startedAt) {
           this.stale.delete(moduleFilePath);
         }
-        this.events.emit({ type: "render:result", moduleFilePath });
+        this.events.emit({ type: "preview:result", moduleFilePath });
       } else if (result.status === "unknown-module") {
-        // Not an error: a module with no instance simply has no render. Cache
+        // Not an error: a module with no instance simply has no preview. Cache
         // the absence so every field in it does not re-ask the host.
-        this.renders.delete(moduleFilePath);
+        this.previews.delete(moduleFilePath);
         if (this.generation === startedAt) {
           this.stale.delete(moduleFilePath);
         }
       } else {
-        this.renders.delete(moduleFilePath);
+        this.previews.delete(moduleFilePath);
         if (this.generation === startedAt) {
           this.stale.delete(moduleFilePath);
         }
         this.events.emit({
-          type: "render:error",
+          type: "preview:error",
           moduleFilePath,
           message: result.message,
         });
@@ -527,7 +538,7 @@ export class RenderStore {
     })().finally(() => {
       // Only if it is still ours: a `mustIssue` retry can overlap a request that
       // was already in flight, and clearing the other one's entry would let a
-      // third caller issue a third render.
+      // third caller issue a third preview.
       if (this.inFlight.get(moduleFilePath)?.request === request) {
         this.inFlight.delete(moduleFilePath);
       }
@@ -549,12 +560,12 @@ export class RenderStore {
    *
    * Achieved by recomputing and comparing, not by invalidating a memo. The first
    * fix here DID keep an invalidation list — five call sites, one of them reading
-   * `declaresRender` from another store — and a list like that has to stay
+   * `declaresPreview` from another store — and a list like that has to stay
    * complete forever, failing silently when it does not. Recomputing is cheap (a
    * map lookup and a property read) and cannot go stale. Same reasoning as
    * `SourceStore.peek`.
    */
-  peek(path: SourcePath): RenderRead {
+  peek(path: SourcePath): PreviewRead {
     const next = this.computePeek(path);
     const previous = this.peeked.get(path);
     if (previous !== undefined && sameRead(previous, next)) {
@@ -565,88 +576,87 @@ export class RenderStore {
   }
 
   /**
-   * Every module's cached render, in the shape the engine's
-   * `getAllRendersSnapshot` returned: `null` where there is nothing rendered.
+   * Every module's cached preview, in the shape the engine's whole-project
+   * snapshot returned: `null` where there is nothing previewed.
    *
    * PEEKED, not computed. That is the whole difference from the engine, which
-   * ran `computeRender` for every module the project has a schema for — so a
-   * consumer reading "all renders" paid for the entire project's `select`
-   * closures whether or not anything was on screen. Here a module that nobody
-   * has asked about is simply absent, and the render arrives when demand does:
-   * a field mounting on a path emits `source:listen`, which is what makes this
-   * store compute.
+   * computed for every module the project has a schema for — so a consumer
+   * reading "all previews" paid for the entire project's closures whether or not
+   * anything was on screen. Here a module that nobody has asked about is simply
+   * absent, and the preview arrives when demand does: a field mounting on a path
+   * emits `source:listen`, which is what makes this store compute.
    *
-   * A consumer that needs a render it cannot see should read it through
-   * `useRenderOverrideAtPath` — asking IS the demand signal. Two consumers do
+   * A consumer that needs a preview it cannot see should read it through
+   * `usePreviewAtPath` — asking IS the demand signal. Two consumers do
    * genuinely want the whole map (`useRichTextEditorConfig`, `RouteField`), and
-   * for them "what has been rendered so far" is the honest answer: both are
+   * for them "what has been previewed so far" is the honest answer: both are
    * reading configuration that the module they render in has already caused.
    *
    * Reference-stable, like every other snapshot here, and by recomputing and
    * comparing rather than by maintaining a version. Five places mutate the
-   * render map — a listener count reaching zero, an invalidation, and the three
-   * outcomes of a render — and a counter bumped at each is a list that has to
+   * preview map — a listener count reaching zero, an invalidation, and the three
+   * outcomes of a preview — and a counter bumped at each is a list that has to
    * stay complete forever and fails silently when it does not. The rebuild walks
-   * only modules that HAVE a cached render, which is modules with a mounted
+   * only modules that HAVE a cached preview, which is modules with a mounted
    * field, so it is bounded by what is on screen rather than by the project.
    * Same reasoning as `peek`, and as `SourceStore.peek` before it.
    */
-  all(): Record<ModuleFilePath, ReifiedRender | null> {
-    const next: Record<ModuleFilePath, ReifiedRender | null> = {};
-    for (const [moduleFilePath, entry] of this.renders) {
+  all(): Record<ModuleFilePath, ReifiedPreview | null> {
+    const next: Record<ModuleFilePath, ReifiedPreview | null> = {};
+    for (const [moduleFilePath, entry] of this.previews) {
       next[moduleFilePath] = this.stale.has(moduleFilePath)
         ? null
-        : entry.render;
+        : entry.preview;
     }
-    const previous = this.allRenders;
-    if (previous !== null && sameRenders(previous, next)) {
+    const previous = this.allPreviews;
+    if (previous !== null && samePreviews(previous, next)) {
       return previous;
     }
-    this.allRenders = next;
+    this.allPreviews = next;
     return next;
   }
 
-  private computePeek(path: SourcePath): RenderRead {
+  private computePeek(path: SourcePath): PreviewRead {
     const [moduleFilePath] = Internal.splitModuleFilePathAndModulePath(path);
     // Asked FIRST, because it is the one case where asking cannot help: the
-    // module's schema declares no render at all, so there is nothing to compute
+    // module's schema declares no preview at all, so there is nothing to compute
     // however many times a caller asks. Distinguishing it from the two below is
-    // the whole reason `needs-render` exists.
-    if (!this.schemaStore.declaresRender(moduleFilePath)) {
-      return { status: "no-render" };
+    // the whole reason `needs-preview` exists.
+    if (!this.schemaStore.declaresPreview(moduleFilePath)) {
+      return { status: "no-preview" };
     }
     if (this.stale.has(moduleFilePath)) {
-      return { status: "needs-render" };
+      return { status: "needs-preview" };
     }
-    const entry = this.renders.get(moduleFilePath);
+    const entry = this.previews.get(moduleFilePath);
     if (entry === undefined) {
-      return { status: "needs-render" };
+      return { status: "needs-preview" };
     }
     /**
-     * A path the cached render was not computed FOR is `needs-render`.
+     * A path the cached preview was not computed FOR is `needs-preview`.
      *
      * This used to skip the `covers` check that `get` makes, on the grounds that
      * `peek` reports what is cached and has no third thing to say. It does have
-     * one — that is what `needs-render` is — and without it a row scrolled into
-     * view was stuck: `source:listen` returns early when a render already exists,
+     * one — that is what `needs-preview` is — and without it a row scrolled into
+     * view was stuck: `source:listen` returns early when a preview already exists,
      * so the scope never widened, and the reader never asked because `peek`
-     * answered `rendered` (the container's render, which does not contain that
-     * row) or `no-render-at-path`. Either way the new row showed no preview until
+     * answered `previewed` (the container's preview, which does not contain that
+     * row) or `no-preview-at-path`. Either way the new row showed no preview until
      * something else in the module changed.
      *
      * It cannot loop: `refreshFor` puts the asked-for path in the new scope, so
      * the next `covers` is true whatever the host returned.
      */
     if (!this.covers(moduleFilePath, path)) {
-      return { status: "needs-render" };
+      return { status: "needs-preview" };
     }
     // The container fallback, for the same reason as in `get` above — a row reads
-    // the windowed render it appears in.
+    // the windowed container preview it appears in.
     const at =
-      entry.render[path] ??
-      entry.render[moduleFilePath as string as SourcePath];
+      entry.preview[path] ??
+      entry.preview[moduleFilePath as string as SourcePath];
     return at === undefined
-      ? { status: "no-render-at-path" }
-      : { status: "rendered", render: at };
+      ? { status: "no-preview-at-path" }
+      : { status: "previewed", preview: at };
   }
 }

--- a/packages/ui/spa/stores/SchemaStore.ts
+++ b/packages/ui/spa/stores/SchemaStore.ts
@@ -23,14 +23,14 @@ export class SchemaStore {
   private schemas: Record<ModuleFilePath, SerializedSchema> = {};
   private versions = new Map<ModuleFilePath, number>();
   /**
-   * Whether each module's schema declares a render anywhere, by version.
+   * Whether each module's schema declares a preview anywhere, by version.
    *
    * Cached against the version rather than recomputed, and answered from the
-   * SCHEMA rather than from a render that came back empty — the difference
-   * matters at mount, when nothing has been rendered yet. See
-   * {@link SchemaStore.declaresRender}.
+   * SCHEMA rather than from a preview that came back empty — the difference
+   * matters at mount, when nothing has been previewed yet. See
+   * {@link SchemaStore.declaresPreview}.
    */
-  private renderDeclared = new Map<
+  private previewDeclared = new Map<
     ModuleFilePath,
     { version: number; declared: boolean }
   >();
@@ -77,55 +77,62 @@ export class SchemaStore {
   }
 
   /**
-   * Can this module produce a render at all?
+   * Can this module produce a preview at all?
    *
-   * The render itself needs the host — `select` is a user closure — but whether
-   * one is DECLARED is in the serialized schema, and asking here first is what
-   * stops the render store crossing the host seam for a module that can only
-   * answer "nothing".
+   * The preview itself needs the host — it is a user closure — but whether one
+   * is DECLARED is in the serialized schema, and asking here first is what stops
+   * the preview store crossing the host seam for a module that can only answer
+   * "nothing".
    *
    * This is not a micro-optimisation: browser measurement showed mounting 260
-   * fields across 141 modules spending ~2.3ms of 3.1ms inside `executeRender`
+   * fields across 141 modules spending ~2.3ms of 3.1ms inside `executePreview`
    * on modules that returned an empty result. In a real project most modules
-   * declare no render, so most of that work was provably wasted.
+   * declare no preview, so most of that work was provably wasted.
    *
    * `false` for a module whose schema has not arrived — there is nothing to
-   * render yet either way, and the store's `module-loading`/absent handling
+   * preview yet either way, and the store's `module-loading`/absent handling
    * covers it.
    *
-   * VERSION SKEW: this trusts the `render` marker to be present whenever a
-   * render is declared. It is set by `executeSerialize` on a real instance, so
+   * VERSION SKEW: this trusts the `preview` marker to be present whenever a
+   * preview is declared. It is set by `executeSerialize` on a real instance, so
    * it is there for schemas from local modules AND from `GET /schema` (the
    * server serializes from instances too). A server old enough to predate the
-   * marker would serve schemas without it, and renders would then silently stop
+   * marker would serve schemas without it, and previews would then silently stop
    * appearing rather than fail — which is why Val's existing schema-skew check
    * (`schema-out-of-date`) is the thing that has to catch that, not this.
    */
-  declaresRender(moduleFilePath: ModuleFilePath): boolean {
+  declaresPreview(moduleFilePath: ModuleFilePath): boolean {
     const version = this.version(moduleFilePath);
-    const cached = this.renderDeclared.get(moduleFilePath);
+    const cached = this.previewDeclared.get(moduleFilePath);
     if (cached !== undefined && cached.version === version) {
       return cached.declared;
     }
     const schema = this.schemas[moduleFilePath];
-    const declared = schema === undefined ? false : declaresRender(schema);
-    this.renderDeclared.set(moduleFilePath, { version, declared });
+    const declared = schema === undefined ? false : declaresPreview(schema);
+    this.previewDeclared.set(moduleFilePath, { version, declared });
     return declared;
   }
 }
 
 /**
- * Does this schema, or anything under it, declare a render?
+ * Does this schema, or anything under it, declare a preview?
  *
- * Only three schemas can: `array` and `record` (a list, via `select`) and
- * `string` (a static layout hint). Every other node is pure recursion, which is
- * why the walk only has to look for the `render` marker and descend.
+ * Only two schemas can: `array` and `record`, the containers that have items to
+ * preview. Every other node is pure recursion, which is why the walk only has to
+ * look for the `preview` marker and descend.
+ *
+ * There is deliberately NO `string` arm. `s.string().render({as:"textarea"})` is
+ * a render, not a preview: static config that travels WITH the serialized schema
+ * and is read where the field is drawn, so a module whose only such declaration
+ * is a string layout must never be sent to the host. Restoring an arm here would
+ * put that whole-module walk back for a fact the schema already carried. See
+ * `core/src/render.ts`.
  *
  * `seen` guards a schema that refers to itself structurally, so this cannot
  * recurse forever — the same guard `collectReferences` and
  * `jsonValuesLoadRequirements` use.
  */
-function declaresRender(
+function declaresPreview(
   schema: SerializedSchema,
   seen: Set<SerializedSchema> = new Set(),
 ): boolean {
@@ -133,17 +140,15 @@ function declaresRender(
   seen.add(schema);
   switch (schema.type) {
     case "array":
-      return schema.render === true || declaresRender(schema.item, seen);
+      return schema.preview === true || declaresPreview(schema.item, seen);
     case "record":
-      return schema.render === true || declaresRender(schema.item, seen);
-    case "string":
-      return schema.render === true;
+      return schema.preview === true || declaresPreview(schema.item, seen);
     case "object":
       return Object.values(schema.items).some((item) =>
-        declaresRender(item, seen),
+        declaresPreview(item, seen),
       );
     case "union":
-      return schema.items.some((item) => declaresRender(item, seen));
+      return schema.items.some((item) => declaresPreview(item, seen));
     default:
       return false;
   }

--- a/packages/ui/spa/stores/SourceStore.ts
+++ b/packages/ui/spa/stores/SourceStore.ts
@@ -778,7 +778,7 @@ export class SourceStore {
    * Peeking the same unchanged path twice returns the SAME OBJECT. Callers rely on
    * it: `useSyncExternalStore` requires a snapshot that only changes when the
    * value does, and a fresh object per call makes React re-render forever. The
-   * same requirement bit `ValidationStore.peek` and `RenderStore.peek`, and all
+   * same requirement bit `ValidationStore.peek` and `PreviewStore.peek`, and all
    * three now honour it — "safe to call on a render path" has to mean this, or it
    * means nothing.
    *

--- a/packages/ui/spa/stores/activity.ts
+++ b/packages/ui/spa/stores/activity.ts
@@ -23,7 +23,7 @@
  * be proportional to the edited field rather than to the project, and that is a
  * claim about HOW MANY times each expensive thing runs. This channel is what
  * turns that claim into an assertion: "one keystroke ⇒ one clone, one apply, one
- * listener woken, zero renders, zero validations" is a test, not a hope.
+ * listener woken, zero previews, zero validations" is a test, not a hope.
  *
  * It is deliberately in-process rather than `performance.mark`-based. A count is
  * exactly reproducible in a node test; a duration is not.
@@ -132,13 +132,13 @@ export type WorkKind =
   | "schema:receive"
   // --- host: the only place user closures run ------------------------------
   | "host:serialize-schema"
-  | "host:execute-render"
+  | "host:execute-preview"
   | "host:execute-validate"
-  // --- render: router, so hit/miss is the whole story ----------------------
-  | "render:cache-hit"
-  | "render:cache-miss"
-  /** A concurrent caller joined an in-flight render instead of starting one. */
-  | "render:share-in-flight"
+  // --- preview: router, so hit/miss is the whole story ---------------------
+  | "preview:cache-hit"
+  | "preview:cache-miss"
+  /** A concurrent caller joined an in-flight preview instead of starting one. */
+  | "preview:share-in-flight"
   // --- validation: two seams, counted separately --------------------------
   | "validation:cache-hit"
   | "validation:cache-miss"

--- a/packages/ui/spa/stores/activityCost.test.ts
+++ b/packages/ui/spa/stores/activityCost.test.ts
@@ -31,21 +31,37 @@ const authors = () => {
 };
 
 /**
- * A module that actually declares a render.
+ * A module that actually declares a preview.
  *
- * Needed because `RenderStore` no longer crosses the host seam for a module
- * whose schema declares no render — so a test about how many host calls a render
- * costs has to use a module that can produce one, or it measures nothing.
+ * Needed because `PreviewStore` no longer crosses the host seam for a module
+ * whose schema declares no preview — so a test about how many host calls a
+ * preview costs has to use a module that can produce one, or it measures
+ * nothing.
  */
-const rendered = () => {
+const previewed = () => {
   const { c, s } = initVal();
   return c.define(
-    "/rendered.val.ts",
-    s.array(s.object({ title: s.string() })).render({
-      as: "list",
-      select: ({ val }) => ({ title: val.title }),
-    }),
+    "/previewed.val.ts",
+    s
+      .array(s.object({ title: s.string() }))
+      .preview(({ val }) => ({ title: val.title })),
     [{ title: "one" }, { title: "two" }],
+  );
+};
+
+/**
+ * A module whose only `render` is a string layout hint.
+ *
+ * A render is static config carried by the SERIALIZED schema, so this module has
+ * nothing for the host to compute — see `declaresPreview`, which deliberately
+ * has no `string` arm.
+ */
+const stringRendered = () => {
+  const { c, s } = initVal();
+  return c.define(
+    "/stringRendered.val.ts",
+    s.object({ body: s.string().render({ as: "textarea" }) }),
+    { body: "hello" },
   );
 };
 
@@ -61,7 +77,7 @@ describe("cost of intake", () => {
     expect(activity.count("schema:receive")).toBe(1);
 
     // Lazy is the point: intake marks things stale and computes nothing.
-    expect(activity.count("host:execute-render")).toBe(0);
+    expect(activity.count("host:execute-preview")).toBe(0);
     expect(activity.count("validation:schema-validate")).toBe(0);
     expect(activity.count("host:execute-validate")).toBe(0);
     expect(activity.count("search:build-index")).toBe(0);
@@ -96,7 +112,7 @@ describe("cost of one keystroke", () => {
     expect(activity.count("source:wake-listener", { since: before })).toBe(1);
 
     // Nothing else in the system may do work on a keystroke.
-    expect(activity.count("host:execute-render", { since: before })).toBe(0);
+    expect(activity.count("host:execute-preview", { since: before })).toBe(0);
     expect(
       activity.count("validation:schema-validate", { since: before }),
     ).toBe(0);
@@ -195,8 +211,8 @@ describe("cost of one keystroke", () => {
     expect(activity.count("source:apply-patch", { since: before })).toBe(40);
     expect(activity.count("source:clone-module", { since: before })).toBe(40);
     expect(activity.count("source:wake-listener", { since: before })).toBe(40);
-    // The whole point of lazy: 40 keystrokes, zero renders, zero validations.
-    expect(activity.count("host:execute-render", { since: before })).toBe(0);
+    // The whole point of lazy: 40 keystrokes, zero previews, zero validations.
+    expect(activity.count("host:execute-preview", { since: before })).toBe(0);
     expect(
       activity.count("validation:schema-validate", { since: before }),
     ).toBe(0);
@@ -270,62 +286,89 @@ describe("cost of reading", () => {
   });
 
   /**
-   * CLAIM (`RenderStore`): "In-flight requests, so N fields asking at once
+   * CLAIM (`PreviewStore`): "In-flight requests, so N fields asking at once
    * produce ONE host call", and one request "fills the cache for every path in
    * the module".
    */
-  it("renders a module once for concurrent readers of different paths", async () => {
-    const { sourceStore, renderStore, activity, dispose } = initTestSystem();
+  it("previews a module once for concurrent readers of different paths", async () => {
+    const { sourceStore, previewStore, activity, dispose } = initTestSystem();
 
-    await sourceStore.testReceive([rendered()]);
+    await sourceStore.testReceive([previewed()]);
     const before = activity.position();
 
     await Promise.all([
-      renderStore.get(sp("/rendered.val.ts?p=0")),
-      renderStore.get(sp("/rendered.val.ts?p=1")),
-      renderStore.get(sp("/rendered.val.ts?p=0")),
+      previewStore.get(sp("/previewed.val.ts?p=0")),
+      previewStore.get(sp("/previewed.val.ts?p=1")),
+      previewStore.get(sp("/previewed.val.ts?p=0")),
     ]);
 
-    expect(activity.count("host:execute-render", { since: before })).toBe(1);
+    expect(activity.count("host:execute-preview", { since: before })).toBe(1);
     dispose();
   });
 
   /**
-   * CLAIM (`SchemaStore.declaresRender`): a module that cannot render is never
-   * sent to the host to be rendered.
+   * CLAIM (`SchemaStore.declaresPreview`): a module that cannot preview is never
+   * sent to the host to be previewed.
    *
    * Measured, not guessed: mounting 260 fields across 141 modules in Chromium
-   * spent ~2.3ms of 3.1ms inside `executeRender` on modules that returned an
-   * empty result. In a real project most modules declare no render, so most of
+   * spent ~2.3ms of 3.1ms inside `executePreview` on modules that returned an
+   * empty result. In a real project most modules declare no preview, so most of
    * that work was provably wasted.
    */
-  it("never asks the host to render a module that declares no render", async () => {
-    const { sourceStore, renderStore, activity, listeners, dispose } =
+  it("never asks the host to preview a module that declares no preview", async () => {
+    const { sourceStore, previewStore, activity, listeners, dispose } =
       initTestSystem();
 
     await sourceStore.testReceive([blogs(), authors()]);
-    // Both routes to a render: a field mounting, and a caller asking.
+    // Both routes to a preview: a field mounting, and a caller asking.
     listeners.set('/blogs.val.ts?p="title"');
-    const read = await renderStore.get(sp('/blogs.val.ts?p="title"'));
+    const read = await previewStore.get(sp('/blogs.val.ts?p="title"'));
 
-    expect(activity.count("host:execute-render")).toBe(0);
+    expect(activity.count("host:execute-preview")).toBe(0);
     // And the answer is the same one the host would have produced from an empty
-    // render, so nothing downstream can tell the difference.
-    expect(read.status).toBe("no-render-at-path");
+    // preview, so nothing downstream can tell the difference.
+    expect(read.status).toBe("no-preview-at-path");
     dispose();
   });
 
-  it("serves a second render read from cache", async () => {
-    const { sourceStore, renderStore, activity, dispose } = initTestSystem();
+  /**
+   * CLAIM (the preview/render split): a string's `render` is not a preview, so a
+   * module whose only declaration is one never reaches the host at all.
+   *
+   * This is what `declaresPreview` dropping its `string` arm buys, and nothing
+   * else would catch it being put back: the layout is read off the serialized
+   * schema where the field is drawn, so restoring the arm would cost a
+   * whole-module walk per such module and change nothing on screen.
+   */
+  it("never asks the host to preview a module whose only render is a string layout", async () => {
+    const { sourceStore, previewStore, activity, listeners, dispose } =
+      initTestSystem();
 
-    await sourceStore.testReceive([rendered()]);
-    await renderStore.get(sp("/rendered.val.ts?p=0"));
+    await sourceStore.testReceive([stringRendered()]);
+    listeners.set('/stringRendered.val.ts?p="body"');
+    const read = await previewStore.get(sp('/stringRendered.val.ts?p="body"'));
+
+    expect(activity.count("host:execute-preview")).toBe(0);
+    // `peek` names the reason — the schema declares none — while `get` answers
+    // as it would for any path the host had nothing for.
+    expect(
+      previewStore.peek(sp('/stringRendered.val.ts?p="body"')).status,
+    ).toBe("no-preview");
+    expect(read.status).toBe("no-preview-at-path");
+    dispose();
+  });
+
+  it("serves a second preview read from cache", async () => {
+    const { sourceStore, previewStore, activity, dispose } = initTestSystem();
+
+    await sourceStore.testReceive([previewed()]);
+    await previewStore.get(sp("/previewed.val.ts?p=0"));
 
     const before = activity.position();
-    await renderStore.get(sp("/rendered.val.ts?p=0"));
+    await previewStore.get(sp("/previewed.val.ts?p=0"));
 
-    expect(activity.count("host:execute-render", { since: before })).toBe(0);
-    expect(activity.count("render:cache-hit", { since: before })).toBe(1);
+    expect(activity.count("host:execute-preview", { since: before })).toBe(0);
+    expect(activity.count("preview:cache-hit", { since: before })).toBe(1);
     dispose();
   });
 });

--- a/packages/ui/spa/stores/architecture.md
+++ b/packages/ui/spa/stores/architecture.md
@@ -29,12 +29,16 @@ proportional to the edited field instead of to the project.
 ## Two realms, and the line between them is drawn by closures
 
 The constraint that decides the whole layout: **`Schema` instances carry the
-user's `select`, `render` and custom `validate` closures, and closures cannot be
+user's `preview` and custom `validate` closures, and closures cannot be
 structured-cloned.** So anything that has to _execute_ one must sit next to one.
 
-`executeRender` and custom `validate` both need an instance **and** the patched
+`executePreview` and custom `validate` both need an instance **and** the patched
 source. Therefore patched source lives in the host realm too — otherwise every
-render would ship a module across a thread boundary, and `handboka` is 129 KB.
+preview would ship a module across a thread boundary, and `handboka` is 129 KB.
+
+(A string's `render` is not in this group. It is static config with no closure
+behind it, so it serializes and travels with the schema — see
+`core/src/render.ts`.)
 
 ```
 HOST REALM (main thread)                      WORKER REALM
@@ -44,7 +48,7 @@ source    ── patched source  ◄── read         patch sets  ── group
 schema    ── serialized schemas               (schema validation)
 patch     ── chain + head
 stat      ── server truth
-render    ── routes to host
+preview   ── routes to host
 validation── schema half → worker seam
              custom half → host seam
                               │
@@ -96,9 +100,9 @@ realm** but come from **different bundles**, each with its own copy of
 
 - Nothing may use `instanceof Schema` across it — the class identities differ.
   `extractValModules` already documents this; bracket access to
-  `executeSerialize` / `executeRender` / `executeValidate` is the contract.
+  `executeSerialize` / `executePreview` / `executeValidate` is the contract.
 - **No clone is involved**, because no thread is crossed. `HostBridge` is async
-  anyway, so an expensive `executeRender` can be deferred rather than blocking
+  anyway, so an expensive `executePreview` can be deferred rather than blocking
   whoever asked — and so the seam survives if it ever does become a real
   boundary.
 
@@ -122,41 +126,41 @@ realm** but come from **different bundles**, each with its own copy of
                 │      │──────────────►│  source  │  │              │
                 └──────┘               └────┬─────┘  │              ▼
                    ▲                        │        │        ┌──────────┐
-      render ──────┘  executeRender         │        │        │  search  │ (worker)
+     preview ──────┘  executePreview        │        │        │  search  │ (worker)
       customValidate  executeValidate       │        ├── push ►└──────────┘
                    ▲                        │        │        ┌──────────┐
                    │                        │        └── push ►│references│ (worker)
                    │                        │                 └──────────┘
                    │                        ▼
               ┌────┴─────┐        per-path field events
-              │ render   │        (external-patch / internal-patch)
+              │ preview  │        (external-patch / internal-patch)
               │validation│                 │
               └──────────┘                 ▼
                                   hooks / web components
 ```
 
-## Render and validation are ROUTERS, not computers
+## Preview and validation are ROUTERS, not computers
 
 Both own everything _around_ the work — the cache, the staleness, the events,
 the per-path lookup — and route the work itself outward.
 
-### Render store
+### Preview store
 
-`executeRender` runs the user's `render({ as, select })` closures, so only the
-host can do it. The store's API is **per-path** (`get(path)`); underneath,
-`executeRender` takes a whole module and returns
-`ReifiedRender = Record<SourcePath, WithStatus<RenderTypes>>`, so one request
+`executePreview` runs the user's `preview()` closures, so only the host can do
+it. The store's API is **per-path** (`get(path)`); underneath, `executePreview`
+takes a whole module and returns
+`ReifiedPreview = Record<SourcePath, WithStatus<PreviewTypes>>`, so one request
 fills the cache for every path in the module.
 
-The per-path interface is the point: making renders genuinely path-scoped needs a
-new entry point in `packages/core`, and when it lands it lands behind this
+The per-path interface is the point: making previews genuinely path-scoped needs
+a new entry point in `packages/core`, and when it lands it lands behind this
 signature with no caller changing.
 
-**What this does and does not fix.** Today renders are computed eagerly, per
+**What this does and does not fix.** Today previews are computed eagerly, per
 module, on every keystroke. This makes them lazy, cached, and de-duplicated
 (concurrent readers of one module share a single host call). It does **not** fix
-the worst case: `handboka` has `select` at two nested array levels, so one
-request still walks every chapter and section. Lazy + cached turns that from
+the worst case: `handboka` previews at two nested array levels, so one request
+still walks every chapter and section. Lazy + cached turns that from
 per-keystroke into per-change-then-read. Only path-scoping turns it into
 per-visible-row.
 
@@ -187,23 +191,23 @@ has no instance for the module, `customValidateStatus: "unavailable"` is reporte
 rather than the custom half being silently dropped — a green module that was
 never fully checked is worse than an honest gap.
 
-## Lazy is the point, for render, validation and search
+## Lazy is the point, for preview, validation and search
 
 All three react to a change by marking modules **stale** and saying so
-(`render:invalidate`, `validation:invalidate`, `search:invalidate`), computing
+(`preview:invalidate`, `validation:invalidate`, `search:invalidate`), computing
 nothing. Work happens when someone asks.
 
 Typing 40 characters into one field costs 40 set-inserts and **zero** validations
-and **zero** renders, against one validation round-trip _and_ one whole-module
-render _per keystroke_ today.
+and **zero** previews, against one validation round-trip _and_ one whole-module
+preview _per keystroke_ today.
 
 All three also only **announce** staleness when it is news — when something
 cached actually went stale. Without that rule, intake alone emits an invalidate
 per module per store and the signal that matters drowns in it.
 
-## Render and search run for what is being looked at
+## Preview and search run for what is being looked at
 
-Neither may run because something CHANGED. The demand signal for a render is **a
+Neither may run because something CHANGED. The demand signal for a preview is **a
 listener existing at a path**; for search it is **a query**.
 
 A listener is the system's own record that a field is on screen showing a path,
@@ -213,26 +217,27 @@ speculative or already-unmounted caller can do that too.
 
 Two moments, and the distinction between them is load-bearing:
 
-- **Demand arriving** — a field mounts, so `source:listen` fires and the render
-  is computed then. This is the "user clicks to a path that needs a render" case.
+- **Demand arriving** — a field mounts, so `source:listen` fires and the preview
+  is computed then. This is the "user clicks to a path that needs a preview" case.
 - **Demand disturbed** — the source changed under a field. This only MARKS.
-  Recomputing here would cost one whole-module render per keystroke, which is the
+  Recomputing here would cost one whole-module preview per keystroke, which is the
   cost this design exists to remove. Nothing is lost by waiting, because the same
   call that changed the source wakes the fields on the affected paths, and a
   woken field re-reads — so the following read pays once, however many changes
   preceded it.
 
-Demand leaving (`source:unlisten`) drops the module's cached render, so a module
-nobody is looking at cannot be re-rendered by a later change to it.
+Demand leaving (`source:unlisten`) drops the module's cached preview, so a module
+nobody is looking at cannot be recomputed by a later change to it.
 
-And the render itself is now scoped to the demand, not just triggered by it.
-`RenderScope` (in `packages/core`) is passed to `executeRender`, so a listener on
-one row of a list costs one `select` call instead of one per row; a request for
-the CONTAINER still renders every row, because a list view needs all of them.
-The cache entry carries the scope it was computed at — a render scoped to one row
-answers for that row and nothing else, and serving it elsewhere would be wrong
-rather than merely slow. See `openquestions.md` item 3 for the full reasoning,
-including why `ListArrayRender.items` had to start carrying its indices.
+And the preview itself is now scoped to the demand, not just triggered by it.
+`PreviewScope` (in `packages/core`) is passed to `executePreview`, so a listener
+on one row of a list costs one closure call instead of one per row; a request for
+the CONTAINER still previews every row, because a list view needs all of them.
+The cache entry carries the scope it was computed at — a preview scoped to one
+row answers for that row and nothing else, and serving it elsewhere would be
+wrong rather than merely slow. See `openquestions.md` item 3 for the full
+reasoning, including why `ArrayPreview.items` had to start carrying its
+indices.
 
 Patch sets follow the same rule for a different reason: they are built from the
 chain when the review UI asks, not accumulated per patch. The store always said
@@ -256,7 +261,7 @@ custom-validate walk) asks for the same thing.
 
 **The read is the demand signal, and the read WAITS.** A read at a path inside an
 unloaded entry is exactly the moment the content is wanted — the same rule as a
-render being computed when a listener appears. `get` triggers the fetch, awaits
+preview being computed when a listener appears. `get` triggers the fetch, awaits
 it, re-resolves once and answers with the content:
 
 - it must NOT answer `absent`, which is the trap the `absent` / `module-loading`
@@ -551,9 +556,9 @@ _before its cause_, and a ledger reading `validation:invalidate` then
 | `host`       | host   | the real `Schema` instances; intake                 | The only thing that may hold a closure. It defines the edge of what can be threaded, and it is the entry point, mirroring `setValModules`.                                                                                                                           |
 | `stat`       | host   | what the server says exists (patch **ids**, no ops) | The only store with an outside input. Keeping ops out of it is what makes `external-partial` a real state rather than a fiction.                                                                                                                                     |
 | `patch`      | host   | the linear chain, origins, which ids have data      | Knows a patch _exists_; the source store knows whether it _landed_. The head is where those two facts meet, so neither can compute it alone.                                                                                                                         |
-| `schema`     | host   | serialized schemas                                  | Own change sources (`/schema`, HMR swapping a schema under existing source) and own consumers (validation, render, search). Today they merely happen to arrive with source.                                                                                          |
-| `source`     | host   | patched source **and** the listener registry        | Invariant 1 requires them together. In the host realm because renders need it without a clone.                                                                                                                                                                       |
-| `render`     | host   | reified renders, cached and lazy                    | Owns caching/staleness so the host is asked once per change, not once per field per keystroke.                                                                                                                                                                       |
+| `schema`     | host   | serialized schemas                                  | Own change sources (`/schema`, HMR swapping a schema under existing source) and own consumers (validation, preview, search). Today they merely happen to arrive with source.                                                                                         |
+| `source`     | host   | patched source **and** the listener registry        | Invariant 1 requires them together. In the host realm because previews need it without a clone.                                                                                                                                                                      |
+| `preview`    | host   | reified previews, cached and lazy                   | Owns caching/staleness so the host is asked once per change, not once per field per keystroke.                                                                                                                                                                       |
 | `validation` | host   | errors and their staleness                          | Coordinates the two-seam split above; neither seam can own the merge.                                                                                                                                                                                                |
 | `patch sets` | worker | patches grouped into reviewable units               | Answers _"what are the units of change?"_ — coalesced across many patches, only when the review UI is open, and INCREMENTALLY: a read after one keystroke inserts one patch, not the chain. The source store answers _"who do I wake?"_ — exact, now, per keystroke. |
 | `search`     | worker | the full-text index                                 | The most expensive walk in the system, so it must never be a side effect of an edit.                                                                                                                                                                                 |
@@ -589,7 +594,7 @@ plus
 - a fake patch server behind the real `fetchPatches` seam, deliberately async so
   no store can come to depend on the fetch resolving synchronously;
 - the **host store** itself, so a test drives intake the way the app does and can
-  assert that a render or a custom validator really reached an instance.
+  assert that a preview or a custom validator really reached an instance.
 
 `noMessages()` waits for the pipeline to quiesce _before_ asserting. Asserting
 immediately would pass for a system that had not started yet — the most
@@ -600,9 +605,9 @@ should look like:
 
 ```
 host:receive → schema:init → source:init → search:invalidate
-→ render:result → validation:result → search:build-index
+→ preview:result → validation:result → search:build-index
 → patch:create → source:patch-apply → patch:head
-→ render:invalidate → validation:invalidate → search:invalidate
+→ preview:invalidate → validation:invalidate → search:invalidate
 → patch-set:update
 ```
 
@@ -671,7 +676,7 @@ Every cost claim above is an invocation COUNT asserted in node, and a count
 cannot say whether the thing it counted takes 20 microseconds or 20
 milliseconds. `../bench/` closes that: both systems run in a real Chromium, and
 the unit of measurement is **a field becoming ready** — source, validation and
-render in hand — because timing `addPatch` against `createPatch` would time the
+preview in hand — because timing `addPatch` against `createPatch` would time the
 eager system doing all the work and the lazy system doing none of it. See
 `bench/README.md` for the fairness contract and `openquestions.md` item 1 for the
 numbers, the provenance, and the corrections.
@@ -688,7 +693,7 @@ non-overlapping ranges:
 
 | scenario                          | engine  | stores  |           |
 | --------------------------------- | ------- | ------- | --------- |
-| keystroke into a rendered list    | 18.3 ms | 0.4 ms  | **45.7x** |
+| keystroke into a previewed list   | 18.3 ms | 0.4 ms  | **45.7x** |
 | mount                             | 17.5 ms | 0.4 ms  | **43.8x** |
 | keystroke                         | 17.0 ms | 0.4 ms  | **42.5x** |
 | nested-row (the `handboka` shape) | 17.9 ms | 0.9 ms  | **19.9x** |
@@ -713,9 +718,9 @@ keeping the harness rather than treating it as a one-off:
 
 - `listenedPaths` walked the whole listener registry, making a mount
   O(fields x modules). Now indexed per module.
-- Mounting rendered every module, spending most of its time inside
-  `executeRender` on modules that declare no render. `SerializedSchema` carries
-  `render?: true` and `SchemaStore.declaresRender` answers from the schema.
+- Mounting previewed every module, spending most of its time inside
+  `executePreview` on modules that declare no preview. `SerializedSchema` carries
+  `preview?: true` and `SchemaStore.declaresPreview` answers from the schema.
 - **The listener scan was O(all registered paths) per patch.** The comment in
   `applyEntries` said exactly that while the design promised cost proportional to
   affected fields — and on a 1202-field mount a 40-key burst made the stores
@@ -740,10 +745,10 @@ Unfinished work, as distinct from the undecided questions in
 [`openquestions.md`](./openquestions.md). Named so they are not mistaken for
 finished work.
 
-- ~~**Renders are not path-scoped.**~~ **Done.** `RenderScope` in
-  `packages/core` is threaded through every `executeRender`, so a listener on one
-  row of a list costs one `select` call rather than one per row, and a nested list
-  prunes the sibling subtrees. A request for a CONTAINER still renders all of it,
+- ~~**Previews are not path-scoped.**~~ **Done.** `PreviewScope` in
+  `packages/core` is threaded through every `executePreview`, so a listener on one
+  row of a list costs one closure call rather than one per row, and a nested list
+  prunes the sibling subtrees. A request for a CONTAINER still previews all of it,
   because a list view needs every row. See `openquestions.md` item 3.
 - ~~**No references store.**~~ **Done.** See below.
 - ~~**No rebase.**~~ **Done.** The source store now keeps base source and the
@@ -818,9 +823,9 @@ finished work.
 
   Writing them found four bugs no store-level test could see, because all four are
   about what a SUBSCRIBER is told rather than what a reader is returned:
-  `ValidationStore.peek` and `RenderStore.peek` built fresh result objects per
-  call and so looped `useSyncExternalStore` to React's abort; `RenderStore.peek`
-  answered `no-render` for three different situations, so a caller could not tell
+  `ValidationStore.peek` and `PreviewStore.peek` built fresh result objects per
+  call and so looped `useSyncExternalStore` to React's abort; `PreviewStore.peek`
+  answered `no-preview` for three different situations, so a caller could not tell
   whether asking would help; `SourceStore.receive` bumped every revision and told
   no listener, so a field mounted before its module arrived rendered `loading`
   forever — the normal startup order; and `PatchSync` changed its state without
@@ -833,13 +838,13 @@ finished work.
   `e2e/studio-ui.spec.ts` drives the result by clicking and typing, which is the
   only thing that can check hooks whose signatures did not change.
 
-- ~~**Only the source/patch/stat path is tested.**~~ Host, render, validation,
+- ~~**Only the source/patch/stat path is tested.**~~ Host, preview, validation,
   search and patch sets are now covered: `systemFlow` (one session-order flow),
   `systemInvariants` (one claim per test), `activityCost` (how many times each
-  expensive thing runs), `demandDriven` (render and search only run for what is
+  expensive thing runs), `demandDriven` (preview and search only run for what is
   being looked at).
 - ~~**Unmeasured in a browser.**~~ **Done.** Work COUNTS are asserted in node via
-  the activity channel — see `activity.ts` — which is what caught render being put
+  the activity channel — see `activity.ts` — which is what caught previews being put
   back on the keystroke path. Durations are measured in a real Chromium by
   [`../bench/`](../bench/README.md), which is also where the engine's last numbers
   are recorded: keystroke 10.6 ms → 0.40 ms, `select` on the nested-row case 650 →

--- a/packages/ui/spa/stores/bridges.ts
+++ b/packages/ui/spa/stores/bridges.ts
@@ -1,6 +1,6 @@
 import type {
   ModuleFilePath,
-  ReifiedRender,
+  ReifiedPreview,
   SerializedSchema,
   Source,
   SourcePath,
@@ -22,9 +22,9 @@ import type {
  * Consequences, both load-bearing:
  * - Nothing may use `instanceof Schema` across it — the class identities differ.
  *   `extractValModules` already documents this; bracket access to
- *   `executeSerialize` / `executeRender` is the contract instead.
+ *   `executeSerialize` / `executePreview` is the contract instead.
  * - No clone is involved, because no thread is crossed. It is async anyway, so
- *   an expensive `executeRender` can be deferred or yielded rather than blocking
+ *   an expensive `executePreview` can be deferred or yielded rather than blocking
  *   whoever asked.
  *
  * The host can never move into a worker: it holds the user's `select` and
@@ -45,8 +45,8 @@ import type {
  * running inside arbitrary customer apps cannot require.
  */
 
-export type HostRenderResult =
-  | { status: "rendered"; render: ReifiedRender }
+export type HostPreviewResult =
+  | { status: "previewed"; preview: ReifiedPreview }
   /** The host has no instance for this module (not loaded, or not a val module). */
   | { status: "unknown-module" }
   | { status: "error"; message: string };
@@ -57,7 +57,7 @@ export type HostCustomValidateResult =
   | { status: "error"; message: string };
 
 /**
- * What the render and validation stores are allowed to ask the host for.
+ * What the preview and validation stores are allowed to ask the host for.
  *
  * Deliberately narrow: exactly the two operations that cannot be done without
  * the real `Schema` instances. Everything else those stores do — caching,
@@ -66,18 +66,18 @@ export type HostCustomValidateResult =
  *
  * No `source` parameter: the host reads patched source directly, because the
  * source store is in the host realm. That is the whole point of putting it
- * there — a `source` argument here would be a 129 KB copy per render.
+ * there — a `source` argument here would be a 129 KB copy per preview.
  */
 export interface HostBridge {
   /**
-   * @param only The paths a render is actually wanted for. Omitting it renders
+   * @param only The paths a preview is actually wanted for. Omitting it previews
    * the whole module, which is what a whole-list view wants; passing the visible
-   * paths is what makes one row cost one `select` call. See `RenderScope`.
+   * paths is what makes one row cost one closure call. See `PreviewScope`.
    */
-  render(
+  preview(
     moduleFilePath: ModuleFilePath,
     only?: readonly SourcePath[],
-  ): Promise<HostRenderResult>;
+  ): Promise<HostPreviewResult>;
   customValidate(
     moduleFilePath: ModuleFilePath,
     paths: SourcePath[],

--- a/packages/ui/spa/stores/createSystem.ts
+++ b/packages/ui/spa/stores/createSystem.ts
@@ -23,7 +23,7 @@ import { StatStore } from "./StatStore";
 import { StatusStore } from "./StatusStore";
 import { PatchSync, type ResyncChain, type SavePatches } from "./PatchSync";
 import { HostStore } from "./HostStore";
-import { RenderStore } from "./RenderStore";
+import { PreviewStore } from "./PreviewStore";
 import { PatchSetStore, type PatchSetRequest } from "./PatchSetStore";
 import { PatchSetChain, type PatchSetPlan } from "./PatchSetChain";
 import type { PatchErrorEntry, PatchRecord } from "./types";
@@ -117,7 +117,7 @@ export type HostRealm = {
    * and because a retry timer has to live where the chain does.
    */
   patchSync: PatchSync;
-  renderStore: RenderStore;
+  previewStore: PreviewStore;
   validationStore: ValidationStore;
 };
 
@@ -419,7 +419,7 @@ export function createSystem(options: SystemOptions): System {
   patchStore.setParentRefSource(() => patchSync.currentParentRef());
   const host = new HostStore(schemaStore, sourceStore, activity);
   const hostBridge = options.hostBridge ?? host;
-  const renderStore = new RenderStore(
+  const previewStore = new PreviewStore(
     hostBridge,
     sourceStore,
     schemaStore,
@@ -757,7 +757,7 @@ export function createSystem(options: SystemOptions): System {
       // else would retry it: `patch:create` already fired and found no base.
       void patchSync.flush();
     }),
-    renderStore.listenTo(),
+    previewStore.listenTo(),
     validationStore.listenTo(),
 
     /**
@@ -957,7 +957,7 @@ export function createSystem(options: SystemOptions): System {
     sourceStore,
     patchStore,
     patchSync,
-    renderStore,
+    previewStore,
     validationStore,
     searchStore,
     patchSetStore,

--- a/packages/ui/spa/stores/demandDriven.test.ts
+++ b/packages/ui/spa/stores/demandDriven.test.ts
@@ -2,11 +2,11 @@ import { initVal } from "@valbuild/core";
 import { initTestSystem, mfp, sp } from "./testSystem";
 
 /**
- * Render and search are the two most expensive things in the system, and neither
+ * Preview and search are the two most expensive things in the system, and neither
  * should ever run because something CHANGED. They should run because someone is
  * looking.
  *
- * The demand signal for a render is a listener existing at a path — not a caller
+ * The demand signal for a preview is a listener existing at a path — not a caller
  * happening to invoke `get()`. That distinction is the whole point: `get()` is a
  * caller choosing to pay, so nothing stops a speculative or unmounted caller
  * paying for a whole module. A registered listener is the system's own record of
@@ -17,10 +17,10 @@ import { initTestSystem, mfp, sp } from "./testSystem";
  *
  * Tests marked SPEC describe wiring that does not exist yet and are expected to
  * fail. Tests marked GUARD pass today and are here so that satisfying a SPEC
- * cannot be done by simply rendering more.
+ * cannot be done by simply previewing more.
  */
 
-/** A module whose render counts how many items `select` was run over. */
+/** A module whose preview counts how many items the closure was run over. */
 function listModule(itemCount: number): {
   module: ReturnType<ReturnType<typeof initVal>["c"]["define"]>;
   selectCalls: () => number;
@@ -32,12 +32,9 @@ function listModule(itemCount: number): {
   }));
   const module = c.define(
     "/list.val.ts",
-    s.array(s.object({ title: s.string() })).render({
-      as: "list",
-      select: ({ val }) => {
-        calls++;
-        return { title: val.title };
-      },
+    s.array(s.object({ title: s.string() })).preview(({ val }) => {
+      calls++;
+      return { title: val.title };
     }),
     items,
   );
@@ -49,9 +46,9 @@ function plainModule(path: string) {
   return c.define(path, s.object({ title: s.string() }), { title: "Hello" });
 }
 
-describe("render is driven by demand, not by change", () => {
-  /** GUARD: nothing renders on its own. */
-  it("does not render a module nobody is listening to", async () => {
+describe("preview is driven by demand, not by change", () => {
+  /** GUARD: nothing previews on its own. */
+  it("does not preview a module nobody is listening to", async () => {
     const { sourceStore, patchStore, activity, dispose } = initTestSystem();
     const { module } = listModule(3);
 
@@ -62,35 +59,35 @@ describe("render is driven by demand, not by change", () => {
       ]);
     }
 
-    expect(activity.count("host:execute-render")).toBe(0);
+    expect(activity.count("host:execute-preview")).toBe(0);
     dispose();
   });
 
   /**
-   * SPEC: a listener appearing at a path is what asks for the render.
+   * SPEC: a listener appearing at a path is what asks for the preview.
    *
-   * This is the "user clicks to a path that needs a render" case. Nobody calls
+   * This is the "user clicks to a path that needs a preview" case. Nobody calls
    * `get()` here — a field mounted, and that alone should be enough for the
-   * render to be ready when it looks.
+   * preview to be ready when it looks.
    */
-  it("renders when a listener appears at a path", async () => {
-    const { sourceStore, renderStore, activity, listeners, ledger, dispose } =
+  it("previews when a listener appears at a path", async () => {
+    const { sourceStore, previewStore, activity, listeners, ledger, dispose } =
       initTestSystem();
     const { module } = listModule(3);
 
     await sourceStore.testReceive([module]);
-    expect(activity.count("host:execute-render")).toBe(0);
+    expect(activity.count("host:execute-preview")).toBe(0);
 
     listeners.set("/list.val.ts?p=1");
 
     await ledger.has({
-      type: "render:result",
+      type: "preview:result",
       moduleFilePath: "/list.val.ts",
     });
-    expect(activity.count("host:execute-render")).toBe(1);
-    // `peek` never triggers work, so this asserts the render is genuinely ready
+    expect(activity.count("host:execute-preview")).toBe(1);
+    // `peek` never triggers work, so this asserts the preview is genuinely ready
     // rather than merely obtainable.
-    expect(renderStore.peek(sp("/list.val.ts?p=1")).status).toBe("rendered");
+    expect(previewStore.peek(sp("/list.val.ts?p=1")).status).toBe("previewed");
     dispose();
   });
 
@@ -99,7 +96,7 @@ describe("render is driven by demand, not by change", () => {
    *
    * Deliberately not "the change recomputes". An earlier draft of this test
    * asserted that, and the 40-keystroke guard in `activityCost.test.ts` caught
-   * it immediately: recomputing on change costs one whole-module render per
+   * it immediately: recomputing on change costs one whole-module preview per
    * keystroke, which is the exact cost this design exists to remove. A change
    * marks; demand computes. Nothing is lost, because the change wakes the
    * fields on the affected paths and a woken field re-reads.
@@ -108,7 +105,7 @@ describe("render is driven by demand, not by change", () => {
     const {
       sourceStore,
       patchStore,
-      renderStore,
+      previewStore,
       activity,
       listeners,
       dispose,
@@ -117,7 +114,7 @@ describe("render is driven by demand, not by change", () => {
 
     await sourceStore.testReceive([module]);
     listeners.set("/list.val.ts?p=1");
-    await renderStore.get(sp("/list.val.ts?p=1"));
+    await previewStore.get(sp("/list.val.ts?p=1"));
 
     const beforeEdits = activity.position();
     for (let index = 0; index < 3; index++) {
@@ -126,29 +123,29 @@ describe("render is driven by demand, not by change", () => {
       ]);
     }
     // Three changes, no reads: nothing recomputed.
-    expect(activity.count("host:execute-render", { since: beforeEdits })).toBe(
+    expect(activity.count("host:execute-preview", { since: beforeEdits })).toBe(
       0,
     );
 
     const beforeRead = activity.position();
-    await renderStore.get(sp("/list.val.ts?p=1"));
-    // One read, one render, covering all three changes.
-    expect(activity.count("host:execute-render", { since: beforeRead })).toBe(
+    await previewStore.get(sp("/list.val.ts?p=1"));
+    // One read, one preview, covering all three changes.
+    expect(activity.count("host:execute-preview", { since: beforeRead })).toBe(
       1,
     );
     dispose();
   });
 
   /**
-   * GUARD: the complement of the SPEC above. Re-rendering on change must be
-   * gated on demand, or "re-render what is listened to" becomes "re-render
+   * GUARD: the complement of the SPEC above. Recomputing on change must be
+   * gated on demand, or "re-preview what is listened to" becomes "re-preview
    * everything", which is the behaviour this design exists to replace.
    */
-  it("does not re-render a module whose listeners have all gone", async () => {
+  it("does not re-preview a module whose listeners have all gone", async () => {
     const {
       sourceStore,
       patchStore,
-      renderStore,
+      previewStore,
       activity,
       listeners,
       dispose,
@@ -157,7 +154,7 @@ describe("render is driven by demand, not by change", () => {
 
     await sourceStore.testReceive([module]);
     const listener = listeners.set("/list.val.ts?p=1");
-    await renderStore.get(sp("/list.val.ts?p=1"));
+    await previewStore.get(sp("/list.val.ts?p=1"));
 
     listener.unsubscribe();
     const before = activity.position();
@@ -165,13 +162,13 @@ describe("render is driven by demand, not by change", () => {
       { op: "replace", path: ["1", "title"], value: "changed" },
     ]);
 
-    expect(activity.count("host:execute-render", { since: before })).toBe(0);
+    expect(activity.count("host:execute-preview", { since: before })).toBe(0);
     dispose();
   });
 
   /** GUARD: demand in one module never pays for another. */
-  it("does not render a module because another one is listened to", async () => {
-    const { sourceStore, renderStore, activity, listeners, dispose } =
+  it("does not preview a module because another one is listened to", async () => {
+    const { sourceStore, previewStore, activity, listeners, dispose } =
       initTestSystem();
 
     await sourceStore.testReceive([
@@ -179,10 +176,10 @@ describe("render is driven by demand, not by change", () => {
       plainModule("/b.val.ts"),
     ]);
     listeners.set('/a.val.ts?p="title"');
-    await renderStore.get(sp('/a.val.ts?p="title"'));
+    await previewStore.get(sp('/a.val.ts?p="title"'));
 
     expect(
-      activity.count("host:execute-render", { subject: "/b.val.ts" }),
+      activity.count("host:execute-preview", { subject: "/b.val.ts" }),
     ).toBe(0);
     dispose();
   });
@@ -191,20 +188,20 @@ describe("render is driven by demand, not by change", () => {
    * One listener, on one row of a three-row list. `select` is the user's own
    * closure and the actual expense — `handboka` has it at two nested array
    * levels — so counting `select` invocations is the only honest measure of
-   * whether a render is path-scoped.
+   * whether a preview is path-scoped.
    *
-   * This was `it.failing` while renders were whole-module: it ran 3 times to
-   * serve 1 listened row. `RenderScope` is what closed it — `ArraySchema`'s list
-   * render is now WINDOWED, carrying only the rows that were asked for, which is
-   * why `ListArrayRender.items` pairs each item with its index.
+   * This was `it.failing` while previews were whole-module: it ran 3 times to
+   * serve 1 listened row. `PreviewScope` is what closed it — `ArraySchema`'s
+   * preview is now WINDOWED, carrying only the rows that were asked for, which is
+   * why `ArrayPreview.items` pairs each item with its index.
    */
   it("runs select only for the path being listened to", async () => {
-    const { sourceStore, renderStore, listeners, dispose } = initTestSystem();
+    const { sourceStore, previewStore, listeners, dispose } = initTestSystem();
     const { module, selectCalls } = listModule(3);
 
     await sourceStore.testReceive([module]);
     listeners.set("/list.val.ts?p=1");
-    await renderStore.get(sp("/list.val.ts?p=1"));
+    await previewStore.get(sp("/list.val.ts?p=1"));
 
     expect(selectCalls()).toBe(1);
     dispose();
@@ -216,68 +213,68 @@ describe("render is driven by demand, not by change", () => {
    * A list VIEW asks for the container, and it needs every row — a windowed
    * answer there would be a list with rows missing. So `wants(containerPath)`
    * means the whole list, and only a request for descendants alone windows it.
-   * Without this the fix for the test above would just be "render less", which
+   * Without this the fix for the test above would just be "preview less", which
    * breaks the screen that renders lists.
    */
   it("runs select for every row when the list itself is what is asked for", async () => {
-    const { sourceStore, renderStore, listeners, dispose } = initTestSystem();
+    const { sourceStore, previewStore, listeners, dispose } = initTestSystem();
     const { module, selectCalls } = listModule(3);
 
     await sourceStore.testReceive([module]);
     listeners.set("/list.val.ts");
-    const read = await renderStore.get(sp("/list.val.ts"));
+    const read = await previewStore.get(sp("/list.val.ts"));
 
     expect(selectCalls()).toBe(3);
-    if (read.status !== "rendered" || read.render.status !== "success") {
-      throw new Error("expected the list to render");
+    if (read.status !== "previewed" || read.preview.status !== "success") {
+      throw new Error("expected the list to preview");
     }
-    const data = read.render.data;
-    if (data.layout !== "list" || data.parent !== "array") {
-      throw new Error("expected an array list render");
+    const data = read.preview.data;
+    if (data.parent !== "array" || data.parent !== "array") {
+      throw new Error("expected an array preview");
     }
     expect(data.items.map(([index]) => index)).toEqual([0, 1, 2]);
     dispose();
   });
 
   /**
-   * And the windowed render says WHICH rows it carries.
+   * And the windowed preview says WHICH rows it carries.
    *
-   * The reason `ListArrayRender.items` became `[index, value][]`: a windowed
-   * render is a shorter array, so a consumer reading `items[n]` positionally
+   * The reason `ArrayPreview.items` became `[index, value][]`: a windowed
+   * preview is a shorter array, so a consumer reading `items[n]` positionally
    * would silently get a different row. Carrying the index makes that
    * unrepresentable — the two call sites in the UI became lookups, and the
    * compiler pointed at both.
    */
-  it("labels a windowed list render with the indices it covers", async () => {
-    const { sourceStore, renderStore, listeners, dispose } = initTestSystem();
+  it("labels a windowed list preview with the indices it covers", async () => {
+    const { sourceStore, previewStore, listeners, dispose } = initTestSystem();
     const { module } = listModule(3);
 
     await sourceStore.testReceive([module]);
     listeners.set("/list.val.ts?p=1");
-    const read = await renderStore.get(sp("/list.val.ts?p=1"));
+    const read = await previewStore.get(sp("/list.val.ts?p=1"));
 
-    if (read.status !== "rendered" || read.render.status !== "success") {
-      throw new Error("expected a render");
+    if (read.status !== "previewed" || read.preview.status !== "success") {
+      throw new Error("expected a preview");
     }
-    const data = read.render.data;
-    if (data.layout !== "list" || data.parent !== "array") {
-      throw new Error("expected an array list render");
+    const data = read.preview.data;
+    if (data.parent !== "array" || data.parent !== "array") {
+      throw new Error("expected an array preview");
     }
     expect(data.items).toEqual([[1, { title: "item 1" }]]);
     dispose();
   });
 
   /**
-   * Two rows visible, read concurrently: ONE render, covering both.
+   * Two rows visible, read concurrently: ONE preview, covering both.
    *
-   * The case that makes scoping worth having rather than a way to render twice.
-   * A scoped render's coverage is fixed when it is issued, so a reader that
+   * The case that makes scoping worth having rather than a way to preview twice.
+   * A scoped preview's coverage is fixed when it is issued, so a reader that
    * arrives after that either gets an answer about someone else's path or needs
-   * its own render — which for a scrolling list would be one render per row.
+   * its own preview — which for a scrolling list would be one preview per row.
    * `refreshFor` collects the asked-for paths across the turn and issues once.
    */
-  it("serves concurrent readers of different rows with one render", async () => {
-    const { sourceStore, renderStore, activity, listeners, dispose } =
+  it("serves concurrent readers of different rows with one preview", async () => {
+    const { sourceStore, previewStore, activity, listeners, dispose } =
       initTestSystem();
     const { module, selectCalls } = listModule(10);
 
@@ -287,72 +284,75 @@ describe("render is driven by demand, not by change", () => {
     const before = activity.position();
 
     await Promise.all([
-      renderStore.get(sp("/list.val.ts?p=3")),
-      renderStore.get(sp("/list.val.ts?p=4")),
+      previewStore.get(sp("/list.val.ts?p=3")),
+      previewStore.get(sp("/list.val.ts?p=4")),
     ]);
 
-    // The eager render on the first `listeners.set` saw only row 3, so the reads
+    // The eager preview on the first `listeners.set` saw only row 3, so the reads
     // owe one more pass — but one, not one each, and it covers both rows.
-    expect(activity.count("host:execute-render", { since: before })).toBe(1);
+    expect(activity.count("host:execute-preview", { since: before })).toBe(1);
     // Two rows of ten. `select` ran for those two and no others.
     expect(selectCalls()).toBeLessThanOrEqual(4);
-    const read = await renderStore.get(sp("/list.val.ts?p=4"));
-    if (read.status !== "rendered" || read.render.status !== "success") {
+    const read = await previewStore.get(sp("/list.val.ts?p=4"));
+    if (read.status !== "previewed" || read.preview.status !== "success") {
       throw new Error("expected row 4 to be covered");
     }
-    const data = read.render.data;
-    if (data.layout !== "list" || data.parent !== "array") {
-      throw new Error("expected an array list render");
+    const data = read.preview.data;
+    if (data.parent !== "array" || data.parent !== "array") {
+      throw new Error("expected an array preview");
     }
     expect(data.items.map(([index]) => index)).toEqual([3, 4]);
     dispose();
   });
 
   /**
-   * SPEC: a row that scrolls into view says `needs-render`, not `rendered`.
+   * SPEC: a row that scrolls into view says `needs-preview`, not `previewed`.
    *
    * The one case where nothing else asks on the reader's behalf. A field
-   * mounting is normally what triggers the render, but `source:listen`
+   * mounting is normally what triggers the preview, but `source:listen`
    * deliberately returns early once the module has one — that is the coalescing
-   * that makes twenty mounting rows cost two renders instead of twenty — so the
+   * that makes twenty mounting rows cost two previews instead of twenty — so the
    * new row's own read is the only thing left that can widen the scope. It only
-   * reads when `peek` tells it to, and `peek` used to answer `rendered` here:
-   * the WINDOWED container render is keyed under the container, so the fallback
+   * reads when `peek` tells it to, and `peek` used to answer `previewed` here:
+   * the WINDOWED container preview is keyed under the container, so the fallback
    * found it, even though its `items` do not contain this row. The row then sat
    * with no preview until something else in the module changed.
    */
-  it("reports needs-render for a row outside the rendered scope", async () => {
-    const { sourceStore, renderStore, activity, listeners, ledger, dispose } =
+  it("reports needs-preview for a row outside the previewed scope", async () => {
+    const { sourceStore, previewStore, activity, listeners, ledger, dispose } =
       initTestSystem();
     const { module } = listModule(10);
 
     await sourceStore.testReceive([module]);
     listeners.set("/list.val.ts?p=3");
-    await ledger.has({ type: "render:result", moduleFilePath: "/list.val.ts" });
-    expect(renderStore.peek(sp("/list.val.ts?p=3")).status).toBe("rendered");
+    await ledger.has({
+      type: "preview:result",
+      moduleFilePath: "/list.val.ts",
+    });
+    expect(previewStore.peek(sp("/list.val.ts?p=3")).status).toBe("previewed");
 
-    // Row 7 scrolls into view. Its listener does NOT trigger a render, so the
+    // Row 7 scrolls into view. Its listener does NOT trigger a preview, so the
     // cached one still only covers row 3.
     const before = activity.position();
     listeners.set("/list.val.ts?p=7");
-    expect(activity.count("host:execute-render", { since: before })).toBe(0);
+    expect(activity.count("host:execute-preview", { since: before })).toBe(0);
 
-    expect(renderStore.peek(sp("/list.val.ts?p=7")).status).toBe(
-      "needs-render",
+    expect(previewStore.peek(sp("/list.val.ts?p=7")).status).toBe(
+      "needs-preview",
     );
 
-    // And asking resolves it, in one render, without leaving row 3 behind.
-    const read = await renderStore.get(sp("/list.val.ts?p=7"));
-    expect(activity.count("host:execute-render", { since: before })).toBe(1);
-    if (read.status !== "rendered" || read.render.status !== "success") {
+    // And asking resolves it, in one preview, without leaving row 3 behind.
+    const read = await previewStore.get(sp("/list.val.ts?p=7"));
+    expect(activity.count("host:execute-preview", { since: before })).toBe(1);
+    if (read.status !== "previewed" || read.preview.status !== "success") {
       throw new Error(`expected row 7 to be covered, got ${read.status}`);
     }
-    const data = read.render.data;
-    if (data.layout !== "list" || data.parent !== "array") {
-      throw new Error("expected an array list render");
+    const data = read.preview.data;
+    if (data.parent !== "array" || data.parent !== "array") {
+      throw new Error("expected an array preview");
     }
     expect(data.items.map(([index]) => index)).toEqual([3, 7]);
-    expect(renderStore.peek(sp("/list.val.ts?p=7")).status).toBe("rendered");
+    expect(previewStore.peek(sp("/list.val.ts?p=7")).status).toBe("previewed");
     dispose();
   });
 });
@@ -422,7 +422,7 @@ describe("search is driven by demand, not by change", () => {
    * SPEC: a query after an edit rebuilds, once, at the point of the query.
    *
    * The rebuild is owed to the edit but paid at the query — which is the same
-   * rule as the render: the change marks, the demand computes.
+   * rule as the preview: the change marks, the demand computes.
    */
   it("rebuilds once on the first query after an edit", async () => {
     const { sourceStore, patchStore, search, activity, dispose } =

--- a/packages/ui/spa/stores/demandDriven.test.ts
+++ b/packages/ui/spa/stores/demandDriven.test.ts
@@ -229,7 +229,7 @@ describe("preview is driven by demand, not by change", () => {
       throw new Error("expected the list to preview");
     }
     const data = read.preview.data;
-    if (data.parent !== "array" || data.parent !== "array") {
+    if (data.parent !== "array") {
       throw new Error("expected an array preview");
     }
     expect(data.items.map(([index]) => index)).toEqual([0, 1, 2]);
@@ -257,7 +257,7 @@ describe("preview is driven by demand, not by change", () => {
       throw new Error("expected a preview");
     }
     const data = read.preview.data;
-    if (data.parent !== "array" || data.parent !== "array") {
+    if (data.parent !== "array") {
       throw new Error("expected an array preview");
     }
     expect(data.items).toEqual([[1, { title: "item 1" }]]);
@@ -298,7 +298,7 @@ describe("preview is driven by demand, not by change", () => {
       throw new Error("expected row 4 to be covered");
     }
     const data = read.preview.data;
-    if (data.parent !== "array" || data.parent !== "array") {
+    if (data.parent !== "array") {
       throw new Error("expected an array preview");
     }
     expect(data.items.map(([index]) => index)).toEqual([3, 4]);
@@ -348,7 +348,7 @@ describe("preview is driven by demand, not by change", () => {
       throw new Error(`expected row 7 to be covered, got ${read.status}`);
     }
     const data = read.preview.data;
-    if (data.parent !== "array" || data.parent !== "array") {
+    if (data.parent !== "array") {
       throw new Error("expected an array preview");
     }
     expect(data.items.map(([index]) => index)).toEqual([3, 7]);

--- a/packages/ui/spa/stores/openquestions.md
+++ b/packages/ui/spa/stores/openquestions.md
@@ -22,7 +22,7 @@ it was entirely possible those bought most of the available win.
 **Answered, and it is not close.** `bench/` runs both systems in a real Chromium.
 The fairness contract is at the top of `bench/drivers.ts`; the short version is
 that the unit of measurement is **a field becoming ready** (source + validation +
-render in hand), because timing `addPatch` against `createPatch` would time the
+preview in hand), because timing `addPatch` against `createPatch` would time the
 eager system doing all the work and the lazy system doing none of it.
 
 ### First, the fixture — because it decided the answer three times
@@ -58,7 +58,7 @@ found on `page` and nowhere else — but they are not descriptions of a session.
 
 | scenario                          | engine  | stores  |                     |
 | --------------------------------- | ------- | ------- | ------------------- |
-| keystroke into a rendered list    | 18.3 ms | 0.4 ms  | **45.7x**           |
+| keystroke into a previewed list   | 18.3 ms | 0.4 ms  | **45.7x**           |
 | mount (register + first paint)    | 17.5 ms | 0.4 ms  | **43.8x**           |
 | keystroke                         | 17.0 ms | 0.4 ms  | **42.5x**           |
 | nested-row (the `handboka` shape) | 17.9 ms | 0.9 ms  | **19.9x**           |
@@ -114,9 +114,9 @@ Three, all real, all fixed. This is the argument for keeping the harness:
 
 1. `listenedPaths(module)` walked the whole listener registry, making a mount
    O(fields x modules). Now indexed per module.
-2. Mounting rendered every module — ~2.3 ms of 3.1 ms inside `executeRender` on
-   modules that declare no render. `SerializedSchema` carries `render?: true` and
-   `SchemaStore.declaresRender` answers from the schema.
+2. Mounting previewed every module — ~2.3 ms of 3.1 ms inside `executePreview` on
+   modules that declare no preview. `SerializedSchema` carries `preview?: true`
+   and `SchemaStore.declaresPreview` answers from the schema.
 3. **The listener scan was O(all registered paths) per patch.** On the
    1202-field shape a 40-key burst walked all 1202 paths 40 times and made the
    stores **slower than the engine** (12.8 ms vs 9.2 ms). The comment in
@@ -356,73 +356,77 @@ much cheaper before hooks exist than after.
 
 ---
 
-## 3. ~~Renders are not path-scoped~~ — FIXED, in `packages/core`
+## 3. ~~Previews are not path-scoped~~ — FIXED, in `packages/core`
 
-**Was:** `RenderStore.get(path)` is per-path, but `executeRender` took a whole
-module, so one request walked everything. For `handboka` — `select` at two nested
-array levels — that was every chapter and every section on any change to the
-module. Measured: one listener on one row of a three-row list cost **3** `select`
-invocations to serve **1**.
+> Renamed 2026-08-28: what this section calls a "render" is now a **preview**
+> (`.preview(select)` on `array` and `record`), and `render` names the unrelated
+> static field layout on `string`. See `core/src/render.ts`.
+
+**Was:** `PreviewStore.get(path)` is per-path, but `executePreview` took a whole
+module, so one request walked everything. For `handboka` — a preview at two
+nested array levels — that was every chapter and every section on any change to
+the module. Measured: one listener on one row of a three-row list cost **3**
+closure invocations to serve **1**.
 
 **Done**, once changing `packages/core` was allowed (decided 2026-08-23: no
 external users, two internal ones).
 
-`RenderScope` in `packages/core/src/render.ts` is threaded as an optional third
-argument through every `executeRender`. It answers two questions, and the split
+`PreviewScope` in `packages/core/src/preview.ts` is threaded as an optional third
+argument through every `executePreview`. It answers two questions, and the split
 is the whole design:
 
-- `wants(path)` — is a render AT this exact path wanted? A container answers
-  `true` when the whole of it is being shown, and its list render is computed in
+- `wants(path)` — is a preview AT this exact path wanted? A container answers
+  `true` when the whole of it is being shown, and its preview is computed in
   full. **A list VIEW asks for the container and needs every row**, so windowing
   there would be a list with rows missing — a broken screen, not a saving.
 - `wantsUnder(path)` — could anything at or below this path be wanted? Recursion
   is pruned where this is `false`, and a container whose own path is NOT wanted
-  but which has wanted descendants renders a **window**: only the items asked
+  but which has wanted descendants previews a **window**: only the items asked
   for. That is what a single visible row is.
 
 It compares path SEGMENTS, not string prefixes. `"title"` is a string prefix of
 `"titles"` but not a path ancestor of it, and a key may contain a dot or a quote,
-so `startsWith` silently renders siblings. Pinned in `render.test.ts`.
+so `startsWith` silently previews siblings. Pinned in `preview.test.ts`.
 
-`ListArrayRender.items` became `[index, value][]` — the shape
-`ListRecordRender` already had. This is the load-bearing part: a windowed render
-is a SHORTER array, so a consumer reading `items[n]` positionally would get a
-different row. Carrying the index makes that unrepresentable, and the compiler
-pointed at both UI call sites (`SortableList.tsx`, `useRefPreview.ts`) rather
-than letting them read the wrong row at runtime.
+`ArrayPreview.items` became `[index, value][]` — the shape `RecordPreview`
+already had. This is the load-bearing part: a windowed preview is a SHORTER
+array, so a consumer reading `items[n]` positionally would get a different row.
+Carrying the index makes that unrepresentable, and the compiler pointed at both
+UI call sites (`SortableList.tsx`, `useRefPreview.ts`) rather than letting them
+read the wrong row at runtime.
 
-A side effect worth naming: `array`'s `select` is now wrapped per ITEM rather
+A side effect worth naming: `array`'s closure is now wrapped per ITEM rather
 than per list, matching what `record` already did. Before, one throwing row
 produced an error at the container and NO items at all — one bad row took out the
 whole list.
 
-Above core, `RenderStore` had to learn two things:
+Above core, `PreviewStore` had to learn two things:
 
-- **The cache entry carries the scope it was computed at.** A render scoped to
+- **The cache entry carries the scope it was computed at.** A preview scoped to
   one visible row says nothing about another row, and serving it there is worse
   than a cache miss — a miss is slow, that is wrong. Coverage is asked per
   CALLER, not "is every listened path covered": folding those together makes one
   field's read pay for everyone else's, which is the fan-out being removed.
-- **Concurrent readers of different paths must still cost one render.** Sharing
+- **Concurrent readers of different paths must still cost one preview.** Sharing
   an already-issued request cannot do it, because its scope was fixed when it was
   issued. `refreshFor` collects the asked-for paths across the turn (one
   microtask) and issues once. The in-flight map carries its scope too, so a
   request that will not answer the caller's question is not mistaken for one that
   will; that case retries exactly once and then issues unconditionally, because a
-  duplicate render costs time whereas a wrong `no-render-at-path` is a bug.
+  duplicate preview costs time whereas a wrong `no-preview-at-path` is a bug.
 
 The eager `source:listen` path deliberately does NOT wait a microtask: it is
-dispatched synchronously from `addListener`, and "the render is ready when the
+dispatched synchronously from `addListener`, and "the preview is ready when the
 mounting field first looks" is the whole promise of computing on demand arriving.
 Only the FIRST listener in a module triggers it — twenty rows mounting would
 otherwise refresh twenty times at growing scope, strictly worse than the one
-whole-module render this replaces. The other nineteen are covered by their own
-reads, and the first of those renders at the scope of everything mounted by then:
-**twenty rows cost two renders, not twenty.**
+whole-module preview this replaces. The other nineteen are covered by their own
+reads, and the first of those previews at the scope of everything mounted by
+then: **twenty rows cost two previews, not twenty.**
 
-Four callers of `executeRender` remain; only `HostStore` passes a scope.
-`ValOps.ts:595` (server) and `InlineField.stories.tsx:70` want whole modules and
-pass nothing, which is exactly the old behaviour.
+Three callers of `executePreview` remain; only `HostStore` passes a scope.
+`ValOps.ts` (server) and the story harnesses want whole modules and pass nothing,
+which is exactly the old behaviour.
 
 ## 4. `executeValidate` has no custom-only mode, so errors are merged by message. 🟡
 
@@ -837,8 +841,8 @@ ask-rather-than-infer shape works for `jsonEntriesSha`.
 
 ## 9. ~~Five of the nine stores have no committed test.~~ ✅ CLOSED
 
-`host`, `render`, `validation`, `search` and `patch sets` were verified end to end
-by hand — render routed through the host, a custom validator's own message came
+`host`, `preview`, `validation`, `search` and `patch sets` were verified end to end
+by hand — a preview routed through the host, a custom validator's own message came
 back, search and patch sets worked off pushed snapshots — and that scratch test
 was **deleted** rather than committed, per instruction.
 
@@ -846,7 +850,7 @@ was **deleted** rather than committed, per instruction.
 
 - [x] Committed. `systemFlow` walks one session in order; `systemInvariants`
       takes one claim per test; `activityCost` asserts how many times each
-      expensive thing runs; `demandDriven` asserts that render and search run
+      expensive thing runs; `demandDriven` asserts that preview and search run
       only for what is being looked at. Between them they found six defects, of
       which five are fixed and one — item 3 — needs the decision below.
 
@@ -952,7 +956,7 @@ makes the author write it twice.
       unreferenced patch files is the only real answer; until then the bytes leak.
 - [x] **~~`.jsonValues()` is not handled at all.~~** Implemented. Entry content
       is fetched on demand and substituted where source lives, so fields,
-      renders, validation and the search walk all see real content without
+      previews, validation and the search walk all see real content without
       knowing markers exist. The read IS the demand signal and the read WAITS
       (`get` triggers the fetch and awaits it); `peek` is the side-effect-free
       companion, because the moment a read can cause a fetch, anything that

--- a/packages/ui/spa/stores/react/storySystem.ts
+++ b/packages/ui/spa/stores/react/storySystem.ts
@@ -1,7 +1,7 @@
 import type {
   Json,
   ModuleFilePath,
-  ReifiedRender,
+  ReifiedPreview,
   SerializedSchema,
 } from "@valbuild/core";
 import { createSystem, type System } from "../createSystem";
@@ -12,14 +12,14 @@ import type { HostBridge } from "../bridges";
  *
  * ## Why a `HostBridge` rather than `host.receive`
  *
- * Intake takes real `ValModule` instances and derives schema, source and renders
- * from them. A story has none: it has serialized schemas, plain JSON sources and
- * hand-written renders, which is the point — a story is meant to pin one visual
- * state, not to evaluate a project.
+ * Intake takes real `ValModule` instances and derives schema, source and
+ * previews from them. A story has none: it has serialized schemas, plain JSON
+ * sources and hand-written previews, which is the point — a story is meant to
+ * pin one visual state, not to evaluate a project.
  *
  * So the stores are fed directly (`schemaStore.receive`, `sourceStore.receive`)
- * and the render/validate seam is answered by a bridge that returns the story's
- * renders. `HostBridge` is a seam, `HostStore` is one implementation of it, and
+ * and the preview/validate seam is answered by a bridge that returns the story's
+ * previews. `HostBridge` is a seam, `HostStore` is one implementation of it, and
  * this is the second — the same shape of substitution `workerRealm` and
  * `schemaValidation` already have.
  *
@@ -34,18 +34,18 @@ import type { HostBridge } from "../bridges";
 export function createStorySystem({
   schemas,
   sources,
-  renders,
+  previews,
 }: {
   schemas: Record<ModuleFilePath, SerializedSchema | undefined>;
   sources: Record<ModuleFilePath, Json | undefined>;
-  renders?: Record<ModuleFilePath, ReifiedRender | null>;
+  previews?: Record<ModuleFilePath, ReifiedPreview | null>;
 }): System {
   const hostBridge: HostBridge = {
-    async render(moduleFilePath) {
-      const render = renders?.[moduleFilePath];
-      return render === undefined || render === null
+    async preview(moduleFilePath) {
+      const preview = previews?.[moduleFilePath];
+      return preview === undefined || preview === null
         ? { status: "unknown-module" }
-        : { status: "rendered", render };
+        : { status: "previewed", preview };
     },
     async customValidate() {
       // A story has no user closures to run — its schemas are already

--- a/packages/ui/spa/stores/systemInvariants.test.ts
+++ b/packages/ui/spa/stores/systemInvariants.test.ts
@@ -759,7 +759,7 @@ describe("source store: patches that carry files", () => {
 
 describe("peek is reference-stable in every store", () => {
   /**
-   * CLAIM (`SourceStore.peek`, `ValidationStore.peek`, `RenderStore.peek`): all
+   * CLAIM (`SourceStore.peek`, `ValidationStore.peek`, `PreviewStore.peek`): all
    * three are "safe to call on a render path".
    *
    * That phrase has to mean reference-stable, or it means nothing. A
@@ -769,7 +769,7 @@ describe("peek is reference-stable in every store", () => {
    * gives up — its own words were "maximum update depth exceeded". Two of the
    * three did exactly that, and it was invisible until a hook subscribed.
    *
-   * One test per store, because they achieve it differently: source and render
+   * One test per store, because they achieve it differently: source and preview
    * recompute and compare, validation stores its result pre-wrapped.
    */
   const module = () => {
@@ -818,18 +818,18 @@ describe("peek is reference-stable in every store", () => {
     dispose();
   });
 
-  it("render: an unchanged path peeks to the same object", async () => {
-    const { sourceStore, renderStore, dispose } = initTestSystem();
+  it("preview: an unchanged path peeks to the same object", async () => {
+    const { sourceStore, previewStore, dispose } = initTestSystem();
     await sourceStore.testReceive([module()]);
-    await renderStore.get(sp('/t.val.ts?p="rows"'));
+    await previewStore.get(sp('/t.val.ts?p="rows"'));
 
-    expect(renderStore.peek(sp('/t.val.ts?p="rows"'))).toBe(
-      renderStore.peek(sp('/t.val.ts?p="rows"')),
+    expect(previewStore.peek(sp('/t.val.ts?p="rows"'))).toBe(
+      previewStore.peek(sp('/t.val.ts?p="rows"')),
     );
     // Including the common "nothing here" answer, which is what most paths get
     // and therefore what most fields would have churned on.
-    expect(renderStore.peek(sp('/t.val.ts?p="title"'))).toBe(
-      renderStore.peek(sp('/t.val.ts?p="title"')),
+    expect(previewStore.peek(sp('/t.val.ts?p="title"'))).toBe(
+      previewStore.peek(sp('/t.val.ts?p="title"')),
     );
     dispose();
   });

--- a/packages/ui/spa/stores/testSystem.ts
+++ b/packages/ui/spa/stores/testSystem.ts
@@ -553,7 +553,7 @@ export type TestSystem = {
    * needs a test-only method. Their whole API is already on-demand (`get`,
    * `validate`, `getPatchSets`, `search`), which is what a test wants to drive.
    */
-  renderStore: System["renderStore"];
+  previewStore: System["previewStore"];
   patchSetStore: System["patchSetStore"];
   validationStore: System["validationStore"];
   searchStore: System["searchStore"];
@@ -888,7 +888,7 @@ export function initTestSystem(): TestSystem {
     workerSearch.events.onAny((event) => ledger.record(event)),
     workerReferences.events.onAny((event) => ledger.record(event)),
     system.host.events.onAny((event) => ledger.record(event)),
-    system.renderStore.events.onAny((event) => ledger.record(event)),
+    system.previewStore.events.onAny((event) => ledger.record(event)),
     // The write path emits on its own bus, and the conflict/rejected events are
     // the only record that a save went wrong at all — a test that could not see
     // them could only assert the recovery, never that recovery was needed.
@@ -1013,7 +1013,7 @@ export function initTestSystem(): TestSystem {
     listeners,
     host: system.host,
     status: system.status,
-    renderStore: system.renderStore,
+    previewStore: system.previewStore,
     patchSetStore: system.patchSetStore,
     validationStore: system.validationStore,
     searchStore: system.searchStore,

--- a/packages/ui/spa/stores/types.ts
+++ b/packages/ui/spa/stores/types.ts
@@ -216,7 +216,7 @@ export type SystemEvent =
    * A reader registered interest in a path, or dropped it.
    *
    * This IS coordination rather than observation, which is why it is a
-   * `SystemEvent` and not a work record: the render store reacts to it. A
+   * `SystemEvent` and not a work record: the preview store reacts to it. A
    * listener existing at a path is the system's own record that a field is on
    * screen showing it, and therefore the only trustworthy signal that the
    * expensive work behind that path is actually wanted. A caller invoking
@@ -417,14 +417,14 @@ export type SystemEvent =
       /** Whether the custom half actually ran, or the host could not do it. */
       customValidateStatus: "ran" | "not-needed" | "unavailable" | "error";
     }
-  /** Cached renders for these modules are stale. Nothing was recomputed. */
-  | { type: "render:invalidate"; modules: ModuleFilePath[] }
-  | { type: "render:result"; moduleFilePath: ModuleFilePath }
+  /** Cached previews for these modules are stale. Nothing was recomputed. */
+  | { type: "preview:invalidate"; modules: ModuleFilePath[] }
+  | { type: "preview:result"; moduleFilePath: ModuleFilePath }
   /**
-   * A render threw. Deliberately not fatal: a render is decoration, and a
-   * schema whose render throws must not take the module's fields down with it.
+   * A preview threw. Deliberately not fatal: a preview is decoration, and a
+   * schema whose preview throws must not take the module's fields down with it.
    */
-  | { type: "render:error"; moduleFilePath: ModuleFilePath; message: string }
+  | { type: "preview:error"; moduleFilePath: ModuleFilePath; message: string }
   | { type: "search:invalidate"; modules: ModuleFilePath[] }
   | {
       type: "search:build-index";

--- a/packages/ui/spa/stores/workerSeam.test.ts
+++ b/packages/ui/spa/stores/workerSeam.test.ts
@@ -40,9 +40,11 @@ const project = () => {
         // Every serialized-schema shape that could plausibly hide something
         // non-cloneable, in one module: a regexp (serialized as {source, flags}
         // rather than a RegExp), a keyOf (carries a path), an image (carries a
-        // referencedModule), a route, a richtext (carries an options object), and
-        // a union (carries an items array).
+        // referencedModule), a route, a richtext (carries an options object), a
+        // union (carries an items array), and a `render` (which is the LAYOUT
+        // itself now, not a boolean marker, so it is new data on this seam).
         slug: s.string().regexp(/^[a-z-]+$/),
+        notes: s.string().render({ as: "code", language: "json" }),
         owner: s.keyOf(authors),
         hero: s.image(),
         link: s.route(),
@@ -56,6 +58,7 @@ const project = () => {
       {
         title: "Hello",
         slug: "hello",
+        notes: "{}",
         owner: "ada",
         hero: {
           path: "/public/val/x.png",
@@ -70,10 +73,9 @@ const project = () => {
     ),
     c.define(
       "/list.val.ts",
-      s.array(s.object({ name: s.string() })).render({
-        as: "list",
-        select: ({ val }) => ({ title: val.name }),
-      }),
+      s
+        .array(s.object({ name: s.string() }))
+        .preview(({ val }) => ({ title: val.name })),
       [{ name: "one" }, { name: "two" }],
     ),
   ];


### PR DESCRIPTION
**Breaking.** `.render({ as: "list", select })` on `array` and `record` becomes `.preview(select)`. `s.string().render({ as: "textarea" | "code" })` is unchanged.

## Why

`render` was two unrelated things wearing one name:

1. **On `array` and `record`** — a user closure over source, producing the rows the Studio shows for a container's items. Dynamic, expensive, computed on demand for the paths on screen (`RenderScope`, `RenderStore`, the host seam). Its output is what the UI already called a *preview* everywhere it was consumed: `useRefPreview`, `ListPreviewItem`, `PreviewWithRender`, `RefPreview`, `KeyPreview`.
2. **On `string`** — a static layout hint. `StringSchema.executeRender` did not even take `src`.

Because they shared a name they also shared a type (`ReifiedRender`), a pipeline (`executeRender`), a store (`RenderStore`), a host round-trip and a wire field. A module whose only "render" was `s.string().render({as:"textarea"})` was sent across the host seam and walked in full to learn a fact the serialized schema already carried.

## What changed

A **preview** is what a container shows for its items. A **render** is how one field is laid out. Nothing is shared between them.

```ts
// before
s.array(item).render({ as: "list", select: ({ val }) => ({ title: val.name }) })
s.record(item).render({ as: "list", select: ({ key, val }) => ({ title: val.name }) })

// after
s.array(item).preview(({ val }) => ({ title: val.name }))
s.record(item).preview(({ key, val }) => ({ title: val.name }))

// unchanged
s.string().render({ as: "code", language: "typescript" })
```

- **New `core/src/preview.ts`** — `PreviewItem`, `ArrayPreview`, `RecordPreview`, `ReifiedPreview`, `PreviewScope` / `previewScope`. `Schema.executeRender` → `executePreview`.
- **`core/src/render.ts` shrinks** to `CodeLanguage` (now derived from an exported `CODE_LANGUAGES` list, so `shared`'s zod validator can enumerate it without a second copy) and `StringRender`.
- **A string's render moves into the serialized schema** — `SerializedStringSchema.render?: StringRender` instead of `render?: true`. `StringField` reads it off `useSchemaAtPath`, which it already called. `SchemaStore.declaresPreview` loses its `string` arm, so such a module never reaches the host.
- **`as: "list"` is gone** (it was the only value) and preview data no longer carries `layout` — `parent: "array" | "record"` was already the discriminant every consumer read. That removes two unreachable error branches, a dead `renderLayout` prop, five casts, and the `as`→`layout` translation asymmetry in `record`.
- **Wire:** `/sources/~` returns `preview` per module where it returned `render`. `ValOps.getRenders` → `getPreviews`.
- **UI renames:** `RenderStore` → `PreviewStore` (statuses `previewed` / `needs-preview` / `no-preview[-at-path]`, events `preview:*`), `HostBridge.render` → `.preview`, `useRenderOverrideAtPath` → `usePreviewAtPath`, `useAllRenders` → `useAllPreviews`, `PreviewWithRender` → `RefPreview`.

## The assumption, written down

A render is static **today**, and this change assumes it stays static — deliberately, for simplicity, not as a law. That assumption is what lets it ride in the serialized schema instead of having a pipeline, so it is stated where a future reader will hit it: the header of `core/src/render.ts`, `SchemaStore.declaresPreview` (why there is no `string` arm), and `StringField`. If a render ever needs to depend on source, it gets its own execute/store pair back rather than being re-merged with previews.

## Two bugs this surfaced

- **`StringField`'s textarea was uncontrolled** and only ever worked because the layout arrived a tick *after* the effect that fills `currentValue`. Making the layout synchronous removes that ordering. `.value` still looked right (a textarea's value follows `defaultValue` while untouched) but `AutoGrowingTextarea` seeds its invisible sizing ghost from props exactly once, so the box would render one line tall for any amount of text. Now controlled, with the ghost following the controlled value — and `aria-hidden`, which it should always have been, since it duplicated the text for screen readers.
- **`deserializeSchema` dropped a string's render.** Harmless while it was a marker recomputed from instances; data loss once the serialized schema is the source of truth.

## Tests

New: `core/src/schema/string.test.ts` (the serialized render round-trips and survives every chained builder — the guard `array`/`record` have had since `cedeea8` and `string` never did, despite ten threading sites), `StringField.test.tsx` (verified to fail with the uncontrolled textarea restored), and an `activityCost` case pinning that a string-render-only module never reaches the host.

Migrated: `core/src/render.test.ts` → `preview.test.ts`, the array/record/union schema tests, `ValRouter.test.ts`, and the four UI store suites. The chaining loops in `array.test.ts` / `record.test.ts` are kept intact — they guard exactly the threading sites this rewrites.

## Verified

`pnpm run lint`, `pnpm -w run format`, `pnpm run -r typecheck`, `pnpm test` (2336 passed), `pnpm run build`, `cd examples/next && pnpm run build` — all green. `val validate --root examples/next` reports `16 valid` with the two pre-existing image-metadata errors (confirmed identical on `main`), through both `tsx src/cli.ts` and the packaged `bin.js`.

Not run: the Playwright e2e suite and a hand-check of the Studio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUxReAGbQhLDWqorqQ9tRQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AUxReAGbQhLDWqorqQ9tRQ)_