### PR TITLE
Stop losing the edit you make after discarding changes

### DIFF
--- a/.changeset/discarded-patch-as-parent.md
+++ b/.changeset/discarded-patch-as-parent.md
@@ -1,0 +1,27 @@
+---
+"@valbuild/ui": patch
+---
+
+Stop losing the edit you make after discarding changes
+
+In proxy mode, discarding a set of changes and then editing again failed with
+"An edit could not be saved and has been reverted." and `Parent patch not
+found`, and it kept failing for every edit after that until the tab was
+reloaded. The edits were gone, not merely unsaved.
+
+Every write names its parent, because the chain is linear. The sync computes
+that parent from what the content service has said exists — and a discard
+deleted the patches without telling it, so the next write named one of the
+deleted ids. A service refuses a parent it does not hold differently from one
+that is merely out of date: out of date is a conflict, which is re-synced and
+retried, while a parent that is gone is a permanent refusal, and a permanent
+refusal is answered by dropping the patch and putting the field back. Hence a
+lost edit rather than a slow one.
+
+It could not recover on its own, either. The sync releases an id it is holding
+only when a fresh `/stat` lists it, which is right — a snapshot taken before our
+own write must not walk the parent backwards — but a deleted patch is never
+listed again, so nothing could clear it.
+
+A patch leaving the chain now reaches the sync, whether it left through a
+discard here, a discard in another tab, or a refusal by the server.

--- a/architecture/quirks.md
+++ b/architecture/quirks.md
@@ -226,6 +226,25 @@ two backwards and you either resurrect deleted edits as permanent failures, or
 wait forever on changes that will never arrive — the second of which is a real
 bug that shipped. See `architecture/patch-store.md`.
 
+**A parent the content service does not HOLD is fatal; a parent that is merely
+stale is not.** Every write names its parent, and the service answers the two
+cases differently: not-the-head is a 409, which `ValOpsHttp` maps to
+`patch-head-conflict` and `PatchSync` re-syncs and retries; a parent that has
+been deleted is `Parent patch not found` with a status that is not 409, which
+becomes `other` → a 400 `patch-error` → `rejected`, and rejected is PERMANENT —
+the patch is dropped and the field reverts. So the whole cost of naming a
+deleted parent is the editor's work, reported as "An edit could not be saved and
+has been reverted."
+
+Which is what a discard used to do. `PatchSync` computes the parent from what
+the server has said exists, and the discard told it nothing; worse,
+`savedNotInStat` releases an id only when a stat LISTS it, and a deleted patch
+never is — so one discard poisoned every later edit until the tab was reloaded.
+`patch:drop` now reaches `PatchSync.forget`. Pinned by `e2e/http/discard.spec.ts`
+and by "the write after a discard" in `patchSync.test.ts`; the mock content host
+answers the two cases apart, which it did not, and could therefore not reproduce
+any of this.
+
 **An AI-written `file` op carries a session key where every other one carries
 bytes.** An image the editor attaches in the chat is uploaded to the content
 service straight from the browser; the assistant is only ever told an opaque key,

