### PR TITLE
Stop the draft-mode handshake loading the whole Studio route

### DIFF
--- a/.changeset/draft-ready-no-next-document.md
+++ b/.changeset/draft-ready-no-next-document.md
@@ -1,0 +1,28 @@
+---
+"@valbuild/next": patch
+"@valbuild/server": patch
+"@valbuild/shared": patch
+---
+
+Stop the draft-mode handshake loading the whole Studio route
+
+Turning draft mode on in a Next app has to happen server-side, so Val points a
+hidden iframe at `/api/val/draft/enable` and waits for something to load and post
+`val-ready` back. That something was `/val?message_onready=true` — the entire
+Studio route, React tree and SPA script — to send one message.
+
+Being a Next document, it connected a dev HMR client, and that is not free: `next
+dev` answers a client connecting by _broadcasting_ a `sync` carrying the current
+webpack compilation hash, and every other document reloads itself when that hash
+has moved since it last synced. So loading `/val` in a hidden iframe could reload
+the Studio the editor was working in.
+
+It now lands on `/api/val/draft/ready`: plain HTML served by the API route, with
+no client bundle, so it opens no HMR socket. `ValApp`'s `?message_onready=true`
+branch stays for a redirect already in flight, and its `setInterval` — created
+with no delay, so it posted as fast as the event loop allowed — now has one and a
+bound.
+
+`architecture/quirks.md` records the whole chain, including the part Val cannot
+fix (a canvas navigation to a route `next dev` has not compiled yet), and
+`e2e/dev-reload.spec.ts` measures it.

--- a/architecture/quirks.md
+++ b/architecture/quirks.md
@@ -401,3 +401,76 @@ route into dynamic rendering for everyone.
 including the two that differ ONLY in whether the gate was on for the deciding
 render. `e2e/uncommitted-routes.spec.ts` covers the path end to end; its
 single-module case is `test.fixme` for (3).
+
+## `next dev` reloads the Studio because another document connected
+
+The symptom is "the whole Next app reloads when we save", and it is not a save.
+Reproduced and instrumented in `e2e/dev-reload.spec.ts` (the instruments are in
+`e2e/devReload.ts`); the chain is:
+
+1. A new same-origin Next document opens. In the Studio that is the canvas
+   iframe — pointed at a route of the app, remounted on every canvas
+   navigation.
+2. If `next dev` has not compiled that route yet, compiling it moves webpack's
+   compilation hash.
+3. The new document's HMR client connects. `next dev` handles a connect in
+   `HotReloaderWebpack`'s `onHMR` by calling **`publish`** — a broadcast, not a
+   reply to the connecting client — sending a `sync` that carries the current
+   hash (`next/dist/server/dev/hot-middleware.js`).
+4. Every other connected document receives it. In
+   `next/dist/client/dev/hot-reloader/app/web-socket.js`, the `SYNC` branch
+   reads:
+
+   ```js
+   if (
+     mostRecentCompilationHash !== null &&
+     mostRecentCompilationHash !== message.hash
+   ) {
+     window.location.reload(); // "the server may have restarted"
+   }
+   ```
+
+   The Studio is one of those documents, and its recorded hash is the one from
+   before the compile. So it reloads itself.
+
+The Studio's own code is not involved: nothing in `packages/ui/spa` calls
+`location.reload()` outside a button, and the canvas `reloadKey`
+(`PageWorkspace.tsx`) is bumped only by the "Reload" control. The measurements
+that establish it:
+
+- A canvas navigation to a route not served yet in the session replaces the
+  Studio document; the same navigation to an already-served route does not.
+  Whether the route's content comes from a `.val.json` entry makes no
+  difference — it is the first compile, not the content.
+- Navigating the Studio alone, with no canvas open, does not replace it. So the
+  deep URLs the Studio pushes through `history.pushState` (which Next
+  intercepts and turns into a router restore) are not the cause.
+- Chromium reports the navigation with `reason=reload`, and a CDP breakpoint on
+  `location.reload` lands in Next's `handleMessage` — the socket handler above.
+
+### Two traps if you go measuring this yourself
+
+**Do not wrap `location.reload` from page script to find the caller.** `reload`,
+`assign`, `replace` and `href` are `[LegacyUnforgeable]`, which Chromium
+implements as own, non-configurable properties of each `location`;
+`Location.prototype` has none of them. So `Object.defineProperty` on the
+prototype _succeeds_ and is never reached, and the wrapper reports that nothing
+called anything. Use `Debugger.setBreakpointOnFunctionCall` over CDP instead.
+
+**Log every websocket, not just `/_next/`.** Filtering to Next's socket is how a
+reload with "no dev-server instruction" comes to look unexplained.
+
+### What Val does about it
+
+The canvas has to be a document of the app, that document has to connect an HMR
+client, and the first broadcast after any hash movement reloads every client
+whose hash is older — so the canvas case cannot be fixed from Val's side. It is
+pinned as a test that is expected to pass; when it starts failing, Next has
+changed and both it and this section should go.
+
+What Val stopped doing is opening a _second_ Next document for no reason. The
+draft-mode handshake used to redirect its hidden iframe to
+`/val?message_onready=true` — the whole Studio route, to post one message back.
+It now lands on `/api/val/draft/ready` (`VAL_DRAFT_READY_PATH`), plain HTML
+served by the API route with no client bundle, so it opens no HMR socket and
+provokes no broadcast.

