### PR TITLE
Show the module header beside the canvas, and even out the view switch

### DIFF
--- a/.changeset/olive-donkeys-hear.md
+++ b/.changeset/olive-donkeys-hear.md
@@ -1,0 +1,7 @@
+---
+"@valbuild/ui": patch
+---
+
+Show the module header — the title and the scope breadcrumb — in the editor column while the canvas is open. It was hidden there, so opening a page on the canvas lost the one line that named what was being edited, along with the only links back up the scope.
+
+Give the canvas view switch the same air around "Normal" and around "Fields": the options are now as wide as what is written on them, rather than sharing one column width that the field count made the wider option decide.

--- a/packages/ui/spa/components/Module.tsx
+++ b/packages/ui/spa/components/Module.tsx
@@ -41,19 +41,9 @@ import { ScopeTrail } from "./ModuleScope";
 export function Module({
   path,
   showModuleGalleryChild,
-  hideHeader,
 }: {
   path: SourcePath;
   showModuleGalleryChild: SourcePath | null;
-  /**
-   * Drop the breadcrumb and the title.
-   *
-   * For the canvas, where the page itself is on screen beside the fields: the
-   * breadcrumb repeats what the address bar says, and its title repeats the
-   * page's own heading. The record tools stay — they are the only way to add an
-   * item, and they navigate nowhere.
-   */
-  hideHeader?: boolean;
 }) {
   const schemaAtPath = useSchemaAtPath(path);
   const { path: maybeParentPath, schema: parentSchema } = useParent(path);
@@ -177,44 +167,42 @@ export function Module({
            * of the column on the part that does not change.
            */}
           <div className="flex gap-4 justify-between items-start min-h-6">
-            {!hideHeader && (
-              /*
-               * The title and its description, in ONE column.
-               *
-               * The description was a sibling of this whole row, so its top
-               * margin was measured from the row's bottom — and the row is as
-               * tall as the tools on its right, not as tall as the title. That
-               * put a fixed 12px between title and description no matter what
-               * was asked for, the same 12px that then separated it from the
-               * scope: three evenly spaced lines, with nothing saying which one
-               * the description belonged to. Inside the column it sits against
-               * the title, and the tools cannot push it around.
-               */
-              <div className="min-w-0 flex-1">
-                {/*
-                 * A heading, in the role sense: the editor column had none, so
-                 * nothing announced what was being edited and nothing could jump
-                 * to it. Not an `<h1>` element, because the title of a router
-                 * page is a breadcrumb — and a `<nav>` inside a heading element
-                 * is not valid HTML.
-                 */}
-                <div
-                  role="heading"
-                  aria-level={1}
-                  className="text-2xl leading-tight"
-                >
-                  {titleNode}
-                </div>
-                {keyDescription && (
-                  <div className="mt-1 text-sm text-fg-tertiary">
-                    {keyDescription}
-                  </div>
-                )}
+            {/*
+             * The title and its description, in ONE column.
+             *
+             * The description was a sibling of this whole row, so its top
+             * margin was measured from the row's bottom — and the row is as
+             * tall as the tools on its right, not as tall as the title. That
+             * put a fixed 12px between title and description no matter what
+             * was asked for, the same 12px that then separated it from the
+             * scope: three evenly spaced lines, with nothing saying which one
+             * the description belonged to. Inside the column it sits against
+             * the title, and the tools cannot push it around.
+             */}
+            <div className="min-w-0 flex-1">
+              {/*
+               * A heading, in the role sense: the editor column had none, so
+               * nothing announced what was being edited and nothing could jump
+               * to it. Not an `<h1>` element, because the title of a router
+               * page is a breadcrumb — and a `<nav>` inside a heading element
+               * is not valid HTML.
+               */}
+              <div
+                role="heading"
+                aria-level={1}
+                className="text-2xl leading-tight"
+              >
+                {titleNode}
               </div>
-            )}
+              {keyDescription && (
+                <div className="mt-1 text-sm text-fg-tertiary">
+                  {keyDescription}
+                </div>
+              )}
+            </div>
             {tools}
           </div>
-          {!hideHeader && init.length > 0 && (
+          {init.length > 0 && (
             <ScopeTrail
               parts={init}
               portalContainer={portalContainer}

--- a/packages/ui/spa/components/shell/ValShell.tsx
+++ b/packages/ui/spa/components/shell/ValShell.tsx
@@ -263,12 +263,9 @@ function ValShellBody({ state }: { state: ReturnType<typeof useShellData> }) {
           (navigation.currentSourcePath || selection.sourcePath) as SourcePath
         }
         showModuleGalleryChild={null}
-        // No breadcrumb or title beside the canvas: the address bar says which
-        // route this is and the page itself carries its own heading.
-        hideHeader={viewState.canvasOpen}
       />
     ),
-    [navigation.currentSourcePath, viewState.canvasOpen],
+    [navigation.currentSourcePath],
   );
 
   /**
@@ -720,11 +717,7 @@ function ValShellBody({ state }: { state: ReturnType<typeof useShellData> }) {
   ) : navigation.isErrorsView ? (
     <ValidationErrorsView />
   ) : unlistedModulePath ? (
-    <Module
-      path={unlistedModulePath}
-      showModuleGalleryChild={null}
-      hideHeader={viewState.canvasOpen}
-    />
+    <Module path={unlistedModulePath} showModuleGalleryChild={null} />
   ) : null;
 
   return (

--- a/packages/ui/spa/components/shell/canvas/PageWorkspace.tsx
+++ b/packages/ui/spa/components/shell/canvas/PageWorkspace.tsx
@@ -546,6 +546,7 @@ export function PageWorkspace({
         onChange={onViewChange}
         fieldCount={fieldCount}
         animate={!reducedMotion}
+        compact={isPhone}
       />
     ) : null;
 
@@ -964,6 +965,7 @@ function SegmentedControl<T extends string>({
   onChange,
   options,
   animate,
+  compact,
 }: {
   label: string;
   value: T;
@@ -976,6 +978,16 @@ function SegmentedControl<T extends string>({
     badge?: number;
   }>;
   animate: boolean;
+  /**
+   * The tighter padding, for where the room is not there.
+   *
+   * The phone strip carries BOTH switches on one line that does not wrap, in
+   * `viewport - 24`; at the roomier padding that line runs off a 390px screen
+   * and takes the pane switch — the only visible way to the canvas — with it.
+   * Every option still gets the same padding as every other, which is what
+   * this control is for; there is just less of it.
+   */
+  compact?: boolean;
 }) {
   const index = Math.max(
     0,
@@ -1036,18 +1048,29 @@ function SegmentedControl<T extends string>({
       aria-label={label}
       className="relative inline-flex rounded-md border border-border-float bg-bg-float p-0.5"
     >
-      <span
-        aria-hidden
-        style={{
-          width: thumb?.width ?? 0,
-          transform: `translateX(${thumb?.left ?? 0}px)`,
-          transition:
-            animate && thumb !== null
+      {/*
+       * Only once there is a measurement to draw it at.
+       *
+       * Not `width: 0` until then: a transition runs off the style the element
+       * was last painted with, and measuring forces a style recalculation — so
+       * a thumb that exists at zero width has a zero width to animate FROM,
+       * and every mount of the control played the pill growing out of nothing.
+       * A node that was not there has no previous style, so its first paint is
+       * simply where it belongs.
+       */}
+      {thumb !== null && (
+        <span
+          aria-hidden
+          style={{
+            width: thumb.width,
+            transform: `translateX(${thumb.left}px)`,
+            transition: animate
               ? `transform ${SWITCH_MS}ms ${OPEN_EASE}, width ${SWITCH_MS}ms ${OPEN_EASE}`
               : undefined,
-        }}
-        className="absolute inset-y-0.5 left-0 rounded bg-bg-float-raised shadow-sm"
-      />
+          }}
+          className="absolute inset-y-0.5 left-0 rounded bg-bg-float-raised shadow-sm"
+        />
+      )}
       {options.map((option) => (
         <button
           key={option.value}
@@ -1057,7 +1080,8 @@ function SegmentedControl<T extends string>({
           onClick={() => onChange(option.value)}
           className={cn(
             // Above the thumb, which is painted behind the whole row.
-            "relative inline-flex h-7 shrink-0 items-center justify-center gap-1.5 rounded px-4 text-[0.6875rem] transition-colors",
+            "relative inline-flex h-7 shrink-0 items-center justify-center gap-1.5 rounded text-[0.6875rem] transition-colors",
+            compact ? "px-2.5" : "px-4",
             value === option.value
               ? "font-medium text-fg-primary"
               : "text-fg-secondary hover:text-fg-primary",
@@ -1097,6 +1121,8 @@ function PaneToggle({
       value={pane}
       onChange={onChange}
       animate={animate}
+      // Only ever on the phone strip, which is where the room runs out.
+      compact
       options={[
         { value: "editor", label: "Editor", icon: PanelLeft },
         { value: "canvas", label: "Canvas", icon: Layers },
@@ -1116,12 +1142,15 @@ function ViewToggle({
   onChange,
   fieldCount,
   animate,
+  compact,
 }: {
   view: CanvasView;
   onChange: (view: CanvasView) => void;
   /** How many fields the page reported. Shown on the Fields tab. */
   fieldCount?: number;
   animate: boolean;
+  /** See `SegmentedControl`: on the phone it shares its line with the panes. */
+  compact?: boolean;
 }) {
   return (
     <SegmentedControl
@@ -1129,6 +1158,7 @@ function ViewToggle({
       value={view}
       onChange={onChange}
       animate={animate}
+      compact={compact}
       options={[
         {
           value: "normal",

--- a/packages/ui/spa/components/shell/canvas/PageWorkspace.tsx
+++ b/packages/ui/spa/components/shell/canvas/PageWorkspace.tsx
@@ -2,6 +2,7 @@ import {
   ReactNode,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -935,6 +936,9 @@ function SplitDivider({
 /** Which half of the workspace a phone is showing. */
 export type WorkspacePane = "editor" | "canvas";
 
+/** Where the thumb sits, in pixels from the inside of the control's border. */
+type SegmentedThumb = { left: number; width: number };
+
 /**
  * A two-state switch whose selected state travels between the options.
  *
@@ -942,8 +946,17 @@ export type WorkspacePane = "editor" | "canvas";
  * pane switch and the swipe do the same thing — and a control that slides
  * says that, where one that blinks between two colours does not.
  *
- * Options are laid out in equal columns (`auto-cols-fr`) so the thumb can be
- * one column wide and travel by exactly one column, whatever the labels say.
+ * Each option is as wide as what is written on it, so every label gets the
+ * SAME padding either side of it. Equal columns (`auto-cols-fr`) did not: the
+ * widest option decides the column, so it ends up flush against its own
+ * padding while every shorter one is centred in the slack left over. On the
+ * canvas switch that is "Fields 18" against "Normal" — the count made the
+ * fields option the wide one, so the selected pill looked tight around
+ * "Fields 18" and roomy around "Normal", from the same `px-4`.
+ *
+ * The price is that the thumb can no longer be "one column, moved by one
+ * column": it is measured off the selected button instead, which is what
+ * {@link SegmentedThumb} holds.
  */
 function SegmentedControl<T extends string>({
   label,
@@ -968,22 +981,72 @@ function SegmentedControl<T extends string>({
     0,
     options.findIndex((option) => option.value === value),
   );
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const [thumb, setThumb] = useState<SegmentedThumb | null>(null);
+
+  /*
+   * Measured, and re-measured whenever a label's width can have changed.
+   *
+   * A layout effect rather than an effect: the first measurement has to land
+   * before the browser paints, or the thumb is drawn at zero width and then
+   * springs open. The observer covers the rest — a webfont arriving, the badge
+   * going from 9 to 10, the control being laid out in a narrower column.
+   */
+  useLayoutEffect(() => {
+    const list = listRef.current;
+    if (list === null) {
+      return;
+    }
+    const measure = () => {
+      const buttons = list.querySelectorAll("button");
+      const selected = buttons[index];
+      if (selected === undefined) {
+        return;
+      }
+      // Against the padding box, which is what `absolute; left: 0` is measured
+      // from — `clientLeft` takes the border back off.
+      const left =
+        selected.getBoundingClientRect().left -
+        list.getBoundingClientRect().left -
+        list.clientLeft;
+      const width = selected.getBoundingClientRect().width;
+      setThumb((current) =>
+        current !== null && current.left === left && current.width === width
+          ? current
+          : { left, width },
+      );
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(list);
+    list
+      .querySelectorAll("button")
+      .forEach((button) => observer.observe(button));
+    return () => observer.disconnect();
+    // `options.length` rather than `options`: the array is a literal at every
+    // call site, so depending on it would tear down and re-observe on every
+    // render. What the effect reads off it is how many buttons there are; a
+    // label or badge that changes width is what the observer is for.
+  }, [index, options.length]);
+
   return (
     <div
+      ref={listRef}
       role="tablist"
       aria-label={label}
-      className="relative inline-grid auto-cols-fr grid-flow-col rounded-md border border-border-float bg-bg-float p-0.5"
+      className="relative inline-flex rounded-md border border-border-float bg-bg-float p-0.5"
     >
       <span
         aria-hidden
         style={{
-          width: `calc((100% - 4px) / ${options.length})`,
-          transform: `translateX(${index * 100}%)`,
-          transition: animate
-            ? `transform ${SWITCH_MS}ms ${OPEN_EASE}`
-            : undefined,
+          width: thumb?.width ?? 0,
+          transform: `translateX(${thumb?.left ?? 0}px)`,
+          transition:
+            animate && thumb !== null
+              ? `transform ${SWITCH_MS}ms ${OPEN_EASE}, width ${SWITCH_MS}ms ${OPEN_EASE}`
+              : undefined,
         }}
-        className="absolute inset-y-0.5 left-0.5 rounded bg-bg-float-raised shadow-sm"
+        className="absolute inset-y-0.5 left-0 rounded bg-bg-float-raised shadow-sm"
       />
       {options.map((option) => (
         <button
@@ -994,7 +1057,7 @@ function SegmentedControl<T extends string>({
           onClick={() => onChange(option.value)}
           className={cn(
             // Above the thumb, which is painted behind the whole row.
-            "relative inline-flex h-7 items-center justify-center gap-1.5 rounded px-2.5 text-[0.6875rem] transition-colors",
+            "relative inline-flex h-7 shrink-0 items-center justify-center gap-1.5 rounded px-4 text-[0.6875rem] transition-colors",
             value === option.value
               ? "font-medium text-fg-primary"
               : "text-fg-secondary hover:text-fg-primary",


### PR DESCRIPTION
## The module header, beside the canvas

The editor column dropped its title and scope breadcrumb whenever the canvas was open — `Module` took a `hideHeader` prop and `ValShell` passed `viewState.canvasOpen` into it. The reasoning was that the address bar already says which route it is and the page carries its own heading, but that leaves the column with nothing naming the module being edited and no links back up the scope (the browser's back button and the Pages panel were the only ways up).

So on `/val/~/app/page.val.ts?p="/"` the header reads

```
/
App / ‹ Page
```

and it now reads the same with `&canvas=1`. `hideHeader` is gone rather than made conditional on the view: the module column is the only place `Module` renders, and in the Fields view it is replaced by the fields panel — so there was no second case left for it.

## The view switch

`SegmentedControl` laid its options out in equal columns (`auto-cols-fr`). The widest option decides that column, so it ends up flush against its own padding while every shorter one is centred in the slack left over. On the canvas switch the field count made "Fields 18" the wide one, so the selected pill had 10px around "Fields 18" and 16px around "Normal" — the same `px`, two different amounts of air.

Each option is now as wide as what is written on it, so every label gets the same padding either side. The price is that the thumb can no longer be "one column, moved by one column" — it is measured off the selected button with a layout effect and kept honest by a `ResizeObserver`.

## Second commit: two defects the review found

Both were confirmed in a browser before and after, not reasoned about.

1. **The thumb played itself open on every mount.** The layout effect lands before paint, but measuring forces a style recalculation, so the thumb *had* a resolved `width: 0px` to animate from — and the render that set the real width was also the first render to put `width` in the transition list. Measured across frames: `0, 8.3, 23.1, 44.6, 63.1, …, 97.6`. That fired once per mount of the control: opening the canvas, the field count first arriving, and every swipe back to the editor pane on a phone, where the strip unmounts the switch. The thumb is no longer rendered at all until there is a measurement to draw it at — a node that was never painted has no previous style, so nothing transitions.

2. **The phone strip overflowed.** It carries *both* switches on one line that does not wrap, inside `viewport - 24`, and `px-4` plus `shrink-0` pushed the pane switch — the only visible way to the canvas pane — past the right edge at every common phone width: its right edge landed at 381px against a strip ending at 348 / 363 / 378px for a 360 / 375 / 390px screen. Both switches take the tighter padding there.

## Measured

| | left air | right air |
|---|---|---|
| Desktop, "Normal" selected | 16px | 16px |
| Desktop, "Fields 18" selected | 16px | 16px |
| Phone, canvas view switch | 10px | 10px |
| Phone, pane switch | 10px | 10px |

The pane switch now ends exactly on the strip's right edge at 360, 375, 390 and 430px, and the thumb still travels (sampled `91 → 176.5` across frames on a click).

## Verified

- The studio itself (`examples/next` on :3456), on the URL above with and without `canvas=1`: heading `/`, scope `App / Page` in both.
- Storybook `Shell/Shell` — `CanvasNormalView`, `CanvasFieldsView`, `CanvasOnMobile` — measured and screenshotted at 360/375/390/430px.
- `pnpm run lint`, `pnpm -w run format`, `pnpm run -r typecheck`, `pnpm test` (206 suites, 2395 tests), `pnpm run build`, and `cd examples/next && pnpm run build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3NEaqNqqckAZGdhu8Aawy