--- a/e2e/http/discard.spec.ts
+++ b/e2e/http/discard.spec.ts
@@ -1,0 +1,160 @@
+import { expect, test } from "@playwright/test";
+import {
+  currentParentRef,
+  discardAll,
+  mock,
+  openHttpStudio,
+  reportedErrors,
+  sessionCookie,
+  tryWritePatch,
+  writePatch,
+} from "./httpMode";
+
+/**
+ * Editing again after a discard.
+ *
+ * The reported failure is two lines in the Studio — "An edit could not be saved
+ * and has been reverted." with `<module>: Parent patch not found` under it — and
+ * it is the worst shape a bug can take here, because the edit is GONE. Every
+ * later edit fails the same way until the tab is reloaded.
+ *
+ * ## Why it happens
+ *
+ * The chain is linear and every write names its parent. `PatchSync` computes
+ * that parent from `/stat`, and in proxy mode `/stat` is only re-read when the
+ * WebSocket says the chain moved — the poll behind it waits twenty minutes while
+ * a socket is carrying changes (`WebSocketStatInterval` in `useStatus.ts`). A
+ * discard deletes patches through `DELETE /patches` and drops them from
+ * `PatchStore`, and tells `PatchSync` nothing. So between the discard and the
+ * next stat the sync still names a patch the content service no longer has —
+ * and `PatchSync.savedNotInStat` keeps a discarded id even once a stat HAS
+ * arrived, because ids leave that list only by being listed, and a deleted patch
+ * never is.
+ *
+ * ## Why that costs the edit rather than a round trip
+ *
+ * `PatchSync` splits a refused write in two, and the split is the whole
+ * difference: a 409 is `conflict`, which re-syncs and retries; anything else is
+ * `rejected`, which is permanent, so the patch is dropped and the field reverts.
+ * The content service answers a parent it does not have with `Parent patch not
+ * found` and a status that is not 409, so a stale parent lands on the
+ * destroying side of that split. The mock answers the same way — see
+ * `savePatch` in `e2e/mock-content-host/server.ts`.
+ */
+
+const MODULE = "/content/authors.val.ts";
+
+test.use({
+  storageState: { cookies: [sessionCookie("ada")], origins: [] },
+});
+
+// Deliberately NOT `serial`, unlike the rest of this directory: serial skips
+// every later test once one fails, and these three are three separate facts
+// about the same sequence. A reader needs all three, especially the third —
+// whether the Studio recovers is the difference between one lost edit and an
+// editor that cannot save until it is reloaded. `mock.reset()` plus a page each
+// is all the isolation they need.
+
+test.beforeEach(async () => {
+  await mock.reset();
+});
+
+test.describe("editing after a discard", () => {
+  /**
+   * The cause, on its own, so a failure points at the sync rather than the save.
+   *
+   * Not a restatement of the test below: this one fails the moment the client
+   * holds a parent that cannot work, which is true whatever the content service
+   * decides to answer. If the service were changed to answer 409 the write would
+   * recover and the test below would pass — and this would still be the bug.
+   */
+  test("the parent named next is one the content service still has", async ({
+    page,
+  }) => {
+    await openHttpStudio(page);
+    await writePatch(page, MODULE, [
+      { op: "replace", path: ["teddy", "name"], value: "Before the discard" },
+    ]);
+
+    await discardAll(page);
+
+    const parent = await currentParentRef(page);
+    if (parent?.type !== "patch") {
+      // `head` is the correct answer here — the chain is empty — and so is any
+      // id the service still holds. Only a dangling id is the bug.
+      return;
+    }
+    const live = (await mock.state()).patches.map((patch) => patch.patchId);
+    expect(
+      live,
+      "the next write would name a patch the discard deleted",
+    ).toContain(parent.patchId);
+  });
+
+  /**
+   * The same sequence, taken all the way to what the editor sees.
+   *
+   * Three assertions rather than one because they fail for different reasons and
+   * a reader needs to know which happened: the edit never reached the service,
+   * the Studio threw it away locally, and it said so in the words from the
+   * report.
+   */
+  test("the next edit is saved rather than reverted", async ({ page }) => {
+    await openHttpStudio(page);
+    await writePatch(page, MODULE, [
+      { op: "replace", path: ["teddy", "name"], value: "Before the discard" },
+    ]);
+
+    await discardAll(page);
+
+    const written = await tryWritePatch(page, MODULE, [
+      { op: "replace", path: ["teddy", "name"], value: "After the discard" },
+    ]);
+
+    const errors = await reportedErrors(page);
+    const state = await mock.state();
+    expect(
+      state.patches.map((patch) => patch.patchId),
+      `the edit after the discard never reached the content service. The Studio said: ${JSON.stringify(errors)}`,
+    ).toContain(written.patchId);
+    expect(
+      written.keptLocally,
+      "the edit was dropped locally: the Studio took the refusal as permanent",
+    ).toBe(true);
+    expect(
+      errors.map((error) => error.message),
+      "the Studio reported the edit as reverted",
+    ).not.toContain("An edit could not be saved and has been reverted.");
+  });
+
+  /**
+   * And it does not heal, which is the half of the report that makes it urgent.
+   *
+   * One lost edit is a bad afternoon; a Studio that cannot save anything until
+   * the tab is reloaded is an editor stuck. The second write goes out after the
+   * first has already been refused, so every notification the discard produces
+   * has had time to arrive — if the parent were merely stale, this one would
+   * work.
+   */
+  test("a later edit is not lost too", async ({ page }) => {
+    await openHttpStudio(page);
+    await writePatch(page, MODULE, [
+      { op: "replace", path: ["teddy", "name"], value: "Before the discard" },
+    ]);
+
+    await discardAll(page);
+    await tryWritePatch(page, MODULE, [
+      { op: "replace", path: ["teddy", "name"], value: "After the discard" },
+    ]);
+
+    const second = await tryWritePatch(page, MODULE, [
+      { op: "replace", path: ["teddy", "name"], value: "And again" },
+    ]);
+
+    const state = await mock.state();
+    expect(
+      state.patches.map((patch) => patch.patchId),
+      "the Studio never recovered: a second edit was lost the same way",
+    ).toContain(second.patchId);
+  });
+});

