### PR TITLE
fix(ui): substitute the build version even when the bundler escapes it

### DIFF
--- a/.changeset/fix-ui-static-app-mime-type.md
+++ b/.changeset/fix-ui-static-app-mime-type.md
@@ -1,0 +1,9 @@
+---
+"@valbuild/ui": patch
+---
+
+Fix the Studio failing to load on 0.108.0 with `Failed to load module script: Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of ""`.
+
+`@valbuild/ui` substitutes the package version into its bundled server after Vite has run, by replacing a `$$BUILD_$$…$$` placeholder in the emitted JavaScript. Vite 8 (rolldown/oxc) constant-folds the app path into a single template literal and escapes every `$` while printing it, so the plain string replace no longer found it and the placeholder shipped. `/api/val/static/<version>/app` then matched nothing and fell through to the SPA fallback, which returned the index HTML — with an empty `Content-Type` — where the browser expected the app bundle.
+
+The substitution now tolerates however the bundler prints the placeholder, the build fails if any placeholder survives, and a new post-build step loads the packaged server bundle and asserts that `/<version>/app` is served as `application/javascript`. The SPA fallback also declares `text/html` instead of an empty content type.

--- a/architecture/quirks.md
+++ b/architecture/quirks.md
@@ -346,6 +346,42 @@ cleanup cancels, which is the only pass that writes to the editor that survives.
 resolving `dist/`. Also delete `examples/next/.next` — a production build left
 there makes the dev server 500 with `MODULE_NOT_FOUND` on Studio routes.
 
+## The `@valbuild/ui` build substitutes placeholders into bundler output
+
+`packages/ui` ships two strings that only get their real values _after_ Vite has
+bundled: the package version and the base64 record of the whole SPA build.
+`fix-server-hack.js` and `fix-version-hack.js` do that substitution by reading
+the emitted `.js` files and replacing `$$BUILD_$$REPLACE_WITH_VERSION$$` /
+`$$BUILD_$$REPLACE_WITH_RECORD$$` in the text.
+
+**A bundler is free to re-print a string literal however it likes, and that
+breaks the substitution silently.** Vite 8 (rolldown/oxc) constant-folds
+
+```ts
+path === `${VERSION ? `/${VERSION}` : ""}${VAL_APP_PATH}`;
+```
+
+into one template literal and escapes every `$` while printing it:
+
+```js
+path === `/\$\$BUILD_\$\$REPLACE_WITH_VERSION\$\$/app`;
+```
+
+Vite 7 kept `const VERSION = "$$BUILD_..."` as its own literal, so the plain
+`String.replace` found it. In 0.108.0 it did not, and the placeholder shipped.
+Nothing threw: `/api/val/static/0.108.0/app` simply stopped matching, fell
+through to the SPA fallback, and every Studio got the index HTML where it asked
+for the app bundle — `Failed to load module script: ... MIME type of ""`. The
+version in the _client_ bundle was substituted fine, so the URL the browser
+asked for was right; only the server's comparison string was wrong.
+
+So the substitution is escape-tolerant (`buildPlaceholders.js`), it fails the
+build if a marker survives, and `verify-build.js` loads the packaged server
+bundle at the end of `pnpm --filter @valbuild/ui build` and asserts that
+`/<version>/app` really comes back as `application/javascript`. **That last
+check is the one that does not care how the placeholder is implemented** — keep
+it if you ever replace the hacks with something better.
+
 ## A request "pending" in dev is usually queued, not slow
 
 The devtools show a request as pending from the moment it is _created_, which

