### PR TITLE
create: install with the package manager that ran the command

### DIFF
--- a/.agent/rules.md
+++ b/.agent/rules.md
@@ -488,6 +488,27 @@ supplies the dimensions and mime type at resolve time.
 
 The `/api/val/files` endpoint (`ValServer.ts`) serves draft files by loading them from the patch directory (via `getBase64EncodedBinaryFileFromPatch`) and published files directly from the filesystem (`getBinaryFile`). No auth is required on this endpoint (patch IDs serve as unguessable tokens).
 
+## Releasing
+
+Releases go out through changesets: land a PR with a changeset on `main`, the
+Release workflow opens a "Version Packages" PR, and merging that publishes to
+npm.
+
+**After a release, ask whether to update the starter template** — and default to
+yes. The template repository ([`valbuild/template-nextjs-starter`](https://github.com/valbuild/template-nextjs-starter))
+pins `@valbuild/*` versions in its `package.json`, so it keeps serving the old
+release to everyone who runs `npm create @valbuild` / `pnpm create @valbuild`
+until someone bumps it. So, once the new version is on npm:
+
+1. Ask the user whether to update the template now, proposing that we do.
+2. Bump the `@valbuild/*` dependencies in the template's `package.json`, install
+   so the lock file follows, and open a PR on the template repository.
+3. **Test it out** — do not ship the bump on a green typecheck alone. Install and
+   run the template against the new version, open `/val`, and check that the
+   Studio loads and that an edit can be made and saved. Breakage from a release
+   shows up here first, and this is the last place to catch it before it is what
+   every new project starts from.
+
 ## Common Fixes
 
 ### "Type 'X' does not satisfy constraint 'Source'"

--- a/.changeset/create-package-manager.md
+++ b/.changeset/create-package-manager.md
@@ -19,3 +19,10 @@ the project is left with exactly one, and it is real.
 To override the detection, pass `--use-npm`, `--use-pnpm`, `--use-yarn` or
 `--use-bun` (or `--package-manager <name>`). An unrecognized name is an error
 rather than a silent fall back to npm.
+
+The `[project-name]` argument the help text has always advertised is now honoured
+too, so `npm create @valbuild my-app --use-pnpm` runs without a prompt; without
+it, the prompt is unchanged. And the printed `val connect` line runs the new
+project's own `val` binary under pnpm, yarn and bun, while npm keeps naming
+`@valbuild/cli` explicitly — a bare `npx val` would offer to fetch an unrelated
+package called `val` from the registry.

--- a/.changeset/create-package-manager.md
+++ b/.changeset/create-package-manager.md
@@ -1,0 +1,21 @@
+---
+"@valbuild/create": minor
+---
+
+Install with the package manager that ran `create`, not always npm
+
+`pnpm create @valbuild` used to hand the new project to `npm install`: it wrote
+a `node_modules` and a `package-lock.json` the person who asked for pnpm did not
+want, next to the template's own committed `package-lock.json`, and then told
+them to run `npm run dev`.
+
+The package manager that invoked us is now the one used. Every package manager
+sets `npm_config_user_agent` when it runs a lifecycle script, so pnpm, yarn and
+bun are recognized the same way npm is, and the install command, the printed
+next steps and the `val connect` line all follow. The lock files belonging to
+the package managers not chosen are removed from the downloaded template, so
+the project is left with exactly one, and it is real.
+
+To override the detection, pass `--use-npm`, `--use-pnpm`, `--use-yarn` or
+`--use-bun` (or `--package-manager <name>`). An unrecognized name is an error
+rather than a silent fall back to npm.

--- a/packages/create/README.md
+++ b/packages/create/README.md
@@ -6,6 +6,21 @@ Bootstrap a Val project from the CLI.
 
 ```sh
 npm create @valbuild@latest
+# or
+pnpm create @valbuild@latest
 ```
+
+The new project is installed with the package manager that ran the command, so
+`pnpm create` gives you a pnpm project (`pnpm-lock.yaml`, `pnpm run dev`) and
+`npm create` an npm one. yarn and bun are detected the same way.
+
+To choose the package manager yourself, pass one of:
+
+```sh
+npm create @valbuild@latest -- --use-pnpm
+npm create @valbuild@latest -- --package-manager pnpm   # same thing, spelled out
+```
+
+`--use-npm`, `--use-pnpm`, `--use-yarn` and `--use-bun` are all accepted.
 
 See the [documentation](https://val.build/docs) for more information.

--- a/packages/create/README.md
+++ b/packages/create/README.md
@@ -23,4 +23,10 @@ npm create @valbuild@latest -- --package-manager pnpm   # same thing, spelled ou
 
 `--use-npm`, `--use-pnpm`, `--use-yarn` and `--use-bun` are all accepted.
 
+The project name can be given as an argument instead of answering the prompt:
+
+```sh
+pnpm create @valbuild@latest my-app
+```
+
 See the [documentation](https://val.build/docs) for more information.

--- a/packages/create/src/index.ts
+++ b/packages/create/src/index.ts
@@ -128,7 +128,7 @@ ${chalk.cyan("Next steps:")}
   ${chalk.cyan(`${commands.run} dev`)}
 
 ${chalk.bold("Optionally run:")}
-  ${chalk.cyan(`${commands.exec} val connect`)}  
+  ${chalk.cyan(`${commands.valCli} connect`)}  
 ${chalk.bold("to connect your project to Val Build")}
 
 ${chalk.bold("Need help?")} Join our community on Discord: ${chalk.underline(
@@ -139,6 +139,20 @@ ${chalk.green("Happy coding! 🚀")}
 `);
 
   process.stdout.write(nextSteps);
+}
+
+/** True, or the reason this is not a usable project name. */
+function validateProjectName(value: string): true | string {
+  if (!value || value.trim().length === 0) {
+    return "Project name cannot be empty";
+  }
+  if (value.includes(" ")) {
+    return "Project name cannot contain spaces";
+  }
+  if (!/^[a-zA-Z0-9-_]+$/.test(value)) {
+    return "Project name can only contain letters, numbers, hyphens, and underscores";
+  }
+  return true;
 }
 
 // Template processing function
@@ -234,29 +248,29 @@ async function main() {
     }
     const packageManager = resolved.packageManager;
     const commands = PACKAGE_MANAGER_COMMANDS[packageManager];
-    // Keep parsing off the package manager flags from here on.
-    args.splice(0, args.length, ...resolved.rest);
+
+    // The help text has always advertised `[project-name]`: whatever is left
+    // once the flags are out is it.
+    const projectNameArg = resolved.rest[0];
+    if (projectNameArg !== undefined) {
+      const invalid = validateProjectName(projectNameArg);
+      if (invalid !== true) {
+        console.error(chalk.red(`❌ Error: ${invalid}.`));
+        process.exit(1);
+      }
+    }
 
     let currentStep = 0;
     renderTimeline(currentStep);
 
-    // Step 1: Enter project name
-    const projectName = await input({
-      message: chalk.bold("What is your project named?"),
-      default: DEFAULT_PROJECT_NAME,
-      validate: (value) => {
-        if (!value || value.trim().length === 0) {
-          return "Project name cannot be empty";
-        }
-        if (value.includes(" ")) {
-          return "Project name cannot contain spaces";
-        }
-        if (!/^[a-zA-Z0-9-_]+$/.test(value)) {
-          return "Project name can only contain letters, numbers, hyphens, and underscores";
-        }
-        return true;
-      },
-    });
+    // Step 1: Enter project name — unless it was given as an argument
+    const projectName =
+      projectNameArg ??
+      (await input({
+        message: chalk.bold("What is your project named?"),
+        default: DEFAULT_PROJECT_NAME,
+        validate: validateProjectName,
+      }));
     currentStep++;
     renderTimeline(currentStep);
 

--- a/packages/create/src/index.ts
+++ b/packages/create/src/index.ts
@@ -1,9 +1,16 @@
 import { execSync } from "child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import degit from "degit";
 import { input } from "@inquirer/prompts";
 import chalk from "chalk";
+import {
+  foreignLockFiles,
+  PACKAGE_MANAGER_COMMANDS,
+  PACKAGE_MANAGERS,
+  PackageManager,
+  resolvePackageManager,
+} from "./packageManager";
 
 const PKG = {
   name: "@valbuild/create",
@@ -33,11 +40,20 @@ function printHelp() {
   console.log(`
 ${chalk.bold("Usage:")}
   ${chalk.cyan("npm create @valbuild [project-name]")}
+  ${chalk.cyan("pnpm create @valbuild [project-name]")}
 
 ${chalk.bold("Options:")}
   -h, --help Show help
   -v, --version Show version
   --root <path> Specify the root directory for project creation (default: current directory)
+  --use-npm, --use-pnpm, --use-yarn, --use-bun Use this package manager instead of the one that ran this command
+  --package-manager <${PACKAGE_MANAGERS.join(
+    "|",
+  )}> Same, spelled out (--pm also works)
+
+${chalk.dim(
+  "By default the package manager that ran this command is used, so `pnpm create @valbuild` installs with pnpm.",
+)}
 `);
 }
 
@@ -101,14 +117,18 @@ function displayValLogo() {
   process.stdout.write(logo);
 }
 
-function displaySuccessMessage(projectName: string) {
+function displaySuccessMessage(
+  projectName: string,
+  packageManager: PackageManager,
+) {
+  const commands = PACKAGE_MANAGER_COMMANDS[packageManager];
   const nextSteps = chalk.bold(`
 ${chalk.cyan("Next steps:")}
   ${chalk.cyan("cd")} ${chalk.white(projectName)}
-  ${chalk.cyan("npm run dev")}
+  ${chalk.cyan(`${commands.run} dev`)}
 
 ${chalk.bold("Optionally run:")}
-  ${chalk.cyan("npx -p @valbuild/cli val connect")}  
+  ${chalk.cyan(`${commands.exec} val connect`)}  
 ${chalk.bold("to connect your project to Val Build")}
 
 ${chalk.bold("Need help?")} Join our community on Discord: ${chalk.underline(
@@ -148,6 +168,30 @@ function processTemplateFiles(projectPath: string, projectName: string) {
   });
 }
 
+/**
+ * Drop the lock files of every package manager but the one we are about to use.
+ *
+ * The template commits a lock file for one package manager. Left in place, it
+ * is at best noise — pnpm, yarn and bun all ignore `package-lock.json` while
+ * writing their own lock file — and at worst a stale second source of truth
+ * that `npm ci` in a deploy pipeline would prefer.
+ */
+function pruneForeignLockFiles(
+  projectPath: string,
+  packageManager: PackageManager,
+) {
+  for (const lockFile of foreignLockFiles(packageManager)) {
+    const lockFilePath = join(projectPath, lockFile);
+    if (existsSync(lockFilePath)) {
+      try {
+        rmSync(lockFilePath);
+      } catch {
+        console.log(chalk.dim(`Note: Could not remove ${lockFile}`));
+      }
+    }
+  }
+}
+
 async function main() {
   try {
     const args = process.argv.slice(2);
@@ -168,6 +212,30 @@ async function main() {
       // Remove --root and its value from args for project name parsing
       args.splice(rootIndex, 2);
     }
+
+    // Which package manager to install with: a flag if given, otherwise the
+    // one that ran this command.
+    const resolved = resolvePackageManager(
+      args,
+      process.env.npm_config_user_agent,
+    );
+    if (resolved.invalidFlag !== null) {
+      console.error(
+        chalk.red(
+          `❌ Error: unknown package manager "${resolved.invalidFlag}".`,
+        ),
+      );
+      console.error(
+        chalk.yellow(
+          `Supported package managers: ${PACKAGE_MANAGERS.join(", ")}`,
+        ),
+      );
+      process.exit(1);
+    }
+    const packageManager = resolved.packageManager;
+    const commands = PACKAGE_MANAGER_COMMANDS[packageManager];
+    // Keep parsing off the package manager flags from here on.
+    args.splice(0, args.length, ...resolved.rest);
 
     let currentStep = 0;
     renderTimeline(currentStep);
@@ -266,14 +334,24 @@ async function main() {
 
     // Process template files
     processTemplateFiles(projectPath, projectName);
+    pruneForeignLockFiles(projectPath, packageManager);
 
     // Change to project directory and install dependencies
-    process.stdout.write(chalk.bold("\n📦 Installing dependencies...\n"));
+    process.stdout.write(
+      chalk.bold(`\n📦 Installing dependencies with ${packageManager}...\n`),
+    );
+    if (resolved.source !== "flag") {
+      process.stdout.write(
+        chalk.dim(
+          "  Use --use-npm, --use-pnpm, --use-yarn or --use-bun to pick another package manager.\n",
+        ),
+      );
+    }
 
     try {
-      execSync("npm install", {
+      execSync(commands.install, {
         cwd: projectPath,
-        stdio: "inherit", // Show npm output in real-time
+        stdio: "inherit", // Show install output in real-time
       });
 
       // Clear the npm output and show success
@@ -291,14 +369,14 @@ async function main() {
       );
 
       // Show final success message
-      displaySuccessMessage(projectName);
+      displaySuccessMessage(projectName, packageManager);
       process.stdout.write("\n");
       process.exit(0);
     } catch (error) {
       renderTimeline(currentStep, currentStep);
       console.error(
         chalk.red(
-          '❌ Failed to install dependencies. You can try running "npm install" manually.',
+          `❌ Failed to install dependencies. You can try running "${commands.install}" manually.`,
         ),
       );
       console.error("Error:", error);

--- a/packages/create/src/packageManager.test.ts
+++ b/packages/create/src/packageManager.test.ts
@@ -1,5 +1,8 @@
 import {
   detectPackageManager,
+  PACKAGE_MANAGER_COMMANDS,
+  PACKAGE_MANAGERS,
+  PackageManager,
   foreignLockFiles,
   parsePackageManagerArgs,
   resolvePackageManager,
@@ -138,5 +141,24 @@ describe("foreignLockFiles", () => {
       "bun.lockb",
     ]);
     expect(foreignLockFiles("pnpm")).not.toContain("pnpm-lock.yaml");
+  });
+});
+
+describe("PACKAGE_MANAGER_COMMANDS", () => {
+  test("covers every supported package manager, in one list", () => {
+    expect(PACKAGE_MANAGERS).toEqual(["npm", "pnpm", "yarn", "bun"]);
+  });
+
+  test("npm names @valbuild/cli, because npx would fetch the unrelated `val` package", () => {
+    expect(PACKAGE_MANAGER_COMMANDS.npm.valCli).toContain("-p @valbuild/cli");
+  });
+
+  test("the others run the project's own binary, never a registry fetch", () => {
+    const localOnly: PackageManager[] = ["pnpm", "yarn", "bun"];
+    for (const packageManager of localOnly) {
+      const { valCli } = PACKAGE_MANAGER_COMMANDS[packageManager];
+      expect(valCli).not.toMatch(/\b(npx|bunx|dlx)\b/);
+      expect(valCli.endsWith(" val")).toBe(true);
+    }
   });
 });

--- a/packages/create/src/packageManager.test.ts
+++ b/packages/create/src/packageManager.test.ts
@@ -1,0 +1,142 @@
+import {
+  detectPackageManager,
+  foreignLockFiles,
+  parsePackageManagerArgs,
+  resolvePackageManager,
+} from "./packageManager";
+
+describe("detectPackageManager", () => {
+  test("reads the package manager out of npm_config_user_agent", () => {
+    expect(
+      detectPackageManager(
+        "npm/10.9.0 node/v22.11.0 linux x64 workspaces/false",
+      ),
+    ).toBe("npm");
+    expect(
+      detectPackageManager("pnpm/10.4.1 npm/? node/v22.11.0 linux x64"),
+    ).toBe("pnpm");
+    expect(
+      detectPackageManager("yarn/1.22.22 npm/? node/v22.11.0 linux x64"),
+    ).toBe("yarn");
+    expect(
+      detectPackageManager("bun/1.2.2 npm/? node/v22.11.0 linux x64"),
+    ).toBe("bun");
+  });
+
+  test("is null when there is nothing usable to read", () => {
+    expect(detectPackageManager(undefined)).toBeNull();
+    expect(detectPackageManager("")).toBeNull();
+    expect(detectPackageManager("deno/2.1.4 node/v22.11.0")).toBeNull();
+  });
+});
+
+describe("parsePackageManagerArgs", () => {
+  test("recognizes the --use-<name> flags", () => {
+    expect(parsePackageManagerArgs(["--use-pnpm"])).toEqual({
+      packageManager: "pnpm",
+      invalidFlag: null,
+      rest: [],
+    });
+    expect(parsePackageManagerArgs(["--use-bun"]).packageManager).toBe("bun");
+  });
+
+  test("recognizes --package-manager and --pm, joined or separate", () => {
+    expect(parsePackageManagerArgs(["--package-manager", "pnpm"])).toEqual({
+      packageManager: "pnpm",
+      invalidFlag: null,
+      rest: [],
+    });
+    expect(
+      parsePackageManagerArgs(["--package-manager=yarn"]).packageManager,
+    ).toBe("yarn");
+    expect(parsePackageManagerArgs(["--pm", "npm"]).packageManager).toBe("npm");
+    expect(parsePackageManagerArgs(["--pm=pnpm"]).packageManager).toBe("pnpm");
+  });
+
+  test("leaves every other argument alone", () => {
+    expect(
+      parsePackageManagerArgs(["my-app", "--use-pnpm", "--root", "/tmp"]),
+    ).toEqual({
+      packageManager: "pnpm",
+      invalidFlag: null,
+      rest: ["my-app", "--root", "/tmp"],
+    });
+  });
+
+  test("does not mistake the value of --package-manager for a project name", () => {
+    expect(
+      parsePackageManagerArgs(["--package-manager", "pnpm", "my-app"]).rest,
+    ).toEqual(["my-app"]);
+  });
+
+  test("the last flag wins", () => {
+    expect(
+      parsePackageManagerArgs(["--package-manager", "pnpm", "--use-npm"])
+        .packageManager,
+    ).toBe("npm");
+  });
+
+  test("reports an unknown package manager verbatim, without picking one", () => {
+    expect(parsePackageManagerArgs(["--use-deno"])).toEqual({
+      packageManager: null,
+      invalidFlag: "--use-deno",
+      rest: [],
+    });
+    expect(
+      parsePackageManagerArgs(["--package-manager", "deno"]).invalidFlag,
+    ).toBe("--package-manager deno");
+    expect(parsePackageManagerArgs(["--package-manager"]).invalidFlag).toBe(
+      "--package-manager",
+    );
+  });
+});
+
+describe("resolvePackageManager", () => {
+  test("a flag beats the package manager that ran the command", () => {
+    const resolved = resolvePackageManager(
+      ["--use-pnpm"],
+      "npm/10.9.0 node/v22",
+    );
+    expect(resolved.packageManager).toBe("pnpm");
+    expect(resolved.source).toBe("flag");
+  });
+
+  test("without a flag, the package manager that ran the command is used", () => {
+    const resolved = resolvePackageManager([], "pnpm/10.4.1 node/v22");
+    expect(resolved.packageManager).toBe("pnpm");
+    expect(resolved.source).toBe("user-agent");
+  });
+
+  test("falls back to npm when there is nothing to go on", () => {
+    const resolved = resolvePackageManager([], undefined);
+    expect(resolved.packageManager).toBe("npm");
+    expect(resolved.source).toBe("default");
+  });
+
+  test("an unknown flag does not silently fall back", () => {
+    const resolved = resolvePackageManager(
+      ["--use-deno"],
+      "pnpm/10.4.1 node/v22",
+    );
+    expect(resolved.invalidFlag).toBe("--use-deno");
+  });
+});
+
+describe("foreignLockFiles", () => {
+  test("keeps the chosen package manager's own lock files", () => {
+    expect(foreignLockFiles("npm")).toEqual([
+      "pnpm-lock.yaml",
+      "yarn.lock",
+      "bun.lock",
+      "bun.lockb",
+    ]);
+    expect(foreignLockFiles("pnpm")).toEqual([
+      "package-lock.json",
+      "npm-shrinkwrap.json",
+      "yarn.lock",
+      "bun.lock",
+      "bun.lockb",
+    ]);
+    expect(foreignLockFiles("pnpm")).not.toContain("pnpm-lock.yaml");
+  });
+});

--- a/packages/create/src/packageManager.ts
+++ b/packages/create/src/packageManager.ts
@@ -10,13 +10,6 @@
 
 export type PackageManager = "npm" | "pnpm" | "yarn" | "bun";
 
-export const PACKAGE_MANAGERS: PackageManager[] = [
-  "npm",
-  "pnpm",
-  "yarn",
-  "bun",
-];
-
 export const DEFAULT_PACKAGE_MANAGER: PackageManager = "npm";
 
 type PackageManagerCommands = {
@@ -24,8 +17,15 @@ type PackageManagerCommands = {
   install: string;
   /** Run a package.json script, e.g. `${run} dev`. */
   run: string;
-  /** Run a binary from the project's dependencies, e.g. `${exec} val connect`. */
-  exec: string;
+  /**
+   * Run the Val CLI from the new project, e.g. `${valCli} connect`.
+   *
+   * pnpm, yarn and bun run the project's own `val` binary and nothing else.
+   * npm's `npx` falls back to the registry when the local binary is missing —
+   * and `val` there is an unrelated package by that name — so npm names the
+   * package it wants explicitly.
+   */
+  valCli: string;
   /** Lock files this package manager writes, and which therefore may be kept. */
   lockFiles: string[];
 };
@@ -37,32 +37,42 @@ export const PACKAGE_MANAGER_COMMANDS: Record<
   npm: {
     install: "npm install",
     run: "npm run",
-    exec: "npx",
+    valCli: "npx -p @valbuild/cli val",
     lockFiles: ["package-lock.json", "npm-shrinkwrap.json"],
   },
   pnpm: {
     install: "pnpm install",
     run: "pnpm run",
-    exec: "pnpm exec",
+    valCli: "pnpm exec val",
     lockFiles: ["pnpm-lock.yaml"],
   },
   yarn: {
     install: "yarn",
     run: "yarn",
-    exec: "yarn",
+    valCli: "yarn val",
     lockFiles: ["yarn.lock"],
   },
   bun: {
     install: "bun install",
     run: "bun run",
-    exec: "bunx",
+    valCli: "bun run val",
     lockFiles: ["bun.lock", "bun.lockb"],
   },
 };
 
 function isPackageManager(value: string): value is PackageManager {
-  return (PACKAGE_MANAGERS as string[]).includes(value);
+  return Object.prototype.hasOwnProperty.call(PACKAGE_MANAGER_COMMANDS, value);
 }
+
+/**
+ * Every package manager we support, derived from the commands above so the two
+ * cannot drift: a `PackageManager` added to the union without commands is a
+ * type error, and one added with commands shows up in the help text and the
+ * error messages for free.
+ */
+export const PACKAGE_MANAGERS: PackageManager[] = Object.keys(
+  PACKAGE_MANAGER_COMMANDS,
+).filter(isPackageManager);
 
 /**
  * The package manager that invoked us, or null if we cannot tell.

--- a/packages/create/src/packageManager.ts
+++ b/packages/create/src/packageManager.ts
@@ -1,0 +1,186 @@
+/**
+ * Which package manager should the new project use?
+ *
+ * The command that bootstrapped us already tells us: package managers set
+ * `npm_config_user_agent` when they run a lifecycle script, so
+ * `npm create @valbuild` arrives as "npm/10.9.0 node/v22.11.0 linux x64" and
+ * `pnpm create @valbuild` as "pnpm/10.4.1 node/v22.11.0 linux x64". We use
+ * that, unless the user overrides it with a flag.
+ */
+
+export type PackageManager = "npm" | "pnpm" | "yarn" | "bun";
+
+export const PACKAGE_MANAGERS: PackageManager[] = [
+  "npm",
+  "pnpm",
+  "yarn",
+  "bun",
+];
+
+export const DEFAULT_PACKAGE_MANAGER: PackageManager = "npm";
+
+type PackageManagerCommands = {
+  /** Install every dependency in the project directory. */
+  install: string;
+  /** Run a package.json script, e.g. `${run} dev`. */
+  run: string;
+  /** Run a binary from the project's dependencies, e.g. `${exec} val connect`. */
+  exec: string;
+  /** Lock files this package manager writes, and which therefore may be kept. */
+  lockFiles: string[];
+};
+
+export const PACKAGE_MANAGER_COMMANDS: Record<
+  PackageManager,
+  PackageManagerCommands
+> = {
+  npm: {
+    install: "npm install",
+    run: "npm run",
+    exec: "npx",
+    lockFiles: ["package-lock.json", "npm-shrinkwrap.json"],
+  },
+  pnpm: {
+    install: "pnpm install",
+    run: "pnpm run",
+    exec: "pnpm exec",
+    lockFiles: ["pnpm-lock.yaml"],
+  },
+  yarn: {
+    install: "yarn",
+    run: "yarn",
+    exec: "yarn",
+    lockFiles: ["yarn.lock"],
+  },
+  bun: {
+    install: "bun install",
+    run: "bun run",
+    exec: "bunx",
+    lockFiles: ["bun.lock", "bun.lockb"],
+  },
+};
+
+function isPackageManager(value: string): value is PackageManager {
+  return (PACKAGE_MANAGERS as string[]).includes(value);
+}
+
+/**
+ * The package manager that invoked us, or null if we cannot tell.
+ *
+ * A user agent we do not recognize (a package manager we have no commands for)
+ * is the same as no user agent at all: the caller falls back to the default.
+ */
+export function detectPackageManager(
+  userAgent: string | undefined,
+): PackageManager | null {
+  if (!userAgent) {
+    return null;
+  }
+  const name = userAgent.trim().split(" ")[0].split("/")[0];
+  if (isPackageManager(name)) {
+    return name;
+  }
+  return null;
+}
+
+export type PackageManagerArgs = {
+  /** The package manager the flags asked for, or null if none did. */
+  packageManager: PackageManager | null;
+  /** The first flag we could not make sense of, verbatim, for the error message. */
+  invalidFlag: string | null;
+  /** `args` without the package manager flags, so other parsing is unaffected. */
+  rest: string[];
+};
+
+/**
+ * Read `--use-npm` / `--use-pnpm` / `--use-yarn` / `--use-bun` and
+ * `--package-manager <name>` (or `--package-manager=<name>`) out of `args`.
+ *
+ * The last flag wins, so a later `--use-npm` overrides an earlier
+ * `--package-manager pnpm` rather than erroring.
+ */
+export function parsePackageManagerArgs(args: string[]): PackageManagerArgs {
+  let packageManager: PackageManager | null = null;
+  let invalidFlag: string | null = null;
+  const rest: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const useMatch = /^--use-(.+)$/.exec(arg);
+    if (useMatch) {
+      if (isPackageManager(useMatch[1])) {
+        packageManager = useMatch[1];
+      } else if (invalidFlag === null) {
+        invalidFlag = arg;
+      }
+      continue;
+    }
+    if (arg === "--package-manager" || arg === "--pm") {
+      const value = args[i + 1];
+      if (value !== undefined && isPackageManager(value)) {
+        packageManager = value;
+      } else if (invalidFlag === null) {
+        invalidFlag = value === undefined ? arg : `${arg} ${value}`;
+      }
+      // Skip the value too, unless the flag was last and has none.
+      if (value !== undefined) {
+        i++;
+      }
+      continue;
+    }
+    const valueMatch = /^--(?:package-manager|pm)=(.*)$/.exec(arg);
+    if (valueMatch) {
+      if (isPackageManager(valueMatch[1])) {
+        packageManager = valueMatch[1];
+      } else if (invalidFlag === null) {
+        invalidFlag = arg;
+      }
+      continue;
+    }
+    rest.push(arg);
+  }
+
+  return { packageManager, invalidFlag, rest };
+}
+
+export type ResolvedPackageManager = PackageManagerArgs & {
+  /** The package manager to actually use. */
+  packageManager: PackageManager;
+  /** Where the choice came from, so we can say so in the output. */
+  source: "flag" | "user-agent" | "default";
+};
+
+/** Flags beat the invoking package manager, which beats the default. */
+export function resolvePackageManager(
+  args: string[],
+  userAgent: string | undefined,
+): ResolvedPackageManager {
+  const parsed = parsePackageManagerArgs(args);
+  if (parsed.packageManager) {
+    return { ...parsed, packageManager: parsed.packageManager, source: "flag" };
+  }
+  const detected = detectPackageManager(userAgent);
+  if (detected) {
+    return { ...parsed, packageManager: detected, source: "user-agent" };
+  }
+  return {
+    ...parsed,
+    packageManager: DEFAULT_PACKAGE_MANAGER,
+    source: "default",
+  };
+}
+
+/**
+ * Lock files that belong to some *other* package manager.
+ *
+ * The template repository commits a lock file for one package manager (npm),
+ * so a project created with another one has to lose it: pnpm would ignore
+ * `package-lock.json` while writing `pnpm-lock.yaml`, leaving two lock files
+ * in the tree and only one of them real.
+ */
+export function foreignLockFiles(packageManager: PackageManager): string[] {
+  const own = PACKAGE_MANAGER_COMMANDS[packageManager].lockFiles;
+  return PACKAGE_MANAGERS.flatMap(
+    (candidate) => PACKAGE_MANAGER_COMMANDS[candidate].lockFiles,
+  ).filter((lockFile) => !own.includes(lockFile));
+}


### PR DESCRIPTION
## The problem

`pnpm create @valbuild` handed the new project to `npm install`. Someone who asked for pnpm got an npm `node_modules`, a `package-lock.json` written next to the template's committed one, and a closing message telling them to run `npm run dev` and `npx -p @valbuild/cli val connect`.

## The fix

Every package manager sets `npm_config_user_agent` when it runs a lifecycle script (`pnpm/10.4.1 npm/? node/v22…`) — including `pnpm dlx`, which is the path `pnpm create` actually takes — so the one that invoked us is knowable, and is now the one used: for the install command, the printed next steps and the `val connect` line alike. pnpm, yarn and bun are recognized the same way npm is; anything unrecognized falls back to npm.

Lock files belonging to the package managers *not* chosen are removed from the downloaded template, so the project keeps exactly one and it is the real one. pnpm, yarn and bun all ignore `package-lock.json` while writing their own, and a stale one left in the tree is what `npm ci` in a deploy pipeline would prefer.

### Overriding it

```sh
npm create @valbuild@latest -- --use-pnpm
npm create @valbuild@latest -- --package-manager pnpm   # same, spelled out; --pm works too
```

`--use-npm`, `--use-pnpm`, `--use-yarn`, `--use-bun`. A flag beats the user agent, which beats the npm default. An unrecognized name (`--use-deno`) is an error naming the supported set, not a silent fall back to npm — a silent fall back is exactly the bug this PR fixes. When the choice was *not* explicit, the install line says which package manager it picked and how to pick another.

Detection and parsing live in `packageManager.ts` as pure functions, covered by 16 unit tests; `index.ts` only wires them up. The list of supported managers is derived from the commands table, so the two cannot drift.

### Two things the review turned up, fixed here

- **`npx val connect` can reach the registry.** A bare `npx val` / `bunx val` resolves the project's own binary only if cwd is right and the install finished; otherwise it fetches — and `val` on npm is an unrelated package by that name. npm therefore keeps naming the package (`npx -p @valbuild/cli val connect`); pnpm, yarn and bun use their local runners, which never fetch.
- **`[project-name]` was advertised and ignored.** The help text has always shown it. The argument left once the flags are parsed is now used — validated by the same rules as the prompt — so `npm create @valbuild my-app --use-pnpm` runs without prompting. With no argument, the prompt is unchanged.

## Also: a Releasing rule

`.agent/rules.md` gains a **Releasing** section. The starter template pins `@valbuild/*` in its own `package.json`, so it keeps serving the previous release to everyone running `npm create @valbuild` until someone bumps it. The rule: after a release, ask whether to update the template — proposing that we do — and **test the bump by running the template** (install, `/val`, make and save an edit), not on a green typecheck alone.

## Verified

Repo checks: `pnpm run lint`, `pnpm -w run format`, `pnpm run -r typecheck`, `pnpm test` (2341 tests, 203 suites), and `pnpm run build` — all green.

Three real end-to-end runs of the CLI, creating projects from the template's `main`:

| run | install | lock files after | next steps printed |
| --- | --- | --- | --- |
| under pnpm, no flags | `pnpm install` | `pnpm-lock.yaml` only | `pnpm run dev`, `pnpm exec val connect` |
| under pnpm, `--use-npm` | `npm install` | `package-lock.json` only | `npm run dev`, `npx -p @valbuild/cli val connect` |
| under pnpm, `positional-app` as argument | `pnpm install` | `pnpm-lock.yaml` only | no prompt; `cd positional-app` |

And in the pnpm-created project: `pnpm run build` green (5 routes), `pnpm run lint` clean, `pnpm run validate` clean, `pnpm run dev` serving `/` 200, `/val` 200, `/api/val/session` 200, with the Studio stylesheet served out of `@valbuild/ui` through pnpm's symlinked `node_modules`. Plus the `--help` and invalid-flag paths.

Template-side companion: [valbuild/template-nextjs-starter#2](https://github.com/valbuild/template-nextjs-starter/pull/2).