--- a/e2e/dev-reload.spec.ts
+++ b/e2e/dev-reload.spec.ts
@@ -1,0 +1,312 @@
+import { expect, test, type Page } from "@playwright/test";
+import {
+  clearPatchChain,
+  closeNavPanel,
+  expandRow,
+  openSiteMap,
+} from "./studio";
+import {
+  observeDevReloads,
+  reportTrail,
+  type DevReloadObserver,
+} from "./devReload";
+
+/**
+ * What reloads the Studio document in development, and what no longer does.
+ *
+ * The report: "sometimes the whole Next application reloads when we save",
+ * narrowed over several rounds to "if I go to a new route in Val and the page
+ * loads the draft mode thing again". The mechanism, measured rather than
+ * reasoned about (see `devReload.ts` for the instruments and
+ * `architecture/quirks.md` for the write-up):
+ *
+ * 1. A new same-origin Next document opens — the canvas iframe, or any iframe
+ *    Val points at a route of the app.
+ * 2. If `next dev` has not compiled that route yet, compiling it moves webpack's
+ *    compilation hash.
+ * 3. The new document's HMR client connects. `next dev` answers a connect by
+ *    **broadcasting** a `sync` carrying the current hash — `publish`, not a
+ *    reply to the connecting client (`next/dist/server/dev/hot-middleware.js`,
+ *    `onHMR`).
+ * 4. Every OTHER document gets it too. A client whose recorded hash differs
+ *    concludes the dev server restarted and calls `window.location.reload()`
+ *    (`next/dist/client/dev/hot-reloader/app/web-socket.js`, the `SYNC` branch).
+ *    The Studio is one of those documents.
+ *
+ * So the Studio is reloaded by a handshake that was never meant for it. Val's
+ * lever is the number of Next documents it opens: the canvas has to be one, the
+ * draft-mode handshake did not — it used to load the entire `/val` route just to
+ * post one message, which is what the first test here pins shut.
+ *
+ * `openStudio` is deliberately not used: it waits on intake, and these cases
+ * need the observer installed before the very first navigation.
+ */
+
+/** Long enough for `next dev` to compile a route it has not served yet. */
+const COMPILE_TIMEOUT = 60_000;
+
+/** Open the Studio with the observer already attached. */
+async function openObservedStudio(
+  page: Page,
+  route = "/val",
+): Promise<DevReloadObserver> {
+  const observer = await observeDevReloads(page);
+  await page.goto(route);
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          const bag = window as unknown as {
+            __VAL_STORES__?: { received: boolean };
+          };
+          return bag.__VAL_STORES__?.received === true;
+        }),
+      {
+        timeout: COMPILE_TIMEOUT,
+        message: "the store system never took the project in",
+      },
+    )
+    .toBe(true);
+  return observer;
+}
+
+/**
+ * Open the canvas on the page the site map's `blogs/blog1` row selects, WITH
+ * preview mode on.
+ *
+ * Turning preview on is not decoration here: the draft-mode machinery this file
+ * is about is gated on the page mounting Val's client code, which needs the Val
+ * Enable cookie. Without it the canvas comes up blocked, no draft-mode iframe is
+ * ever opened, and a test that meant to measure that iframe measures nothing —
+ * and passes either way.
+ */
+async function openCanvasOnBlog1(page: Page) {
+  const studio = await openSiteMap(page);
+  await expandRow(studio, "blogs");
+  await expandRow(studio, "blog1");
+  await closeNavPanel(studio, "Pages");
+  await studio
+    .getByRole("button", { name: /Open the canvas|^Canvas$/ })
+    .click();
+  const route = studio.getByLabel("Canvas route");
+  await expect(route).toHaveValue("/blogs/blog1", { timeout: COMPILE_TIMEOUT });
+
+  const turnOn = studio.getByRole("button", { name: "Turn on preview mode" });
+  if (await turnOn.isVisible().catch(() => false)) {
+    await turnOn.click();
+    // The overlay goes when the page answers `ready` with draft mode on. It is
+    // a fresh document behind a redirect through `/api/val/enable`, so this
+    // waits for a load, not a re-render.
+    await expect(turnOn).toBeHidden({ timeout: COMPILE_TIMEOUT });
+  }
+  return { studio, route };
+}
+
+/**
+ * Give the dev server time to compile, broadcast, and reload.
+ *
+ * A fixed wait, not a condition: what is being measured is whether anything
+ * happens at all, and polling for the thing would hide a late one.
+ */
+async function settle(page: Page, ms: number) {
+  await page.waitForTimeout(ms);
+}
+
+test.describe("what reloads the studio in dev", () => {
+  test.describe.configure({ mode: "serial", timeout: 240_000 });
+
+  test.beforeAll(async ({ request }) => {
+    await clearPatchChain(request);
+  });
+
+  /**
+   * The document the draft-mode handshake lands on is not a Next route.
+   *
+   * This is the fix. Turning draft mode on happens server-side, so Val points a
+   * hidden iframe at `/api/val/draft/enable`, and something has to load
+   * afterwards and post `val-ready` back. That used to be
+   * `/val?message_onready=true` — the whole Studio route, React tree and SPA
+   * script, to send one message. Being a Next document it connected an HMR
+   * client, and by the chain at the top of this file a new client connecting
+   * reloads every other document whose compilation hash has moved since — after
+   * a save, say, which rewrites the `.val.ts` files.
+   *
+   * Asserted at the endpoint rather than through the UI: the iframe is opened
+   * only when the on-page overlay toggles draft mode, which nothing in this
+   * suite drives. What is checkable here is that the document Val now points at
+   * exists, announces itself, and carries no Next client bundle — which is the
+   * property that keeps it out of the HMR broadcast.
+   */
+  test("the draft-mode handshake lands on a document with no next client", async ({
+    request,
+  }) => {
+    const res = await request.get("/api/val/draft/ready");
+    expect(res.status(), "the ready document was not served").toBe(200);
+    expect(res.headers()["content-type"]).toContain("text/html");
+
+    const body = await res.text();
+    expect(
+      body,
+      "the ready document does not announce itself, so the provider would " +
+        "never take its iframe down",
+    ).toContain("val-ready");
+    // The property that matters: no Next bundle, so no HMR client, so no
+    // `sync` broadcast when it loads.
+    expect(
+      body,
+      "the ready document pulls in Next's client bundle, which is the thing " +
+        "that made loading /val reload the studio",
+    ).not.toContain("/_next/");
+  });
+
+  /**
+   * A canvas navigation to a route already served leaves the Studio alone.
+   *
+   * The control that makes the pinned case below mean something: it is the FIRST
+   * compile that moves the hash, so a second visit broadcasts a `sync` the
+   * Studio already agrees with.
+   */
+  test("a canvas navigation to an already-served route leaves the studio alone", async ({
+    page,
+  }) => {
+    const observer = await openObservedStudio(page);
+    const { route } = await openCanvasOnBlog1(page);
+
+    // Serve it once so it is compiled, then come back to it.
+    await route.fill("/support/getting-started");
+    await route.press("Enter");
+    await settle(page, 15_000);
+    await route.fill("/blogs/blog1");
+    await route.press("Enter");
+    await settle(page, 5_000);
+
+    const before = await observer.stamp();
+    observer.reset();
+    await route.fill("/support/getting-started");
+    await route.press("Enter");
+    await settle(page, 10_000);
+
+    expect(
+      await observer.stamp(),
+      "the studio document was replaced by a navigation to a route the dev " +
+        "server had already compiled\n" +
+        observer.report("second visit"),
+    ).toBe(before);
+  });
+
+  /**
+   * Navigating the Studio itself, with no canvas, leaves it alone.
+   *
+   * Isolates the Studio's own router from the canvas. The Studio pushes deep
+   * URLs through `history.pushState`, which Next intercepts and turns into a
+   * router restore; this says that is not what replaces the document.
+   */
+  test("a studio navigation with no canvas leaves the studio alone", async ({
+    page,
+  }) => {
+    const observer = await openObservedStudio(page);
+    const studio = await openSiteMap(page);
+    await expandRow(studio, "blogs");
+    await expandRow(studio, "blog1");
+    await expect(studio.locator("input").first()).toHaveValue("Blog 1", {
+      timeout: COMPILE_TIMEOUT,
+    });
+
+    const before = await observer.stamp();
+    observer.reset();
+    // A module never opened in this session, so the Studio's own route changes
+    // and its editor mounts for the first time — but no app route is requested.
+    await expandRow(studio, "support");
+    await expandRow(studio, "getting-started");
+    await closeNavPanel(studio, "Pages");
+    await settle(page, 15_000);
+
+    expect(
+      await observer.stamp(),
+      "the studio document was replaced by its own navigation, with no canvas " +
+        "open\n" +
+        observer.report("studio navigation"),
+    ).toBe(before);
+  });
+
+  /**
+   * Editing with the canvas open on a served route leaves the Studio alone.
+   *
+   * The case an editor spends all day in, and the one the report said was fine.
+   * A save rewrites the `.val.ts` files, which moves the compilation hash — so
+   * this also guards the fix above: with the draft-mode iframe no longer loading
+   * a Next document, a moved hash has no new client to be broadcast at.
+   */
+  test("an edit with the canvas open leaves the studio alone", async ({
+    page,
+    request,
+  }) => {
+    const observer = await openObservedStudio(page);
+    const { studio } = await openCanvasOnBlog1(page);
+
+    const before = await observer.stamp();
+    observer.reset();
+    await studio.locator("input").first().fill("Blog 1 measured");
+    await settle(page, 12_000);
+
+    const after = await observer.stamp();
+    const report = observer.report("an edit");
+    // Restored before the assertion, so a failure does not leave the fixture
+    // edited for every suite that reads it.
+    await clearPatchChain(request);
+    expect(
+      after,
+      "the studio document was replaced by an edit on an already-served " +
+        "route\n" +
+        report,
+    ).toBe(before);
+  });
+
+  /**
+   * PINNED, and not Val's to fix: a canvas navigation to a route `next dev` has
+   * not compiled yet DOES reload the Studio.
+   *
+   * Asserted as it is rather than left out, because it is the last piece of the
+   * report still standing and someone will otherwise spend an afternoon
+   * re-deriving it. The chain is at the top of this file; the part that makes it
+   * Next's is `onHMR` using `publish` — a per-client handshake sent to every
+   * client — so a document that only ever loaded the Studio is reloaded by
+   * another document's connect.
+   *
+   * Val cannot avoid it from the client side: the canvas has to be a document of
+   * the app, that document has to connect an HMR client, and the first broadcast
+   * after any hash movement reloads every client whose hash is older. The ways
+   * out are upstream (answer a connect on that client's socket only) or
+   * structural (the Studio not being a route of the app it edits).
+   *
+   * When this test starts FAILING, that has happened: delete it, and the
+   * `architecture/quirks.md` entry with it.
+   */
+  test("PINNED (next dev): a canvas navigation to an uncompiled route reloads the studio", async ({
+    page,
+  }) => {
+    const observer = await openObservedStudio(page);
+    const { route } = await openCanvasOnBlog1(page);
+
+    const before = await observer.stamp();
+    observer.reset();
+    // `/notes/first` rather than a `.val.json`-backed route: the report named
+    // one, but it is the first compile that matters, not what the content is.
+    await route.fill("/notes/first");
+    await route.press("Enter");
+    await settle(page, 15_000);
+
+    const after = await observer.stamp();
+    const report =
+      observer.report("uncompiled route") +
+      "\n" +
+      reportTrail(await observer.trail());
+    expect(
+      after,
+      "the studio document SURVIVED a canvas navigation to an uncompiled " +
+        "route. If Next fixed the broadcast, delete this test and the " +
+        "quirks.md entry; if a Val change did it, that is the reload gone.\n" +
+        report,
+    ).not.toBe(before);
+  });
+});