--- a/packages/ui/buildPlaceholders.js
+++ b/packages/ui/buildPlaceholders.js
@@ -1,0 +1,126 @@
+/**
+ * The build-time placeholders that `fix-server-hack.js` and
+ * `fix-version-hack.js` substitute into the Vite output, and the helpers that
+ * substitute them.
+ *
+ * These are plain string markers in the sources (`src/index.ts`,
+ * `src/vite-index.ts`, `src/vite-server.ts`) that only get their real values
+ * after bundling. That means the bundler has already had its way with them by
+ * the time we look for them, and a bundler is free to re-print a string
+ * literal however it likes.
+ *
+ * That is not hypothetical: Vite 8 (rolldown/oxc) constant-folds
+ *
+ *     `${VERSION ? `/${VERSION}` : ""}${VAL_APP_PATH}`
+ *
+ * in `vite-server.ts` down to a single template literal and escapes every `$`
+ * while printing it, so the output reads
+ *
+ *     `/\$\$BUILD_\$\$REPLACE_WITH_VERSION\$\$/app`
+ *
+ * A plain `String.replace("$$BUILD_$$REPLACE_WITH_VERSION$$", version)` finds
+ * nothing there, and the shipped server then compares the request path against
+ * a literal placeholder instead of `/0.108.0/app`. Nothing throws: the request
+ * for the app bundle just falls through to the SPA fallback and the browser
+ * refuses the HTML it gets back with "Expected a JavaScript-or-Wasm module
+ * script but the server responded with a MIME type of ''".
+ *
+ * So: match the placeholders escape-tolerantly, replace every occurrence, and
+ * make the build fail loudly if any marker survives.
+ */
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+
+const VERSION_PLACEHOLDER = "$$BUILD_$$REPLACE_WITH_VERSION$$";
+const RECORD_PLACEHOLDER = "$$BUILD_$$REPLACE_WITH_RECORD$$";
+
+/**
+ * The part of a placeholder that survives any amount of `$` escaping, so it is
+ * what we scan for when asserting that a substitution actually happened.
+ */
+const VERSION_MARKER = "REPLACE_WITH_VERSION";
+const RECORD_MARKER = "REPLACE_WITH_RECORD";
+
+/** `$$BUILD_$$REPLACE_WITH_VERSION$$`, with each `$` optionally backslash-escaped. */
+const VERSION_PLACEHOLDER_PATTERN =
+  /(?:\\?\$){2}BUILD_(?:\\?\$){2}REPLACE_WITH_VERSION(?:\\?\$){2}/g;
+/** `$$BUILD_$$REPLACE_WITH_RECORD$$`, with each `$` optionally backslash-escaped. */
+const RECORD_PLACEHOLDER_PATTERN =
+  /(?:\\?\$){2}BUILD_(?:\\?\$){2}REPLACE_WITH_RECORD(?:\\?\$){2}/g;
+
+/**
+ * Replace every occurrence of `pattern` in `content` with `value`.
+ *
+ * `value` is inserted verbatim - a `$` in it is never treated as a
+ * replacement pattern (`$&`, `$1`, ...).
+ *
+ * @param {string} content
+ * @param {RegExp} pattern
+ * @param {string} value
+ * @returns {{ content: string, count: number }}
+ */
+function replaceAllOccurrences(content, pattern, value) {
+  let count = 0;
+  const replaced = content.replace(new RegExp(pattern.source, "g"), () => {
+    count++;
+    return value;
+  });
+  return { content: replaced, count };
+}
+
+/**
+ * @param {string} content
+ * @param {string} version
+ * @returns {{ content: string, count: number }}
+ */
+function replaceVersionPlaceholder(content, version) {
+  return replaceAllOccurrences(content, VERSION_PLACEHOLDER_PATTERN, version);
+}
+
+/**
+ * @param {string} content
+ * @param {string} record
+ * @returns {{ content: string, count: number }}
+ */
+function replaceRecordPlaceholder(content, record) {
+  return replaceAllOccurrences(content, RECORD_PLACEHOLDER_PATTERN, record);
+}
+
+/**
+ * Throw if a placeholder marker survived substitution.
+ *
+ * This is the check that turns "the published package silently serves HTML
+ * where the app bundle should be" into a failed build.
+ *
+ * @param {string} content
+ * @param {string} filePath
+ * @param {string[]} [markers]
+ */
+function assertNoPlaceholdersLeft(
+  content,
+  filePath,
+  markers = [VERSION_MARKER, RECORD_MARKER],
+) {
+  for (const marker of markers) {
+    const index = content.indexOf(marker);
+    if (index !== -1) {
+      throw new Error(
+        `Build placeholder '${marker}' was not replaced in ${filePath}: ` +
+          `${JSON.stringify(content.slice(Math.max(0, index - 40), index + 40))}. ` +
+          `The bundler most likely re-printed the placeholder in a form ` +
+          `buildPlaceholders.js does not recognise - see the comment at the ` +
+          `top of that file.`,
+      );
+    }
+  }
+}
+
+module.exports = {
+  VERSION_PLACEHOLDER,
+  RECORD_PLACEHOLDER,
+  VERSION_MARKER,
+  RECORD_MARKER,
+  replaceVersionPlaceholder,
+  replaceRecordPlaceholder,
+  assertNoPlaceholdersLeft,
+};

