### PR TITLE
Make the field update loop cost what it is supposed to cost

### DIFF
--- a/.changeset/field-update-loops.md
+++ b/.changeset/field-update-loops.md
@@ -1,0 +1,83 @@
+---
+"@valbuild/ui": patch
+"@valbuild/next": patch
+---
+
+Make the field update loop cost what it is supposed to cost again
+
+The stores are demand-driven and per path, and they still are. What had
+accumulated on top of them was a set of subscriptions that are not — every one
+of them mounted once per field, so each turned a single edit back into
+O(project) work, which is the cost the whole architecture exists to remove,
+reintroduced one layer up. Along the way, three things that looked like "the
+editor is slow" turned out to be specific faults.
+
+**A rich text field could render blank and stay blank.** Two independent
+things had to be true for it, and each hid the other. The field passed the
+editor neither `value` nor `defaultValue`, so the ProseMirror view was always
+built empty and the content arrived afterwards through an imperative `reset()`
+in an effect — which made that effect load-bearing for the first paint, and
+its dependencies are the SOURCE. Meanwhile the view is destroyed and rebuilt
+when `readOnly` or a toolbar feature changes, and a rebuild re-parsed a
+`defaultValue` that was not there. So a rebuild emptied the field and nothing
+refilled it: the consumer only re-seeds when source moves, and source had not
+moved. The trigger in practice was not anything a user did — `useValPortal`
+is filled on commit, so the portal container arrives as `null` and then as an
+element on the very next render.
+
+Fixed three times over, because each closes it alone and all three are worth
+having: the field seeds the editor with its source, the editor carries its
+live document across a rebuild, and the portal container is read at use time
+so it is not a dependency of the view at all. `ValPortalProvider` holds the
+node in state rather than handing out a ref read during render, so its arrival
+is an update React knows about instead of one delivered to whichever consumer
+happens to re-render next.
+
+**`/stat` was a project-wide render pulse on a timer.** It long polls in `fs`
+mode on a watcher over `.val/patches`, so it answers on every write and again
+every twenty seconds — and the answer is usually the chain the client already
+holds. `patch:chain` went out regardless, which rebuilds the file-patch map for
+every media field, re-renders every `useChainVersion` reader, and reschedules
+the pending-module validation pass. The bump now sits where the mutation is.
+The first stat and a reorder of the same ids are still announced, because
+`chainSettled()` gates the whole editor on the first one and `/stat` is the
+authority on order.
+
+**One broken `.jsonValues()` entry was a fetch every 200ms.** `peek` draws a
+deliberate line between "ask for it" and "stop asking and say so", and the bulk
+prefetch did not observe it: a failure is recorded apart from the loaded
+content, so a `has(key)` test called the entry wanted forever. The canvas relay
+calls that path on every source change. It now skips a recorded failure — and
+forgets one whenever something contradicts it, so an entry that failed during a
+dev-server restart is not broken for the life of the tab.
+
+**The canvas asked the page to re-render work it had already done.** The
+`router.refresh()` loop was armed by the ARRIVAL of a source update rather than
+by the value moving, and the editor re-sends everything it holds every time the
+page becomes a new document — which with auto-save on is once per pause in
+typing, since publishing rewrites the `.val.ts` files and `next dev` reloads.
+`ValExternalStore.update` reports whether it changed anything, and the refresh
+is armed on that. Separately, the fast `/draft/stat` poll that runs while
+preview mode is being toggled had no deadline: the only thing that ended it was
+a message from a frame that may never load, so a failed handshake left the page
+asking ten times a second, against a browser that allows six connections per
+origin. It gives up after ten seconds and says so.
+
+**And the per-field subscriptions themselves.** `Field` read the write queue,
+so every save round trip re-rendered the whole mounted tree twice and disabled
+every checkbox in the Studio while it was in flight. `usePendingPatches` walked
+the whole chain per field on every chain movement; it reads a shared per-path
+index now, reference-stable so only the affected field wakes. The rich text and
+route fields read every module's source through `useRoutesOf` on every
+keystroke anywhere; that walk is shared and its answer is stable, so a change
+that does not move the routes — which is almost all of them — re-renders
+nothing.
+
+Two seams so this is legible rather than merely correct. `PatchIntake` makes
+the three ways a patch reaches source three named variants of one union, with
+one place deciding who each wakes. `useValField` mints a field's identity and
+never hands it out — which found the rule already broken everywhere, since an
+editable field also resolves its schema at its path and that hook registered a
+source listener under an id of its own, waking every field on its own
+keystroke. `perFieldSubscriptions.test.ts` now covers every field file against
+six hooks, with a reason required for each exception.

--- a/architecture/stores.md
+++ b/architecture/stores.md
@@ -51,6 +51,16 @@ per field _instance_, because one path can be rendered twice (studio field and
 inline overlay). A controlled input re-rendered by its own keystroke loses the
 caret.
 
+An editable field gets its identity from **`useValField`**, which mints the id
+and never hands it out. That is not sugar: a field registers more than one
+source listener — resolving its schema needs source too — and every one of them
+has to carry the same id or the field is a second instance to itself.
+
+> The other half of this rule lives one layer up, and it is easy to undo:
+> nothing mounted per field may subscribe to a whole-project hook.
+> `perFieldSubscriptions.test.ts` is the guard, and it covers every file under
+> `components/fields/` plus the per-field components outside it.
+
 Corollary worth knowing: **suppression means a field does not see its own edit
 land.** Anything read on a render path that moves with the _patch chain_ rather
 than with source — "do I have an unsaved edit" — must therefore be read fresh on
@@ -77,6 +87,7 @@ never produce a value, and leaving it blocks every later save to its module.
 | you want                                   | look at                                           |
 | ------------------------------------------ | ------------------------------------------------- |
 | the read hooks a field uses                | `packages/ui/spa/components/ValFieldProvider.tsx` |
+| how a patch gets INTO source               | `SourceStore.intake` and `PatchIntake`            |
 | source, patch application, `.jsonValues()` | `stores/SourceStore.ts`                           |
 | the chain, `/stat` reconciliation, uploads | `stores/PatchStore.ts`, `stores/PatchSync.ts`     |
 | wiring, publish, discard                   | `stores/createSystem.ts`                          |

--- a/packages/next/src/ValExternalStore.test.ts
+++ b/packages/next/src/ValExternalStore.test.ts
@@ -90,3 +90,59 @@ describe("ValExternalStore.get", () => {
     expect(store.get([path])).toBe(a);
   });
 });
+
+/**
+ * Whether an update actually MOVED the value.
+ *
+ * `ValNextProvider` arms its `router.refresh()` loop on this, and it has to,
+ * because the same source arrives more than once by design: the editor sends a
+ * catch-up snapshot of everything it holds every time the page becomes a new
+ * document — a reload, or the one `next dev` does when a publish rewrites the
+ * `.val.ts` files. Counting those bought a whole-route request per publish
+ * whether or not the page was out of date, which with auto-save on is one per
+ * pause in typing.
+ */
+describe("ValExternalStore.update reports whether anything changed", () => {
+  const path = "/content/page.val.ts" as ModuleFilePath;
+
+  it("is a change the first time a module arrives", () => {
+    const store = new ValExternalStore();
+    expect(store.update(path, { foo: "bar" })).toBe(true);
+  });
+
+  it("is NOT a change when the same value arrives again", () => {
+    const store = new ValExternalStore();
+    store.update(path, { foo: "bar" });
+    // A fresh object with the same content: the canvas relays over
+    // `postMessage`, so identity never survives the trip.
+    expect(store.update(path, { foo: "bar" })).toBe(false);
+  });
+
+  it("is a change when the value differs", () => {
+    const store = new ValExternalStore();
+    store.update(path, { foo: "bar" });
+    expect(store.update(path, { foo: "baz" })).toBe(true);
+  });
+
+  it("does not wake subscribers for an unchanged value", () => {
+    const store = new ValExternalStore();
+    let woken = 0;
+    store.subscribe([path])(() => {
+      woken++;
+    });
+    store.update(path, { foo: "bar" });
+    const afterFirst = woken;
+
+    store.update(path, { foo: "bar" });
+
+    expect(woken).toBe(afterFirst);
+  });
+
+  it("still resolves waitForLoad on the first arrival", async () => {
+    const store = new ValExternalStore();
+    store.subscribe([path])(() => {});
+    const promise = store.waitForLoad([path]);
+    store.update(path, { foo: "bar" });
+    await expect(promise).resolves.toBeUndefined();
+  });
+});

--- a/packages/next/src/ValNextProvider.tsx
+++ b/packages/next/src/ValNextProvider.tsx
@@ -74,6 +74,38 @@ const SAFETY_REFRESH_WINDOW_MS = 30_000;
  */
 const VAL_EDIT_LANDED = "val-edit-landed";
 
+/**
+ * How often `/draft/stat` is asked when nothing is in progress.
+ *
+ * Draft mode changes when someone toggles it, which the handshake below already
+ * covers — so this is only there to notice it being changed somewhere else.
+ */
+const DRAFT_IDLE_POLL_MS = 20_000;
+
+/**
+ * And how often while the enable/disable handshake is in flight.
+ *
+ * Fast on purpose: the hidden iframe redirects through `/draft/enable`, and the
+ * page cannot do anything useful until that has landed.
+ */
+const DRAFT_HANDSHAKE_POLL_MS = 100;
+
+/**
+ * How long that fast phase may last before it gives up.
+ *
+ * Without a deadline it does not end: the only thing that clears `iframeSrc` is
+ * a `val-ready` message posted by the redirect target, so a frame that fails to
+ * load — a 500, an auth redirect, a dev server still compiling — left the page
+ * asking ten times a second, forever. A browser runs about six connections per
+ * origin, so that is enough to push `/stat`, `/patches` and the canvas document
+ * itself into the browser's own queue, where they are indistinguishable from a
+ * slow server.
+ *
+ * Generous enough for a first compile in `next dev`, which is the slowest case
+ * that is not a fault.
+ */
+const DRAFT_HANDSHAKE_TIMEOUT_MS = 10_000;
+
 export const ValNextProvider = (props: {
   children: React.ReactNode | React.ReactNode[];
   config: ValConfig;
@@ -454,12 +486,41 @@ export const ValNextProvider = (props: {
             return;
           }
           pollDraftStatIdRef.current--;
+          const handshaking = iframeSrc !== null;
+          if (
+            handshaking &&
+            Date.now() - startedAt > DRAFT_HANDSHAKE_TIMEOUT_MS
+          ) {
+            /**
+             * The handshake did not complete, so stop hammering.
+             *
+             * Clearing `iframeSrc` unmounts the hidden frame and takes the poll
+             * back to its idle interval — which is the honest state: nothing is
+             * in progress any more. Leaving it set is what made this
+             * unrecoverable, because the ONLY other thing that clears it is the
+             * `val-ready` message the frame never sent.
+             */
+            console.warn(
+              "Val: draft mode did not confirm in time. Falling back to the " +
+                "idle poll — try toggling preview again.",
+            );
+            setIframeSrc(null);
+            return;
+          }
           timeout = setTimeout(
             pollCurrentDraftMode,
-            iframeSrc === null ? 20000 : 100,
+            handshaking ? DRAFT_HANDSHAKE_POLL_MS : DRAFT_IDLE_POLL_MS,
           );
         });
     }