--- a/e2e/devReload.ts
+++ b/e2e/devReload.ts
@@ -1,0 +1,412 @@
+import type { Page, WebSocket } from "@playwright/test";
+
+/**
+ * What made the page reload — observed, not inferred.
+ *
+ * The Studio is an ordinary route in the app it edits, so its document is
+ * subject to whatever `next dev` decides to do about a file changing. Reasoning
+ * about which of Val's own moves provokes that has been wrong more than once, so
+ * this records the things that distinguish the candidates and lets a test read
+ * them back:
+ *
+ * - **Document loads, per URL.** A second document request for `/val` in one
+ *   session is not a reload of the Studio — it is Val loading the whole Studio
+ *   route again inside the hidden draft-mode iframe. Only counting navigations
+ *   cannot tell those apart, so requests are counted by URL.
+ * - **The main document's identity.** A stamp written before any of the page's
+ *   own scripts run. A changed stamp is proof the document was replaced; an
+ *   unchanged one is proof it was not, however much re-rendering happened.
+ * - **How it was replaced.** `performance`'s navigation type (`reload` versus
+ *   `navigate`) plus CDP's own reason for the navigation. The trail lives in
+ *   `sessionStorage`, so the document that comes up after a reload can report
+ *   what the one before it saw — the only way to keep a record a reload
+ *   destroys.
+ *
+ *   Note what is deliberately NOT here: wrapping `location.reload` and friends
+ *   to catch the caller. It cannot work. `reload`, `assign`, `replace` and
+ *   `href` are `[LegacyUnforgeable]`, which Chromium implements as own,
+ *   non-configurable properties of each `location` — `Location.prototype` has
+ *   none of them. A `defineProperty` on the prototype therefore SUCCEEDS and is
+ *   never reached, so the wrapper reports "nothing called anything" for a page
+ *   that called it every time. Attribution has to come from CDP or from
+ *   bisecting the suspects, not from page script.
+ * - **The dev HMR socket.** The messages `next dev` sends the client, verbatim.
+ *   This is how "the dev server told this client to reload" is told apart from
+ *   "something in the page navigated it".
+ * - **Console lines.** A Fast Refresh full-reload warning names itself, and sits
+ *   next to the navigation it caused.
+ *
+ * Everything is timestamped on one clock so the order can be read off.
+ */
+export type DevReloadLog = {
+  /** Document (top-level or iframe) requests, in order. */
+  documents: { at: number; url: string }[];
+  /** RSC payload requests — Next's own soft navigations. */
+  rsc: { at: number; url: string }[];
+  /** Main-frame navigations, in order. */
+  navigations: { at: number; url: string }[];
+  /** Console messages, in order. */
+  console: { at: number; type: string; text: string }[];
+  /** Frames received on the `next dev` HMR socket, in order. */
+  hmr: { at: number; payload: string }[];
+  /**
+   * Frames SENT on the dev HMR socket.
+   *
+   * This is what names the reload site. Next's dev client reports itself before
+   * it reloads — `client-full-reload` (carrying the stack trace of the update it
+   * could not apply) or `client-reload-page` — so a frame sent says which of the
+   * client's four reload paths fired, where a received frame only says what the
+   * server asked for.
+   */
+  sent: { at: number; payload: string }[];
+  /**
+   * Call stacks captured at `location.reload()`, via a CDP breakpoint.
+   *
+   * The only way to name the caller. `location.reload` is
+   * `[LegacyUnforgeable]` — an own, non-configurable property of each
+   * `location`, with nothing on `Location.prototype` — so page script cannot
+   * wrap it: a `defineProperty` on the prototype succeeds and is never reached.
+   * `Debugger.setBreakpointOnFunctionCall` on the function object itself is not
+   * subject to that, and `Debugger.paused` carries the stack.
+   */
+  reloadStacks: { at: number; frames: string[] }[];
+  /**
+   * Navigations Chromium was asked to perform, with the REASON it recorded.
+   *
+   * This is the measurement that closes the case. `Location.prototype.href` is
+   * `[LegacyUnforgeable]`, so it cannot be wrapped from page script — meaning a
+   * `location.href = ...` assignment is invisible to the wrappers while still
+   * producing a `reload`-typed navigation when the URL is unchanged. CDP names
+   * the reason directly: `reload` is a real reload, `scriptInitiated` is the
+   * page navigating itself.
+   */
+  requested: { at: number; reason: string; url: string; frame: string }[];
+  /**
+   * Open/close/error on the dev HMR socket.
+   *
+   * A dropped socket is a reload cause that arrives as NO message: Next's client
+   * reloads when it reconnects to a server whose build has moved. Without this,
+   * that case looks like a reload nothing asked for.
+   */
+  socket: { at: number; event: string; url: string }[];
+};
+
+/** One document's own account of how it came to exist, and what it then did. */
+export type NavigationTrailEntry = {
+  stamp: string;
+  /** `performance`'s navigation type: `navigate`, `reload`, `back_forward`. */
+  navigationType: string;
+  url: string;
+};
+
+export type DevReloadObserver = {
+  log: DevReloadLog;
+  /**
+   * The current main document's stamp, or `null` before the first load.
+   *
+   * Read it twice around an action: a different value means the document was
+   * replaced.
+   */
+  stamp(): Promise<string | null>;
+  /**
+   * Every document this tab has had, oldest first, with how it arrived.
+   */
+  trail(): Promise<NavigationTrailEntry[]>;
+  /** Document requests whose URL path is exactly this, ignoring the query. */
+  documentsFor(pathname: string): { at: number; url: string }[];
+  /** A human-readable dump, for a test that is measuring. */
+  report(title: string): string;
+  /** Forget everything recorded so far, so a case can measure one action. */
+  reset(): void;
+};
+
+const STAMP_KEY = "__valDevReloadStamp";
+const TRAIL_KEY = "__valDevReloadTrail";
+
+/**
+ * Start observing. Must be called before the first `goto`.
+ *
+ * The init script runs in every frame before the page's own scripts, so the
+ * canvas frame and the hidden `/val` iframe are covered too, and a stamp is
+ * never missed because a load was fast.
+ */
+export async function observeDevReloads(
+  page: Page,
+): Promise<DevReloadObserver> {
+  const started = Date.now();
+  const now = () => Date.now() - started;
+  const log: DevReloadLog = {
+    documents: [],
+    rsc: [],
+    navigations: [],
+    console: [],
+    hmr: [],
+    socket: [],
+    requested: [],
+    sent: [],
+    reloadStacks: [],
+  };
+
+  await page.addInitScript(
+    ({ stampKey, trailKey }: { stampKey: string; trailKey: string }) => {
+      const stamp = Math.random().toString(36).slice(2, 10);
+      const bag = window as unknown as Record<string, string>;
+      bag[stampKey] = stamp;
+
+      // Only the top document keeps a trail. The canvas frame and the hidden
+      // iframe load constantly and legitimately; mixing them in would bury the
+      // one document whose replacement is the bug.
+      if (window.top !== window.self) {
+        return;
+      }
+
+      type Entry = {
+        stamp: string;
+        navigationType: string;
+        url: string;
+      };
+      const read = (): Entry[] => {
+        try {
+          const raw = window.sessionStorage.getItem(trailKey);
+          return raw === null ? [] : (JSON.parse(raw) as Entry[]);
+        } catch {
+          return [];
+        }
+      };
+      const write = (entries: Entry[]) => {
+        try {
+          window.sessionStorage.setItem(trailKey, JSON.stringify(entries));
+        } catch {
+          // A document with no storage access still gets the stamp, which is
+          // enough to see THAT it was replaced — just not how.
+        }
+      };
+
+      const navigation = performance.getEntriesByType("navigation")[0];
+      const entry: Entry = {
+        stamp,
+        navigationType:
+          navigation instanceof PerformanceNavigationTiming
+            ? navigation.type
+            : "unknown",
+        url: window.location.href,
+      };
+      const entries = read();
+      entries.push(entry);
+      write(entries);
+    },
+    { stampKey: STAMP_KEY, trailKey: TRAIL_KEY },
+  );
+
+  // Chromium-only, which is what this project runs. Attached before the first
+  // navigation so the very first load is in the record too.
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send("Page.enable");
+  await cdp.send("Debugger.enable");
+  await cdp.send("Runtime.enable");
+  cdp.on("Debugger.paused", (event) => {
+    log.reloadStacks.push({
+      at: now(),
+      frames: event.callFrames
+        .slice(0, 12)
+        .map(
+          (frame) =>
+            `${frame.functionName || "(anonymous)"} @ ${frame.url}:${
+              frame.location.lineNumber + 1
+            }`,
+        ),
+    });
+    void cdp.send("Debugger.resume").catch(() => {
+      // The document may already be going away, which is the normal case here.
+    });
+  });
+
+  /**
+   * Arm the breakpoint for the current document.
+   *
+   * Re-armed per document: the function object dies with its realm, so the
+   * objectId from the previous page is stale the moment a reload lands.
+   */
+  const armReloadBreakpoint = async () => {
+    try {
+      const evaluated = await cdp.send("Runtime.evaluate", {
+        expression: "location.reload",
+      });
+      const objectId = evaluated.result.objectId;
+      if (objectId === undefined) return;
+      await cdp.send("Debugger.setBreakpointOnFunctionCall", { objectId });
+    } catch {
+      // A navigation in flight makes this fail harmlessly; the next arm wins.
+    }
+  };
+
+  cdp.on("Page.frameRequestedNavigation", (event) => {
+    log.requested.push({
+      at: now(),
+      reason: event.reason,
+      url: event.url,
+      frame: event.frameId,
+    });
+  });
+
+  page.on("request", (request) => {
+    const url = request.url();
+    if (request.resourceType() === "document") {
+      log.documents.push({ at: now(), url });
+      return;
+    }
+    if (url.includes("_rsc=")) {
+      log.rsc.push({ at: now(), url });
+    }
+  });
+  page.on("framenavigated", (frame) => {
+    if (frame !== page.mainFrame()) return;
+    log.navigations.push({ at: now(), url: frame.url() });
+    void armReloadBreakpoint();
+  });
+  page.on("console", (message) => {
+    log.console.push({ at: now(), type: message.type(), text: message.text() });
+  });
+  page.on("websocket", (socket: WebSocket) => {
+    // EVERY socket, not only `next dev`'s. In dev the Studio SPA is served by
+    // Vite through the Next app (`packages/ui/src/server.ts` proxies
+    // `/api/val/static`), so a second HMR client — with its own reload
+    // behaviour — is live in the Studio document. Filtering to `/_next/` hid it,
+    // which is how a reload with "no dev-server instruction" came to look
+    // unexplained.
+    log.socket.push({ at: now(), event: "open", url: socket.url() });
+    socket.on("close", () => {
+      log.socket.push({ at: now(), event: "close", url: socket.url() });
+    });
+    socket.on("socketerror", (error) => {
+      log.socket.push({
+        at: now(),
+        event: `error ${error}`,
+        url: socket.url(),
+      });
+    });
+    socket.on("framesent", (frame) => {
+      const payload =
+        typeof frame.payload === "string"
+          ? frame.payload
+          : frame.payload.toString("utf-8");
+      log.sent.push({ at: now(), payload });
+    });
+    socket.on("framereceived", (frame) => {
+      const payload =
+        typeof frame.payload === "string"
+          ? frame.payload
+          : frame.payload.toString("utf-8");
+      log.hmr.push({ at: now(), payload });
+    });
+  });
+
+  const observer: DevReloadObserver = {
+    log,
+    async stamp() {
+      return page.evaluate(
+        ({ key }) => {
+          const bag = window as unknown as Record<string, string | undefined>;
+          return bag[key] ?? null;
+        },
+        { key: STAMP_KEY },
+      );
+    },
+    async trail() {
+      return page.evaluate(
+        ({ key }) => {
+          try {
+            const raw = window.sessionStorage.getItem(key);
+            return raw === null
+              ? []
+              : (JSON.parse(raw) as NavigationTrailEntry[]);
+          } catch {
+            return [];
+          }
+        },
+        { key: TRAIL_KEY },
+      );
+    },
+    documentsFor(pathname) {
+      return log.documents.filter((entry) => {
+        try {
+          return new URL(entry.url).pathname === pathname;
+        } catch {
+          return false;
+        }
+      });
+    },
+    report(title) {
+      const lines = [`--- ${title} ---`];
+      const rows: { at: number; text: string }[] = [
+        ...log.documents.map((d) => ({ at: d.at, text: `DOCUMENT ${d.url}` })),
+        ...log.rsc.map((r) => ({ at: r.at, text: `RSC      ${r.url}` })),
+        ...log.navigations.map((n) => ({
+          at: n.at,
+          text: `NAVIGATE ${n.url}`,
+        })),
+        ...log.hmr.map((h) => ({
+          at: h.at,
+          // Truncated, EXCEPT a frame that might carry a reload instruction:
+          // those are the whole point, and the action name can sit anywhere in
+          // a frame that also carries a module list.
+          text: `HMR      ${
+            /reload|action|fullReload|RELOAD/i.test(h.payload)
+              ? h.payload
+              : h.payload.slice(0, 160)
+          }`,
+        })),
+        ...log.reloadStacks.map((r) => ({
+          at: r.at,
+          text: `RELOAD@  ${r.frames.join("\n           ")}`,
+        })),
+        ...log.sent.map((s) => ({
+          at: s.at,
+          // Never truncated: the stack trace in a `client-full-reload` is the
+          // answer this whole harness exists to get.
+          text: `SENT     ${s.payload}`,
+        })),
+        ...log.requested.map((r) => ({
+          at: r.at,
+          text: `REQUESTED reason=${r.reason} ${r.url}`,
+        })),
+        ...log.socket.map((s) => ({
+          at: s.at,
+          text: `SOCKET   ${s.event} ${s.url}`,
+        })),
+        ...log.console.map((c) => ({
+          at: c.at,
+          text: `CONSOLE  [${c.type}] ${c.text.slice(0, 220)}`,
+        })),
+      ];
+      rows.sort((a, b) => a.at - b.at);
+      for (const row of rows) {
+        lines.push(`${String(row.at).padStart(6)}ms  ${row.text}`);
+      }
+      return lines.join("\n");
+    },
+    reset() {
+      log.documents.length = 0;
+      log.rsc.length = 0;
+      log.navigations.length = 0;
+      log.console.length = 0;
+      log.hmr.length = 0;
+      log.socket.length = 0;
+      log.requested.length = 0;
+      log.sent.length = 0;
+      log.reloadStacks.length = 0;
+    },
+  };
+  return observer;
+}
+
+/** The trail, formatted for a test that is measuring. */
+export function reportTrail(trail: NavigationTrailEntry[]): string {
+  const lines = ["--- how each document arrived ---"];
+  for (const [index, entry] of trail.entries()) {
+    lines.push(
+      `${index + 1}. ${entry.stamp} via ${entry.navigationType}  ${entry.url}`,
+    );
+  }
+  return lines.join("\n");
+}