--- a/packages/ui/buildPlaceholders.test.js
+++ b/packages/ui/buildPlaceholders.test.js
@@ -1,0 +1,111 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const {
+  VERSION_PLACEHOLDER,
+  RECORD_PLACEHOLDER,
+  replaceVersionPlaceholder,
+  replaceRecordPlaceholder,
+  assertNoPlaceholdersLeft,
+} = require("./buildPlaceholders");
+
+describe("replaceVersionPlaceholder", () => {
+  test("replaces the placeholder as written in the sources", () => {
+    const { content, count } = replaceVersionPlaceholder(
+      `export const VERSION = "${VERSION_PLACEHOLDER}";`,
+      "1.2.3",
+    );
+    expect(content).toBe(`export const VERSION = "1.2.3";`);
+    expect(count).toBe(1);
+  });
+
+  test("replaces the placeholder as Vite 8 re-prints it, with every $ escaped", () => {
+    // This is verbatim what rolldown/oxc emits for
+    // `${VERSION ? `/${VERSION}` : ""}${VAL_APP_PATH}` once it folds the
+    // template literal - and what the plain string replace it replaced could
+    // not find, which is what shipped a broken 0.108.0.
+    const { content, count } = replaceVersionPlaceholder(
+      "path === `/\\$\\$BUILD_\\$\\$REPLACE_WITH_VERSION\\$\\$/app`",
+      "1.2.3",
+    );
+    expect(content).toBe("path === `/1.2.3/app`");
+    expect(count).toBe(1);
+  });
+
+  test("replaces every occurrence, not just the first", () => {
+    const { content, count } = replaceVersionPlaceholder(
+      "`/\\$\\$BUILD_\\$\\$REPLACE_WITH_VERSION\\$\\$/app` " +
+        `"${VERSION_PLACEHOLDER}"`,
+      "1.2.3",
+    );
+    expect(content).toBe('`/1.2.3/app` "1.2.3"');
+    expect(count).toBe(2);
+  });
+
+  test("leaves content without the placeholder alone", () => {
+    const { content, count } = replaceVersionPlaceholder("no marker", "1.2.3");
+    expect(content).toBe("no marker");
+    expect(count).toBe(0);
+  });
+
+  test("does not touch the record placeholder", () => {
+    const { content, count } = replaceVersionPlaceholder(
+      RECORD_PLACEHOLDER,
+      "1.2.3",
+    );
+    expect(content).toBe(RECORD_PLACEHOLDER);
+    expect(count).toBe(0);
+  });
+});
+
+describe("replaceRecordPlaceholder", () => {
+  test("inserts the record verbatim, treating $ in it as data", () => {
+    // `$&` and friends are replacement patterns for String.replace: a file
+    // record that happened to contain one must not be re-interpreted.
+    const record = JSON.stringify({ "/index.html": "YSQmYg==$&" });
+    const { content, count } = replaceRecordPlaceholder(
+      `JSON.parse(\`${RECORD_PLACEHOLDER}\`)`,
+      record,
+    );
+    expect(content).toBe(`JSON.parse(\`${record}\`)`);
+    expect(count).toBe(1);
+  });
+
+  test("replaces the placeholder with every $ escaped", () => {
+    const { content, count } = replaceRecordPlaceholder(
+      "JSON.parse(`\\$\\$BUILD_\\$\\$REPLACE_WITH_RECORD\\$\\$`)",
+      "{}",
+    );
+    expect(content).toBe("JSON.parse(`{}`)");
+    expect(count).toBe(1);
+  });
+});
+
+describe("assertNoPlaceholdersLeft", () => {
+  test("passes for fully substituted content", () => {
+    expect(() =>
+      assertNoPlaceholdersLeft("const VERSION = '1.2.3';", "some-file.js"),
+    ).not.toThrow();
+  });
+
+  test("throws when a version placeholder survived in any form", () => {
+    expect(() =>
+      assertNoPlaceholdersLeft(
+        "path === `/\\$\\$BUILD_\\$\\$REPLACE_WITH_VERSION\\$\\$/app`",
+        "some-file.js",
+      ),
+    ).toThrow(/REPLACE_WITH_VERSION.*was not replaced in some-file\.js/s);
+  });
+
+  test("throws when a record placeholder survived", () => {
+    expect(() =>
+      assertNoPlaceholdersLeft(RECORD_PLACEHOLDER, "some-file.js"),
+    ).toThrow(/REPLACE_WITH_RECORD/);
+  });
+
+  test("can be limited to a subset of the markers", () => {
+    expect(() =>
+      assertNoPlaceholdersLeft(VERSION_PLACEHOLDER, "some-file.js", [
+        "REPLACE_WITH_RECORD",
+      ]),
+    ).not.toThrow();
+  });
+});