+    /**
+     * When this spell of polling began.
+     *
+     * The effect re-runs when `iframeSrc` changes, so for the fast phase this is
+     * the moment the handshake started — which is what the deadline below is
+     * measured from.
+     */
+    const startedAt = Date.now();
     pollCurrentDraftMode();
     return () => {
       clearTimeout(timeout);

--- a/packages/next/src/ValNextProvider.tsx
+++ b/packages/next/src/ValNextProvider.tsx
@@ -557,8 +557,26 @@ export const ValNextProvider = (props: {
               const moduleFilePath = event.detail?.moduleFilePath;
               const source = event.detail?.source;
               if (typeof moduleFilePath === "string" && source !== undefined) {
-                valStore.update(moduleFilePath as ModuleFilePath, source);
-                if (!props.disableRefresh) {
+                const changed = valStore.update(
+                  moduleFilePath as ModuleFilePath,
+                  source,
+                );
+                /**
+                 * Armed by a CHANGE, not by a message.
+                 *
+                 * The editor re-sends everything it holds whenever this page
+                 * becomes a new document — a reload, or the one `next dev` does
+                 * when a publish rewrites the `.val.ts` files — and most of that
+                 * snapshot is content this page already has. Counting those
+                 * bought a whole-route request per publish whether or not the
+                 * page was out of date, which with auto-save on is one per pause
+                 * in typing.
+                 *
+                 * The catch-up that MATTERS still refreshes: a page whose server
+                 * render predates the write has no value for that module, so the
+                 * first arrival counts as a change.
+                 */
+                if (changed && !props.disableRefresh) {
                   rerenderCounterRef.current++;
                   window.dispatchEvent(new Event(VAL_EDIT_LANDED));
                 }

--- a/packages/next/src/ValOverlayContext.tsx
+++ b/packages/next/src/ValOverlayContext.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { Json, ModuleFilePath } from "@valbuild/core";
+import { deepEqual } from "@valbuild/core/patch";
 import React from "react";
 
 // How long waitForLoad waits for draft data before giving up and resolving
@@ -50,8 +51,35 @@ export class ValExternalStore {
     };
   };
 
-  update(path: ModuleFilePath, source: Json) {
+  /**
+   * Take a module's source from the editor.
+   *
+   * Returns whether this actually MOVED the value, which the caller needs and
+   * cannot work out for itself: the same source arrives more than once by
+   * design. The editor sends a catch-up snapshot of everything it holds every
+   * time the page becomes a new document — a reload, or the one `next dev` does
+   * when a publish rewrites the `.val.ts` files — and most of that snapshot is
+   * content this page already has.
+   *
+   * Without the answer, `ValNextProvider` armed its `router.refresh()` loop on
+   * the arrival rather than on the change, so every publish bought a whole-route
+   * request whether or not the page was out of date. With auto-save on that is
+   * one per pause in typing, which in development is a re-render (and sometimes
+   * a recompile) of the page — and it is what leaves the canvas looking
+   * permanently busy.
+   */
+  update(path: ModuleFilePath, source: Json): boolean {
+    // `Json` has no `undefined`, so absent and "stored as undefined" cannot be
+    // confused: a miss here means this page has never been given this module.
+    const before = this.loadedSources.get(path);
+    const changed = before === undefined || !deepEqual(before, source);
     this.loadedSources.set(path, source);
+    if (!changed) {
+      // Nothing downstream to do: every subscriber's snapshot still answers
+      // with the same value, so invalidating them would be a re-render that
+      // shows exactly what is already on screen.
+      return false;
+    }
     // Invalidate cached snapshots that include this path so the next get()
     // rebuilds a fresh (new-reference) record, then notify their listeners.
     for (const subscriberId of Array.from(this.snapshots.keys())) {
@@ -68,6 +96,7 @@ export class ValExternalStore {
     for (const listener of Array.from(this.loadListeners)) {
       listener();
     }
+    return true;
   }
 
   private emitChange(subscriberId: SubscriberId) {

--- a/packages/ui/spa/components/FieldValidationError.tsx
+++ b/packages/ui/spa/components/FieldValidationError.tsx
@@ -7,7 +7,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "./designSystem/tooltip";
-import { useGetNavPath, useLoadingStatus } from "./ValFieldProvider";
+import { useGetNavPath, useIsInitialized } from "./ValFieldProvider";
 import { useAllValidationErrors } from "./ValErrorProvider";
 import { useNavigation } from "./ValRouter";
 
@@ -36,8 +36,14 @@ export function FieldValidationErrorCompact({ path }: { path: SourcePath }) {
   const { navigate } = useNavigation();
   const getNavPath = useGetNavPath();
   const validationErrors = useAllValidationErrors();
-  const loadingStatus = useLoadingStatus();
-  const isLoading = loadingStatus === "loading";
+  /**
+   * The spinner means "the project has not been taken in yet", which is what
+   * this badge can honestly say. `useLoadingStatus()` also carries the write
+   * queue, so every compact row's icon flipped between a spinner and a warning
+   * triangle on every save round trip — a flicker with no information in it,
+   * on a component that is mounted once per row.
+   */
+  const isLoading = !useIsInitialized();
   const messages: string[] = [];
   if (validationErrors) {
     for (const errorPath in validationErrors) {

--- a/packages/ui/spa/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/ui/spa/components/RichTextEditor/RichTextEditor.tsx
@@ -253,6 +253,31 @@ export const RichTextEditor = forwardRef(function RichTextEditor(
   const uploadProgressRef = useRef(uploadProgress);
   const buttonVariantsRef = useRef(buttonVariants);
   const detailsVariantsRef = useRef(detailsVariants);
+  /**
+   * Where a popup mounts, read at USE time rather than at view-creation time.
+   *
+   * This used to be closed over by `getPortalContainer` and therefore had to be
+   * a dependency of the effect that builds the `EditorView` — so a portal
+   * container that arrives after the first paint (which is the normal order:
+   * `useValPortal` is filled on commit) destroyed and rebuilt the view. A ref
+   * takes it out of the deps entirely: the popups ask when they open, and the
+   * answer is whatever is current then.
+   */
+  const portalContainerRef = useRef(portalContainer);
+  /**
+   * The live document, carried across a view REBUILD.
+   *
+   * The view is recreated whenever `readOnly` or one of the toolbar features
+   * changes, and a recreated view used to parse `defaultValue` again — which for
+   * an uncontrolled editor means the document it mounted with, or nothing. Since
+   * `schema` is fixed at mount, the ProseMirror node is still valid, so carrying
+   * it is exact and costs no serialization.
+   *
+   * The alternative — asking the consumer to re-seed after a rebuild — is what
+   * `RichTextField` was implicitly relying on, and it cannot work: the consumer
+   * re-seeds from source, and source has not moved.
+   */
+  const carriedDocRef = useRef<PMNode | null>(null);
   const isControlled = value !== undefined;
 
   useEffect(() => {
@@ -268,6 +293,7 @@ export const RichTextEditor = forwardRef(function RichTextEditor(
     uploadProgressRef.current = uploadProgress;
     buttonVariantsRef.current = buttonVariants;
     detailsVariantsRef.current = detailsVariants;
+    portalContainerRef.current = portalContainer;
     if (hasGalleryImages) {
       imageSelectRendererRef.current = (currentSrc, onSelectUrl) => (
         <MediaPickerList
@@ -319,15 +345,29 @@ export const RichTextEditor = forwardRef(function RichTextEditor(
 
     const initialDoc = isControlled ? value : (defaultValue ?? []);
     let doc;
-    try {
-      doc = parseEditorDocument(initialDoc ?? [], schema);
-    } catch {
-      doc = schema.node("doc", null, [schema.node("paragraph")]);
+    /**
+     * A REBUILD keeps the document it was showing.
+     *
+     * `carriedDocRef` is only set by this effect's own cleanup, so it is null on
+     * the first mount and a live node on every rebuild after it. The schema
+     * guard is belt and braces: `schema` is memoised on `[]` today, so it never
+     * changes under a mounted editor, but a node from another schema cannot be
+     * put in this view and failing loudly here would be worse than re-parsing.
+     */
+    const carried = carriedDocRef.current;
+    carriedDocRef.current = null;
+    if (carried !== null && carried.type.schema === schema) {
+      doc = carried;
+    } else {
+      try {
+        doc = parseEditorDocument(initialDoc ?? [], schema);
+      } catch {
+        doc = schema.node("doc", null, [schema.node("paragraph")]);
+      }
+      prevDocRef.current = initialDoc ?? [];
     }
 
-    prevDocRef.current = initialDoc ?? [];
-
-    const getPortalContainer = () => portalContainer ?? null;
+    const getPortalContainer = () => portalContainerRef.current ?? null;
 
     const plugins = [
       ...buildKeymap(schema, features),
@@ -477,6 +517,10 @@ export const RichTextEditor = forwardRef(function RichTextEditor(
     viewRef.current = view;
 
     return () => {
+      // Handed to whatever runs next. React clears this on unmount too, but a
+      // ref on an unmounted component is unreachable, so there is nothing to
+      // release.
+      carriedDocRef.current = view.state.doc;
       linkHelper.destroy();
       view.destroy();
       viewRef.current = null;
@@ -487,7 +531,6 @@ export const RichTextEditor = forwardRef(function RichTextEditor(
     features.fixedToolbar,
     features.floatingToolbar,
     features.gutter,
-    portalContainer,
   ]);
 
   useEffect(() => {

--- a/packages/ui/spa/components/RichTextEditor/__tests__/viewRebuild.test.tsx
+++ b/packages/ui/spa/components/RichTextEditor/__tests__/viewRebuild.test.tsx
@@ -49,11 +49,13 @@ function textOf(editor: RichTextEditorRef | null): string {
 describe("RichTextEditor: where the document comes from", () => {
   test("mounts with the document it was given", () => {
     const ref = createRef<RichTextEditorRef>();
-    render(<RichTextEditor
+    render(
+      <RichTextEditor
         ref={ref}
         features={NO_MEASURING}
         defaultValue={doc("Hello")}
-      />);
+      />,
+    );
 
     expect(textOf(ref.current)).toContain("Hello");
   });

--- a/packages/ui/spa/components/RichTextEditor/__tests__/viewRebuild.test.tsx
+++ b/packages/ui/spa/components/RichTextEditor/__tests__/viewRebuild.test.tsx
@@ -1,0 +1,153 @@
+/** @jest-environment jsdom */
+// FIRST, and it must stay first: the editor pulls in the shared bundle, which
+// builds a `TextEncoder` at module scope.
+import "../../../stores/react/testPolyfills";
+import { createRef } from "react";
+import { render } from "@testing-library/react";
+import { RichTextEditor } from "../RichTextEditor";
+import type { EditorDocument, RichTextEditorRef } from "../types";
+
+/**
+ * The editor is UNCONTROLLED, so where its document comes from is the whole
+ * question.
+ *
+ * Two things were wrong at once and each hid the other.
+ *
+ * `RichTextField` passed neither `value` nor `defaultValue`, so the view always
+ * mounted empty and the content arrived afterwards through `reset()` in an
+ * effect whose dependencies are the SOURCE. And the view is destroyed and
+ * rebuilt whenever `readOnly` or a toolbar feature changes — a rebuild that
+ * re-parsed `defaultValue`, which was not there.
+ *
+ * So a rebuild emptied the field, and nothing refilled it: the consumer only
+ * re-seeds when source moves, and source had not moved. The field rendered
+ * blank and stayed blank until someone edited it somewhere else.
+ *
+ * The fix is both halves — mount with the document, and carry the live document
+ * across a rebuild — and this file pins both, because either one alone leaves a
+ * way for the field to go empty.
+ */
+const doc = (text: string): EditorDocument => [{ tag: "p", children: [text] }];
+
+/**
+ * The toolbars and the gutter measure the document, and jsdom has no layout —
+ * `getClientRects()` returns nothing and `coordsAtPos` throws. They are not what
+ * these tests are about, and turning them off is not a workaround for the
+ * subject: the view is rebuilt by `readOnly` just as readily.
+ */
+const NO_MEASURING = {
+  fixedToolbar: false,
+  floatingToolbar: false,
+  gutter: false,
+} as const;
+
+function textOf(editor: RichTextEditorRef | null): string {
+  const value = editor?.getDocument() ?? [];
+  return JSON.stringify(value);
+}
+
+describe("RichTextEditor: where the document comes from", () => {
+  test("mounts with the document it was given", () => {
+    const ref = createRef<RichTextEditorRef>();
+    render(<RichTextEditor
+        ref={ref}
+        features={NO_MEASURING}
+        defaultValue={doc("Hello")}
+      />);
+
+    expect(textOf(ref.current)).toContain("Hello");
+  });
+
+  /**
+   * The regression guard.
+   *
+   * `readOnly` is one of the props the create-view effect depends on, so
+   * flipping it is the cheapest way to make the view be rebuilt. What must
+   * survive is the document that was on screen — not `defaultValue`, which for
+   * an uncontrolled editor is a mount-time seed and says nothing about what has
+   * been typed since.
+   */
+  test("keeps its document when the view is rebuilt", () => {
+    const ref = createRef<RichTextEditorRef>();
+    const { rerender } = render(
+      <RichTextEditor
+        ref={ref}
+        features={NO_MEASURING}
+        defaultValue={doc("Hello")}
+      />,
+    );
+    expect(textOf(ref.current)).toContain("Hello");
+
+    // A rebuild with NO defaultValue at all: the old view is the only place the
+    // content exists, so this fails outright if the document is not carried.
+    rerender(<RichTextEditor ref={ref} features={NO_MEASURING} readOnly />);
+
+    expect(textOf(ref.current)).toContain("Hello");
+  });
+
+  /**
+   * And a rebuild does not reach back to the mount-time seed.
+   *
+   * The weaker version of the test above would pass by re-parsing
+   * `defaultValue`, which is right only for the case where nothing has changed.
+   * Here the live document has moved on from the seed, so re-parsing would
+   * silently revert it.
+   */
+  test("carries the live document, not the mount-time default", () => {
+    const ref = createRef<RichTextEditorRef>();
+    const { rerender } = render(
+      <RichTextEditor
+        ref={ref}
+        features={NO_MEASURING}
+        defaultValue={doc("First")}
+      />,
+    );
+    ref.current?.reset(doc("Second"));
+    expect(textOf(ref.current)).toContain("Second");
+
+    rerender(
+      <RichTextEditor
+        ref={ref}
+        features={NO_MEASURING}
+        defaultValue={doc("First")}
+        readOnly
+      />,
+    );
+
+    expect(textOf(ref.current)).toContain("Second");
+    expect(textOf(ref.current)).not.toContain("First");
+  });
+
+  /**
+   * The portal container must NOT rebuild the view.
+   *
+   * It is filled on commit, so it arrives as `null` and then as an element on
+   * the very next render — which made this the trigger in practice, before
+   * anything a user did. It is read at use time now, so it is not a dependency
+   * of the view at all.
+   */
+  test("does not rebuild when the portal container arrives", () => {
+    const ref = createRef<RichTextEditorRef>();
+    const container = document.createElement("div");
+    const { rerender } = render(
+      <RichTextEditor
+        ref={ref}
+        features={NO_MEASURING}
+        defaultValue={doc("Hello")}
+        portalContainer={null}
+      />,
+    );
+    ref.current?.reset(doc("Edited"));
+
+    rerender(
+      <RichTextEditor
+        ref={ref}
+        features={NO_MEASURING}
+        defaultValue={doc("Hello")}
+        portalContainer={container}
+      />,
+    );
+
+    expect(textOf(ref.current)).toContain("Edited");
+  });
+});

--- a/packages/ui/spa/components/ValFieldProvider.tsx
+++ b/packages/ui/spa/components/ValFieldProvider.tsx
@@ -289,7 +289,11 @@ export function useHasUnsavedFrom(
     [val, moduleFilePath, creatorId],
   );
   return useSyncExternalStore(
-    val === null ? noopSubscribe : subscribe,
+    // No creator, no question — so no subscription either. `useValField` calls
+    // this unconditionally and passes an id only when the caller asked to watch,
+    // which is what lets it stay a hook while costing nothing for the fields
+    // (every text input) that must NOT be woken by their own writes.
+    val === null || creatorId === undefined ? noopSubscribe : subscribe,
     getSnapshot,
     getSnapshot,
   );
@@ -553,6 +557,108 @@ export function useAddPatch(
   };
 }
 
+/**
+ * Everything an EDITABLE field needs, under one identity.
+ *
+ * ## Why this exists rather than four hooks
+ *
+ * A field's read id and its write id have to be the same string. `SourceStore`
+ * compares the id that registered a listener with the id that created a patch
+ * and leaves the match asleep, so a field that reads under one id and writes
+ * under another is woken by its own keystroke — and a controlled input
+ * re-rendered by its own keystroke loses the caret.
+ *
+ * Assembled by hand, that rule lives in a doc comment: mint an id, pass it to
+ * `useShallowSourceAtPath`, pass the SAME id to `useAddPatch`, and remember
+ * that `clientSideOnly` must be read fresh rather than subscribed to. Four
+ * calls, one invariant between them, and nothing checking it. Here the id never
+ * leaves the hook, so there is nothing to thread and nothing to get wrong.
+ *
+ * ## What it deliberately does not do
+ *
+ * It does not replace the individual hooks. A READ-ONLY reader of a path — a
+ * preview row, a compare view, an overlay that shows a value it does not
+ * write — wants a distinct instance so that it IS woken by everything,
+ * including the studio field's edits. `useShallowSourceAtPath` with no creator
+ * id is right there, and stays.
+ */
+export function useValField<SchemaType extends SerializedSchema["type"]>(
+  path: SourcePath,
+  type: SchemaType,
+  options?: {
+    /**
+     * Also report, LIVE, whether this instance has an edit the server has not
+     * acknowledged.
+     *
+     * Off by default, and the default is the important one. `source` already
+     * carries `clientSideOnly`, read fresh on each render and subscribing to
+     * nothing — which is what a text input needs, because being woken when its
+     * own edit saves is a re-render that loses the caret.
+     *
+     * Turn this on where there is no caret to lose and a stale indicator would
+     * be visible. An array field's drag handle is the case it was written for:
+     * it is a `<button disabled>` driven by this answer, so a value frozen at
+     * the moment of the drag disables reordering until something unrelated
+     * moves.
+     */
+    watchUnsaved?: boolean;
+  },
+): {
+  /** The value, plus `clientSideOnly` for this instance. */
+  source: ShallowSourceOf<SchemaType>;
+  schema: SchemaAtPathResult;
+  /** Always `false` unless `watchUnsaved` was asked for. See the option. */
+  hasUnsavedOwnEdit: boolean;
+  /** The patch path to write ops at. */
+  patchPath: string[];
+  addPatch: (patch: Patch, type: SerializedSchema["type"]) => void;
+  addAndUploadPatchWithFileOps: (
+    patch: Patch,
+    type: "image" | "file",
+    onError: (message: string) => void,
+    onProgress: (
+      bytesUploaded: number,
+      totalBytes: number,
+      currentFile: number,
+      totalFiles: number,
+    ) => void,
+  ) => Promise<void>;
+  addModuleFilePatch: (
+    moduleFilePath: ModuleFilePath,
+    patch: Patch,
+    type: SerializedSchema["type"],
+  ) => void;
+} {
+  // Minted here and never returned: this IS the seam. See the note above.
+  const creatorId = useFieldCreatorId();
+  const source = useShallowSourceAtPath(path, type, creatorId);
+  // The same id, so this hook's own source listener is not a second instance —
+  // see `useSchemaAtPathInternal`.
+  const schema = useSchemaAtPath(path, creatorId);
+  const [moduleFilePath] = Internal.splitModuleFilePathAndModulePath(path);
+  const hasUnsavedOwnEdit = useHasUnsavedFrom(
+    moduleFilePath,
+    // Passing no id is what makes this free — see `useHasUnsavedFrom`, which
+    // does not even subscribe without one.
+    options?.watchUnsaved === true ? creatorId : undefined,
+  );
+  const {
+    patchPath,
+    addPatch,
+    addAndUploadPatchWithFileOps,
+    addModuleFilePatch,
+  } = useAddPatch(path, creatorId);
+  return {
+    source,
+    schema,
+    hasUnsavedOwnEdit,
+    patchPath,
+    addPatch,
+    addAndUploadPatchWithFileOps,
+    addModuleFilePatch,
+  };
+}
+
 export function useGetDirectFileUploadSettings() {
   return useValFieldContext().getDirectFileUploadSettings;
 }
@@ -733,6 +839,22 @@ type ResolvedSchemaAtPathResult =
 
 function useSchemaAtPathInternal(
   sourcePath: SourcePath | ModuleFilePath,
+  /**
+   * The field INSTANCE this resolution belongs to, where there is one.
+   *
+   * Resolving a schema needs the module's source, so this hook registers a
+   * source listener of its own — and a listener under an id of its own is a
+   * SECOND instance as far as suppression is concerned. So a component that
+   * renders this hook alongside `useShallowSourceAtPath` under its own creator
+   * id was woken by its own keystroke through this one, which is precisely what
+   * per-instance suppression exists to prevent. Every editable field does render
+   * both.
+   *
+   * `useValField` passes its id, so the two listeners are one instance.
+   * `useId()` remains the fallback for a standalone reader, which is correctly
+   * woken by everything.
+   */
+  creatorId?: string,
 ): SchemaWithResolvedPathResult {
   const val = useValSystem();
   const sourceOverride = useContext(FieldSourceOverrideContext);
@@ -752,7 +874,7 @@ function useSchemaAtPathInternal(
    * sibling's keystroke does neither, and must not.
    */
   const ownId = useId();
-  const seen = usePeek(val, path, ownId);
+  const seen = usePeek(val, path, creatorId ?? ownId);
   useEntryDemand(val, path, seen);
 
   const resolvedSchemaAtPathRes = useMemo<ResolvedSchemaAtPathResult>(() => {
@@ -886,8 +1008,10 @@ function useSchemaAtPathInternal(
 
 export function useSchemaAtPath(
   sourcePath: SourcePath | ModuleFilePath,
+  /** See {@link useSchemaAtPathInternal}. Omit unless you also write here. */
+  creatorId?: string,
 ): SchemaAtPathResult {
-  const res = useSchemaAtPathInternal(sourcePath);
+  const res = useSchemaAtPathInternal(sourcePath, creatorId);
   // Memoised for the same reason as the internal hook above: dropping
   // `resolvedPath` by building a new object made every render a new reference.
   return useMemo<SchemaAtPathResult>(() => {

--- a/packages/ui/spa/components/ValFieldProvider.tsx
+++ b/packages/ui/spa/components/ValFieldProvider.tsx
@@ -323,6 +323,23 @@ function useSchemasVersion(val: ValSystem | null): number {
 export type LoadingStatus = "loading" | "not-asked" | "error" | "success";
 
 /**
+ * Has the project been taken in yet?
+ *
+ * The cheap half of {@link useLoadingStatus}, and the half most callers
+ * actually want. It wakes exactly once per session — `host:receive` — where
+ * `useLoadingStatus` also carries the WRITE QUEUE, which moves on every save.
+ *
+ * Use this wherever the question is "is there anything to show yet". Reach for
+ * `useLoadingStatus` only where the answer is genuinely about whether edits have
+ * reached the server, and never from a component mounted once per field: see
+ * `perFieldSubscriptions.test.ts`.
+ */
+export function useIsInitialized(): boolean {
+  const val = useValSystem();
+  return useInitialized(val) !== null;
+}
+
+/**
  * Is the system busy?
  *
  * The engine counted queued operations, most of which were reads it had issued
@@ -920,6 +937,43 @@ export function useSchemas():
     // that invalidated the cache.
     return { status: "success", data: val.system.schemaStore.all() };
   }, [val, initializedAt, schemaVersion]);
+}
+
+/**
+ * One module's schema.
+ *
+ * For a field that needs a schema OTHER than its own — a gallery-backed media
+ * field reading the gallery's `accept` and `directory`, say. `useSchemas()`
+ * answers the same question and is a whole-project subscription, so reaching for
+ * it from a per-field component makes a keystroke O(project) for one lookup.
+ *
+ * `schema:init` only, which fires on intake and on an HMR schema swap. There is
+ * no source subscription here on purpose: a schema is not a function of source,
+ * and adding one would put this back on the keystroke path.
+ */
+export function useModuleSchema(
+  moduleFilePath: ModuleFilePath | undefined,
+): SerializedSchema | undefined {
+  const val = useValSystem();
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      if (val === null) return () => {};
+      return val.system.schemaStore.events.on("schema:init", onChange);
+    },
+    [val],
+  );
+  const getSnapshot = useCallback(
+    () =>
+      val === null || moduleFilePath === undefined
+        ? undefined
+        : val.system.schemaStore.get(moduleFilePath),
+    [val, moduleFilePath],
+  );
+  return useSyncExternalStore(
+    val === null ? noopSubscribe : subscribe,
+    getSnapshot,
+    getSnapshot,
+  );
 }
 
 export function useAllSources(): Record<ModuleFilePath, Json> {

--- a/packages/ui/spa/components/ValPortalProvider.tsx
+++ b/packages/ui/spa/components/ValPortalProvider.tsx
@@ -1,8 +1,8 @@
-import React, { useContext, useRef } from "react";
+import React, { useContext, useMemo, useState } from "react";
 import { useTheme } from "./ValThemeProvider";
 
 type ValPortalContextValue = {
-  portalRef: React.RefObject<HTMLDivElement | null>;
+  portalNode: HTMLDivElement | null;
 };
 
 const ValPortalContext = React.createContext<ValPortalContextValue>(
@@ -18,19 +18,48 @@ const ValPortalContext = React.createContext<ValPortalContextValue>(
   ) as ValPortalContextValue,
 );
 
+/**
+ * The one element every Studio popup portals into.
+ *
+ * It has to be inside the shadow root — a portal to `document.body` lands
+ * outside it and loses every Val style — and it has to be a real node before a
+ * consumer can use it, which is a commit and not a render.
+ *
+ * ## Held in STATE, not read off a ref during render
+ *
+ * `useValPortal()` used to return `portalRef.current`, read in the render body.
+ * A ref is attached at commit, so the answer was `null` on any render that
+ * happened before this provider's own commit and an element on every render
+ * after — a change React was never told about, delivered to whichever consumer
+ * happened to re-render next, for its own unrelated reason.
+ *
+ * That is exactly the kind of untracked prop change `quirks.md` warns about,
+ * and it cost the rich text editor its content: the editor took the container
+ * as a dependency of the effect that builds its `EditorView`, so the switch
+ * from `null` to the element destroyed and rebuilt the view — and the rebuild
+ * re-parsed a `defaultValue` that was not there. The field went blank and
+ * stayed blank, because nothing about the SOURCE had changed to re-seed it.
+ *
+ * A callback ref into state makes the arrival a real update: one extra render
+ * at mount, and consumers that memoise or key on the container are correct by
+ * construction rather than by luck.
+ */
 export function ValPortalProvider({ children }: { children: React.ReactNode }) {
-  const portalRef = useRef<HTMLDivElement>(null);
+  const [portalNode, setPortalNode] = useState<HTMLDivElement | null>(null);
   const { theme } = useTheme();
+  // Memoised, because a context value built inline is a fresh object every
+  // render — harmless until something downstream takes it as a dependency, and
+  // then it is the whole subtree recomputing. See `quirks.md`.
+  const value = useMemo<ValPortalContextValue>(
+    () => ({ portalNode }),
+    [portalNode],
+  );
 
   return (
-    <ValPortalContext.Provider
-      value={{
-        portalRef,
-      }}
-    >
+    <ValPortalContext.Provider value={value}>
       <div
         data-val-portal="true"
-        ref={portalRef}
+        ref={setPortalNode}
         {...(theme ? { "data-mode": theme } : {})}
       ></div>
       {children}
@@ -39,6 +68,6 @@ export function ValPortalProvider({ children }: { children: React.ReactNode }) {
 }
 
 export function useValPortal() {
-  const { portalRef } = useContext(ValPortalContext);
-  return portalRef.current;
+  const { portalNode } = useContext(ValPortalContext);
+  return portalNode;
 }

--- a/packages/ui/spa/components/ValProvider.tsx
+++ b/packages/ui/spa/components/ValProvider.tsx
@@ -14,7 +14,6 @@ import React, {
 import {
   hasRemoteFileSchema,
   ImageMetadata,
-  Internal,
   Json,
   ModuleFilePath,
   ModulePath,
@@ -55,6 +54,7 @@ import { ValStoreProvider } from "../stores/react/ValStoreProvider";
 import { useValSystem } from "../stores/react/SystemContext";
 import type { StatusSnapshot } from "../stores/StatusStore";
 import type { PatchErrorEntry, PatchRecord } from "../stores/types";
+import type { PatchAtPath } from "../stores/PatchStore";
 import { ValOverlayEmitter } from "../stores/react/ValOverlayEmitter";
 import { createValSystem } from "../stores/react/createValSystem";
 import { ValRemoteProvider } from "./ValRemoteProvider";
@@ -1401,33 +1401,54 @@ export type PendingPatch = {
     commitSha: string;
   };
 };
+const NO_PATCHES_AT_PATH: PatchAtPath[] = [];
+
+/**
+ * The chain entries that touch one path.
+ *
+ * ## Per PATH, not a chain walk per field
+ *
+ * `FieldPatchAuthorsSection` renders this on every non-compact field, and it
+ * used to subscribe to `patch:chain` — a project-wide wake-up — and then walk
+ * `allRecords()` itself. So a chain movement cost O(fields on screen x chain
+ * length) and re-rendered every one of those fields, whether or not its own
+ * answer had changed.
+ *
+ * `PatchStore.patchesByPath()` builds the index once per chain version and
+ * hands back the SAME array for a path whose answer has not moved, which is what
+ * lets `useSyncExternalStore` bail out. So one field's keystroke wakes that
+ * field's path and nobody else's, and the walk happens once for the whole
+ * screen rather than once per field.
+ */
 export function usePendingPatches(
   sourcePath: SourcePath | ModuleFilePath,
 ): PendingPatch[] | null {
   const val = useValSystem();
-  const chainVersion = useChainVersion();
-  return useMemo((): PendingPatch[] | null => {
-    if (val === null) return null;
-    void chainVersion;
-    const [moduleFilePath, modulePath] =
-      Internal.splitModuleFilePathAndModulePath(sourcePath);
-    const store = val.system.patchStore;
-    const patches: PendingPatch[] = [];
-    for (const record of store.allRecords()) {
-      if (record.moduleFilePath !== moduleFilePath) continue;
-      // A module-level path matches every patch in the module; a deeper one
-      // matches only the ops that touch it.
-      const matches =
-        !modulePath ||
-        record.patch.some(
-          (op) => Internal.patchPathToModulePath(op.path) === modulePath,
-        );
-      if (matches) {
-        patches.push(toPendingPatch(record, store.isPending(record.patchId)));
-      }
-    }
-    return patches;
-  }, [val, chainVersion, sourcePath]);
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      if (val === null) return () => {};
+      return val.system.patchStore.events.on("patch:chain", onChange);
+    },
+    [val],
+  );
+  const getSnapshot = useCallback(
+    () =>
+      val === null
+        ? null
+        : (val.system.patchStore.patchesByPath().get(sourcePath) ??
+          NO_PATCHES_AT_PATH),
+    [val, sourcePath],
+  );
+  const at = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  // Mapped to the review shape here, keyed on the store's own stable array — so
+  // this is stable for exactly as long as that one is.
+  return useMemo(
+    () =>
+      at === null
+        ? null
+        : at.map((entry) => toPendingPatch(entry.record, entry.isPending)),
+    [at],
+  );
 }
 
 export function usePendingPatchesForModule(

--- a/packages/ui/spa/components/ValProvider.tsx
+++ b/packages/ui/spa/components/ValProvider.tsx
@@ -1318,14 +1318,47 @@ export function usePendingClientSidePatchIds(): PatchId[] {
  */
 export function useInitialPatchesApplied(): boolean {
   const val = useValSystem();
-  const chainVersion = useChainVersion();
+  /**
+   * Woken by the head as well as by the chain, and the head is the one that
+   * matters here.
+   *
+   * `chainSettled()` needs every announced patch to be FETCHED and APPLIED, and
+   * those are two different stores' answers. The chain version moves when a
+   * patch's ops arrive; what moves when the source store finally applies them is
+   * `patch:head`, emitted from `PatchStore`'s `source:patch-apply` handler.
+   *
+   * Listening to the chain alone left the last step unheard — this latch is what
+   * holds every field dimmed and inert, so it stayed dimmed until some unrelated
+   * re-render happened to re-read. It survived only because a repeated `/stat`
+   * used to bump the chain unconditionally, which is exactly the wasted pulse
+   * that has now been removed.
+   *
+   * Cheap to widen: there is one of these in the Studio, it latches once, and
+   * after that the subscription answers `true` without reading anything.
+   */
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      if (val === null) return () => {};
+      const offChain = val.system.patchStore.events.on("patch:chain", onChange);
+      const offHead = val.system.patchStore.events.on("patch:head", onChange);
+      return () => {
+        offChain();
+        offHead();
+      };
+    },
+    [val],
+  );
+  const getSnapshot = useCallback(
+    () => (val === null ? false : val.system.patchStore.chainSettled()),
+    [val],
+  );
+  const chainSettled = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getSnapshot,
+  );
   const [settled, setSettled] = useState(false);
-  const ready =
-    settled ||
-    (val !== null &&
-      // `void`, not a dependency: the version is the wake-up, the store is the
-      // answer.
-      (void chainVersion, val.system.patchStore.chainSettled()));
+  const ready = settled || chainSettled;
   useEffect(() => {
     if (ready) setSettled(true);
   }, [ready]);

--- a/packages/ui/spa/components/fields/ArrayFields.tsx
+++ b/packages/ui/spa/components/fields/ArrayFields.tsx
@@ -1,12 +1,9 @@
-import { Internal, SourcePath, SerializedArraySchema } from "@valbuild/core";
+import { SourcePath, SerializedArraySchema } from "@valbuild/core";
 import {
-  useAddPatch,
-  useFieldCreatorId,
-  useHasUnsavedFrom,
   usePreviewAtPath,
-  useSchemaAtPath,
   useShallowSourceAtPath,
   useSourceAtPath,
+  useValField,
 } from "../ValFieldProvider";
 import { FieldLoading } from "../../components/FieldLoading";
 import { FieldNotFound } from "../../components/FieldNotFound";
@@ -37,25 +34,25 @@ export function ArrayFields({
   errorDisplay?: "default" | "compact" | "none";
 }) {
   const type = "array";
-  const creatorId = useFieldCreatorId();
   const { navigate } = useNavigation();
-  const schemaAtPath = useSchemaAtPath(path);
   const previewAtPath = usePreviewAtPath(path);
-  const shallowSourceAtPath = useShallowSourceAtPath(path, type, creatorId);
   const sourceAtPath = useSourceAtPath(path);
-
-  const { addPatch, patchPath } = useAddPatch(path, creatorId);
-  const [moduleFilePathOfPath] = Internal.splitModuleFilePathAndModulePath(
-    path as SourcePath,
-  );
   /**
-   * Subscribed, unlike the same fact inside `useShallowSourceAtPath`.
+   * `watchUnsaved`, unlike almost every other field.
    *
    * A list has no caret to lose, and an indicator that says "saving" after the
    * save has landed is a visible lie — so this one is allowed to wake the
-   * component. See `useHasUnsavedFrom` for why a text input must not.
+   * component. It is also load-bearing: the drag handle is a `<button disabled>`
+   * driven by this answer, so a value frozen at the moment of the drag disables
+   * reordering until something unrelated moves.
    */
-  const hasUnsavedOwnEdit = useHasUnsavedFrom(moduleFilePathOfPath, creatorId);
+  const {
+    source: shallowSourceAtPath,
+    schema: schemaAtPath,
+    addPatch,
+    patchPath,
+    hasUnsavedOwnEdit,
+  } = useValField(path, type, { watchUnsaved: true });
 
   if (schemaAtPath.status === "error") {
     return (

--- a/packages/ui/spa/components/fields/FileField.tsx
+++ b/packages/ui/spa/components/fields/FileField.tsx
@@ -15,11 +15,9 @@ import { FieldSchemaMismatchError } from "../FieldSchemaMismatchError";
 import { FieldSourceError } from "../FieldSourceError";
 import {
   useValConfig,
-  useSchemaAtPath,
   useShallowSourceAtPath,
-  useAddPatch,
-  useFieldCreatorId,
-  useSchemas,
+  useValField,
+  useModuleSchema,
   useFilePatchIds,
 } from "../ValFieldProvider";
 import {
@@ -124,23 +122,21 @@ export function FileField({
   compact?: boolean;
 }) {
   const type = "file";
-  const creatorId = useFieldCreatorId();
   const config = useValConfig();
   const currentRemoteFileBucket = useCurrentRemoteFileBucket();
   const remoteFiles = useRemoteFiles();
-  const schemas = useSchemas();
-  const schemaAtPath = useSchemaAtPath(path);
-  const sourceAtPath = useShallowSourceAtPath(path, type, creatorId);
   const [showAsVideo, setShowAsVideo] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [url, setUrl] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const {
+    source: sourceAtPath,
+    schema: schemaAtPath,
     addPatch,
     patchPath,
     addAndUploadPatchWithFileOps,
     addModuleFilePatch,
-  } = useAddPatch(path, creatorId);
+  } = useValField(path, type);
   const portalContainer = useValPortal();
   /**
    * The hidden file input, clicked by name.
@@ -207,8 +203,18 @@ export function FileField({
       ? schemaAtPath.data
       : undefined;
   const referencedModule = fileSchema?.referencedModule;
+  /**
+   * The referenced GALLERY's schema, not the project's.
+   *
+   * `useSchemas()` answers the same question and wakes on every schema change
+   * anywhere; this component is mounted once per media field. See
+   * `perFieldSubscriptions.test.ts`.
+   */
+  const referencedModuleSchema = useModuleSchema(
+    referencedModule as ModuleFilePath | undefined,
+  );
   const acceptOptions = useMemo(() => {
-    if (!fileSchema || schemas.status !== "success") {
+    if (!fileSchema) {
       return undefined;
     }
     if (fileSchema.options?.accept) {
@@ -217,12 +223,14 @@ export function FileField({
     if (!referencedModule) {
       return undefined;
     }
-    const moduleSchema = schemas.data[referencedModule as ModuleFilePath];
-    if (moduleSchema?.type === "record" && moduleSchema.accept) {
-      return moduleSchema.accept;
+    if (
+      referencedModuleSchema?.type === "record" &&
+      referencedModuleSchema.accept
+    ) {
+      return referencedModuleSchema.accept;
     }
     return undefined;
-  }, [fileSchema, referencedModule, schemas]);
+  }, [fileSchema, referencedModule, referencedModuleSchema]);
   /**
    * Where an upload from this field is stored: the gallery it references, or
    * `createFilePatch`'s `/public/val` default.
@@ -232,10 +240,10 @@ export function FileField({
    * an API change to `packages/core`, not a fix.
    */
   const uploadDirectory = useMemo(() => {
-    if (!referencedModule || schemas.status !== "success") return undefined;
-    const moduleSchema = schemas.data[referencedModule as ModuleFilePath];
-    return moduleSchema?.type === "record" ? moduleSchema.directory : undefined;
-  }, [referencedModule, schemas]);
+    return referencedModuleSchema?.type === "record"
+      ? referencedModuleSchema.directory
+      : undefined;
+  }, [referencedModuleSchema]);
   if (schemaAtPath.status === "error") {
     return (
       <FieldSchemaError path={path} error={schemaAtPath.error} type={type} />
@@ -280,10 +288,8 @@ export function FileField({
     schemaAtPath.data.remote &&
     remoteFiles.status !== "ready";
   const missingModules =
-    referencedModule && schemas.status === "success"
-      ? schemas.data[referencedModule as ModuleFilePath]
-        ? []
-        : [referencedModule]
+    referencedModule && referencedModuleSchema === undefined
+      ? [referencedModule]
       : [];
   const disabled =
     readonly || remoteFileUploadDisabled || missingModules.length > 0;

--- a/packages/ui/spa/components/fields/ImageField.tsx
+++ b/packages/ui/spa/components/fields/ImageField.tsx
@@ -4,12 +4,10 @@ import { FieldNotFound } from "../../components/FieldNotFound";
 import { FieldSchemaError } from "../../components/FieldSchemaError";
 import { FieldSourceError } from "../../components/FieldSourceError";
 import {
-  useSchemaAtPath,
   useShallowSourceAtPath,
-  useAddPatch,
-  useFieldCreatorId,
+  useValField,
   useValConfig,
-  useSchemas,
+  useModuleSchema,
   useFilePatchIds,
 } from "../ValFieldProvider";
 import {
@@ -45,13 +43,17 @@ export function ImageField({
   hideUpload?: boolean;
 }) {
   const type = "image";
-  const creatorId = useFieldCreatorId();
   const config = useValConfig();
   const remoteFiles = useRemoteFiles();
   const currentRemoteFileBucket = useCurrentRemoteFileBucket();
-  const schemas = useSchemas();
-  const schemaAtPath = useSchemaAtPath(path);
-  const sourceAtPath = useShallowSourceAtPath(path, type, creatorId);
+  const {
+    source: sourceAtPath,
+    schema: schemaAtPath,
+    addPatch,
+    patchPath,
+    addAndUploadPatchWithFileOps,
+    addModuleFilePatch,
+  } = useValField(path, type);
   const [hotspot, setHotspot] = useState<{ y: number; x: number } | undefined>(
     undefined,
   );
@@ -70,12 +72,6 @@ export function ImageField({
    * field mounts with no value — which is every empty image field.
    */
   const [previewOpen, setPreviewOpen] = useState(false);
-  const {
-    addPatch,
-    patchPath,
-    addAndUploadPatchWithFileOps,
-    addModuleFilePatch,
-  } = useAddPatch(path, creatorId);
   const portalContainer = useValPortal();
   /**
    * The hidden file input, clicked by name.
@@ -134,8 +130,18 @@ export function ImageField({
       ? schemaAtPath.data
       : undefined;
   const referencedModule = imageSchema?.referencedModule;
+  /**
+   * The referenced GALLERY's schema, not the project's.
+   *
+   * `useSchemas()` answers the same question and wakes on every schema change
+   * anywhere; this component is mounted once per media field. See
+   * `perFieldSubscriptions.test.ts`.
+   */
+  const referencedModuleSchema = useModuleSchema(
+    referencedModule as ModuleFilePath | undefined,
+  );
   const acceptOptions = useMemo(() => {
-    if (!imageSchema || schemas.status !== "success") {
+    if (!imageSchema) {
       return undefined;
     }
     if (imageSchema.options?.accept) {
@@ -144,12 +150,14 @@ export function ImageField({
     if (!referencedModule) {
       return undefined;
     }
-    const moduleSchema = schemas.data[referencedModule as ModuleFilePath];
-    if (moduleSchema?.type === "record" && moduleSchema.accept) {
-      return moduleSchema.accept;
+    if (
+      referencedModuleSchema?.type === "record" &&
+      referencedModuleSchema.accept
+    ) {
+      return referencedModuleSchema.accept;
     }
     return undefined;
-  }, [imageSchema, referencedModule, schemas]);
+  }, [imageSchema, referencedModule, referencedModuleSchema]);
   /**
    * Where an upload from this field is stored.
    *
@@ -163,10 +171,10 @@ export function ImageField({
     if (imageSchema?.options?.directory) {
       return imageSchema.options.directory;
     }
-    if (!referencedModule || schemas.status !== "success") return undefined;
-    const moduleSchema = schemas.data[referencedModule as ModuleFilePath];
-    return moduleSchema?.type === "record" ? moduleSchema.directory : undefined;
-  }, [imageSchema, referencedModule, schemas]);
+    return referencedModuleSchema?.type === "record"
+      ? referencedModuleSchema.directory
+      : undefined;
+  }, [imageSchema, referencedModuleSchema]);
   const existingAlt =
     maybeSourceData && typeof maybeSourceData.alt === "string"
       ? maybeSourceData.alt
@@ -237,10 +245,8 @@ export function ImageField({
     schemaAtPath.data.remote &&
     remoteFiles.status !== "ready";
   const missingModules =
-    referencedModule && schemas.status === "success"
-      ? schemas.data[referencedModule as ModuleFilePath]
-        ? []
-        : [referencedModule]
+    referencedModule && referencedModuleSchema === undefined
+      ? [referencedModule]
       : [];
   const disabled =
     readonly || remoteFileUploadDisabled || missingModules.length > 0;

--- a/packages/ui/spa/components/fields/RichTextField.tsx
+++ b/packages/ui/spa/components/fields/RichTextField.tsx
@@ -17,8 +17,8 @@ import {
   ShallowSource,
   useAddPatch,
   useFieldCreatorId,
+  useModuleSchema,
   useSchemaAtPath,
-  useSchemas,
   useShallowSourceAtPath,
   useValConfig,
 } from "../ValFieldProvider";
@@ -50,7 +50,6 @@ export function RichTextField({
   const config = useValConfig();
   const remoteFiles = useRemoteFiles();
   const currentRemoteFileBucket = useCurrentRemoteFileBucket();
-  const schemas = useSchemas();
   const schemaAtPath = useSchemaAtPath(path);
   const sourceAtPath = useShallowSourceAtPath(path, type, creatorId);
   const currentSourceData =
@@ -144,26 +143,34 @@ export function RichTextField({
 
   const hasImageEnabled = !!schemaOptions?.inline?.img;
 
-  const imageReferencedModule = imageSchema?.referencedModule;
+  const imageReferencedModule = imageSchema?.referencedModule as
+    | ModuleFilePath
+    | undefined;
+  /**
+   * The GALLERY's schema, not the project's.
+   *
+   * This used to read `useSchemas()` — every schema in the project, woken by
+   * every schema change — to look up one module and take two fields off it.
+   * `useSchemas` is a whole-project subscription and this component is mounted
+   * once per rich text field.
+   */
+  const imageModuleSchema = useModuleSchema(imageReferencedModule);
   const imageAcceptOptions = useMemo(() => {
     if (!hasImageEnabled) return undefined;
     if (imageSchema?.options?.accept) return imageSchema.options.accept;
-    if (imageReferencedModule && schemas.status === "success") {
-      const moduleSchema =
-        schemas.data[imageReferencedModule as ModuleFilePath];
-      if (moduleSchema?.type === "record" && moduleSchema.accept) {
-        return moduleSchema.accept;
-      }
+    if (imageModuleSchema?.type === "record" && imageModuleSchema.accept) {
+      return imageModuleSchema.accept;
     }
     return undefined;
-  }, [hasImageEnabled, imageSchema, imageReferencedModule, schemas]);
+  }, [hasImageEnabled, imageSchema, imageModuleSchema]);
 
-  const imageModuleDirectory = useMemo(() => {
-    if (!imageReferencedModule || schemas.status !== "success")
-      return undefined;
-    const moduleSchema = schemas.data[imageReferencedModule as ModuleFilePath];
-    return moduleSchema?.type === "record" ? moduleSchema.directory : undefined;
-  }, [imageReferencedModule, schemas]);
+  const imageModuleDirectory = useMemo(
+    () =>
+      imageModuleSchema?.type === "record"
+        ? imageModuleSchema.directory
+        : undefined,
+    [imageModuleSchema],
+  );
 
   const imageRemoteData = useMemo(() => {
     if (

--- a/packages/ui/spa/components/fields/RichTextField.tsx
+++ b/packages/ui/spa/components/fields/RichTextField.tsx
@@ -15,12 +15,10 @@ import { deepEqual, JSONValue } from "@valbuild/core/patch";
 import { PreviewLoading, PreviewNull } from "../../components/Preview";
 import {
   ShallowSource,
-  useAddPatch,
-  useFieldCreatorId,
   useModuleSchema,
-  useSchemaAtPath,
   useShallowSourceAtPath,
   useValConfig,
+  useValField,
 } from "../ValFieldProvider";
 import {
   useCurrentRemoteFileBucket,
@@ -46,12 +44,17 @@ export function RichTextField({
   compact?: boolean; // TODO: implement compact
 }) {
   const type = "richtext";
-  const creatorId = useFieldCreatorId();
   const config = useValConfig();
   const remoteFiles = useRemoteFiles();
   const currentRemoteFileBucket = useCurrentRemoteFileBucket();
-  const schemaAtPath = useSchemaAtPath(path);
-  const sourceAtPath = useShallowSourceAtPath(path, type, creatorId);
+  const {
+    source: sourceAtPath,
+    schema: schemaAtPath,
+    patchPath,
+    addPatch,
+    addAndUploadPatchWithFileOps,
+    addModuleFilePatch,
+  } = useValField(path, type);
   const currentSourceData =
     "data" in sourceAtPath
       ? (sourceAtPath.data as RichTextSource<AllRichTextOptions>)
@@ -81,13 +84,6 @@ export function RichTextField({
    */
   const pendingDocRef = useRef<EditorDocument | null>(null);
   const [uploadProgress, setUploadProgress] = useState<number | null>(null);
-
-  const {
-    patchPath,
-    addPatch,
-    addAndUploadPatchWithFileOps,
-    addModuleFilePatch,
-  } = useAddPatch(path, creatorId);
 
   const maybeClientSideOnly =
     "clientSideOnly" in sourceAtPath && sourceAtPath.clientSideOnly;

--- a/packages/ui/spa/components/fields/RichTextField.tsx
+++ b/packages/ui/spa/components/fields/RichTextField.tsx
@@ -449,6 +449,22 @@ export function RichTextField({
     <div id={path} className="m-1">
       <RichTextEditor
         ref={editorRef}
+        /**
+         * The document the editor MOUNTS with.
+         *
+         * It used to be given none, so the view was always built empty and the
+         * content arrived afterwards through `reset()` in the sync effect above.
+         * That made the effect load-bearing for the initial paint, and the
+         * effect's deps are the source — so anything that rebuilt the view
+         * without moving source (a toolbar feature settling, a portal container
+         * arriving) left a permanently blank field with nothing to refill it.
+         *
+         * Uncontrolled still: this is read once, at mount. `reset()` remains how
+         * a FOREIGN change lands.
+         */
+        defaultValue={
+          (currentSourceData as unknown as EditorDocument | null) ?? []
+        }
         features={features}
         linkCatalog={linkCatalog}
         readOnly={readonly || disabledRef.current}

--- a/packages/ui/spa/components/fields/StringField.test.tsx
+++ b/packages/ui/spa/components/fields/StringField.test.tsx
@@ -30,6 +30,18 @@ jest.mock("../ValFieldProvider", () => ({
   useSchemaAtPath: () => mockSchema(),
   useShallowSourceAtPath: () => mockSource(),
   useAddPatch: () => ({ patchPath: [], addPatch: jest.fn() }),
+  // The seam the field actually reads through. Composed from the two mocks
+  // above rather than stubbed separately, so what this file controls — the
+  // schema and the source — is unchanged by where the field gets them from.
+  useValField: () => ({
+    schema: mockSchema(),
+    source: mockSource(),
+    hasUnsavedOwnEdit: false,
+    patchPath: [],
+    addPatch: jest.fn(),
+    addAndUploadPatchWithFileOps: jest.fn(),
+    addModuleFilePatch: jest.fn(),
+  }),
 }));
 
 // `Preview` is the generic field dispatcher, so importing it drags in the whole

--- a/packages/ui/spa/components/fields/StringField.tsx
+++ b/packages/ui/spa/components/fields/StringField.tsx
@@ -1,12 +1,7 @@
 import React from "react";
 import { SourcePath } from "@valbuild/core";
 import { Input } from "../designSystem/input";
-import {
-  useAddPatch,
-  useFieldCreatorId,
-  useSchemaAtPath,
-  useShallowSourceAtPath,
-} from "../ValFieldProvider";
+import { useShallowSourceAtPath, useValField } from "../ValFieldProvider";
 import { FieldLoading } from "../../components/FieldLoading";
 import { FieldNotFound } from "../../components/FieldNotFound";
 import { FieldSchemaError } from "../../components/FieldSchemaError";
@@ -30,10 +25,12 @@ export function StringField({
   compact?: boolean;
 }) {
   const type = "string";
-  const creatorId = useFieldCreatorId();
-  const schemaAtPath = useSchemaAtPath(path);
-  const sourceAtPath = useShallowSourceAtPath(path, "string", creatorId);
-  const { patchPath, addPatch } = useAddPatch(path, creatorId);
+  const {
+    source: sourceAtPath,
+    schema: schemaAtPath,
+    patchPath,
+    addPatch,
+  } = useValField(path, type);
   const [currentValue, setCurrentValue] = useState<string | null>(null);
   /**
    * One patch per PAUSE in typing, not per keystroke.

--- a/packages/ui/spa/components/perFieldSubscriptions.test.ts
+++ b/packages/ui/spa/components/perFieldSubscriptions.test.ts
@@ -2,37 +2,169 @@ import fs from "fs";
 import path from "path";
 
 /**
- * `useAllSources()` and `useSchemas()` are whole-project subscriptions.
+ * A component mounted once per field may not subscribe to the whole project.
  *
- * `getAllSourcesSnapshot()` walks every module, calls `getPatchedSource` and
- * `deepClone`s the result; `invalidateSource` drops its cache on every keystroke,
- * so the snapshot is a NEW object every time and `useSyncExternalStore` can never
- * bail out. A component that subscribes therefore re-renders - and forces a fresh
- * deep clone of the entire project - on every keystroke anywhere in the Studio.
+ * ## What these hooks cost
  *
- * That is affordable in the handful of whole-project views that genuinely need all
- * sources (Search, Module, ValidationErrors, the reference hooks). It is NOT
- * affordable in a component mounted once per field: `Field` wraps every leaf field
- * in the editor, so subscribing there made a single keystroke cost
- * O(project size), for data that only a click handler ever read.
+ * Each of them wakes on something that moves for reasons that have nothing to
+ * do with the field reading it:
  *
- * This is a STATIC guard, not a behavioural one: `packages/ui` has no
- * `jest-environment-jsdom`, so no component can be rendered in this suite. If that
- * changes, replace this with a render test that counts commits.
+ * - `useAllSources` / `useSchemas` — every keystroke anywhere, every schema
+ *   change. `useAllSources`'s snapshot is a version NUMBER, so it cannot bail
+ *   out: the reader re-renders whether or not its own answer moved.
+ * - `useAllPreviews` — every preview computed or invalidated, project-wide.
+ * - `useChainVersion` — every patch created, saved, dropped or fetched.
+ * - `useLoadingStatus` — the WRITE QUEUE, so twice per save round trip.
+ * - `useAllValidationErrors` — every validation result and invalidation.
  *
- * Components here must use `useGetNavPath()` (or another on-demand read) instead.
+ * Any one of those is affordable in a whole-project view — Search, the errors
+ * page, the nav tree. In a per-field component it makes a single edit
+ * O(project), which is the cost the store layer exists to remove and which is
+ * therefore trivial to reintroduce one level up. It has been reintroduced
+ * twice, both times by an innocuous-looking hook two calls deep:
+ * `useLoadingStatus` inside `useFieldState`, and `useAllSources` inside
+ * `useRoutesOf` inside `useRichTextEditorConfig`.
+ *
+ * ## Why it is static
+ *
+ * `packages/ui` has no `jest-environment-jsdom` by default, so this suite
+ * cannot render anything and count commits. `valFieldHooks.test.tsx` does that
+ * for the hooks it covers; this is the cheap net over every field file, and it
+ * catches the transitive case a render test would need a fixture for.
+ *
+ * ## Adding a file here
+ *
+ * Everything under `components/fields/` is covered automatically, so a new
+ * field is guarded the day it is written. {@link EXTRA_FILES} is for the
+ * per-field components that live elsewhere, and {@link ALLOWED} is the
+ * escape hatch — with a reason, because an entry without one is how a guard
+ * stops being one.
  */
-const PER_FIELD_COMPONENTS = ["Field.tsx", "FieldValidationError.tsx"];
+const FIELDS_DIR = path.join(__dirname, "fields");
 
-const WHOLE_PROJECT_HOOKS = ["useAllSources", "useSchemas"];
+/** Per-field components that do not live under `fields/`. */
+const EXTRA_FILES = [
+  "Field.tsx",
+  "InlineField.tsx",
+  "useFieldState.ts",
+  "AnyField.tsx",
+  "InlineAnyField.tsx",
+  "FieldValidationError.tsx",
+  "FieldPatchAuthorsSection.tsx",
+];
+
+/** Hooks that wake for something other than the field reading them. */
+const WHOLE_PROJECT_HOOKS = [
+  "useAllSources",
+  "useSchemas",
+  "useAllPreviews",
+  "useChainVersion",
+  "useLoadingStatus",
+  "useAllValidationErrors",
+];
+
+/**
+ * Known exceptions, each with the reason it is one.
+ *
+ * These are not "allowed because they are there". Every entry is a component
+ * that genuinely needs a project-wide answer and pays for it with a snapshot
+ * that is reference-stable, so an unchanged answer re-renders nothing.
+ */
+const ALLOWED: Record<string, { hooks: string[]; because: string }> = {
+  // `useAllPreviews` returns the same object when no preview moved
+  // (`PreviewStore.all` recomputes and compares), so an unrelated keystroke
+  // costs one map rebuild and no render. The route selector genuinely needs
+  // every router module's preview to label its options.
+  "RouteField.tsx": {
+    hooks: ["useAllPreviews"],
+    because:
+      "the route selector labels every route in the project, and PreviewStore.all() is reference-stable",
+  },
+  // Same reasoning, for the rich text link catalogue.
+  "useRichTextEditorConfig.ts": {
+    hooks: ["useAllPreviews"],
+    because:
+      "the link catalogue labels every route in the project, and PreviewStore.all() is reference-stable",
+  },
+  // `useAllValidationErrors` is reference-stable by recompute-and-compare (see
+  // `ValErrorProvider`), and a compact row shows errors for a whole subtree
+  // rather than for one path.
+  "FieldValidationError.tsx": {
+    hooks: ["useAllValidationErrors"],
+    because:
+      "the compact badge summarises a subtree, and useAllValidationErrors is reference-stable",
+  },
+  // A gallery and a record list are whole-MODULE views: each renders every
+  // entry of the record it is pointed at and shows an error badge per row, so
+  // a per-path read would be one subscription per tile. And
+  // `useAllValidationErrors` is reference-stable by recompute-and-compare, so
+  // an unchanged answer re-renders nothing.
+  "ModuleGallery.tsx": {
+    hooks: ["useAllValidationErrors"],
+    because: "a gallery renders a whole record and badges each entry",
+  },
+  "RecordFields.tsx": {
+    hooks: ["useAllValidationErrors"],
+    because: "a record list renders every row and badges each one",
+  },
+};
+
+/**
+ * The file with its comments removed.
+ *
+ * Matched on the CODE, not on the text: three of these files explain in a doc
+ * comment which hook they used to call and why they stopped, and a substring
+ * test over the raw source reads those explanations as violations. Deleting the
+ * explanation to satisfy the guard would be the worst possible outcome.
+ */
+function code(file: string): string {
+  return fs
+    .readFileSync(file, "utf-8")
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1 ");
+}
+
+function perFieldFiles(): string[] {
+  const inFieldsDir = fs
+    .readdirSync(FIELDS_DIR)
+    .filter((file) => /\.(ts|tsx)$/.test(file))
+    .filter((file) => !file.includes(".test.") && !file.includes(".stories."))
+    .map((file) => path.join("fields", file));
+  return [...inFieldsDir, ...EXTRA_FILES];
+}
 
 describe("per-field components do not subscribe to the whole project", () => {
-  for (const file of PER_FIELD_COMPONENTS) {
+  for (const file of perFieldFiles()) {
+    const base = path.basename(file);
     for (const hook of WHOLE_PROJECT_HOOKS) {
-      test(`${file} does not call ${hook}()`, () => {
-        const source = fs.readFileSync(path.join(__dirname, file), "utf-8");
-        expect(source).not.toContain(`${hook}(`);
+      const allowed = ALLOWED[base]?.hooks.includes(hook) === true;
+      const name = allowed
+        ? `${file} may call ${hook}(): ${ALLOWED[base].because}`
+        : `${file} does not call ${hook}()`;
+      test(name, () => {
+        const calls = code(path.join(__dirname, file)).includes(`${hook}(`);
+        expect(calls).toBe(allowed);
       });
     }
+  }
+});
+
+/**
+ * The rich text editor's config hook is not under `fields/`, and it is the one
+ * that put `useAllSources` back on the keystroke path — two calls deep, through
+ * `useRoutesOf`. Named explicitly so the transitive case is covered even though
+ * the file itself is elsewhere.
+ */
+describe("the rich text editor config is a per-field hook", () => {
+  const file = path.join(
+    __dirname,
+    "RichTextEditor/useRichTextEditorConfig.ts",
+  );
+  for (const hook of WHOLE_PROJECT_HOOKS) {
+    const allowed =
+      ALLOWED["useRichTextEditorConfig.ts"]?.hooks.includes(hook) === true;
+    test(`${allowed ? "may" : "does not"} call ${hook}()`, () => {
+      expect(code(file).includes(`${hook}(`)).toBe(allowed);
+    });
   }
 });

--- a/packages/ui/spa/components/useFieldState.ts
+++ b/packages/ui/spa/components/useFieldState.ts
@@ -4,7 +4,7 @@ import {
   useAddPatch,
   useSchemaAtPath,
   useShallowSourceAtPath,
-  useLoadingStatus,
+  type LoadingStatus,
 } from "./ValFieldProvider";
 import { useValidationErrors } from "./ValErrorProvider";
 
@@ -17,11 +17,33 @@ export function useFieldState(
   },
   initialExpanded = true,
 ) {
-  const loadingStatus = useLoadingStatus();
   const validationErrors = useValidationErrors(path);
   const { patchPath, addPatch } = useAddPatch(path);
   const schemaAtPath = useSchemaAtPath(path);
   const sourceAtPath = useShallowSourceAtPath(path, type);
+
+  /**
+   * Is THIS field's data ready? Read from this field's own two reads.
+   *
+   * It used to be `useLoadingStatus()`, which is a different question: that hook
+   * answers whether the write queue has caught up, and it is a whole-project
+   * subscription. `Field` wraps every leaf field in the editor, so every save
+   * round trip re-rendered the entire mounted tree twice — `success` to
+   * `loading` and back — and while it was in flight every nullable checkbox and
+   * every boolean toggle in the Studio went disabled, because that is what this
+   * value gates.
+   *
+   * Both of those are wrong for the same reason: a save somewhere else says
+   * nothing about whether this field can be rendered or operated. The reads
+   * above already say, per path, and they are the reads this component makes
+   * anyway.
+   */
+  const loadingStatus: LoadingStatus =
+    schemaAtPath.status === "loading" || sourceAtPath.status === "loading"
+      ? "loading"
+      : schemaAtPath.status === "error" || sourceAtPath.status === "error"
+        ? "error"
+        : "success";
 
   const [isExpanded, setIsExpanded] = useState(initialExpanded);
   const [showEmptyFileOrImage, setShowEmptyFileOrImage] = useState(false);

--- a/packages/ui/spa/components/useRoutesOf.ts
+++ b/packages/ui/spa/components/useRoutesOf.ts
@@ -1,51 +1,141 @@
-import { useMemo } from "react";
-import {
-  useAllSources,
-  useSchemas,
-  useLoadingStatus,
-} from "./ValFieldProvider";
-import {
-  getRoutesOf,
-  getRoutesWithModulePaths,
-  RouteInfo,
-} from "./getRoutesOf";
+import { useCallback, useSyncExternalStore } from "react";
+import { useValSystem, type ValSystem } from "../stores/react/SystemContext";
+import { getRoutesWithModulePaths, RouteInfo } from "./getRoutesOf";
 
 /**
- * Hook to get all available routes from router modules
+ * Every route the project declares, derived once per source version.
  *
- * Returns an array of route strings from all modules that have routers defined
+ * ## Why this is not two `useMemo`s over `useAllSources()`
+ *
+ * It was, and both hooks below are rendered PER FIELD — `RouteField` for its
+ * selector, and every `RichTextField` through `useRichTextEditorConfig` for its
+ * link catalogue. `useAllSources()` is a whole-project subscription whose
+ * snapshot is a version NUMBER, so it changes on every keystroke anywhere in the
+ * Studio; each of those fields therefore re-rendered and re-walked the project's
+ * routers on every character typed into any other field.
+ *
+ * Two things fix it, and both are needed:
+ *
+ * - the walk is shared and memoised on the source version, so N fields cost ONE
+ *   walk per change rather than N;
+ * - the answer is reference-stable by recompute-and-compare, so a change that
+ *   does not move the routes — which is almost every change, since a route is a
+ *   router record's KEY — hands back the same array and
+ *   `useSyncExternalStore` bails out with no re-render at all.
+ *
+ * Compare rather than invalidate, for the reason the stores give everywhere
+ * else: the list of things that can change a route is longer than it looks
+ * (a key added, a module loaded, a schema replaced by HMR), and a list of call
+ * sites has to stay complete forever and fails silently when it does not.
+ *
+ * The cache hangs off the SYSTEM rather than off a module-level variable, so two
+ * systems in one process — which is every test file — cannot answer for each
+ * other. A `WeakMap`, so a discarded system takes its entry with it.
  */
-export function useRoutesOf(): string[] {
-  const schemas = useSchemas();
-  const loadingStatus = useLoadingStatus();
-  const allSources = useAllSources();
+const routeCache = new WeakMap<
+  object,
+  { version: number; schemas: number; routes: RouteInfo[] }
+>();
 
-  const routes = useMemo(() => {
-    if ("data" in schemas && schemas.data !== undefined) {
-      return getRoutesOf(schemas.data, allSources);
+function sameRoutes(a: RouteInfo[], b: RouteInfo[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let index = 0; index < a.length; index++) {
+    if (
+      a[index].route !== b[index].route ||
+      a[index].moduleFilePath !== b[index].moduleFilePath
+    ) {
+      return false;
     }
-    return [];
-  }, [loadingStatus, allSources, schemas]);
+  }
+  return true;
+}
 
+const NO_ROUTES: RouteInfo[] = [];
+
+function readRoutes(val: ValSystem | null): RouteInfo[] {
+  if (val === null) {
+    return NO_ROUTES;
+  }
+  const version = val.system.sourceStore.sourcesVersion();
+  const schemas = val.system.schemaStore.all();
+  // The schema map is replaced wholesale by intake, so its SIZE moves exactly
+  // when it does — the same reasoning `useSchemasVersion` gives for counting
+  // rather than versioning.
+  const schemaCount = Object.keys(schemas).length;
+  const cached = routeCache.get(val.system);
+  if (
+    cached !== undefined &&
+    cached.version === version &&
+    cached.schemas === schemaCount
+  ) {
+    return cached.routes;
+  }
+  const next = getRoutesWithModulePaths(
+    schemas,
+    val.system.sourceStore.allSources(),
+  );
+  // Recomputed, then compared: the identity only moves when the answer does.
+  const routes =
+    cached !== undefined && sameRoutes(cached.routes, next)
+      ? cached.routes
+      : next;
+  routeCache.set(val.system, { version, schemas: schemaCount, routes });
   return routes;
 }
 
+function useRoutes(): RouteInfo[] {
+  const val = useValSystem();
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      if (val === null) return () => {};
+      const offSource = val.system.sourceStore.events.on(
+        "source:change",
+        onChange,
+      );
+      const offSchema = val.system.schemaStore.events.on(
+        "schema:init",
+        onChange,
+      );
+      return () => {
+        offSource();
+        offSchema();
+      };
+    },
+    [val],
+  );
+  const getSnapshot = useCallback(() => readRoutes(val), [val]);
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
 /**
- * Hook to get all available routes with their module paths from router modules
+ * Every route the project's routers declare.
  *
- * Returns an array of RouteInfo objects containing both the route and its module path
+ * Returns an array of route strings from all modules that have routers defined.
+ */
+export function useRoutesOf(): string[] {
+  // Keyed on the identity of the shared array, so this is stable for exactly as
+  // long as that one is — and shared between callers for the same reason.
+  return routeStrings(useRoutes());
+}
+
+const stringsCache = new WeakMap<RouteInfo[], string[]>();
+
+function routeStrings(routes: RouteInfo[]): string[] {
+  const cached = stringsCache.get(routes);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const strings = routes.map((info) => info.route);
+  stringsCache.set(routes, strings);
+  return strings;
+}
+
+/**
+ * Every route with the module it lives in.
+ *
+ * Returns an array of RouteInfo objects containing both the route and its module
+ * path.
  */
 export function useRoutesWithModulePaths(): RouteInfo[] {
-  const schemas = useSchemas();
-  const loadingStatus = useLoadingStatus();
-  const allSources = useAllSources();
-
-  const routes = useMemo(() => {
-    if ("data" in schemas && schemas.data !== undefined) {
-      return getRoutesWithModulePaths(schemas.data, allSources);
-    }
-    return [];
-  }, [loadingStatus, allSources, schemas]);
-
-  return routes;
+  return useRoutes();
 }

--- a/packages/ui/spa/components/valFieldHooks.test.tsx
+++ b/packages/ui/spa/components/valFieldHooks.test.tsx
@@ -22,6 +22,7 @@ import {
   useSchemaAtPath,
   useShallowSourceAtPath,
   useSourceAtPath,
+  useValField,
 } from "./ValFieldProvider";
 import { useValidationErrors } from "./ValErrorProvider";
 import { ImageField } from "./fields/ImageField";
@@ -365,6 +366,142 @@ describe("per-instance suppression", () => {
     });
 
     expect(renders.current).toBe(before + 1);
+    system.dispose();
+  });
+});
+
+/**
+ * The same field, assembled by `useValField` instead of by hand.
+ *
+ * There is no `readerId` here and there cannot be: the id never leaves the
+ * hook. That is the whole point of the seam — the trap above is not something a
+ * caller has to remember to avoid, it is something a caller cannot express.
+ */
+function SeamedField({
+  renders,
+  onReady,
+}: {
+  renders?: { current: number };
+  onReady: (write: (value: string) => Promise<unknown>) => void;
+}) {
+  if (renders) renders.current++;
+  const { source, patchPath, addPatch } = useValField(
+    '/page.val.ts?p="title"' as SourcePath,
+    "string",
+  );
+  const held = useRef(addPatch);
+  held.current = addPatch;
+  onReady(async (value: string) => {
+    held.current([{ op: "replace", path: patchPath, value }], "string");
+    await Promise.resolve();
+  });
+  return (
+    <span data-testid="seamed">
+      {source.status === "success" ? String(source.data) : source.status}
+    </span>
+  );
+}
+
+describe("useValField", () => {
+  /**
+   * The claim `TypingField` above could not make.
+   *
+   * `TypingField` reads source and writes, and nothing else — so it never
+   * exercised the case every real field is in: an editable field also resolves
+   * its SCHEMA at the same path, and `useSchemaAtPath` registers a source
+   * listener of its own to do it. Under an id of its own that is a second
+   * instance as far as suppression is concerned, so the field was woken by its
+   * own keystroke through the schema hook while the source hook correctly said
+   * nothing.
+   *
+   * `useValField` hands one id to both, which is the only reason this passes.
+   */
+  it("reads and writes under one identity, so its own edit leaves it asleep", async () => {
+    const system = makeSystem();
+    system.host.receive(project());
+    const renders = { current: 0 };
+    let write: ((value: string) => Promise<unknown>) | null = null;
+
+    render(
+      <Harness system={system}>
+        <SeamedField
+          renders={renders}
+          onReady={(fn) => {
+            write = fn;
+          }}
+        />
+      </Harness>,
+    );
+    const before = renders.current;
+
+    await act(async () => {
+      await write?.("typed");
+    });
+
+    expect(renders.current).toBe(before);
+    system.dispose();
+  });
+
+  it("still wakes another instance on the same path", async () => {
+    const system = makeSystem();
+    system.host.receive(project());
+    const overlay = { current: 0 };
+    let write: ((value: string) => Promise<unknown>) | null = null;
+
+    render(
+      <Harness system={system}>
+        <SeamedField
+          onReady={(fn) => {
+            write = fn;
+          }}
+        />
+        <Field path='/page.val.ts?p="title"' renders={overlay} />
+      </Harness>,
+    );
+    const before = overlay.current;
+
+    await act(async () => {
+      await write?.("typed");
+    });
+
+    expect(overlay.current).toBe(before + 1);
+    expect(screen.getByTestId('/page.val.ts?p="title"').textContent).toBe(
+      "typed",
+    );
+    system.dispose();
+  });
+
+  /**
+   * `watchUnsaved` is off by default, and the default is the load-bearing one:
+   * a field that is woken when its own edit saves is a text input that loses
+   * its caret mid-word.
+   */
+  it("does not wake on its own save unless asked to watch", async () => {
+    const system = makeSystem();
+    system.host.receive(project());
+    const renders = { current: 0 };
+    let write: ((value: string) => Promise<unknown>) | null = null;
+
+    render(
+      <Harness system={system}>
+        <SeamedField
+          renders={renders}
+          onReady={(fn) => {
+            write = fn;
+          }}
+        />
+      </Harness>,
+    );
+    await act(async () => {
+      await write?.("typed");
+    });
+    const before = renders.current;
+
+    await act(async () => {
+      system.patchStore.markSaved(system.patchStore.pendingPatchIds());
+    });
+
+    expect(renders.current).toBe(before);
     system.dispose();
   });
 });

--- a/packages/ui/spa/stores/PatchStore.ts
+++ b/packages/ui/spa/stores/PatchStore.ts
@@ -1,4 +1,4 @@
-import type { ModuleFilePath, PatchId } from "@valbuild/core";
+import { Internal, type ModuleFilePath, type PatchId } from "@valbuild/core";
 import type { Json } from "@valbuild/core";
 import type { Patch } from "@valbuild/core/patch";
 import { StoreBus } from "./StoreBus";
@@ -46,6 +46,32 @@ export type FetchPatches = (patchIds: PatchId[]) => Promise<{
 }>;
 
 export type CreatePatchId = () => PatchId;
+
+/**
+ * One chain entry, as a reader AT A PATH sees it.
+ *
+ * The record plus the optimistic axis, because those are the two facts a review
+ * row renders and they move independently: `markSaved` flips `isPending` while
+ * the record stays exactly the same object.
+ */
+export type PatchAtPath = {
+  record: PatchRecord;
+  isPending: boolean;
+};
+
+/** Do these two answers about one path say the same thing? */
+function samePatchesAtPath(a: PatchAtPath[], b: PatchAtPath[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let index = 0; index < a.length; index++) {
+    if (
+      a[index].record !== b[index].record ||
+      a[index].isPending !== b[index].isPending
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
 
 /**
  * Is this the same chain, in the same order?
@@ -1414,6 +1440,93 @@ export class PatchStore {
     this.filePatchIdsAt = { n: this.version, map };
     return map;
   }
+
+  /**
+   * The chain, indexed by the source path a reader would ask about.
+   *
+   * Built ONCE per chain version and shared, with each path's array reused when
+   * its answer has not changed. Both halves are load-bearing, and they answer
+   * different costs:
+   *
+   * - **Built once.** `FieldPatchAuthorsSection` is mounted on every non-compact
+   *   field, and it used to walk `allRecords()` itself. That made a chain
+   *   movement O(fields on screen x chain length) — and `patch:chain` moves on
+   *   every keystroke's patch, on every save, and (before it was fixed) on every
+   *   `/stat` poll.
+   * - **Reused when equal.** A field reads this through
+   *   `useSyncExternalStore`, so an array rebuilt with the same contents is a
+   *   new snapshot and a guaranteed re-render. Comparing means a patch created
+   *   in one field wakes that field's path and nobody else's.
+   *
+   * Keyed at TWO granularities, because that is what callers ask at: the module
+   * file path, which answers for every patch in the module, and the exact source
+   * path of each op. A reader at a deeper path finds itself under its own key or
+   * not at all — the same exact-match rule the walk this replaces used.
+   *
+   * `isPending` travels with the record because it is what a reader renders
+   * (an edit that has not reached the server is shown differently) and because
+   * it moves WITHOUT the chain's membership moving — `markSaved` flips it. A
+   * comparison on records alone would hold the stale answer.
+   */
+  patchesByPath(): ReadonlyMap<string, PatchAtPath[]> {
+    const cached = this.patchesByPathAt;
+    if (cached !== null && cached.n === this.version) {
+      return cached.byPath;
+    }
+    const byPath = new Map<string, PatchAtPath[]>();
+    const seen = new Map<string, Set<PatchId>>();
+    const add = (key: string, entry: PatchAtPath) => {
+      let already = seen.get(key);
+      if (already === undefined) {
+        already = new Set();
+        seen.set(key, already);
+      }
+      // One record per key, however many of its ops land on that path.
+      if (already.has(entry.record.patchId)) return;
+      already.add(entry.record.patchId);
+      const at = byPath.get(key);
+      if (at === undefined) {
+        byPath.set(key, [entry]);
+      } else {
+        at.push(entry);
+      }
+    };
+    for (const patchId of this.ordered) {
+      const record = this.dataById.get(patchId);
+      if (record === undefined) continue;
+      const entry: PatchAtPath = {
+        record,
+        isPending: this.pendingIds.has(patchId),
+      };
+      add(record.moduleFilePath, entry);
+      for (const op of record.patch) {
+        if (op.op === "file") continue;
+        add(
+          Internal.joinModuleFilePathAndModulePath(
+            record.moduleFilePath,
+            Internal.patchPathToModulePath(op.path),
+          ),
+          entry,
+        );
+      }
+    }
+    const previous = cached?.byPath;
+    if (previous !== undefined) {
+      for (const [key, entries] of byPath) {
+        const before = previous.get(key);
+        if (before !== undefined && samePatchesAtPath(before, entries)) {
+          byPath.set(key, before);
+        }
+      }
+    }
+    this.patchesByPathAt = { n: this.version, byPath };
+    return byPath;
+  }
+
+  private patchesByPathAt: {
+    n: number;
+    byPath: ReadonlyMap<string, PatchAtPath[]>;
+  } | null = null;
 
   /**
    * Does this module have an unsaved patch that THIS field instance made?

--- a/packages/ui/spa/stores/PatchStore.ts
+++ b/packages/ui/spa/stores/PatchStore.ts
@@ -48,6 +48,21 @@ export type FetchPatches = (patchIds: PatchId[]) => Promise<{
 export type CreatePatchId = () => PatchId;
 
 /**
+ * Is this the same chain, in the same order?
+ *
+ * Order matters as much as membership — `/stat` is the authority on order, and
+ * another session's patch landing between two of ours is a real change with an
+ * identical id set. So this compares position by position rather than as sets.
+ */
+function sameOrder(a: readonly PatchId[], b: readonly PatchId[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let index = 0; index < a.length; index++) {
+    if (a[index] !== b[index]) return false;
+  }
+  return true;
+}
+
+/**
  * POST one file's bytes to wherever files live, or delete one.
  *
  * `data: null` IS the delete — the same operation in both directions, which is
@@ -360,6 +375,16 @@ export class PatchStore {
     patchIds: PatchId[],
     baseMoved = false,
   ): Promise<void> {
+    /**
+     * The FIRST stat is always news, whatever it announces.
+     *
+     * `chainSettled()` is false until a stat has arrived, and the editor holds
+     * its fields inert until it is true — so a first stat announcing an empty
+     * chain, against an empty local chain, moves nothing in `ordered` and still
+     * has to be told. Without this the common case (a clean project, no pending
+     * changes) leaves every field dimmed forever.
+     */
+    const firstStat = !this.statSeen;
     this.statSeen = true;
     /**
      * A stat older than our own publish is not evidence of anything.
@@ -408,8 +433,28 @@ export class PatchStore {
       }
     }
     const tail = this.ordered.filter((patchId) => !announced.has(patchId));
-    this.ordered = [...named, ...tail];
-    this.bump();
+    const next = [...named, ...tail];
+    /**
+     * A stat that announced the chain we already hold is not news.
+     *
+     * `/stat` in `fs` mode long polls on a watcher over `.val/patches`, so it
+     * answers on every write and again on every polling interval — and the
+     * answer is usually the chain this client already has. Adopting it and
+     * bumping regardless made `patch:chain` a project-wide render pulse on a
+     * timer: `filePatchIds()` rebuilds and hands every media field a new map,
+     * every `useChainVersion` reader re-renders and walks the chain, and the
+     * pending-module validation pass is rescheduled — all for no change.
+     *
+     * So the bump goes where the mutation is, which is the rule
+     * `SourceStore.bump` already follows. `patch:head` is emitted on the same
+     * condition, because the head is a fact about the chain and the chain did
+     * not move.
+     */
+    const moved = firstStat || !sameOrder(this.ordered, next);
+    this.ordered = next;
+    if (moved) {
+      this.bump();
+    }
 
     /**
      * A patch still in flight cannot be in stat, so it is not evidence of
@@ -425,7 +470,9 @@ export class PatchStore {
     const missing = named.filter(
       (patchId) => !this.dataById.has(patchId) && !this.fetching.has(patchId),
     );
-    this.events.emit({ type: "patch:head", head: this.currentHead() });
+    if (moved) {
+      this.events.emit({ type: "patch:head", head: this.currentHead() });
+    }
     if (missing.length === 0) {
       return;
     }

--- a/packages/ui/spa/stores/SourceStore.ts
+++ b/packages/ui/spa/stores/SourceStore.ts
@@ -122,6 +122,57 @@ type Resolved =
   | { status: "error"; message: string };
 
 /**
+ * How a batch of patches arrives at the source store.
+ *
+ * Three variants, and the difference between them is exactly one thing: who is
+ * woken when the source moves. That question used to be answered in three
+ * places — the origin picked at one call site, the creator looked up at
+ * another, and a comment explaining why a drop overrides both at a third — so
+ * "does a field see its own edit land?" could only be reconstructed by reading
+ * all of them.
+ *
+ * Naming the cases is the point. A reader of {@link SourceStore.intake} can see
+ * the whole rule at once, and a fourth way for a patch to arrive has to say
+ * which of these it behaves like.
+ */
+export type PatchIntake =
+  /**
+   * Made HERE, by a field instance in this session.
+   *
+   * `creatorOf` is asked per patch rather than passed as one id, because a
+   * batch can carry patches from different instances — a replay does. The
+   * instance that made a patch is left asleep when it lands; everyone else on
+   * the path, including a second instance rendering the same path, is woken.
+   */
+  | {
+      kind: "local";
+      records: PatchRecord[];
+      creatorOf: (patchId: PatchId) => string | undefined;
+    }
+  /**
+   * Made elsewhere — another tab, another editor, the CLI.
+   *
+   * Foreign to every field here by definition, so there is no instance to leave
+   * asleep and none is looked for.
+   */
+  | { kind: "foreign"; records: PatchRecord[] }
+  /**
+   * Gone: refused by the server, discarded, or dropped as unapplicable.
+   *
+   * The effect has to come back out of source, which means rebuilding the
+   * module from base plus what survives — a JSON patch is not invertible, so
+   * "remove the middle one" can only mean recompute. Everyone is woken,
+   * INCLUDING the author, and that is not an exception to the rule above: the
+   * field that typed the value is exactly the one now showing something that
+   * does not exist anywhere.
+   */
+  | {
+      kind: "revoked";
+      patchIds: readonly PatchId[];
+      modules: readonly ModuleFilePath[];
+    };
+
+/**
  * Owns the patched source, and owns "who is listening where".
  *
  * Both in one store on purpose: because the same code applies the patch and
@@ -1251,36 +1302,71 @@ export class SourceStore {
   }
 
   /**
-   * Reacts to both `patch:receive` (data arrived for an external patch) and
-   * `patch:create` (a local edit). The two are handled identically except for
-   * the origin reported to listeners, which is the only thing a field needs in
-   * order to tell news from its own echo.
+   * The three ways a patch reaches source, as three constructors of
+   * {@link PatchIntake}.
+   *
+   * This used to be three handlers that each assembled the origin and the
+   * creator differently, with the reasoning for each in a comment beside it —
+   * so "does this patch wake the field that made it?" could only be answered by
+   * reading all three and holding the convention between them. The union makes
+   * each case a named thing, and {@link intake} the one place that decides what
+   * a name means.
    */
   listenTo(patchStore: PatchStore): () => void {
     const offReceive = patchStore.events.on("patch:receive", (event) => {
-      this.applyPatches(
-        patchStore.recordsFor(event.patches),
-        "external",
-        // A patch fetched from the server was made elsewhere, so it is foreign
-        // to every field here — there is nobody to leave asleep.
-        () => undefined,
-      );
+      this.intake({
+        kind: "foreign",
+        records: patchStore.recordsFor(event.patches),
+      });
     });
     const offCreate = patchStore.events.on("patch:create", (event) => {
-      this.applyPatches(
-        patchStore.recordsFor(event.patches),
-        "internal",
-        (id) => patchStore.creatorOf(id),
-      );
+      this.intake({
+        kind: "local",
+        records: patchStore.recordsFor(event.patches),
+        creatorOf: (patchId) => patchStore.creatorOf(patchId),
+      });
     });
     const offDrop = patchStore.events.on("patch:drop", (event) => {
-      this.dropFromChains(event.patches, event.modules);
+      this.intake({
+        kind: "revoked",
+        patchIds: event.patches,
+        modules: event.modules,
+      });
     });
     return () => {
       offReceive();
       offCreate();
       offDrop();
     };
+  }
+
+  /**
+   * Take patches in. THE door into source, and the only place that decides who
+   * a patch wakes.
+   *
+   * Each variant of {@link PatchIntake} answers the same question differently,
+   * and the differences are the whole of the "internal vs external" rule:
+   *
+   * - `local` — this session made it, so the field INSTANCE that made it is
+   *   left asleep and every other reader of the path is woken. A controlled
+   *   input re-rendered by its own keystroke loses the caret.
+   * - `foreign` — it came from the server, so it is news to every field here by
+   *   definition and there is nobody to suppress.
+   * - `revoked` — it was refused or deleted, so its effect has to come back OUT
+   *   of source. The author is woken too, and that is not an exception: the
+   *   field that typed the value is precisely the one now showing something
+   *   that no longer exists.
+   */
+  intake(intake: PatchIntake): void {
+    if (intake.kind === "revoked") {
+      this.dropFromChains(intake.patchIds, intake.modules);
+      return;
+    }
+    this.applyPatches(
+      intake.records,
+      intake.kind === "local" ? "internal" : "external",
+      intake.kind === "local" ? intake.creatorOf : () => undefined,
+    );
   }
 
   /**

--- a/packages/ui/spa/stores/SourceStore.ts
+++ b/packages/ui/spa/stores/SourceStore.ts
@@ -617,12 +617,49 @@ export class SourceStore {
    * trusted yet. See `openquestions.md` item 9b.
    */
   markJsonEntriesStale(moduleFilePath: ModuleFilePath): void {
-    if (!this.jsonEntries.has(moduleFilePath)) return;
+    /**
+     * A recorded FAILURE is stale news too, and clearing it is the whole point.
+     *
+     * `peek` reports `entry-failed` so that readers stop asking, and nothing
+     * asks again except an explicit `retryEntry`. That is right for a failure
+     * nothing has contradicted — and it would be a permanent one if the moment
+     * the file changed on disk were not the moment to forget it. So this runs
+     * BEFORE the early return: a module whose every entry failed has nothing in
+     * `jsonEntries` at all, which is exactly the case that needs it most.
+     */
+    const clearedFailures = this.clearEntryFailures(moduleFilePath);
+    if (!this.jsonEntries.has(moduleFilePath)) {
+      if (clearedFailures) this.bump(moduleFilePath);
+      return;
+    }
     this.jsonEntries.delete(moduleFilePath);
     // The base copy too: the file on disk changed, so what the server last said
     // about it is exactly what is now stale.
     this.baseJsonEntries.delete(moduleFilePath);
     this.bump(moduleFilePath);
+  }
+
+  /**
+   * Forget what this module's entries failed with. Returns whether any did.
+   *
+   * The one thing that turns `entry-failed` back into `entry-missing`, short of
+   * someone pressing retry — so it is called from the two places that are new
+   * evidence about the content: the file changing on disk
+   * ({@link markJsonEntriesStale}) and the server resending the module
+   * ({@link receive}). Without it, "stop asking" quietly means "never again",
+   * and an entry that failed once during a dev-server restart stays broken for
+   * the life of the tab.
+   */
+  private clearEntryFailures(moduleFilePath: ModuleFilePath): boolean {
+    if (this.entryFailures.size === 0) return false;
+    const prefix = `${moduleFilePath}\0`;
+    let cleared = false;
+    for (const key of [...this.entryFailures.keys()]) {
+      if (!key.startsWith(prefix)) continue;
+      this.entryFailures.delete(key);
+      cleared = true;
+    }
+    return cleared;
   }
 
   /**
@@ -1493,6 +1530,16 @@ export class SourceStore {
       const base = deepClone(source as JSONValue);
       this.baseSources[moduleFilePath as ModuleFilePath] = base;
       this.sources[moduleFilePath as ModuleFilePath] = deepClone(base);
+      /*
+       * A recorded entry FAILURE does not survive a re-intake.
+       *
+       * `peek` reports `entry-failed` so readers stop asking, which is right
+       * for a failure nothing has contradicted — and the server resending this
+       * module contradicts it. Without this, an entry that failed once (a dev
+       * server mid-restart, a network blip) would stay failed for the life of
+       * the tab, because nothing else asks again.
+       */
+      this.clearEntryFailures(moduleFilePath as ModuleFilePath);
       // The base was replaced, so every reader of this module is holding
       // something that may no longer be right — whatever the patch chain did.
       this.bump(moduleFilePath as ModuleFilePath);

--- a/packages/ui/spa/stores/SourceStore.ts
+++ b/packages/ui/spa/stores/SourceStore.ts
@@ -587,13 +587,33 @@ export class SourceStore {
    * and reported by `peek` as `entry-failed`, which is where a row shows it. A
    * rejected promise here would make a prefetch of twenty rows fail because one
    * of them did.
+   *
+   * ## An entry that FAILED is not asked for again
+   *
+   * The same rule `peek` draws between `entry-missing` ("ask for it") and
+   * `entry-failed` ("stop asking and say so"), applied to the bulk path — which
+   * did not observe it, because a failure is recorded in `entryFailures` and
+   * never in `jsonEntries`, so a `has(key)` test calls it wanted forever.
+   *
+   * That was a fetch storm rather than a wasted call. `ValOverlayEmitter`
+   * re-derives the entries a module's patches touch and calls this on every
+   * `source:change` burst, so one entry the server cannot resolve produced a
+   * `GET /json` every 200ms for as long as the tab was open — which is what
+   * "when there are errors everything is loading" looked like from the outside.
+   *
+   * {@link retryEntry} stays the one door back in: it clears the failure first,
+   * and it goes to {@link loadEntry} directly rather than through here.
    */
   async loadEntries(
     moduleFilePath: ModuleFilePath,
     keys: readonly string[],
   ): Promise<void> {
     const here = this.jsonEntries.get(moduleFilePath);
-    const wanted = keys.filter((key) => here?.has(key) !== true);
+    const wanted = keys.filter(
+      (key) =>
+        here?.has(key) !== true &&
+        !this.entryFailures.has(entryKey(moduleFilePath, key)),
+    );
     if (wanted.length === 0) return;
     /**
      * Coalesced per module per tick, then announced once.

--- a/packages/ui/spa/stores/architecture.md
+++ b/packages/ui/spa/stores/architecture.md
@@ -527,6 +527,17 @@ every local field by definition. So it never has to survive a round trip, which
 is why it is not encoded into the patch id — and could not be, since the server
 validates `patchId.length === 36`.
 
+**A field is one instance only if every listener it registers says so**, and
+that is easier to get wrong than it sounds. An editable field reads its source
+AND resolves its schema at the same path, and `useSchemaAtPath` registers a
+source listener of its own to do the resolving — under its own `useId()`, which
+makes it a second instance and wakes the field on its own keystroke while the
+source listener correctly stays quiet. `useValField` exists to close that: it
+mints one id and hands it to both, and never returns it, so there is nothing to
+thread and nothing to get wrong. The individual hooks stay for read-only
+readers, which genuinely want a distinct instance so they are woken by
+everything.
+
 ### 4. Only registered paths are woken
 
 The source store keeps a registry of watched paths, one `EventTarget` per

--- a/packages/ui/spa/stores/chainSettled.test.ts
+++ b/packages/ui/spa/stores/chainSettled.test.ts
@@ -119,3 +119,56 @@ describe("chainSettled", () => {
     system.dispose();
   });
 });
+
+/**
+ * `chainSettled()` flips on the APPLY, and the apply announces itself on
+ * `patch:head`, not on `patch:chain`.
+ *
+ * Two stores answer this question — the patch store knows a patch exists, the
+ * source store knows whether it landed — and only the second half moves at the
+ * end. A reader listening to the chain alone therefore hears the fetch and not
+ * the apply, and `useInitialPatchesApplied` is that reader: it holds every field
+ * in the Studio dimmed and inert until this is true.
+ *
+ * It survived only because a repeated `/stat` used to bump the chain
+ * unconditionally, which is the wasted project-wide pulse this branch removed.
+ * So the last transition has to be observable on its own.
+ */
+describe("the event that carries the last transition", () => {
+  it("announces settling on patch:head", async () => {
+    const system = createSystem({
+      fetchPatches: async (patchIds) => ({
+        patches: patchIds.map((patchId) =>
+          externalPatch(patchId, "/t.val.ts", [
+            { op: "replace", path: ["title"], value: "from the server" },
+          ]),
+        ),
+      }),
+    });
+    system.host.receive([module()]);
+
+    const settledOn: string[] = [];
+    const record = (type: string) => () => {
+      if (system.patchStore.chainSettled()) settledOn.push(type);
+    };
+    const offChain = system.patchStore.events.on(
+      "patch:chain",
+      record("chain"),
+    );
+    const offHead = system.patchStore.events.on("patch:head", record("head"));
+
+    system.stat.receiveStat({
+      patches: ["settle-1" as PatchId],
+      baseSha: "sha",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(system.patchStore.chainSettled()).toBe(true);
+    // The claim: SOMETHING announced it. Named as `head` because that is where
+    // the apply is reported from, and a reader has to subscribe to it.
+    expect(settledOn).toContain("head");
+    offChain();
+    offHead();
+    system.dispose();
+  });
+});

--- a/packages/ui/spa/stores/jsonValues.test.ts
+++ b/packages/ui/spa/stores/jsonValues.test.ts
@@ -438,6 +438,34 @@ describe("prefetching `.jsonValues()` entries in bulk", () => {
   });
 
   /**
+   * SPEC: "stop asking" must not mean "never again".
+   *
+   * Nothing re-asks for a failed entry, deliberately — so the failure has to be
+   * forgotten the moment something contradicts it, or an entry that failed once
+   * during a dev-server restart is broken for the life of the tab. The server
+   * resending the module is that contradiction.
+   */
+  it("asks again after the module is re-received", async () => {
+    const { sourceStore, jsonEntries, dispose } = initTestSystem();
+    await sourceStore.testReceive([jsonValuesModule()]);
+    jsonEntries.failFor("/blogs.val.ts", "/a", "the network is down");
+    await sourceStore.loadEntries(mfp("/blogs.val.ts"), ["/a"]);
+    jsonEntries.clearFailures();
+
+    // HMR, a refetch, a dev server that has finished restarting.
+    await sourceStore.testReceive([jsonValuesModule()]);
+    await sourceStore.loadEntries(mfp("/blogs.val.ts"), ["/a"]);
+
+    expect(jsonEntries.requests()).toEqual([
+      requested("/blogs.val.ts", "/a"),
+      requested("/blogs.val.ts", "/a"),
+    ]);
+    const peeked = sourceStore.peek('/blogs.val.ts?p="/a"."title"');
+    expect(peeked.status).toBe("ready");
+    dispose();
+  });
+
+  /**
    * `retryEntry` stays the one door back in: it clears the failure first and
    * goes to `loadEntry` directly, so "stop asking" never becomes "never again".
    */

--- a/packages/ui/spa/stores/jsonValues.test.ts
+++ b/packages/ui/spa/stores/jsonValues.test.ts
@@ -384,6 +384,81 @@ describe("the base value inside a `.jsonValues()` entry", () => {
   });
 });
 
+/** The key `TestJsonEntries.requests()` records one fetch under. */
+const requested = (moduleFilePath: string, key: string) =>
+  `${moduleFilePath}\u0000${key}`;
+
+describe("prefetching `.jsonValues()` entries in bulk", () => {
+  /**
+   * SPEC: `loadEntries` does not re-ask for an entry whose fetch FAILED.
+   *
+   * The same rule `peek` draws between `entry-missing` ("ask for it") and
+   * `entry-failed` ("stop asking and say so") — which this path did not observe,
+   * because a failure is recorded in `entryFailures` and never in `jsonEntries`,
+   * so the `has(key)` test called it wanted forever.
+   *
+   * That made it a fetch storm rather than one wasted call: `ValOverlayEmitter`
+   * re-derives the entries a module's patches touch and calls this on every
+   * `source:change` burst, so one entry the server cannot resolve produced a
+   * `GET /json` every 200ms for as long as the tab was open.
+   */
+  it("asks once for an entry that fails, however many times it is prefetched", async () => {
+    const { sourceStore, jsonEntries, dispose } = initTestSystem();
+    await sourceStore.testReceive([jsonValuesModule()]);
+    jsonEntries.failFor("/blogs.val.ts", "/a", "the network is down");
+
+    await sourceStore.loadEntries(mfp("/blogs.val.ts"), ["/a"]);
+    await sourceStore.loadEntries(mfp("/blogs.val.ts"), ["/a"]);
+    await sourceStore.loadEntries(mfp("/blogs.val.ts"), ["/a"]);
+
+    expect(jsonEntries.requests()).toEqual([requested("/blogs.val.ts", "/a")]);
+    dispose();
+  });
+
+  /**
+   * And the entries that DID work are still served, so one bad key cannot take
+   * a window of rows down with it.
+   */
+  it("still loads the healthy entries in the same window", async () => {
+    const { sourceStore, jsonEntries, dispose } = initTestSystem();
+    await sourceStore.testReceive([jsonValuesModule()]);
+    jsonEntries.failFor("/blogs.val.ts", "/a", "the network is down");
+
+    await sourceStore.loadEntries(mfp("/blogs.val.ts"), ["/a", "/b"]);
+    await sourceStore.loadEntries(mfp("/blogs.val.ts"), ["/a", "/b"]);
+
+    expect(jsonEntries.requests()).toEqual([
+      requested("/blogs.val.ts", "/a"),
+      requested("/blogs.val.ts", "/b"),
+    ]);
+    const peeked = sourceStore.peek('/blogs.val.ts?p="/b"."title"');
+    expect(peeked.status).toBe("ready");
+    expect(peeked.status === "ready" && peeked.data).toBe("Beta");
+    dispose();
+  });
+
+  /**
+   * `retryEntry` stays the one door back in: it clears the failure first and
+   * goes to `loadEntry` directly, so "stop asking" never becomes "never again".
+   */
+  it("fetches again when someone explicitly retries", async () => {
+    const { sourceStore, jsonEntries, dispose } = initTestSystem();
+    await sourceStore.testReceive([jsonValuesModule()]);
+    jsonEntries.failFor("/blogs.val.ts", "/a", "the network is down");
+    await sourceStore.loadEntries(mfp("/blogs.val.ts"), ["/a"]);
+    jsonEntries.clearFailures();
+
+    const retried = await sourceStore.retryEntry(mfp("/blogs.val.ts"), "/a");
+
+    expect(retried).toEqual({ status: "ok" });
+    expect(jsonEntries.requests()).toEqual([
+      requested("/blogs.val.ts", "/a"),
+      requested("/blogs.val.ts", "/a"),
+    ]);
+    dispose();
+  });
+});
+
 describe("peeking a `.jsonValues()` record", () => {
   /**
    * The module root must peek to the SAME OBJECT once an entry is loaded.

--- a/packages/ui/spa/stores/patchesByPath.test.ts
+++ b/packages/ui/spa/stores/patchesByPath.test.ts
@@ -1,0 +1,145 @@
+import { initVal, type ModuleFilePath } from "@valbuild/core";
+import { createSystem } from "./createSystem";
+import { mfp } from "./testSystem";
+
+/**
+ * The chain, indexed by the path a reader asks about.
+ *
+ * `FieldPatchAuthorsSection` is mounted on every non-compact field and used to
+ * walk the whole chain itself, per field, woken by `patch:chain` — which moves
+ * on every keystroke's patch and on every save. That is O(fields on screen x
+ * chain length) per movement, and it re-rendered every one of those fields
+ * whether or not its own answer had changed.
+ *
+ * Two claims, and the second is the one that stops the re-renders: the index is
+ * built once per chain version, and a path whose answer has not moved gets the
+ * SAME array back so `useSyncExternalStore` can bail out.
+ */
+const module = () => {
+  const { c, s } = initVal();
+  return c.define(
+    "/t.val.ts",
+    s.object({ title: s.string(), body: s.string() }),
+    { title: "a", body: "b" },
+  );
+};
+
+function build() {
+  const system = createSystem({ fetchPatches: async () => ({ patches: [] }) });
+  system.host.receive([module()]);
+  return system;
+}
+
+const TITLE = '/t.val.ts?p="title"';
+const BODY = '/t.val.ts?p="body"';
+
+describe("PatchStore.patchesByPath", () => {
+  it("indexes a patch under its op path and under its module", async () => {
+    const system = build();
+    await system.patchStore.createPatch(mfp("/t.val.ts"), [
+      { op: "replace", path: ["title"], value: "typed" },
+    ]);
+
+    const byPath = system.patchStore.patchesByPath();
+
+    expect(byPath.get(TITLE)?.length).toBe(1);
+    // A module-level reader sees every patch in the module.
+    expect(byPath.get("/t.val.ts")?.length).toBe(1);
+    // And a sibling path sees nothing — which is the whole point.
+    expect(byPath.get(BODY)).toBeUndefined();
+    system.dispose();
+  });
+
+  it("hands back the SAME array for a path a later patch did not touch", async () => {
+    const system = build();
+    await system.patchStore.createPatch(mfp("/t.val.ts"), [
+      { op: "replace", path: ["title"], value: "typed" },
+    ]);
+    const before = system.patchStore.patchesByPath().get(TITLE);
+
+    // A patch on a sibling path. The chain moved, so the index is rebuilt —
+    // but this path's answer did not, so its identity must not move either.
+    await system.patchStore.createPatch(mfp("/t.val.ts"), [
+      { op: "replace", path: ["body"], value: "also typed" },
+    ]);
+
+    expect(system.patchStore.patchesByPath().get(TITLE)).toBe(before);
+    expect(system.patchStore.patchesByPath().get(BODY)?.length).toBe(1);
+    system.dispose();
+  });
+
+  it("moves the identity when the path's own answer moves", async () => {
+    const system = build();
+    await system.patchStore.createPatch(mfp("/t.val.ts"), [
+      { op: "replace", path: ["title"], value: "typed" },
+    ]);
+    const before = system.patchStore.patchesByPath().get(TITLE);
+
+    await system.patchStore.createPatch(mfp("/t.val.ts"), [
+      { op: "replace", path: ["title"], value: "typed again" },
+    ]);
+
+    expect(system.patchStore.patchesByPath().get(TITLE)).not.toBe(before);
+    expect(system.patchStore.patchesByPath().get(TITLE)?.length).toBe(2);
+    system.dispose();
+  });
+
+  /**
+   * `isPending` moves WITHOUT the chain's membership moving, so it has to be
+   * part of the comparison. A reader that showed "unsaved" would otherwise keep
+   * showing it after the save landed.
+   */
+  it("moves the identity when a patch stops being pending", async () => {
+    const system = build();
+    const created = await system.patchStore.createPatch(mfp("/t.val.ts"), [
+      { op: "replace", path: ["title"], value: "typed" },
+    ]);
+    if (created.status !== "created") {
+      throw new Error(
+        `expected the patch to be created, got ${created.status}`,
+      );
+    }
+    const before = system.patchStore.patchesByPath().get(TITLE);
+    expect(before?.[0].isPending).toBe(true);
+
+    system.patchStore.markSaved([created.record.patchId]);
+
+    const after = system.patchStore.patchesByPath().get(TITLE);
+    expect(after).not.toBe(before);
+    expect(after?.[0].isPending).toBe(false);
+    system.dispose();
+  });
+
+  it("lists a record once however many of its ops land on one path", async () => {
+    const system = build();
+    await system.patchStore.createPatch(mfp("/t.val.ts"), [
+      { op: "replace", path: ["title"], value: "one" },
+      { op: "replace", path: ["title"], value: "two" },
+    ]);
+
+    expect(system.patchStore.patchesByPath().get(TITLE)?.length).toBe(1);
+    system.dispose();
+  });
+
+  it("is the same map on a second read with nothing in between", async () => {
+    const system = build();
+    await system.patchStore.createPatch(mfp("/t.val.ts"), [
+      { op: "replace", path: ["title"], value: "typed" },
+    ]);
+
+    // The memo on the chain version: N fields reading in one commit cost ONE
+    // build, which is the other half of what this replaces.
+    expect(system.patchStore.patchesByPath()).toBe(
+      system.patchStore.patchesByPath(),
+    );
+    system.dispose();
+  });
+
+  it("is empty for a module nothing has touched", () => {
+    const system = build();
+    expect(
+      system.patchStore.patchesByPath().get("/other.val.ts" as ModuleFilePath),
+    ).toBeUndefined();
+    system.dispose();
+  });
+});

--- a/packages/ui/spa/stores/statIdempotence.test.ts
+++ b/packages/ui/spa/stores/statIdempotence.test.ts
@@ -33,7 +33,9 @@ function countChainEvents(system: ReturnType<typeof createSystem>) {
 
 describe("a stat that changes nothing", () => {
   it("announces the first one even when it names no patches", () => {
-    const system = createSystem({ fetchPatches: async () => ({ patches: [] }) });
+    const system = createSystem({
+      fetchPatches: async () => ({ patches: [] }),
+    });
     system.host.receive([module()]);
     const chain = countChainEvents(system);
 

--- a/packages/ui/spa/stores/statIdempotence.test.ts
+++ b/packages/ui/spa/stores/statIdempotence.test.ts
@@ -1,0 +1,134 @@
+import { initVal, type PatchId } from "@valbuild/core";
+import { createSystem } from "./createSystem";
+import { externalPatch } from "./testSystem";
+
+/**
+ * A `/stat` that announces the chain we already hold must announce nothing.
+ *
+ * `patch:chain` is a project-wide wake-up: `filePatchIds()` rebuilds and hands
+ * every media field a new map, every `useChainVersion` reader re-renders and
+ * walks the chain, and `createSystem` reschedules the pending-module validation
+ * pass. That is the right cost for a chain that moved and pure waste for one
+ * that did not.
+ *
+ * And it is not a rare case. `/stat` long polls in `fs` mode on a watcher over
+ * `.val/patches`, so it answers on every write AND again on every polling
+ * interval — so before this, an idle Studio with pending changes re-rendered
+ * every mounted field every twenty seconds, for no news.
+ */
+const module = () => {
+  const { c, s } = initVal();
+  return c.define("/t.val.ts", s.object({ title: s.string() }), {
+    title: "published",
+  });
+};
+
+function countChainEvents(system: ReturnType<typeof createSystem>) {
+  let count = 0;
+  const off = system.patchStore.events.on("patch:chain", () => {
+    count++;
+  });
+  return { read: () => count, off };
+}
+
+describe("a stat that changes nothing", () => {
+  it("announces the first one even when it names no patches", () => {
+    const system = createSystem({ fetchPatches: async () => ({ patches: [] }) });
+    system.host.receive([module()]);
+    const chain = countChainEvents(system);
+
+    system.stat.receiveStat({ patches: [], baseSha: "sha" });
+
+    // The first stat is what makes `chainSettled()` true, and the shell holds
+    // every field inert until it is. An empty first stat against an empty chain
+    // moves nothing in `ordered` and still has to be told.
+    expect(chain.read()).toBe(1);
+    expect(system.patchStore.chainSettled()).toBe(true);
+    chain.off();
+    system.dispose();
+  });
+
+  it("says nothing when a later stat repeats the same chain", async () => {
+    const patchId = "p1" as PatchId;
+    const system = createSystem({
+      fetchPatches: async (ids) => ({
+        patches: ids.map((id) =>
+          externalPatch(id, "/t.val.ts", [
+            { op: "replace", path: ["title"], value: "from the server" },
+          ]),
+        ),
+      }),
+    });
+    system.host.receive([module()]);
+    system.stat.receiveStat({ patches: [patchId], baseSha: "sha" });
+    // Let the fetch and the apply settle, so the chain is at rest.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const chain = countChainEvents(system);
+    system.stat.receiveStat({ patches: [patchId], baseSha: "sha" });
+    system.stat.receiveStat({ patches: [patchId], baseSha: "sha" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(chain.read()).toBe(0);
+    chain.off();
+    system.dispose();
+  });
+
+  it("still announces a chain that gained a patch", async () => {
+    const system = createSystem({
+      fetchPatches: async (ids) => ({
+        patches: ids.map((id) =>
+          externalPatch(id, "/t.val.ts", [
+            { op: "replace", path: ["title"], value: id },
+          ]),
+        ),
+      }),
+    });
+    system.host.receive([module()]);
+    system.stat.receiveStat({ patches: ["p1" as PatchId], baseSha: "sha" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const chain = countChainEvents(system);
+    system.stat.receiveStat({
+      patches: ["p1" as PatchId, "p2" as PatchId],
+      baseSha: "sha",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(chain.read()).toBeGreaterThan(0);
+    chain.off();
+    system.dispose();
+  });
+
+  it("still announces a REORDER of the same ids", async () => {
+    const system = createSystem({
+      fetchPatches: async (ids) => ({
+        patches: ids.map((id) =>
+          externalPatch(id, "/t.val.ts", [
+            { op: "replace", path: ["title"], value: id },
+          ]),
+        ),
+      }),
+    });
+    system.host.receive([module()]);
+    system.stat.receiveStat({
+      patches: ["p1" as PatchId, "p2" as PatchId],
+      baseSha: "sha",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const chain = countChainEvents(system);
+    // Same ids, different order. Stat is the authority on ORDER, so this is a
+    // real change — which is why the comparison is position-wise and not a set
+    // test.
+    system.stat.receiveStat({
+      patches: ["p2" as PatchId, "p1" as PatchId],
+      baseSha: "sha",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(chain.read()).toBeGreaterThan(0);
+    chain.off();
+    system.dispose();
+  });
+});

--- a/packages/ui/spa/stores/testSystem.ts
+++ b/packages/ui/spa/stores/testSystem.ts
@@ -310,6 +310,20 @@ export type TestSourceStore = {
    */
   moduleSource(moduleFilePath: string): Json | undefined;
   loadedModules(): ModuleFilePath[];
+  /**
+   * The BULK prefetch — what a virtualized record's visible window asks for.
+   *
+   * Its own entry point rather than N reads, because the thing worth testing is
+   * what it does with a key it has already failed on: `peek` tells a reader to
+   * stop asking after a failure, and this path has to observe the same rule or
+   * a broken entry becomes a fetch per render burst.
+   */
+  loadEntries(moduleFilePath: string, keys: readonly string[]): Promise<void>;
+  /** The one door back in after a failure. See {@link loadEntries}. */
+  retryEntry(
+    moduleFilePath: string,
+    key: string,
+  ): Promise<{ status: "ok" } | { status: "error"; message: string }>;
 };
 
 export type TestStatStore = {
@@ -1050,6 +1064,10 @@ export function initTestSystem(): TestSystem {
       moduleSource: (moduleFilePath) =>
         system.sourceStore.moduleSource(moduleFilePath as ModuleFilePath),
       loadedModules: () => system.sourceStore.loadedModules(),
+      loadEntries: (moduleFilePath, keys) =>
+        system.sourceStore.loadEntries(moduleFilePath as ModuleFilePath, keys),
+      retryEntry: (moduleFilePath, key) =>
+        system.sourceStore.retryEntry(moduleFilePath as ModuleFilePath, key),
     },
     patchStore: {
       getHead: () => system.patchStore.getHead(),


### PR DESCRIPTION
This started as a read-only analysis of how fields are updated and published, and of why the Studio had stopped feeling snappy after the stores landed. The answer, in short: **the stores are fine.** The write loop, the per-path wake and the per-instance suppression all do what `architecture.md` says. What had accumulated is on the React side of the seam — subscriptions that are not demand-driven, mounted once per field.

Along the way three things that read as "the editor is slow" turned out to be specific faults.

## The faults

**A rich text field could render blank and stay blank.** Two independent things had to be true, and each hid the other. `RichTextField` passed the editor neither `value` nor `defaultValue`, so the ProseMirror view was always built empty and its content arrived afterwards through an imperative `reset()` in an effect — making that effect load-bearing for the first paint, with the SOURCE as its dependencies. Meanwhile the view is destroyed and rebuilt when `readOnly` or a toolbar feature changes, and a rebuild re-parsed a `defaultValue` that was not there. So a rebuild emptied the field and nothing refilled it: the consumer only re-seeds when source moves, and source had not moved.

The trigger in practice was not anything a user did. `useValPortal()` returned a ref read during render, so the portal container arrives as `null` and then as an element on the very next render — an untracked prop change delivered to whichever consumer happened to re-render next.

**`/stat` was a project-wide render pulse on a twenty-second timer.** It long polls in `fs` mode on a watcher over `.val/patches`, so it answers on every write and again every interval — and the answer is usually the chain the client already holds. `patch:chain` went out regardless, which rebuilds the file-patch map for every media field, re-renders every `useChainVersion` reader (each of which walked the whole chain), and reschedules the pending-module validation pass.

**One broken `.jsonValues()` entry was a `GET /json` every 200 ms, forever.** `peek` draws a deliberate line between `entry-missing` ("ask for it") and `entry-failed` ("stop asking and say so"). The bulk prefetch did not observe it, because a failure is recorded apart from the loaded content and so a `has(key)` test called the entry wanted forever — and the canvas relay calls that path on every source change.

**The fast `/draft/stat` poll had no deadline.** While preview mode is being toggled the page polls every 100 ms, and the only thing that ended it was a message from a hidden iframe that may never load. Ten requests a second against a browser that allows six connections per origin is enough to push `/stat`, `/patches` and the canvas document itself into the browser's own queue, where they are indistinguishable from a slow server.

**The canvas asked the page to re-render work it had already done.** The `router.refresh()` loop was armed by the ARRIVAL of a source update rather than by the value moving — and the editor re-sends everything it holds every time the page becomes a new document, which with auto-save on is once per pause in typing.

## The subscriptions

- `Field` read the write queue (`useLoadingStatus`), so every save round trip re-rendered the whole mounted tree twice — and disabled every nullable checkbox and boolean toggle in the Studio while it was in flight, because that value gates them.
- `usePendingPatches`, mounted on every non-compact field, walked the whole chain per field on every chain movement. It reads a shared per-path index now, reference-stable, so only the affected field wakes.
- `useRoutesOf` / `useRoutesWithModulePaths` were `useMemo`s over `useAllSources()`, whose snapshot is a version number — so every rich text and route field re-walked the project's routers on every keystroke anywhere. The walk is shared and its answer is stable now; a route is a router record's KEY, so almost nothing moves it.
- `RichTextField`, `ImageField` and `FileField` read every schema in the project to look up one gallery's `accept` and `directory`.

## The two seams

The analysis asked for one thing above the fixes: that "a patch comes in and an event goes out" and "a field listens, and acts if the change is foreign but not if it is its own" each be a thing you can point at. Both were correct and neither had a name.

**`PatchIntake`** makes the three ways a patch reaches source three named variants of one union — `local`, `foreign`, `revoked` — with `SourceStore.intake` the one place that decides who each wakes. The case that used to read as an exception (a dropped patch deliberately wakes its own author) is now a variant with a reason.

**`useValField`** mints a field's identity and never hands it out. Writing the test for it found the rule **already broken, everywhere**: an editable field also resolves its schema at its path, and `useSchemaAtPath` registered a source listener under its own `useId()` — a second instance, so every field was woken by its own keystroke through the schema hook while the source hook correctly said nothing. No test could see it, because the existing suppression fixture reads source and writes and nothing else.

**`perFieldSubscriptions.test.ts`** covered two files against two hooks by substring. It now covers every file under `components/fields/`, the per-field components outside it, and the rich text config hook — against six hooks, matched on the code with comments stripped, with a required reason for each exception.

## Notes

- Eight focused commits; the last fixes two faults a review of this branch found in its own work, both of which had been masked by the wasted `/stat` pulse.
- New tests: `statIdempotence`, `patchesByPath`, the rich text `viewRebuild` suite, `ValExternalStore.update`'s change reporting, the bulk-prefetch failure rules, `useValField`'s identity, and the `chainSettled` transition. Each was checked to fail without its fix.
- All six CI jobs run locally and green: lint, format, recursive typecheck, jest (2658 tests), `pnpm run build`, and `examples/next` build.
- **Not measured in a browser.** Everything here is reasoned from source and pinned by tests that count events and renders. The four numbers worth capturing before and after are in the analysis: renders per keystroke with an object field expanded, `patch:chain` emissions per minute at idle, `GET /json` rate with one entry failing, and request queue time on `/patches` during the fast poll.

Full analysis, with flow charts of both loops: https://claude.ai/code/artifact/39b47399-8ad7-4267-8eb4-38387e67ae21

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRX5BYVZPkNoqWWWe42jUA

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRX5BYVZPkNoqWWWe42jUA)_