--- a/e2e/http/httpMode.ts
+++ b/e2e/http/httpMode.ts
@@ -396,8 +396,18 @@ type StoreBag = {
         | { status: string; message: string }
       >;
     };
-    patchSync: { flush(): Promise<void> };
+    patchSync: {
+      flush(): Promise<void>;
+      currentParentRef(): {
+        type: "head" | "patch";
+        patchId?: string;
+        headBaseSha?: string;
+      } | null;
+    };
     sourceStore: { peek(path: string): unknown };
+    status: {
+      current(): { errors: readonly { message: string; details?: string }[] };
+    };
     discard(ids: string[]): Promise<{ status: string; message?: string }>;
     publish(
       patchIds: string[],
@@ -434,6 +444,80 @@ export async function writePatch(
     },
     { mfp: moduleFilePath, ops: patch },
   );
+}
+
+/**
+ * Make one edit and report the outcome instead of waiting for it to succeed.
+ *
+ * {@link writePatch} is the happy path and throws on anything else, which is
+ * right for a test whose subject is somewhere after the write. A test whose
+ * subject IS the write needs to see the failure rather than be thrown out of, so
+ * this returns the id and leaves the assertion to the caller: a patch the server
+ * refused is dropped from the store by the time `flush` resolves, so "is this id
+ * still in the chain" is the question that distinguishes saved from lost.
+ */
+export async function tryWritePatch(
+  page: Page,
+  moduleFilePath: string,
+  patch: unknown[],
+): Promise<{ patchId: string; keptLocally: boolean }> {
+  return page.evaluate(
+    async ({ mfp, ops }) => {
+      const bag = window as unknown as { __VAL_STORES__: StoreBag };
+      const system = bag.__VAL_STORES__.system;
+      const res = await system.patchStore.createPatch(mfp, ops);
+      if (!("record" in res)) {
+        throw new Error(`createPatch failed: ${JSON.stringify(res)}`);
+      }
+      const patchId = res.record.patchId;
+      await system.patchSync.flush();
+      return {
+        patchId,
+        keptLocally: system.patchStore
+          .allRecords()
+          .some((record) => record.patchId === patchId),
+      };
+    },
+    { mfp: moduleFilePath, ops: patch },
+  );
+}
+
+/**
+ * What the next write would name as its parent.
+ *
+ * The one piece of client state this suite asserts on directly, because it is
+ * the cause and everything else is the symptom: a parent naming a patch the
+ * content service no longer has is what turns the next edit into a lost one.
+ */
+export function currentParentRef(page: Page): Promise<{
+  type: "head" | "patch";
+  patchId?: string;
+  headBaseSha?: string;
+} | null> {
+  return page.evaluate(() => {
+    const bag = window as unknown as { __VAL_STORES__: StoreBag };
+    return bag.__VAL_STORES__.system.patchSync.currentParentRef();
+  });
+}
+
+/**
+ * Everything the Studio has told the editor is wrong.
+ *
+ * Read from `StatusStore` rather than off the screen. The words are the same
+ * either way — this is what the toast renders — and reading them here means a
+ * test about saving does not also depend on where the notice is drawn or how
+ * long it stays up.
+ */
+export function reportedErrors(
+  page: Page,
+): Promise<{ message: string; details?: string }[]> {
+  return page.evaluate(() => {
+    const bag = window as unknown as { __VAL_STORES__: StoreBag };
+    return bag.__VAL_STORES__.system.status.current().errors.map((error) => ({
+      message: error.message,
+      details: error.details,
+    }));
+  });
 }
 
 /** What the page currently shows at one source path. */