--- a/packages/ui/fix-server-hack.js
+++ b/packages/ui/fix-server-hack.js
@@ -1,10 +1,16 @@
 // We use this to inject the contents of main.jsx into the server
 // We want to use Vite / rollup to do this, but ran out of time and patience to do it
 
-/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 const fs = require("fs");
 const path = require("path");
 const packageJson = require("./package.json");
+const {
+  replaceVersionPlaceholder,
+  replaceRecordPlaceholder,
+  assertNoPlaceholdersLeft,
+  RECORD_MARKER,
+} = require("./buildPlaceholders");
 
 const serverFiles = [
   "server/dist/valbuild-ui-server.esm.js",
@@ -21,9 +27,11 @@ function walk(dir) {
         ...walk(fileOrDirPath),
       };
     }
-    const fileContent = fs
-      .readFileSync(fileOrDirPath, "utf-8")
-      .replaceAll("$$BUILD_$$REPLACE_WITH_VERSION$$", version);
+    const { content: fileContent } = replaceVersionPlaceholder(
+      fs.readFileSync(fileOrDirPath, "utf-8"),
+      version,
+    );
+    assertNoPlaceholdersLeft(fileContent, fileOrDirPath);
     const encodedContent = Buffer.from(fileContent).toString("base64");
     return {
       ...files,
@@ -37,22 +45,20 @@ const stringifiedFiles = JSON.stringify(files);
 
 for (const serverFile of serverFiles) {
   const filePath = path.join(__dirname, serverFile);
-  const replaceString = "$$BUILD_$$REPLACE_WITH_RECORD$$";
-  fs.readFile(filePath, "utf-8", (err, data) => {
-    if (err) {
-      console.error("Error reading file:", err);
-      return;
-    }
-
-    const result = data.replace(replaceString, stringifiedFiles);
-
-    // Write the modified content back to the file
-    fs.writeFile(filePath, result, "utf-8", (err) => {
-      if (err) {
-        console.error("Error writing file:", err);
-        return;
-      }
-      console.log(`Replaced script in ${serverFile} with contents of build!`);
-    });
-  });
+  const data = fs.readFileSync(filePath, "utf-8");
+  const { content: result, count } = replaceRecordPlaceholder(
+    data,
+    stringifiedFiles,
+  );
+  if (count === 0) {
+    throw new Error(
+      `Could not find the '${RECORD_MARKER}' placeholder in ${serverFile}! ` +
+        `Without it the Val UI files are not included in the build.`,
+    );
+  }
+  // NOTE: the version placeholder is still expected here - fix-version-hack.js
+  // runs next and replaces it.
+  assertNoPlaceholdersLeft(result, serverFile, [RECORD_MARKER]);
+  fs.writeFileSync(filePath, result, "utf-8");
+  console.log(`Replaced script in ${serverFile} with contents of build!`);
 }

--- a/packages/ui/fix-version-hack.js
+++ b/packages/ui/fix-version-hack.js
@@ -1,10 +1,15 @@
-// We use this to inject the contents of main.jsx into the server
+// We use this to inject the package version into the build output
 // We want to use Vite / rollup to do this, but ran out of time and patience to do it
 
-/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 const fs = require("fs");
 const path = require("path");
 const packageJson = require("./package.json");
+const {
+  replaceVersionPlaceholder,
+  assertNoPlaceholdersLeft,
+  VERSION_MARKER,
+} = require("./buildPlaceholders");
 
 const files = [
   "dist/valbuild-ui.esm.js",
@@ -16,22 +21,17 @@ const version = packageJson.version;
 
 for (const targetFile of files) {
   const filePath = path.join(__dirname, targetFile);
-  const replaceString = "$$BUILD_$$REPLACE_WITH_VERSION$$";
-  fs.readFile(filePath, "utf-8", (err, data) => {
-    if (err) {
-      console.error("Error reading file:", err);
-      return;
-    }
-
-    const result = data.replace(replaceString, version);
-
-    // Write the modified content back to the file
-    fs.writeFile(filePath, result, "utf-8", (err) => {
-      if (err) {
-        console.error("Error writing file:", err);
-        return;
-      }
-      console.log(`Updated version in ${targetFile}!`);
-    });
-  });
+  const data = fs.readFileSync(filePath, "utf-8");
+  const { content: result, count } = replaceVersionPlaceholder(data, version);
+  if (count === 0) {
+    throw new Error(
+      `Could not find the '${VERSION_MARKER}' placeholder in ${targetFile}! ` +
+        `Every build output is expected to contain at least one: without it ` +
+        `the server compares request paths against an unreplaced placeholder ` +
+        `and serves the SPA fallback instead of the app bundle.`,
+    );
+  }
+  assertNoPlaceholdersLeft(result, targetFile);
+  fs.writeFileSync(filePath, result, "utf-8");
+  console.log(`Updated version in ${targetFile} (${count} occurrences)!`);
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "build": "vite build && vite --config server.vite.config.mts build && rollup --config rollup.config.js && vite --config spa.vite.config.mts build && node fix-server-hack.js && node fix-version-hack.js",
+    "build": "vite build && vite --config server.vite.config.mts build && rollup --config rollup.config.js && vite --config spa.vite.config.mts build && node fix-server-hack.js && node fix-version-hack.js && node verify-build.js",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "dev": "vite",

--- a/packages/ui/src/vite-server.ts
+++ b/packages/ui/src/vite-server.ts
@@ -24,6 +24,16 @@ export function createUIRequestHandler(): ValUIRequestHandler {
       "Val UI files missing (error: is not an object)! This Val version or build is corrupted!",
     );
   }
+  // A build whose version was not substituted still carries the raw build
+  // placeholder here, and a placeholder can never match a request path: every
+  // request for the app bundle would fall through to the SPA fallback below,
+  // and the only symptom would be the browser refusing an HTML response where
+  // it expected JS. `$` cannot occur in a version, so this is that build.
+  if (VERSION.includes("$")) {
+    throw new Error(
+      "Val UI version was not substituted at build time! This Val version or build is corrupted!",
+    );
+  }
   const jsFiles = Object.keys(decodedFiles).filter(
     (path) => path.endsWith(".js") || path.endsWith(".jsx"),
   );
@@ -94,10 +104,13 @@ export function createUIRequestHandler(): ValUIRequestHandler {
           body: decodedFiles[path],
         };
       } else {
+        // The SPA fallback: whatever was asked for, what is returned is the
+        // index page, so that is the content type - never the one the
+        // requested path implies.
         return {
           status: 200,
           headers: {
-            "Content-Type": getServerMimeType(path) || "",
+            "Content-Type": "text/html; charset=utf-8",
             "Cache-Control": "max-age=90", // TODO: change this to something more aggressive
           },
           body: htmlPage,

--- a/packages/ui/verify-build.js
+++ b/packages/ui/verify-build.js
@@ -1,0 +1,96 @@
+/**
+ * Post-build check: load the packaged server bundle and ask it for the files
+ * the Studio actually requests.
+ *
+ * `fix-server-hack.js` and `fix-version-hack.js` patch strings into bundler
+ * output, so they are only ever as correct as the shape that output happens to
+ * have. When that shape changed under them (Vite 8 re-printing a folded
+ * template literal with escaped `$`), nothing failed: the version placeholder
+ * survived into the published package, `/api/val/static/<version>/app` stopped
+ * matching, and every Studio served the SPA fallback HTML in place of the app
+ * bundle - "Failed to load module script: ... MIME type of ''".
+ *
+ * Asserting on the built artifact is the only check that does not care how the
+ * substitution is implemented or how the bundler prints it.
+ */
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const path = require("path");
+const packageJson = require("./package.json");
+
+const VERSION = packageJson.version;
+const APP_PATH = `/${VERSION}/app`;
+const CSS_PATH = `/${VERSION}/spa/index.css`;
+
+/**
+ * @param {string} name
+ * @param {boolean} condition
+ * @param {string} details
+ */
+function check(name, condition, details) {
+  if (!condition) {
+    throw new Error(`Val UI build verification failed: ${name} (${details})`);
+  }
+  console.log(`Verified: ${name}`);
+}
+
+async function main() {
+  const bundlePath = path.join(
+    __dirname,
+    "server/dist/valbuild-ui-server.cjs.js",
+  );
+  const { createUIRequestHandler } = require(bundlePath);
+  const handler = createUIRequestHandler();
+
+  const app = await handler(
+    APP_PATH,
+    `http://localhost/api/val/static${APP_PATH}`,
+  );
+  check(
+    `${APP_PATH} is served as JavaScript`,
+    app.status === 200 &&
+      app.headers?.["Content-Type"] === "application/javascript",
+    `got status ${app.status} and Content-Type ${JSON.stringify(
+      app.headers?.["Content-Type"],
+    )}`,
+  );
+  check(
+    `${APP_PATH} has a body`,
+    typeof app.body === "string" && app.body.length > 0,
+    `body was ${typeof app.body}`,
+  );
+
+  const css = await handler(
+    CSS_PATH,
+    `http://localhost/api/val/static${CSS_PATH}`,
+  );
+  check(
+    `${CSS_PATH} is served as CSS`,
+    css.status === 200 && css.headers?.["Content-Type"] === "text/css",
+    `got status ${css.status} and Content-Type ${JSON.stringify(
+      css.headers?.["Content-Type"],
+    )}`,
+  );
+
+  const index = await handler("/", "http://localhost/api/val/static/");
+  check(
+    "unknown paths fall back to the index page as HTML",
+    index.status === 200 &&
+      typeof index.headers?.["Content-Type"] === "string" &&
+      index.headers["Content-Type"].startsWith("text/html"),
+    `got status ${index.status} and Content-Type ${JSON.stringify(
+      index.headers?.["Content-Type"],
+    )}`,
+  );
+  check(
+    "the index page references the built app bundle",
+    typeof index.body === "string" &&
+      index.body.includes("/api/val/static/assets/index-"),
+    "the index page did not reference /api/val/static/assets/index-*",
+  );
+}
+
+main().catch((err) => {
+  console.error(err.message || err);
+  process.exit(1);
+});


### PR DESCRIPTION
## The bug

The Studio does not load at all on `0.108.0`, in dev and in production alike. Every request for `/api/val/static/<version>/app` returns the SPA fallback HTML with an empty `Content-Type`, and the browser refuses it:

```
Failed to load module script: Expected a JavaScript-or-Wasm module script but
the server responded with a MIME type of "". Strict MIME type checking is
enforced for module scripts per HTML spec.
```

```
GET /api/val/static/0.108.0/app  →  200
cache-control: max-age=90
content-type:                      ← empty
<!doctype html> …                  ← the SPA index page, not the app bundle
```

`0.107.0` serves the same URL as `content-type: application/javascript` with `cache-control: public, max-age=31536000, immutable`.

## Root cause

`packages/ui` writes its version into the bundled server **after** Vite has run: `fix-version-hack.js` reads the emitted JavaScript and replaces the literal `$$BUILD_$$REPLACE_WITH_VERSION$$`.

`0.108.0` bumped Vite 7 → 8 (rolldown/oxc). Vite 8 constant-folds this line in `src/vite-server.ts`

```ts
path === `${VERSION ? `/${VERSION}` : ""}${VAL_APP_PATH}`
```

into a single template literal and **escapes every `$`** while printing it. The published `0.108.0` tarball contains, verbatim:

```js
else if (path === `/\$\$BUILD_\$\$REPLACE_WITH_VERSION\$\$/app`) …
```

`String.replace("$$BUILD_$$REPLACE_WITH_VERSION$$", version)` finds nothing there, so the placeholder shipped. Vite 7 kept `const VERSION = "0.107.0";` as its own literal, which is why the previous release is fine — confirmed by diffing both npm tarballs.

The client bundle was substituted correctly, so the browser always asked for the right URL. Only the server's comparison string was wrong: it matched nothing, fell through to the SPA fallback, and that fallback set `Content-Type: getServerMimeType(path) || ""` — and `getServerMimeType("/0.108.0/app")` reads the extension as `0/app`, returns `undefined`, and yields the empty content type.

Nothing failed loudly anywhere along the way. `fix-version-hack.js` logged `Updated version in …!` unconditionally, so the broken build looked successful.

## The fix

- **`packages/ui/buildPlaceholders.js`** (new) — escape-tolerant substitution shared by both hack scripts, plus an assertion that no placeholder marker survives. Unit-tested, including the exact escaped form Vite 8 emits.
- **`fix-version-hack.js` / `fix-server-hack.js`** — replace *every* occurrence (they used `String.replace`, which does only the first), read and write synchronously, and throw when a placeholder is missing or survives.
- **`packages/ui/verify-build.js`** (new, runs at the end of `pnpm --filter @valbuild/ui build`) — loads the *packaged* server bundle and asserts that `/<version>/app` really comes back as `application/javascript`. **This is the check that does not care how the substitution is implemented**, and the one that would have caught this regardless of how the bundler printed the placeholder. Confirmed to fail on a hand-corrupted artifact.
- **`src/vite-server.ts`** — throw on an unsubstituted version instead of silently serving the fallback, and declare `text/html` on the SPA fallback rather than deriving a content type from a path whose body is always the index page.
- A changeset, and a note in `architecture/quirks.md` explaining why substituting into bundler output is fragile.

## Verification

CI jobs, all green: `lint`, `format`, `-r typecheck`, `test` (2442 passed), root `build`, `examples/next` build. Playwright e2e was skipped for this change — it touches the `@valbuild/ui` build pipeline and the static handler only.

Against `examples/next` running under `next start` (production mode) with the rebuilt package:

| Request | Before | After |
| --- | --- | --- |
| `/api/val/static/0.108.0/app` | 200, `content-type: ` (empty), HTML body | 200, `content-type: application/javascript`, 3.0 MB, `immutable` |
| `/api/val/static/0.108.0/spa/index.css` | 200, empty content type, HTML body | 200, `content-type: text/css` |
| `/api/val/static/nope` | 200, empty content type | 200, `content-type: text/html; charset=utf-8` |
| `/val` | Studio fails to boot | 200, Studio loads |

## Note

This needs a release to reach anyone hitting it. Until `0.108.1` is out, pinning to `0.107.0` is the workaround.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LTuEjSVT1CdqZ2xguJVero)_