--- a/packages/next/src/ValApp.tsx
+++ b/packages/next/src/ValApp.tsx
@@ -2,6 +2,7 @@
 
 import { ValConfig } from "@valbuild/core";
 import { VAL_APP_PATH, VAL_APP_ID, VERSION as UIVersion } from "@valbuild/ui";
+import { VAL_READY_MESSAGE_TYPE } from "@valbuild/shared/internal";
 import Script from "next/script";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { useConfigStorageSave } from "./useConfigStorageSave";
@@ -20,23 +21,41 @@ export const ValApp = ({
   const isClientSIde = inMessageMode === undefined;
   useConfigStorageSave(config);
   const container = useRef<HTMLDivElement>(null);
+  /**
+   * The legacy landing page for the draft-mode iframe.
+   *
+   * Kept for a `redirect_to` that was already in flight, and for a hosted
+   * `valEnableRedirectUrl` chain still pointing here. The normal path is
+   * `/api/val/draft/ready` — plain HTML with no Next client bundle, because
+   * loading this route in an iframe reloads the Studio (see
+   * `VAL_DRAFT_READY_PATH`).
+   *
+   * The interval has a delay. It was created with none, which in an iframe that
+   * lives until its parent hears the message meant posting as fast as the event
+   * loop allowed, on the same dev server that is compiling. Repeated at all
+   * because the parent attaches its listener when the iframe mounts and a fast
+   * load can beat it; bounded so a parent that never hears it leaves a stopped
+   * timer rather than a running one.
+   */
   useEffect(() => {
-    if (location.search === "?message_onready=true") {
-      setInMessageMode(true);
-      const interval = setInterval(() => {
-        window.parent.postMessage(
-          {
-            type: "val-ready",
-          },
-          "*",
-        );
-      });
-      return () => {
-        clearInterval(interval);
-      };
-    } else {
+    if (location.search !== "?message_onready=true") {
       setInMessageMode(false);
+      return;
     }
+    setInMessageMode(true);
+    let sent = 0;
+    const announce = () => {
+      window.parent.postMessage({ type: VAL_READY_MESSAGE_TYPE }, "*");
+      sent++;
+      if (sent > 20) {
+        clearInterval(interval);
+      }
+    };
+    const interval = setInterval(announce, 250);
+    announce();
+    return () => {
+      clearInterval(interval);
+    };
   }, []);
   useEffect(() => {
     if (container.current?.childElementCount === 0) {

--- a/packages/next/src/ValNextProvider.tsx
+++ b/packages/next/src/ValNextProvider.tsx
@@ -21,7 +21,11 @@ import { initSessionTheme } from "./initSessionTheme";
 import { cn, prefixStyles, valPrefixedClass } from "./cssUtils";
 import { hasValEnableCookie } from "./valEnableCookie";
 import { floatDarkBg, floatLightBg } from "./fallbackColors";
-import { isValCanvasFrame } from "@valbuild/shared/internal";
+import {
+  isValCanvasFrame,
+  VAL_DRAFT_READY_PATH,
+  VAL_READY_MESSAGE_TYPE,
+} from "@valbuild/shared/internal";
 import { ValCanvasBridge } from "./ValCanvasBridge";
 import { shouldSafetyRefresh } from "./safetyRefresh";
 
@@ -359,21 +363,30 @@ export const ValNextProvider = (props: {
             event.detail.value === null)
         ) {
           const draftMode = event.detail.value;
+          /**
+           * Where the iframe lands after the flag is flipped.
+           *
+           * `/draft/ready` rather than the `/val` Studio route. Sending one
+           * message back does not need the Studio, and loading it here RELOADED
+           * the Studio: `next dev` answers a new client connecting by
+           * broadcasting a `sync` with the current webpack hash, and every other
+           * document reloads itself when that hash has moved. See
+           * VAL_DRAFT_READY_PATH for the whole chain, with the Next sources.
+           */
+          const readyUrl = encodeURIComponent(
+            window.location.origin + route + VAL_DRAFT_READY_PATH,
+          );
           if (draftMode === true) {
             setIframeSrc((prev) => {
               if (prev === null) {
-                return `${route}/draft/enable?redirect_to=${encodeURIComponent(
-                  window.location.origin + "/val?message_onready=true",
-                )}`;
+                return `${route}/draft/enable?redirect_to=${readyUrl}`;
               }
               return prev;
             });
           } else if (draftMode === false) {
             setIframeSrc((prev) => {
               if (prev === null) {
-                return `${route}/draft/disable?redirect_to=${encodeURIComponent(
-                  window.location.origin + "/val?message_onready=true",
-                )}`;
+                return `${route}/draft/disable?redirect_to=${readyUrl}`;
               }
               return prev;
             });
@@ -533,7 +546,10 @@ export const ValNextProvider = (props: {
       return;
     }
     const listener = (event: MessageEvent) => {
-      if (event.origin === location.origin && event.data.type === "val-ready") {
+      if (
+        event.origin === location.origin &&
+        event.data.type === VAL_READY_MESSAGE_TYPE
+      ) {
         setIframeSrc(null);
       }
     };

--- a/packages/server/src/ValRouter.ts
+++ b/packages/server/src/ValRouter.ts
@@ -5,6 +5,8 @@ import {
   Api,
   ApiEndpoint,
   ValServerGenericResult,
+  VAL_DRAFT_READY_PATH,
+  VAL_READY_MESSAGE_TYPE,
 } from "@valbuild/shared/internal";
 import { createUIRequestHandler } from "@valbuild/ui/server";
 import { ValServer, ValServerCallbacks, ValServerConfig } from "./ValServer";
@@ -527,6 +529,9 @@ export function createValApiRouter<Res>(
       return res;
     }
 
+    if (path === VAL_DRAFT_READY_PATH) {
+      return convert(draftReadyResponse());
+    }
     if (path.startsWith("/static")) {
       return convert(
         await uiRequestHandler(path.slice("/static".length), url.href),
@@ -534,6 +539,60 @@ export function createValApiRouter<Res>(
     } else {
       return convert(await getValServerResponse(path, req));
     }
+  };
+}
+
+/**
+ * Where the draft-mode iframe lands once the flag is flipped.
+ *
+ * Deliberately NOT a Next route. See {@link VAL_DRAFT_READY_PATH}: a new Next
+ * document connecting to the dev server makes it broadcast a `sync` with the
+ * current compilation hash, and every other document reloads itself if that
+ * hash has moved. This is plain HTML with no client bundle, so it opens no HMR
+ * socket and the Studio stays put.
+ *
+ * Answered here rather than through the typed API surface because that surface
+ * is JSON-only, and this has to be a document a browser will run.
+ *
+ * The message repeats for a few seconds rather than once: the parent attaches
+ * its listener when the iframe mounts, so a fast load can beat it. It stops on
+ * its own — the parent removes the iframe when it hears the message — and the
+ * bound is there so a parent that never hears it leaves a stopped timer rather
+ * than one running for the length of the session.
+ */
+function draftReadyResponse(): ValServerGenericResult {
+  const body = `<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Val draft mode</title></head>
+<body>
+<script>
+  (function () {
+    var sent = 0;
+    function announce() {
+      sent++;
+      if (sent > 20) clearInterval(timer);
+      // Opened top-level rather than in the iframe: nothing to tell. Counted
+      // above rather than returned before, so the timer still stops.
+      if (window.parent === window) return;
+      window.parent.postMessage(
+        { type: ${JSON.stringify(VAL_READY_MESSAGE_TYPE)} },
+        window.location.origin
+      );
+    }
+    var timer = setInterval(announce, 250);
+    announce();
+  })();
+</script>
+</body>
+</html>
+`;
+  return {
+    status: 200,
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      "Cache-Control": "no-store",
+    },
+    body,
   };
 }
 

--- a/packages/shared/src/internal/draftReady.ts
+++ b/packages/shared/src/internal/draftReady.ts
@@ -1,0 +1,26 @@
+/**
+ * The document the draft-mode iframe lands on, and the message it sends back.
+ *
+ * Turning draft mode on in a Next app has to happen server-side, so Val does it
+ * by pointing a hidden iframe at `/api/val/draft/enable`, which flips the flag
+ * and redirects. Something then has to load and say "done" — and that used to be
+ * the entire `/val` Studio route, via `ValApp`'s `?message_onready=true` branch.
+ *
+ * Loading a Next route to send one message is not just wasteful, it reloads the
+ * Studio. `next dev` answers a NEW client connecting by *broadcasting* a `sync`
+ * carrying the current webpack compilation hash (`publish`, not a reply to the
+ * connecting client — see `next/dist/server/dev/hot-middleware.js`), and every
+ * other document's HMR client reloads itself if that hash differs from the one
+ * it recorded, on the theory that the dev server restarted (see
+ * `next/dist/client/dev/hot-reloader/app/web-socket.js`). So any Next document
+ * Val opens while the hash has moved takes the Studio down with it.
+ *
+ * This document is served by the API route as plain HTML. It carries no Next
+ * client bundle, so it opens no HMR socket, so it provokes no broadcast.
+ */
+
+/** Appended to the Val API route, e.g. `/api/val/draft/ready`. */
+export const VAL_DRAFT_READY_PATH = "/draft/ready";
+
+/** The `postMessage` type the ready document sends to its parent. */
+export const VAL_READY_MESSAGE_TYPE = "val-ready";

--- a/packages/shared/src/internal/index.ts
+++ b/packages/shared/src/internal/index.ts
@@ -16,3 +16,4 @@ export * from "./resolveSchemaSourceFixes";
 export * from "./getErrorMessageFromUnknownJson";
 export * from "./zod/SerializedSchema";
 export * from "./valCanvasProtocol";
+export * from "./draftReady";


### PR DESCRIPTION
On top of #508.

"Sometimes the whole Next app reloads when we save." It is not the save, and it is
not Val calling `location.reload()` — nothing in `packages/ui/spa` does outside a
button, the canvas `reloadKey` is bumped only by the "Reload" control, and the
schema-out-of-date reload is a dialog. I got the cause wrong twice reasoning from
the code, so this is measured.

## The chain

1. A new same-origin **Next document** opens. In the Studio that is the canvas
   iframe, remounted on every canvas navigation.
2. If `next dev` has not compiled that route yet, compiling it **moves webpack's
   compilation hash**.
3. That document's HMR client connects, and `next dev` handles a connect in
   `HotReloaderWebpack.onHMR` by calling **`publish`** — a broadcast, not a reply
   to the connecting client — sending a `sync` carrying the current hash
   (`next/dist/server/dev/hot-middleware.js`).
4. Every *other* connected document receives it, and
   `next/dist/client/dev/hot-reloader/app/web-socket.js` says:

   ```js
   if (mostRecentCompilationHash !== null && mostRecentCompilationHash !== message.hash) {
     window.location.reload();   // "the server may have restarted"
   }
   ```

   The Studio is one of those documents, and its recorded hash predates the
   compile. So it reloads itself.

The Studio is reloaded by a handshake that was never meant for it. The lever Val
has is **the number of Next documents it opens**.

## What the measurements say

| Case | Studio document |
|---|---|
| Canvas navigated to a route not served yet this session | **replaced** |
| Same navigation to an already-served route | survives |
| Studio navigated to a new module, canvas closed | survives |
| An edit (auto-save) with the canvas open on a served route | survives |

Two further findings: it makes **no difference** whether the route's content comes
from a `.val.json` entry — it is the first compile, not the content; and the
Studio's own deep `history.pushState` URLs (which Next intercepts and turns into a
router restore) are not the cause. Chromium reports the navigation with
`reason=reload`, and a CDP breakpoint on `location.reload` lands in Next's socket
`handleMessage`.

## The change

The canvas has to be a Next document. **The draft-mode handshake did not.**
Turning draft mode on happens server-side, so Val points a hidden iframe at
`/api/val/draft/enable` and waits for something to load and post `val-ready`
back — and that something was `/val?message_onready=true`, the entire Studio
route, React tree and SPA script, to send one message. A second HMR client, and a
second chance to reload the editor (after a save, say, which rewrites the
`.val.ts` files and moves the hash).

It now lands on `/api/val/draft/ready` (`VAL_DRAFT_READY_PATH`): plain HTML served
by the API route, no client bundle, no HMR socket, nothing to be broadcast at.
Answered outside the typed API surface, alongside `/static`, because that surface
is JSON-only and this has to be a document a browser will run. `ValApp`'s
`?message_onready=true` branch stays for a `redirect_to` already in flight and for
a hosted `valEnableRedirectUrl` chain still pointing there — and its `setInterval`,
created with **no delay** so it posted as fast as the event loop allowed, now has
one and a bound.

## Deliberately not fixed

**A canvas navigation to a route `next dev` has not compiled yet still reloads the
Studio.** It cannot be fixed from Val's side: the canvas must be a document of the
app, that document must connect an HMR client, and the first broadcast after any
hash movement reloads every client whose hash is older. The ways out are upstream
(answer a connect on the connecting client's socket only — arguably the real bug)
or structural (the Studio not being a route of the app it edits). It is asserted
as it behaves, so it is on the record rather than rediscovered; when that test
starts failing, Next has changed and it and the `quirks.md` section should go
together.

## Tests

`e2e/dev-reload.spec.ts`:

- the ready document is served, announces itself, and carries no Next bundle —
  the property that keeps it out of the broadcast;
- three controls that pass today and would catch a regression: an already-served
  route, a Studio navigation with no canvas, an edit with the canvas open;
- the uncompiled-route case, pinned.

**Honest about coverage:** the endpoint is tested, but the provider's redirect
change is not covered by a test that fails without it. The hidden iframe is only
opened when the on-page overlay toggles draft mode, which nothing in the e2e suite
drives — I confirmed a `/val`-document-count assertion passed with and without the
fix and removed it rather than ship a test that cannot fail.

`e2e/devReload.ts` holds the instruments, including two traps that cost me a while:
`location.reload` **cannot** be wrapped from page script (`[LegacyUnforgeable]`
means it is an own, non-configurable property of each `location` and
`Location.prototype` has none of them, so a prototype patch *succeeds* and is never
reached — use `Debugger.setBreakpointOnFunctionCall`), and filtering the socket log
to `/_next/` is how a reload comes to look like it had no cause.

`architecture/quirks.md` carries the write-up, since that file is where the
afternoon-costing facts live.

## Checks

`pnpm test` (2356), `pnpm run lint`, `pnpm -w run format`, `pnpm run -r typecheck`,
`pnpm run build`, `examples/next` build, `e2e/canvas.spec.ts` + `e2e/dev-reload.spec.ts`
(16 passed — including "turns preview mode on, then makes the page selectable", the
draft-mode path this touches), and `val validate` through both `src/cli.ts` and
`bin.js` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ugEdEoqLfwQefEn8m9rfy

---
_Generated by [Claude Code](https://claude.ai/code/session_017ugEdEoqLfwQefEn8m9rfy)_