--- a/e2e/mock-content-host/server.ts
+++ b/e2e/mock-content-host/server.ts
@@ -545,6 +545,16 @@ const getApplicablePatches: Handler = (req, res, url) => {
  * single-writer, and a patch whose parent is no longer the head is a 409 the
  * client is built to recover from. Two editors racing is the case that produces
  * it, which is exactly one of the things these tests are for.
+ *
+ * A parent that DOES NOT EXIST is a different answer, and the difference is the
+ * whole of `e2e/http/discard.spec.ts`. The real content service answers a
+ * missing parent with `Parent patch not found` and a status that is not 409, and
+ * that distinction decides what the Studio does with the edit: `ValOpsHttp` maps
+ * 409 to `patch-head-conflict`, which `PatchSync` re-syncs and RETRIES, and
+ * anything else to `other`, which `ValServer` turns into a 400 `patch-error` and
+ * `PatchSync` treats as permanently rejected — the patch is dropped and the
+ * user's edit is gone. Answering both cases 409, as this used to, made the mock
+ * forgiving of exactly the bug that loses an edit after a discard.
  */
 const savePatch: Handler = async (req, res) => {
   const body = await readJsonBody<{
@@ -564,11 +574,20 @@ const savePatch: Handler = async (req, res) => {
     json(res, 200, { patchId: body.patchId });
     return;
   }
+  const parentPatchId = body.parentPatchId ?? null;
+  if (parentPatchId !== null && !state.patches.has(parentPatchId)) {
+    // Gone, not merely stale: nothing the client can re-sync to makes this id
+    // exist again. JSON with a `message`, because that is what `ValOpsHttp`
+    // reads a non-409 body as — a text body would reach the user as the status
+    // line instead of as this sentence.
+    json(res, 404, { message: "Parent patch not found" });
+    return;
+  }
   const head = headPatchId();
-  if ((body.parentPatchId ?? null) !== head) {
+  if (parentPatchId !== head) {
     res.writeHead(409, { "Content-Type": "text/plain", ...corsHeaders(res) });
     res.end(
-      `Parent patch ${body.parentPatchId ?? "<head>"} is not the head of the chain (${head ?? "<empty>"})`,
+      `Parent patch ${parentPatchId ?? "<head>"} is not the head of the chain (${head ?? "<empty>"})`,
     );
     return;
   }

--- a/packages/ui/spa/stores/PatchSync.ts
+++ b/packages/ui/spa/stores/PatchSync.ts
@@ -286,6 +286,50 @@ export class PatchSync {
     );
   }
 
+  /**
+   * These patches are gone from the server. Stop naming them as a parent.
+   *
+   * The counterpart to {@link receiveStat}, and the reason it cannot do this
+   * job itself: a stat drops an id from {@link savedNotInStat} by LISTING it,
+   * because a snapshot that omits a just-saved patch is usually only stale. A
+   * DELETED patch is never listed again, so it would sit there naming itself the
+   * parent of every future write for as long as the tab is open.
+   *
+   * That is not a slow recovery, it is no recovery: the chain is linear, so a
+   * parent the server does not hold is refused — and refused as
+   * `Parent patch not found` with a status that is not 409, which {@link handle}
+   * reads as permanent and answers by DROPPING the patch. One discard therefore
+   * cost every edit made after it, one toast at a time, until a reload.
+   *
+   * Called from the `patch:drop` listener in `createSystem`, so it covers a
+   * discard made here, a discard made in another tab (`reconcileVanished` drops
+   * what stat has stopped naming), and a patch the server refused — rather than
+   * only the one path that happened to be reported.
+   *
+   * One drop is not a deletion: `discardUnapplicable` gives up on a patch the
+   * server will not delete and drops it locally anyway, saying so in the
+   * console. Forgetting that one costs a round trip and no more — the parent
+   * moves back to a patch that IS still the server's head, so the next write is
+   * a 409, which re-syncs and retries. Cheap, self-correcting, and on a path
+   * that has already announced it is broken; the alternative is for this to
+   * know WHY each patch left, which is knowledge `patch:drop` does not carry
+   * and should not have to.
+   */
+  forget(patchIds: readonly PatchId[]): void {
+    if (patchIds.length === 0) {
+      return;
+    }
+    const gone = new Set(patchIds);
+    this.savedNotInStat = this.savedNotInStat.filter(
+      (patchId) => !gone.has(patchId),
+    );
+    // The stat list too: it is the other half of the parent, and between a
+    // discard and the socket message announcing it the two are equally stale.
+    this.statPatchIds = this.statPatchIds.filter(
+      (patchId) => !gone.has(patchId),
+    );
+  }
+
   currentState(): SyncState {
     return this.state;
   }

--- a/packages/ui/spa/stores/PatchSync.ts
+++ b/packages/ui/spa/stores/PatchSync.ts
@@ -308,12 +308,12 @@ export class PatchSync {
    *
    * One drop is not a deletion: `discardUnapplicable` gives up on a patch the
    * server will not delete and drops it locally anyway, saying so in the
-   * console. Forgetting that one costs a round trip and no more — the parent
-   * moves back to a patch that IS still the server's head, so the next write is
-   * a 409, which re-syncs and retries. Cheap, self-correcting, and on a path
-   * that has already announced it is broken; the alternative is for this to
-   * know WHY each patch left, which is knowledge `patch:drop` does not carry
-   * and should not have to.
+   * console. That patch is still the server's head, so forgetting it names the
+   * one BEFORE it — a parent that exists but is no longer the tip, which is a
+   * 409, which re-syncs and retries. A round trip and no more. Cheap,
+   * self-correcting, and on a path that has already announced it is broken; the
+   * alternative is for this to know WHY each patch left, which is knowledge
+   * `patch:drop` does not carry and should not have to.
    */
   forget(patchIds: readonly PatchId[]): void {
     if (patchIds.length === 0) {

--- a/packages/ui/spa/stores/createSystem.ts
+++ b/packages/ui/spa/stores/createSystem.ts
@@ -841,6 +841,24 @@ export function createSystem(options: SystemOptions): System {
     patchStore.events.on("patch:drop", () => {
       patchSetChain.invalidate();
     }),
+    /**
+     * A patch that has left the chain cannot be anybody's parent.
+     *
+     * `PatchSync` computes the parent of the next write from what the SERVER has
+     * said exists, and nothing about a discard reached it: the ids were deleted
+     * through the discard seam and dropped from the store, and the sync went on
+     * naming one of them. See `PatchSync.forget` for what that cost — a discard
+     * followed by an edit lost the edit, and every edit after it, until the tab
+     * was reloaded.
+     *
+     * On `patch:drop` rather than in `discard()` so that the other ways a patch
+     * leaves are covered by the same line: another tab's discard arrives as
+     * `reconcileVanished` dropping what stat has stopped naming, and a patch the
+     * server refuses is dropped by `PatchSync` itself.
+     */
+    patchStore.events.on("patch:drop", (event) => {
+      patchSync.forget(event.patches);
+    }),
   ];
 
   /**

--- a/packages/ui/spa/stores/patchSync.test.ts
+++ b/packages/ui/spa/stores/patchSync.test.ts
@@ -1,7 +1,8 @@
 import { initVal, type PatchId } from "@valbuild/core";
-import type { Patch } from "@valbuild/core/patch";
+import type { ParentRef, Patch } from "@valbuild/core/patch";
 import { externalPatch, initTestSystem, mfp } from "./testSystem";
 import { createSystem } from "./createSystem";
+import type { SaveResult } from "./PatchSync";
 
 /**
  * `PUT /patches`: the write-back path, and whether the head model survives a
@@ -1256,6 +1257,174 @@ describe("a save that keeps failing", () => {
     expect(states).toContain("retrying");
     expect(system.patchSync.currentState().status).toBe("in-sync");
     expect(system.patchStore.pendingPatchIds()).toHaveLength(0);
+    system.dispose();
+  });
+});
+
+/**
+ * The next write after a discard.
+ *
+ * Reported from production: discard a set of changes, start a new page, and the
+ * Studio answers "An edit could not be saved and has been reverted." with
+ * `Parent patch not found` under it — every time, until the tab is reloaded.
+ * `e2e/http/discard.spec.ts` reproduces the whole thing through a browser and a
+ * content service; these two isolate the two halves of it.
+ *
+ * The chain is linear and every write names its parent, and `PatchSync` computes
+ * that parent from what the SERVER has said exists — `savedNotInStat` if it holds
+ * anything, `statPatchIds` otherwise. A discard deletes patches through the
+ * discard seam and drops them from `PatchStore`, and tells `PatchSync` nothing at
+ * all. So the parent it names next is a patch that no longer exists.
+ *
+ * That would be survivable if it were a conflict, which is retried after a
+ * re-sync. It is not: a content service answers a parent it does not hold with
+ * `Parent patch not found` and a status that is not 409, `ValOpsHttp` maps
+ * everything that is not 409 to `other`, and `PatchSync` treats that as
+ * PERMANENT — the patch is dropped and the edit is gone.
+ */
+describe("the write after a discard", () => {
+  /**
+   * A content service with the two answers that matter, told apart.
+   *
+   * A parent it does not hold is `rejected`, not `conflict`, because that is the
+   * distinction the bug turns on: modelling both as a conflict makes the client
+   * look like it recovers, which against a real service it does not.
+   */
+  function contentService() {
+    const chain: PatchId[] = [];
+    const parents: ParentRef[] = [];
+    return {
+      chain,
+      /** The parent each write named, in order. */
+      parents,
+      savePatches: async ({
+        patches,
+        parentRef,
+      }: {
+        patches: { patchId: PatchId }[];
+        parentRef: ParentRef;
+      }): Promise<SaveResult> => {
+        parents.push(parentRef);
+        if (parentRef.type === "patch" && !chain.includes(parentRef.patchId)) {
+          return { status: "rejected", message: "Parent patch not found" };
+        }
+        if (
+          parentRef.type === "patch" &&
+          parentRef.patchId !== chain[chain.length - 1]
+        ) {
+          return { status: "conflict", message: "Not the head of the chain" };
+        }
+        const newPatchIds = patches.map((entry) => entry.patchId);
+        chain.push(...newPatchIds);
+        return {
+          status: "saved",
+          newPatchIds,
+          parentRef: {
+            type: "patch",
+            patchId: newPatchIds[newPatchIds.length - 1],
+          },
+        };
+      },
+      discardPatches: async (
+        patchIds: readonly PatchId[],
+      ): Promise<{ status: "discarded"; patchIds: PatchId[] }> => {
+        const deleted: PatchId[] = [];
+        for (const patchId of patchIds) {
+          const at = chain.indexOf(patchId);
+          if (at === -1) continue;
+          chain.splice(at, 1);
+          deleted.push(patchId);
+        }
+        return { status: "discarded", patchIds: deleted };
+      },
+    };
+  }
+
+  function systemFor(service: ReturnType<typeof contentService>) {
+    let next = 0;
+    const system = createSystem({
+      fetchPatches: async () => ({ patches: [] }),
+      createPatchId: () => `after-discard-${++next}` as PatchId,
+      savePatches: service.savePatches,
+      discardPatches: service.discardPatches,
+      resyncChain: async () => {
+        system.stat.receiveStat({
+          patches: [...service.chain],
+          baseSha: "sha",
+        });
+      },
+      saveBackoffMs: () => 0,
+    });
+    system.host.receive([module()]);
+    system.stat.receiveStat({ patches: [], baseSha: "sha" });
+    return system;
+  }
+
+  it("names a parent the server still has", async () => {
+    const service = contentService();
+    const system = systemFor(service);
+    await system.patchStore.createPatch(mfp("/t.val.ts"), [
+      { op: "replace", path: ["title"], value: "before the discard" },
+    ]);
+    await system.patchSync.flush();
+    const saved = service.chain[0];
+
+    await system.discard([saved]);
+
+    // The whole bug in one assertion. `head` is a correct answer here — the
+    // chain is empty — and so is any id the server still holds; only a
+    // discarded one is wrong, and it is wrong before anything is even written.
+    const parent = system.patchSync.currentParentRef();
+    if (parent?.type === "patch") {
+      expect(service.chain).toContain(parent.patchId);
+    }
+    system.dispose();
+  });
+
+  /**
+   * And a fresh `/stat` does not clear it, which is why it fails every time.
+   *
+   * The stat here is the one the WebSocket would produce the moment the discard
+   * lands, so nothing about this is a race: the server has said what it holds and
+   * the client has taken it in. `receiveStat` drops an id from `savedNotInStat`
+   * only by SEEING it listed, and a deleted patch is never listed again — so the
+   * one thing that would clear the stale parent is the one thing that cannot
+   * happen.
+   */
+  it("recovers when the server says what it has", async () => {
+    const service = contentService();
+    const system = systemFor(service);
+    await system.patchStore.createPatch(mfp("/t.val.ts"), [
+      { op: "replace", path: ["title"], value: "before the discard" },
+    ]);
+    await system.patchSync.flush();
+    const saved = service.chain[0];
+
+    await system.discard([saved]);
+    // What the socket announces when the discard lands: the chain, as it now is.
+    system.stat.receiveStat({ patches: [...service.chain], baseSha: "sha" });
+    await settle();
+
+    const record = await system.patchStore.createPatch(mfp("/t.val.ts"), [
+      { op: "replace", path: ["title"], value: "after the discard" },
+    ]);
+    await system.patchSync.flush();
+    await settle();
+
+    const patchId = "record" in record ? record.record.patchId : null;
+    // The parent first, because it is the cause and it reads as the cause: a
+    // failure here says "the write named the patch the discard deleted" rather
+    // than "an id is missing from an array". `expect` takes no message in jest,
+    // so the explaining has to be done by what is asserted.
+    expect(service.parents[service.parents.length - 1]).not.toEqual({
+      type: "patch",
+      patchId: saved,
+    });
+    expect(service.chain).toContain(patchId);
+    // Not merely unsaved: dropped, and the field with it.
+    expect(
+      system.status.current().errors.map((error) => error.message),
+    ).not.toContain("An edit could not be saved and has been reverted.");
     system.dispose();
   });
 });


### PR DESCRIPTION
Reported from production: discard a set of changes, start a new page, and the Studio answers "An edit could not be saved and has been reverted." with `<module>: Parent patch not found` under it — every time, until the tab is reloaded. The edits are gone, not merely unsaved.

## What happens

The chain is linear, so every write names its parent. `PatchSync` computes that parent from what the **server** has said exists. A discard deletes the patches through the discard seam and drops them from `PatchStore`, and tells `PatchSync` nothing — so the next write names a patch that no longer exists.

That would cost a round trip if it were a conflict. It isn't, because the service tells two cases apart and so does the client:

| the parent is | status | `ValOpsHttp` | `PatchSync` |
| --- | --- | --- | --- |
| not the head | 409 | `patch-head-conflict` | re-sync and **retry** |
| gone | not 409 | `other` → 400 `patch-error` | `rejected`, which is **permanent** — drop the patch, revert the field |

And it never heals, which is the "every time" half: `savedNotInStat` releases an id only when a `/stat` *lists* it — deliberate, since a snapshot older than our own write must not walk the parent backwards — and a deleted patch is never listed again. So one discard poisons every later edit until the tab is reloaded.

## The reproduction, first

The mock content host could not produce any of this: it answered every parent it did not like with a 409, so the client always recovered. It now answers a parent it does not hold with `Parent patch not found`, as the service does.

- `e2e/http/discard.spec.ts` — three tests through a browser and a content service. On the first commit they failed **12 runs out of 12**: the parent named after a discard is a patch the service no longer has, the next edit is lost with exactly the reported words, and the one after that is lost too.
- Two unit tests in `patchSync.test.ts` isolate the mechanism with no timing in them. The second feeds the `/stat` the socket sends the moment the discard lands and shows the parent is *still* the deleted patch.

The first commit is the reproduction alone, so the five tests can be seen failing before anything is fixed.

## The fix

`PatchSync.forget()`, called on `patch:drop` rather than from `discard()` — so a discard here, another tab's discard (`reconcileVanished` drops what stat has stopped naming) and a patch the server refused are covered by the same line. All five tests pass; the e2e went 9/9.

## Checks

`lint`, `format`, `-r typecheck`, `pnpm test` (2409), root `build` and `examples/next build` all green, locally and in CI.

The rest of the e2e suite has pre-existing failures in this sandbox, each confirmed against the base commit: `account` ×2, `gallery-backed-image`, `large-patch-chain` ×2, `screens`, `validation` ×3, and a flaky publish-"refused" in `http/publish.spec.ts:67` / `deployments.spec.ts:163`. `studio.spec.ts:219` fails only inside the full run and passes 10/10 in isolation with the fix.

One thing inferred rather than read: the content service's exact status code. It must be non-409 for the message to have surfaced the way it did, but nobody has read the service's source here. If it is specifically a 404, mapping that to `patch-head-conflict` in `ValOpsHttp` would be a cheap second belt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vjtd1t5GF7pCTyHjHt4Hsb