### PR TITLE
Fix mobile canvas picks landing between panes

### DIFF
--- a/.changeset/mobile-canvas-pick.md
+++ b/.changeset/mobile-canvas-pick.md
@@ -1,0 +1,57 @@
+---
+"@valbuild/ui": patch
+"@valbuild/next": patch
+---
+
+Make picking a field on the mobile canvas land, every time
+
+Tapping an element on the page in the phone's canvas was supposed to open its
+field in the column beside it. Most of the time it did something else: the
+workspace came to rest between its two panes, showing half the editor and half
+the page, and stayed there — selecting a different page did not recover it, and
+only closing the canvas did.
+
+Four things were wrong. They compound, and the last is the one that made the
+others survivable-looking rather than fatal.
+
+**The page could scroll the studio.** After a pick the studio asks the page to
+outline and reveal the field, and the page used `Element.scrollIntoView`. That
+scrolls every scroll container between the element and the viewport — and for a
+same-origin frame the chain does not stop at the frame, it continues into the
+embedder. Measured in Chromium: with the panes placed on the editor, one
+`scrollIntoView` inside the framed page pulls them back onto the canvas, and
+because it is revealing an ELEMENT rather than a pane it can leave them anywhere
+in between. The page now brings its own content into view by hand, one scrollport
+at a time, and the walk stops at its own document.
+
+**And it was asked to, for a field nobody needed to find.** The highlight that
+follows a pick names the element the finger is still on. The studio no longer
+asks for a scroll there, and does ask for one everywhere else — a row in the
+fields column, a search hit, a validation error — where finding it on the page is
+the whole point.
+
+**A pick moved the workspace even when it opened nothing.** Opening the field and
+going to the fields column ran one after the other unconditionally, in two
+different owners. If the path could not be resolved — schemas not loaded yet, the
+module gone, the page tagged with a path that no longer exists — the navigation
+quietly did nothing and the workspace moved anyway, leaving a fields column in
+front of you without the field it was opened for. The two halves are now ordered:
+the pick either lands completely or changes nothing and says why, as a message
+naming what failed and what to do about it. Each of the three reasons is told
+apart, because each has a different next step.
+
+**And a pick could close the canvas outright.** The canvas closed itself whenever
+the selection was not a page, which is most picks: content on a real page mostly
+lives outside the page's own route module — a footer, a setting, an author — so
+picking any of those resolved to a data module and shut the canvas. The rule is
+now whether the editor is on content the canvas page itself reported, which is a
+list the page already sends.
+
+Underneath all of it, the phone's panes are no longer a scroll position and a
+piece of state that can disagree. They are one thing, with one rule: whenever the
+panes come to rest, they are exactly on a pane — the one you swiped to if you
+were swiping, and otherwise the one that was last asked for. The version this
+replaces held the position for 400ms after each placement and then let go, which
+covered the quick causes and none of the slow ones. There is no window now, and
+nothing has to be quicker than the browser: whatever moves the panes, they are put
+back.

--- a/e2e/mobile-canvas.spec.ts
+++ b/e2e/mobile-canvas.spec.ts
@@ -73,4 +73,201 @@ test.describe("the canvas on a phone", () => {
     expect(paneBox.x).toBeGreaterThan(viewport.width / 2);
     expect(paneBox.x + paneBox.width).toBeGreaterThan(viewport.width - 24);
   });
+
+  /**
+   * Picking something on the page, which is what the canvas is for.
+   *
+   * The reported failure: tapping a field showed neither pane properly. The
+   * workspace came to rest between the editor and the canvas — half of each on
+   * screen — and stayed there; selecting a different page did not recover it,
+   * because nothing in the studio ever re-asserted where the panes were.
+   *
+   * It got there because a pane is a scroll position, and the canvas pane holds
+   * an iframe on the customer's site. Clicking inside a frame focuses it and the
+   * browser scrolls ancestors to reveal it; the studio then asked the page to
+   * scroll the picked field into view, and `scrollIntoView` in a same-origin
+   * frame scrolls the EMBEDDER's containers too. Both reveal an element rather
+   * than a pane, so they leave the scroller anywhere.
+   *
+   * Three things changed and any one of them alone would leave a race: the page
+   * no longer scrolls anything outside itself, the studio no longer asks it to
+   * scroll to a field that was just clicked, and the pane scroller puts itself
+   * back on a pane whenever it comes to rest anywhere else. What is asserted
+   * here is the outcome all three exist for, in a real browser with a real
+   * frame — because that is the only place the interaction exists at all.
+   */
+  test("a pick on the page lands on the fields column, whole", async ({
+    page,
+  }) => {
+    await openStudio(page, `${HOME}&canvas=1`);
+
+    /**
+     * Preview mode first: a fresh browser has neither the Val Enable cookie nor
+     * draft mode, so the page mounts none of Val's client code, tags nothing,
+     * and there is nothing on it to pick.
+     */
+    const enable = page.getByRole("button", { name: /Turn on preview mode/ });
+    await expect(enable).toBeVisible({ timeout: 25_000 });
+    await enable.click();
+
+    // The switch appears once the page has reported what is on it, which is
+    // also when picking becomes possible. It lives on the editor pane.
+    const paneSwitch = page.getByRole("tablist", { name: "Workspace pane" });
+    await paneSwitch.getByRole("tab", { name: "Editor" }).click();
+    const fieldsTab = page.getByRole("tab", { name: /Fields/ });
+    await expect(
+      fieldsTab,
+      "the page never reported any content, so preview mode did not take",
+    ).toBeVisible({ timeout: 30_000 });
+    await fieldsTab.click();
+
+    const fields = page.getByRole("heading", { name: "On this page" });
+    await expect(fields).toBeVisible();
+
+    // Go and look at the page, as anyone about to point at something would.
+    await paneSwitch.getByRole("tab", { name: "Canvas" }).click();
+    const frame = page
+      .frames()
+      .find((candidate) => candidate.url().includes("val_canvas"));
+    expect(frame, "the canvas never loaded the page").toBeTruthy();
+
+    /**
+     * Something well inside the pane.
+     *
+     * Not simply the first tagged element: the studio floats its route bar and
+     * its exit button over the top of the canvas pane and its toolbar over the
+     * bottom, and those are in the PARENT document — which the frame's own hit
+     * testing cannot see. A click aimed at an element under one of them is
+     * reported as landing on the element and is actually taken by the overlay,
+     * so the pick never happens and the test fails for a reason that has
+     * nothing to do with the pick.
+     */
+    const tagged = frame!.locator("[data-val-path]");
+    const count = await tagged.count();
+    let target = -1;
+    for (let index = 0; index < count; index++) {
+      const box = await tagged.nth(index).boundingBox();
+      if (box === null) continue;
+      if (box.y > 220 && box.y + box.height < 700 && box.width > 20) {
+        target = index;
+        break;
+      }
+    }
+    expect(
+      target,
+      "nothing on the page was clear of the studio's own controls",
+    ).toBeGreaterThanOrEqual(0);
+    await tagged.nth(target).click();
+
+    /**
+     * Back on the fields column — and all of it on screen.
+     *
+     * The width check is the whole point. "Is the fields column visible" passes
+     * with the panes split down the middle, which is exactly the state being
+     * ruled out, so what is measured is that the column occupies the viewport
+     * rather than half of it.
+     */
+    const viewport = page.viewportSize();
+    expect(viewport).toBeTruthy();
+    const wholeOnScreen = async () => {
+      const box = await fields.boundingBox();
+      if (box === null || viewport === null) return null;
+      return box.x >= -1 && box.x + box.width <= viewport.width + 1;
+    };
+    await expect
+      .poll(wholeOnScreen, {
+        message: "the workspace came to rest between the editor and the canvas",
+      })
+      .toBe(true);
+
+    /*
+     * And it stays there. Everything that used to undo it arrives AFTER the
+     * pick: the browser revealing the frame the click focused, the page's own
+     * highlight scroll, and the fields column re-laying itself out as each
+     * schema resolves.
+     */
+    await page.waitForTimeout(2000);
+    expect(await wholeOnScreen()).toBe(true);
+
+    // And the canvas is still open. A field on the page belongs to the page
+    // whichever module it lives in, so picking one is never a reason to leave.
+    await expect(paneSwitch).toBeVisible();
+  });
+
+  /**
+   * The invariant, forced rather than raced.
+   *
+   * The test above asserts the outcome of a pick; it cannot make the failure
+   * happen on demand, because the failure was a race — something outside the
+   * studio moved the pane scroller, and whether it won depended on how busy the
+   * phone was. Desktop Chromium driving a 390px viewport is not a busy phone, so
+   * that test passes with or without the fix.
+   *
+   * This one removes the race. It does the thing the page used to do, at a
+   * moment of its choosing: a `scrollIntoView` inside the frame, which walks out
+   * of the frame and scrolls the studio's own containers. Reveal an ELEMENT
+   * inside the canvas pane and the scroller ends up wherever that element
+   * happened to need — which is the split view the report described.
+   *
+   * What is asserted is that it does not stay there. Nothing in the studio has
+   * to know which browser behaviour did it, or be quicker than it: the panes are
+   * put back on a pane whenever they come to rest anywhere else.
+   */
+  test("puts itself back when something outside scrolls the panes", async ({
+    page,
+  }) => {
+    await openStudio(page, `${HOME}&canvas=1`);
+    const enable = page.getByRole("button", { name: /Turn on preview mode/ });
+    await expect(enable).toBeVisible({ timeout: 25_000 });
+    await enable.click();
+
+    const paneSwitch = page.getByRole("tablist", { name: "Workspace pane" });
+    await paneSwitch.getByRole("tab", { name: "Editor" }).click();
+    const fieldsTab = page.getByRole("tab", { name: /Fields/ });
+    await expect(fieldsTab).toBeVisible({ timeout: 30_000 });
+    await fieldsTab.click();
+    const fields = page.getByRole("heading", { name: "On this page" });
+    await expect(fields).toBeVisible();
+
+    const frame = page
+      .frames()
+      .find((candidate) => candidate.url().includes("val_canvas"));
+    expect(frame, "the canvas never loaded the page").toBeTruthy();
+
+    /*
+     * The page, doing what the page used to do — on its LAST tagged element, so
+     * the scroll has real work to do. `scrollIntoView` on something already in
+     * view moves nothing, and a test that reveals what is already revealed
+     * asserts nothing.
+     */
+    const moved = await frame!.evaluate(() => {
+      const tagged = document.querySelectorAll("[data-val-path]");
+      const target = tagged[tagged.length - 1];
+      if (target === undefined) return null;
+      const before = window.scrollY;
+      target.scrollIntoView({ block: "center", behavior: "smooth" });
+      return before;
+    });
+    expect(moved, "the page reported nothing to scroll to").not.toBeNull();
+    await expect
+      .poll(() => frame!.evaluate(() => window.scrollY), {
+        message: "the page's own scroll never moved, so nothing was tested",
+      })
+      .not.toBe(moved);
+
+    const viewport = page.viewportSize();
+    expect(viewport).toBeTruthy();
+    await expect
+      .poll(
+        async () => {
+          const box = await fields.boundingBox();
+          if (box === null || viewport === null) return null;
+          return box.x >= -1 && box.x + box.width <= viewport.width + 1;
+        },
+        {
+          message: "the panes were left where the page's scroll put them",
+        },
+      )
+      .toBe(true);
+  });
 });

--- a/packages/next/src/ValCanvasBridge.tsx
+++ b/packages/next/src/ValCanvasBridge.tsx
@@ -302,7 +302,8 @@ export function ValCanvasBridge({
       setHighlighted(message.path);
       if (message.path !== null && message.scrollIntoView) {
         const target = findByPath(message.path);
-        target?.scrollIntoView({ block: "center", behavior: "smooth" });
+        // NOT `scrollIntoView` — see `scrollWithinPage`.
+        if (target !== null) scrollWithinPage(target);
       }
     };
     window.addEventListener("message", listener);
@@ -502,6 +503,100 @@ function highlightRule(path: string): string {
     `[data-val-path*=${inner}]`,
   ].join(",\n");
   return `${selectors} { outline: 2px solid ${SELECTION}; outline-offset: 1px; }`;
+}
+
+/**
+ * Bring an element into view WITHOUT scrolling anything outside this page.
+ *
+ * `Element.scrollIntoView` would be the obvious thing, and it is the thing that
+ * broke the studio. It scrolls every scroll container between the element and
+ * the viewport, and for a same-origin frame that chain does not stop at the
+ * frame: it continues into the embedder and scrolls the studio's own containers
+ * too. Measured in Chromium — with the studio's phone panes placed on the
+ * editor, a single `scrollIntoView` in here pulls them back onto the canvas, and
+ * because it reveals the element rather than the frame it can leave them
+ * anywhere in between, showing half of each.
+ *
+ * That is not a thing the page has any business doing. It was asked to show one
+ * of its own elements; where the studio is looking is the studio's affair. So
+ * the scrolling is done by hand, one scrollport at a time, and the walk stops at
+ * this document.
+ *
+ * Only the document centres the target vertically — it is being pointed out,
+ * and something flush against the top edge of the fold does not read as pointed
+ * out. Every scrollport inside the page is moved as little as it takes to bring
+ * the target inside it: a carousel, a sticky sidebar or a sideways-scrolling
+ * table is showing what it is showing on purpose, and re-centring one that did
+ * not need moving is the page rearranging itself around a highlight.
+ */
+function scrollWithinPage(target: Element): void {
+  let node = target.parentElement;
+  while (node !== null) {
+    const isRoot = node === document.body || node === document.documentElement;
+    if (isRoot) break;
+    if (isScrollable(node)) {
+      const port = node.getBoundingClientRect();
+      const box = target.getBoundingClientRect();
+      node.scrollTop += delta(
+        box.top - port.top,
+        box.height,
+        node.clientHeight,
+        false,
+      );
+      node.scrollLeft += delta(
+        box.left - port.left,
+        box.width,
+        node.clientWidth,
+        false,
+      );
+    }
+    node = node.parentElement;
+  }
+  // And this document, which is the last scrollport there is as far as the page
+  // is concerned. `window`, not `documentElement.scrollIntoView`-by-another-name:
+  // this cannot reach past the frame.
+  const box = target.getBoundingClientRect();
+  window.scrollTo({
+    top: Math.max(
+      0,
+      window.scrollY + delta(box.top, box.height, window.innerHeight, true),
+    ),
+    left: Math.max(
+      0,
+      window.scrollX + delta(box.left, box.width, window.innerWidth, false),
+    ),
+    behavior: "smooth",
+  });
+}
+
+/**
+ * How far a scrollport has to move for `size` at `offset` to be shown.
+ *
+ * `center` asks for the middle of the port; without it the answer is zero
+ * whenever the thing is already inside, which is what keeps a scrollport that
+ * did not need moving from being disturbed.
+ */
+function delta(
+  offset: number,
+  size: number,
+  port: number,
+  center: boolean,
+): number {
+  if (center) return offset - (port - size) / 2;
+  if (offset < 0) return offset;
+  if (offset + size > port) return Math.min(offset, offset + size - port);
+  return 0;
+}
+
+/** Whether this element scrolls its own content, rather than growing with it. */
+function isScrollable(el: Element): boolean {
+  const style = getComputedStyle(el);
+  const scrolls = (value: string) =>
+    value === "auto" || value === "scroll" || value === "overlay";
+  return (
+    (scrolls(style.overflowY) && el.scrollHeight > el.clientHeight) ||
+    (scrolls(style.overflowX) && el.scrollWidth > el.clientWidth)
+  );
 }
 
 function findByPath(path: string): Element | null {

--- a/packages/next/src/canvasBridgeScroll.test.tsx
+++ b/packages/next/src/canvasBridgeScroll.test.tsx
@@ -26,6 +26,29 @@ import { ValCanvasBridge } from "./ValCanvasBridge";
 describe("the canvas bridge bringing a field into view", () => {
   let scrollIntoView: jest.Mock;
   let scrolledTo: ScrollToOptions[];
+  /**
+   * What was on the globals before this suite replaced them.
+   *
+   * Three of these are assigned rather than spied on, so `restoreAllMocks` does
+   * not know about them — and the one that matters most is `scrollIntoView`:
+   * left installed, a later suite would find a mock where jsdom has nothing,
+   * and an accidental call to it would be swallowed instead of throwing. A test
+   * that hides the very thing this file exists to catch is worse than no test.
+   *
+   * Two of the three are ABSENT in jsdom rather than merely different, so
+   * restoring them means removing them again. Hence `Reflect` and `unknown`:
+   * "there was nothing here" is a value this has to be able to carry, and
+   * neither the global's own type nor an assertion can say it.
+   */
+  const originals: { owner: object; key: string; value: unknown }[] = [];
+  const replace = (owner: object, key: string, value: unknown) => {
+    originals.push({
+      owner,
+      key,
+      value: key in owner ? Reflect.get(owner, key) : undefined,
+    });
+    Reflect.set(owner, key, value);
+  };
 
   beforeEach(() => {
     // Installed rather than spied on: jsdom does not implement
@@ -34,20 +57,24 @@ describe("the canvas bridge bringing a field into view", () => {
     // than being caught by an assertion, and this test would be about the wrong
     // thing.
     scrollIntoView = jest.fn();
-    Element.prototype.scrollIntoView = scrollIntoView;
+    replace(Element.prototype, "scrollIntoView", scrollIntoView);
     scrolledTo = [];
     // The bridge re-measures the page whenever it could have moved; jsdom has
     // no layout for it to observe.
-    globalThis.ResizeObserver = class {
-      observe() {}
-      unobserve() {}
-      disconnect() {}
-    };
+    replace(
+      globalThis,
+      "ResizeObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
     // jsdom has no scrolling of its own, and `window.scrollTo` is one of the
     // things it refuses outright rather than stubbing.
-    window.scrollTo = ((options: ScrollToOptions) => {
+    replace(window, "scrollTo", (options: ScrollToOptions) => {
       scrolledTo.push(options);
-    }) as typeof window.scrollTo;
+    });
     jest
       .spyOn(window.parent, "postMessage")
       .mockImplementation(() => undefined);
@@ -55,6 +82,12 @@ describe("the canvas bridge bringing a field into view", () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
+    // And the three the mock registry knows nothing about. See `originals`.
+    for (const { owner, key, value } of originals.reverse()) {
+      if (value === undefined) Reflect.deleteProperty(owner, key);
+      else Reflect.set(owner, key, value);
+    }
+    originals.length = 0;
   });
 
   /** The studio asking for a field to be outlined and shown. */

--- a/packages/next/src/canvasBridgeScroll.test.tsx
+++ b/packages/next/src/canvasBridgeScroll.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, render } from "@testing-library/react";
+import {
+  VAL_CANVAS_MESSAGE,
+  type ValCanvasStudioMessage,
+} from "@valbuild/shared/internal";
+import { ValCanvasBridge } from "./ValCanvasBridge";
+
+/**
+ * The page is not allowed to scroll the studio.
+ *
+ * `Element.scrollIntoView` scrolls every scroll container between the element
+ * and the viewport, and for a same-origin frame that chain does not stop at the
+ * frame — it continues into the embedder. Measured in Chromium: with the
+ * studio's phone panes placed on the editor, one `scrollIntoView` in the framed
+ * page pulls them back onto the canvas, and because it reveals an ELEMENT rather
+ * than a pane it can leave them anywhere in between.
+ *
+ * That is what turned "I tapped a field" into a workspace showing half the
+ * editor and half the page. So this is checked at the boundary where the rule
+ * can actually be stated: the page brings its own content into view by hand,
+ * and never calls the one API that reaches out of the document.
+ */
+describe("the canvas bridge bringing a field into view", () => {
+  let scrollIntoView: jest.Mock;
+  let scrolledTo: ScrollToOptions[];
+
+  beforeEach(() => {
+    // Installed rather than spied on: jsdom does not implement
+    // `scrollIntoView`, so there is nothing on the prototype to wrap — which
+    // also means a call to it in the code under test would throw here rather
+    // than being caught by an assertion, and this test would be about the wrong
+    // thing.
+    scrollIntoView = jest.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+    scrolledTo = [];
+    // The bridge re-measures the page whenever it could have moved; jsdom has
+    // no layout for it to observe.
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+    // jsdom has no scrolling of its own, and `window.scrollTo` is one of the
+    // things it refuses outright rather than stubbing.
+    window.scrollTo = ((options: ScrollToOptions) => {
+      scrolledTo.push(options);
+    }) as typeof window.scrollTo;
+    jest
+      .spyOn(window.parent, "postMessage")
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  /** The studio asking for a field to be outlined and shown. */
+  const highlight = (path: string) => {
+    const message: ValCanvasStudioMessage = {
+      val: VAL_CANVAS_MESSAGE,
+      type: "highlight",
+      path: path as never,
+      scrollIntoView: true,
+    };
+    act(() => {
+      window.dispatchEvent(new MessageEvent("message", { data: message }));
+    });
+  };
+
+  it("scrolls this document and never reaches out of the frame", () => {
+    const path = '/content/page.val.ts?p="title"';
+    render(
+      <>
+        <div data-val-path={path}>Title</div>
+        <ValCanvasBridge draftMode />
+      </>,
+    );
+
+    highlight(path);
+
+    // `scrollIntoView` walks out of the frame and moves the studio's own
+    // scrollers; the page brings its content into view by hand instead.
+    expect(scrollIntoView).not.toHaveBeenCalled();
+    expect(scrolledTo).toHaveLength(1);
+  });
+
+  it("does nothing at all for a path that is not on the page", () => {
+    render(<ValCanvasBridge draftMode />);
+
+    highlight('/content/page.val.ts?p="gone"');
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+    expect(scrolledTo).toHaveLength(0);
+  });
+});

--- a/packages/ui/spa/components/ValFieldProvider.tsx
+++ b/packages/ui/spa/components/ValFieldProvider.tsx
@@ -25,7 +25,11 @@ import type { UploadProgress } from "../stores/PatchStore";
 import type { SourcePeek } from "../stores/SourceStore";
 import { Patch } from "@valbuild/core/patch";
 import { isJsonArray } from "../utils/isJsonArray";
-import { getNavPathFromAll } from "./getNavPath";
+import {
+  getNavPathFromAll,
+  NavPathResolution,
+  resolveNavPath,
+} from "./getNavPath";
 import { concatModulePath } from "../utils/sourcePath";
 
 // --- Source override context ---
@@ -1135,6 +1139,35 @@ export function useGetNavPath(): (
         return null;
       }
       return getNavPathFromAll(
+        path,
+        val.system.sourceStore.allSources(),
+        val.system.schemaStore.all(),
+      );
+    },
+    [val],
+  );
+}
+
+/**
+ * The same resolution as {@link useGetNavPath}, with the reason it failed.
+ *
+ * For callers that have to SAY something when a path cannot be opened. The
+ * canvas is the one that must: the thing that was clicked is visibly there on
+ * the page, so "nothing happened" is not a plausible answer to have given.
+ *
+ * Reads on demand, exactly as `useGetNavPath` does and for the same reason —
+ * see the note there about whole-project subscriptions.
+ */
+export function useResolveNavPath(): (
+  path: SourcePath | ModuleFilePath,
+) => NavPathResolution {
+  const val = useValSystem();
+  return useCallback(
+    (path: SourcePath | ModuleFilePath): NavPathResolution => {
+      if (val === null) {
+        return { status: "schemas-not-loaded" };
+      }
+      return resolveNavPath(
         path,
         val.system.sourceStore.allSources(),
         val.system.schemaStore.all(),

--- a/packages/ui/spa/components/ValProvider.tsx
+++ b/packages/ui/spa/components/ValProvider.tsx
@@ -2106,6 +2106,28 @@ export function useFullValidationRunning(): boolean {
   return running;
 }
 
+/**
+ * Tell the editor something went wrong, once.
+ *
+ * The same queue every other announcement goes through — it surfaces as a toast
+ * and stays in the transient-errors list afterwards — reachable from a component
+ * rather than only from the sync layer. `StatusStore.reportError` de-duplicates
+ * by message, so a handler that fails on every attempt says it once.
+ *
+ * For things the person DID and that visibly did not happen. Not for background
+ * failures the studio recovers from on its own, which have their own reporting
+ * and would only be noise here.
+ */
+export function useReportError(): (message: string, details?: string) => void {
+  const val = useValSystem();
+  return useCallback(
+    (message: string, details?: string) => {
+      val?.system.status.reportError(message, details);
+    },
+    [val],
+  );
+}
+
 export function useGlobalTransientErrors() {
   const val = useValSystem();
   const status = useValStatus();

--- a/packages/ui/spa/components/getNavPath.test.ts
+++ b/packages/ui/spa/components/getNavPath.test.ts
@@ -6,7 +6,7 @@ import {
   ValModule,
   initVal,
 } from "@valbuild/core";
-import { getNavPathFromAll } from "./getNavPath";
+import { getNavPathFromAll, resolveNavPath } from "./getNavPath";
 
 const { c, s } = initVal();
 const module = c.define(
@@ -118,6 +118,76 @@ describe("getNavPath", () => {
     ).toStrictEqual(
       '/app/test.val.ts?p="arrayOfObjects".0."subArrayOfObjects".0',
     );
+  });
+});
+
+/**
+ * Why a path did not resolve, told apart.
+ *
+ * `getNavPathFromAll` answers `null` to all three of these, which is all most
+ * callers can use. The canvas cannot: a click on the running page that opens
+ * nothing has to say something, and "still loading", "that file is gone" and
+ * "the page is tagged with a path that no longer exists" are three different
+ * things to say and three different things to do about them.
+ */
+describe("resolveNavPath", () => {
+  const source = Internal.getSource(module);
+  const moduleFilePath = Internal.getValPath(
+    module,
+  ) as unknown as ModuleFilePath;
+  const schema = Internal.getSchema(module)!["executeSerialize"]();
+  const sources = { [moduleFilePath]: source };
+  const schemas = { [moduleFilePath]: schema };
+
+  test("resolves like getNavPathFromAll does", () => {
+    expect(
+      resolveNavPath(
+        '/app/test.val.ts?p="arrayOfObjects".0."stringInsideArray"' as SourcePath,
+        sources,
+        schemas,
+      ),
+    ).toEqual({
+      status: "resolved",
+      path: '/app/test.val.ts?p="arrayOfObjects".0',
+    });
+  });
+
+  test("says when the schemas have not arrived", () => {
+    expect(
+      resolveNavPath(
+        '/app/test.val.ts?p="arrayOfStrings".0' as SourcePath,
+        sources,
+        undefined,
+      ),
+    ).toEqual({ status: "schemas-not-loaded" });
+  });
+
+  test("says when the module behind the path is not loaded", () => {
+    expect(
+      resolveNavPath(
+        '/app/gone.val.ts?p="title"' as SourcePath,
+        sources,
+        schemas,
+      ),
+    ).toEqual({
+      status: "module-not-loaded",
+      moduleFilePath: "/app/gone.val.ts",
+    });
+  });
+
+  test("says when the path does not point at anything in the module", () => {
+    const resolution = resolveNavPath(
+      '/app/test.val.ts?p="noSuchField"."deeper"' as SourcePath,
+      sources,
+      schemas,
+    );
+    expect(resolution.status).toBe("unresolvable");
+    // The reason travels: it is the only thing that says WHERE the page and the
+    // schema disagree, and it ends up in the details line of the message.
+    if (resolution.status === "unresolvable") {
+      expect(resolution.moduleFilePath).toBe("/app/test.val.ts");
+      expect(resolution.reason.length).toBeGreaterThan(0);
+    }
   });
 });
 

--- a/packages/ui/spa/components/getNavPath.ts
+++ b/packages/ui/spa/components/getNavPath.ts
@@ -26,25 +26,61 @@ function isSchemaNavStop(
   return false;
 }
 
-export function getNavPathFromAll(
+/**
+ * Why a path could not be turned into somewhere to navigate to.
+ *
+ * A reason rather than `null`, because the three of them call for three
+ * different things to be said to the person who asked. "Still loading" is a
+ * wait; "this module is not here" is a stale link or a deleted module; "this
+ * path does not resolve" is content that has moved under a page that is still
+ * tagged with where it used to be. Told apart, each is actionable; collapsed
+ * into nothing, all three are a click that did nothing.
+ *
+ * Introduced for the canvas, where the click is on the running page and the
+ * failure is otherwise completely opaque: the element is right there, and
+ * pointing at it appeared to do nothing at all.
+ */
+export type NavPathResolution =
+  | { status: "resolved"; path: SourcePath | ModuleFilePath }
+  /** The schemas have not been loaded yet. Trying again shortly will work. */
+  | { status: "schemas-not-loaded" }
+  /** No such module, or its source has not been loaded. */
+  | { status: "module-not-loaded"; moduleFilePath: ModuleFilePath }
+  /** The module is here, and the path does not point at anything in it. */
+  | {
+      status: "unresolvable";
+      moduleFilePath: ModuleFilePath;
+      /** What the resolver said, for the details line of a message. */
+      reason: string;
+    };
+
+/**
+ * Where to navigate for a path, or why not.
+ *
+ * The whole of {@link getNavPathFromAll}, which is now the answer with the
+ * reason thrown away — kept because most callers have nothing useful to do with
+ * one, and because a `null` they already handle is better than a reason they
+ * would have to invent a message for.
+ */
+export function resolveNavPath(
   requestedPath: SourcePath | ModuleFilePath,
   allSources: Record<ModuleFilePath, Source>,
   schemas: Record<ModuleFilePath, SerializedSchema> | undefined,
-): SourcePath | ModuleFilePath | null {
+): NavPathResolution {
   if (!schemas) {
-    return null;
+    return { status: "schemas-not-loaded" };
   }
 
   const [moduleFilePath, modulePath] =
     Internal.splitModuleFilePathAndModulePath(requestedPath);
   if (!modulePath) {
-    return moduleFilePath;
+    return { status: "resolved", path: moduleFilePath };
   }
 
   const source = allSources[moduleFilePath];
   const schema = schemas[moduleFilePath];
   if (source === undefined || !schema) {
-    return null;
+    return { status: "module-not-loaded", moduleFilePath };
   }
 
   const resolutionRes = resolvePatchPath(
@@ -52,27 +88,46 @@ export function getNavPathFromAll(
     schema,
     source,
   );
-  if (resolutionRes.success) {
-    // Move upwards in path until we find where to stop:
-    for (let i = resolutionRes.allResolved.length - 1; i >= 0; i--) {
-      const resolved = resolutionRes.allResolved[i];
-      const parent = resolutionRes.allResolved[i - 1];
-      if (isSchemaNavStop(resolved.schema, parent?.schema || null)) {
-        if (resolved.modulePath === "") {
-          return moduleFilePath;
-        }
-        return Internal.joinModuleFilePathAndModulePath(
+  if (!resolutionRes.success) {
+    return {
+      status: "unresolvable",
+      moduleFilePath,
+      reason: String(resolutionRes.error),
+    };
+  }
+  // Move upwards in path until we find where to stop:
+  for (let i = resolutionRes.allResolved.length - 1; i >= 0; i--) {
+    const resolved = resolutionRes.allResolved[i];
+    const parent = resolutionRes.allResolved[i - 1];
+    if (isSchemaNavStop(resolved.schema, parent?.schema || null)) {
+      if (resolved.modulePath === "") {
+        return { status: "resolved", path: moduleFilePath };
+      }
+      return {
+        status: "resolved",
+        path: Internal.joinModuleFilePathAndModulePath(
           moduleFilePath,
           resolved.modulePath,
-        );
-      }
+        ),
+      };
     }
-    return moduleFilePath;
-  } else {
+  }
+  return { status: "resolved", path: moduleFilePath };
+}
+
+export function getNavPathFromAll(
+  requestedPath: SourcePath | ModuleFilePath,
+  allSources: Record<ModuleFilePath, Source>,
+  schemas: Record<ModuleFilePath, SerializedSchema> | undefined,
+): SourcePath | ModuleFilePath | null {
+  const resolution = resolveNavPath(requestedPath, allSources, schemas);
+  if (resolution.status === "resolved") {
+    return resolution.path;
+  }
+  if (resolution.status === "unresolvable") {
     console.error(
-      `Error resolving path: ${resolutionRes.error} for path: ${requestedPath}`,
+      `Error resolving path: ${resolution.reason} for path: ${requestedPath}`,
     );
   }
-
   return null;
 }

--- a/packages/ui/spa/components/shell/Shell.tsx
+++ b/packages/ui/spa/components/shell/Shell.tsx
@@ -6,7 +6,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { ModuleFilePath } from "@valbuild/core";
+import { ModuleFilePath, SourcePath } from "@valbuild/core";
 import { AIChatPanel } from "./AIChatPanel";
 import { DataPanel } from "./DataPanel";
 import { EmptyEditorState, PageEditor } from "./EditorCanvas";
@@ -16,6 +16,11 @@ import {
   PageWorkspaceProps,
 } from "./canvas/PageWorkspace";
 import { CanvasPageData, CanvasTransform } from "./canvas/types";
+import {
+  canvasModulesFromKey,
+  canvasModulesKey,
+  canvasShowsEditedContent,
+} from "./canvasPageScope";
 import {
   GlobalSearch,
   SearchResult,
@@ -553,14 +558,42 @@ export function Shell({
   );
 
   /**
-   * Anything that is not a page leaves the canvas.
+   * What the canvas page is made of, and what the editor is on.
+   *
+   * Refs, read by the effect below and deliberately NOT among its dependencies.
+   * Both change for reasons that are not a move: the page re-reports its
+   * elements whenever anything on it shifts, and the edited path changes when
+   * you go from one field to the next inside the same module. The effect closes
+   * the canvas, so a dependency on either would close a canvas that had been
+   * opened deliberately from a data module — which is exactly when you want to
+   * watch a page react to a setting.
+   *
+   * See {@link canvasModulesKey} for why the modules are keyed by a string.
+   */
+  const modulesKey = useMemo(
+    () => canvasModulesKey(canvasPaths),
+    [canvasPaths],
+  );
+  const canvasModules = useMemo(
+    () => canvasModulesFromKey(modulesKey),
+    [modulesKey],
+  );
+  const canvasScope = useRef<{
+    canvasModules: ReadonlySet<ModuleFilePath>;
+    editedPath: SourcePath | null;
+  }>({ canvasModules, editedPath: selectedCanvasPath ?? null });
+  canvasScope.current = {
+    canvasModules,
+    editedPath: selectedCanvasPath ?? null,
+  };
+
+  /**
+   * Moving to something that is not on the page leaves the canvas.
    *
    * The canvas is still offered everywhere — the Preview button does not come
-   * and go with the selection — but landing on something that is not on a route
-   * means the canvas is showing a page you are no longer editing. In the fields
-   * view it is worse than stale: the editor column IS the page's fields, so the
-   * module you navigated to does not appear at all and the navigation looks like
-   * it did nothing.
+   * and go with the selection. What decides is whether it is still showing the
+   * thing being edited; see {@link canvasShowsEditedContent}, which is also
+   * where the reason a pick must not close it is written down.
    *
    * Here rather than in `select` below, because a selection is not the only way
    * to move: a breadcrumb, a deep link and a validation error all change the
@@ -572,7 +605,14 @@ export function Shell({
    */
   useEffect(() => {
     if (isLoading) return;
-    if (selection?.kind === "page") return;
+    if (
+      canvasShowsEditedContent({
+        selectionKind: selection?.kind ?? null,
+        ...canvasScope.current,
+      })
+    ) {
+      return;
+    }
     setIsCanvasOpen(false);
     setCanvasView("normal");
   }, [isLoading, selection?.kind]);

--- a/packages/ui/spa/components/shell/ValShell.tsx
+++ b/packages/ui/spa/components/shell/ValShell.tsx
@@ -615,9 +615,11 @@ function ValShellBody({ state }: { state: ReturnType<typeof useShellData> }) {
       }
       const resolution = resolveNavPath(path);
       if (resolution.status === "resolved") {
-        navigation.navigate(resolution.path as SourcePath, {
-          scrollToPath: path,
-        });
+        // No assertion: what it resolves to is a module as often as a path
+        // inside one — a field whose nearest nav stop is the module root gives
+        // the former — and `navigate` takes either. Narrowing it to a
+        // `SourcePath` here would be claiming something this does not know.
+        navigation.navigate(resolution.path, { scrollToPath: path });
         return true;
       }
       reportError(...describeUnopenablePick(resolution, path));

--- a/packages/ui/spa/components/shell/ValShell.tsx
+++ b/packages/ui/spa/components/shell/ValShell.tsx
@@ -49,8 +49,14 @@ import {
   usePendingChangesProgress,
   useValMode,
   useAutoPublish,
+  useReportError,
 } from "../ValProvider";
-import { useFilePatchIds, useGetNavPath } from "../ValFieldProvider";
+import {
+  useFilePatchIds,
+  useGetNavPath,
+  useResolveNavPath,
+} from "../ValFieldProvider";
+import type { NavPathResolution } from "../getNavPath";
 import { refToUrl } from "../MediaPicker/refToUrl";
 import { useAllValidationErrors } from "../ValErrorProvider";
 import { AIChatSurface } from "../AIChatSurface";
@@ -572,18 +578,52 @@ function ValShellBody({ state }: { state: ReturnType<typeof useShellData> }) {
   );
 
   /**
-   * A pick on the page opens the field it belongs to.
+   * A pick on the page opens the field it belongs to, or says why it cannot.
    *
    * An element can carry more than one path — a heading built from two fields
    * is one element with two paths — and nothing says which was meant, so the
    * first is opened. The overlay makes the same choice.
+   *
+   * ## Why this returns something
+   *
+   * A pick is one act with two halves in two owners: the shell opens the field,
+   * because it owns navigation, and the canvas goes to the fields column,
+   * because where to LOOK is its business. They used to run one after the other
+   * unconditionally, so a pick that could not be opened still moved the whole
+   * workspace — on a phone, off the page and onto a fields column that did not
+   * contain the field, because the field had not been openable in the first
+   * place. That is the state that reads as the studio having broken.
+   *
+   * So the first half reports whether it happened, and the second half only
+   * runs if it did. A pick either lands completely or changes nothing and says
+   * why.
    */
-  const onPick = useCallback(
-    (paths: SourcePath[]) => {
-      const first = paths[0];
-      if (first !== undefined) openPath(first);
+  const resolveNavPath = useResolveNavPath();
+  const reportError = useReportError();
+  const openPickedPath = useCallback(
+    (paths: SourcePath[]): boolean => {
+      const path = paths[0];
+      if (path === undefined) {
+        // The page tags an element with at least one path, so an empty list
+        // means the two sides disagree about the attribute's format — a version
+        // skew between `@valbuild/next` and the studio, most likely.
+        reportError(
+          "That element on the page has no content behind it",
+          "The page reported a selection with no source path. Check that @valbuild/next and @valbuild/ui are on the same version.",
+        );
+        return false;
+      }
+      const resolution = resolveNavPath(path);
+      if (resolution.status === "resolved") {
+        navigation.navigate(resolution.path as SourcePath, {
+          scrollToPath: path,
+        });
+        return true;
+      }
+      reportError(...describeUnopenablePick(resolution, path));
+      return false;
     },
-    [openPath],
+    [navigation, resolveNavPath, reportError],
   );
 
   /**
@@ -631,10 +671,13 @@ function ValShellBody({ state }: { state: ReturnType<typeof useShellData> }) {
          * The shell opens the field, because it owns navigation; the canvas is
          * told one happened, because where to LOOK afterwards is its business —
          * the fields column, and on a phone the pane that holds it.
+         *
+         * In that order, and the second only if the first worked. See
+         * `openPickedPath`: a workspace moved for a field that never opened is
+         * the broken-looking state this used to leave behind.
          */
         onPick={(paths) => {
-          onPick(paths);
-          onPicked();
+          if (openPickedPath(paths)) onPicked();
         }}
         onPinch={onPinch}
         onZoom={onZoom}
@@ -642,7 +685,7 @@ function ValShellBody({ state }: { state: ReturnType<typeof useShellData> }) {
         onRefreshingChange={onRefreshingChange}
       />
     );
-  }, [canvasUrl, focusedPath, onPick]);
+  }, [canvasUrl, focusedPath, openPickedPath]);
 
   /**
    * Every field with a validation error, as source paths.
@@ -925,6 +968,38 @@ function isPathWithin(path: string, id: string): boolean {
   if (!path.startsWith(id)) return false;
   const next = path[id.length];
   return next === "?" || next === ".";
+}
+
+/**
+ * What to tell someone whose click on the page opened nothing.
+ *
+ * The failure is entirely invisible from where they are standing: the thing
+ * they pointed at is right there on the page, drawn by the app, outlined by
+ * Val. Every one of these has a different next step, which is the reason they
+ * are told apart at all — and the details line carries the path, because the
+ * person who can act on two of the three is a developer reading it over their
+ * shoulder.
+ */
+function describeUnopenablePick(
+  resolution: Exclude<NavPathResolution, { status: "resolved" }>,
+  path: SourcePath,
+): [message: string, details: string] {
+  if (resolution.status === "schemas-not-loaded") {
+    return [
+      "Still loading — try that again in a moment",
+      `The content schema had not arrived yet, so ${path} could not be opened.`,
+    ];
+  }
+  if (resolution.status === "module-not-loaded") {
+    return [
+      "That field's content file is not loaded",
+      `The page points at ${resolution.moduleFilePath}, which the studio does not have. It may have been deleted or renamed since the page was built.`,
+    ];
+  }
+  return [
+    "That field is no longer where the page says it is",
+    `${path} does not resolve in ${resolution.moduleFilePath}: ${resolution.reason}. The page is probably rendering content from before a change to the schema — reload the canvas.`,
+  ];
 }
 
 /**

--- a/packages/ui/spa/components/shell/canvas/CanvasFrame.tsx
+++ b/packages/ui/spa/components/shell/canvas/CanvasFrame.tsx
@@ -121,6 +121,26 @@ export function CanvasFrame({
    */
   const [documentEpoch, setDocumentEpoch] = useState(0);
 
+  /**
+   * The path most recently picked ON the page.
+   *
+   * A pick is followed by a highlight of the thing picked, and asking the page
+   * to scroll to it is asking it to reveal something the finger is still on.
+   * Harmless in itself, and not harmless in practice: the page's scroll walks
+   * out of the frame and moves the studio's own containers with it, which on a
+   * phone is how a pick ended up back on the canvas — or half way to it.
+   *
+   * Consumed by the highlight it suppresses, rather than held: what it excuses
+   * is the ONE highlight that follows a pick. Left standing, it would go on
+   * suppressing the scroll for that field however you arrived at it later — a
+   * row in the fields column, a search hit — where finding it on the page is the
+   * whole point.
+   *
+   * A ref because it is not rendered and must not cause one: it is read while
+   * deciding what to send, and written from a message handler.
+   */
+  const pickedHere = useRef<SourcePath | null>(null);
+
   // The URL the frame is actually given: the page, marked as a canvas load so
   // it renders itself without its own overlay.
   const frameSrc = useMemo(() => withValCanvasParam(url), [url]);
@@ -172,6 +192,7 @@ export function CanvasFrame({
       } else if (message.type === "zoom") {
         onZoom?.(message.factor, message.center);
       } else {
+        pickedHere.current = message.paths[0] ?? null;
         onPick?.(message.paths);
       }
     };
@@ -186,11 +207,17 @@ export function CanvasFrame({
   }, [send, isPicking, state.status]);
 
   useEffect(() => {
+    // Everywhere except straight after a pick on the page, where the thing
+    // being highlighted is the thing that was just clicked and is therefore
+    // already in front of the person who clicked it. See `pickedHere`.
+    const justPicked =
+      highlightedPath !== null && highlightedPath === pickedHere.current;
+    pickedHere.current = null;
     send({
       val: VAL_CANVAS_MESSAGE,
       type: "highlight",
       path: highlightedPath,
-      scrollIntoView: true,
+      scrollIntoView: !justPicked,
     });
   }, [send, highlightedPath, state.status]);
 

--- a/packages/ui/spa/components/shell/canvas/PageWorkspace.tsx
+++ b/packages/ui/spa/components/shell/canvas/PageWorkspace.tsx
@@ -29,6 +29,7 @@ import {
 import { FieldsPanel } from "./FieldsPanel";
 import { CanvasFields } from "./CanvasFields";
 import { CanvasRouteBar } from "./CanvasRouteBar";
+import { usePaneScroller, WorkspacePane } from "./usePaneScroller";
 import { CANVAS_MAX_WIDTH } from "../EditorCanvas";
 import { SourcePath } from "@valbuild/core";
 import { ShellBreakpoint } from "../types";
@@ -45,6 +46,8 @@ import {
 // Re-exported: this module named the type before the canvas had a types file,
 // and the whole shell imports it from here.
 export type { CanvasView };
+// Named here first, and moved to `usePaneScroller` with the state it describes.
+export type { WorkspacePane };
 
 export type PageWorkspaceProps = {
   /** The module editor for the current selection. Shown when it is on. */
@@ -198,16 +201,6 @@ const PHONE_STRIP_CLEARANCE = "6.75rem";
 const OPEN_MS = 320;
 /** The switch thumb moves faster: it is a short distance and a direct answer. */
 const SWITCH_MS = 200;
-/** How long the panes have to be still before the switch reads them. */
-const PANE_SETTLE_MS = 140;
-/**
- * How long a placement holds the pane where it put it.
- *
- * Long enough to outlast the layout changes that follow one — the column's
- * fields arrive one at a time as their schemas resolve — and short enough that
- * it can never be felt as the switch refusing a swipe.
- */
-const PANE_HOLD_MS = 400;
 const OPEN_EASE = "cubic-bezier(0.4, 0, 0.2, 1)";
 
 /**
@@ -322,10 +315,22 @@ export function PageWorkspace({
   );
   const [selectedFieldId, setSelectedFieldId] = useState<string | null>(null);
   const [attachedFieldIds, setAttachedFieldIds] = useState<string[]>([]);
-  const [pane, setPane] = useState<WorkspacePane>("editor");
+
+  /**
+   * The phone's two panes, and where they are.
+   *
+   * One owner for the pane and the scroll position, because they are one fact.
+   * See {@link usePaneScroller} for the invariant that keeps them from resting
+   * anywhere between the two.
+   */
+  const panes = usePaneScroller({
+    enabled: isPhone,
+    paneCount: open ? 2 : 1,
+    animate: !reducedMotion && !skipTransition,
+  });
+  const pane = panes.pane;
 
   const canvasWindowRef = useRef<CanvasWindowHandle>(null);
-  const paneScrollRef = useRef<HTMLDivElement>(null);
   const splitRef = useRef<HTMLDivElement>(null);
 
   /**
@@ -499,126 +504,17 @@ export function PageWorkspace({
     canvasWindowRef.current?.pinch(gesture);
   }, []);
 
-  // Opening the canvas on a phone means going to it; closing means coming
-  // back. The switch and the swipe then agree about where you are.
-  useEffect(() => setPane(open ? "canvas" : "editor"), [open]);
-
-  // The phone's panes are a scroll container, so moving between them is a
-  // scroll — which keeps the swipe and the button doing the same thing, and
-  // means the switch slides the canvas in rather than cutting to it.
-  //
-  // The first placement is not a move anyone made, so it lands without
-  // animating; every later one glides.
-  const hasPlacedPane = useRef(false);
   /**
-   * Whether the next placement should LAND rather than glide.
+   * Opening the canvas on a phone means going to it; closing means coming back.
    *
-   * Set by a pick, and it is not a taste judgement — a glide does not survive
-   * one. Clicking an element inside the frame focuses the frame, and the
-   * browser then scrolls the newly focused frame back into view, which cancels
-   * a smooth scroll that is trying to take it off screen. The animation never
-   * produces a single scroll event; the switch says "Editor", the canvas stays
-   * on screen, and the pick looks like it did nothing.
-   *
-   * A landing has no such window to be cancelled in: it is applied
-   * synchronously, and the snap that follows lands on the pane it is already
-   * sitting on. Nothing is lost either — a pick is a jump to somewhere else,
-   * not a continuation of a gesture, so there is no motion to preserve.
+   * The one place the pane follows something other than a person, and it goes
+   * through the same door every other placement does — see
+   * {@link usePaneScroller}. Nothing else in here touches the scroller.
    */
-  const placePaneInstantly = useRef(false);
-  /**
-   * Where a placement is currently trying to get to, or `null` between them.
-   *
-   * Doubles as the flag that says one is in progress, because those are the same
-   * fact: while the panes are being MOVED, where they are is not an answer to
-   * "which pane did you choose".
-   */
-  const paneTarget = useRef<number | null>(null);
+  const goToPane = panes.goTo;
   useEffect(() => {
-    if (!isPhone) return;
-    const container = paneScrollRef.current;
-    if (!container) return;
-    const instant = placePaneInstantly.current;
-    placePaneInstantly.current = false;
-    const smooth =
-      hasPlacedPane.current && !instant && !skipTransition && !reducedMotion;
-    hasPlacedPane.current = true;
-    const left = pane === "canvas" && open ? container.clientWidth : 0;
-    paneTarget.current = left;
-    container.scrollTo({ left, behavior: smooth ? "smooth" : "auto" });
-    if (smooth) {
-      // An animation is allowed to be somewhere other than its target; it just
-      // must not be READ while it is. See `paneTarget`.
-      const release = setTimeout(() => {
-        paneTarget.current = null;
-      }, PANE_HOLD_MS);
-      return () => clearTimeout(release);
-    }
-    /*
-     * Hold it there.
-     *
-     * A placement is not finished when it is applied. This is a snap container
-     * whose panes change contents as it moves — the fields column fills in as
-     * each schema resolves — and a snap container re-snaps to the area it last
-     * considered current whenever its contents change. So the pane lands, the
-     * layout settles, and it is quietly pulled back to where it came from; the
-     * switch then reads that position, agrees with it, and scrolls the rest of
-     * the way. Two `scrollTo`s later you are exactly where you started, and a
-     * pick looks like it did nothing.
-     *
-     * Re-asserting for a few frames outlasts that without having to know which
-     * layout change caused it, which has proved to be more than one thing.
-     */
-    let frame = 0;
-    const until = Date.now() + PANE_HOLD_MS;
-    const hold = () => {
-      if (container.scrollLeft !== left) container.scrollLeft = left;
-      if (Date.now() < until) {
-        frame = requestAnimationFrame(hold);
-      } else {
-        paneTarget.current = null;
-      }
-    };
-    frame = requestAnimationFrame(hold);
-    return () => {
-      cancelAnimationFrame(frame);
-      paneTarget.current = null;
-    };
-  }, [pane, open, isPhone, skipTransition, reducedMotion]);
-
-  /**
-   * A swipe moves the panes without going through the switch, so the switch
-   * reads the scroll position back rather than assuming it is in charge.
-   *
-   * Read once movement stops, not on every frame: a smooth scroll passes
-   * through the half-way mark on its way, and reacting to that would set the
-   * switch back to where it came from, which sends the scroll back after it.
-   * Waiting for the rest answers the only question worth asking — where did
-   * this end up — and cannot fight an animation still in progress.
-   */
-  const paneSettle = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const onPaneScroll = useCallback(() => {
-    // A placement in progress is not a position anyone chose, and reading it as
-    // one is how a pick ends up back on the canvas: the container bounces off
-    // the target for a frame, the switch believes the bounce, and then moves the
-    // pane to match what it believed. See `paneTarget`.
-    if (paneTarget.current !== null) return;
-    if (paneSettle.current !== null) clearTimeout(paneSettle.current);
-    paneSettle.current = setTimeout(() => {
-      paneSettle.current = null;
-      const container = paneScrollRef.current;
-      if (!container || container.clientWidth === 0) return;
-      const next: WorkspacePane =
-        container.scrollLeft > container.clientWidth / 2 ? "canvas" : "editor";
-      setPane((current) => (current === next ? current : next));
-    }, PANE_SETTLE_MS);
-  }, []);
-  useEffect(
-    () => () => {
-      if (paneSettle.current !== null) clearTimeout(paneSettle.current);
-    },
-    [],
-  );
+    goToPane(open ? "canvas" : "editor");
+  }, [open, goToPane]);
 
   const attachField = useCallback(
     (fieldId: string) => {
@@ -648,26 +544,23 @@ export function PageWorkspace({
    * switched the view left you looking at the page you had just selected on,
    * with the answer on a screen you had to know to swipe to.
    *
-   * The caller acts on the pick itself — it owns navigation — and this is only
-   * the part that is the canvas's: where to look now.
+   * The caller acts on the pick itself — it owns navigation — and only calls
+   * this once that has SUCCEEDED. A pick that could not be turned into a field
+   * to open must not move anything: half a transition, with the fields column
+   * in front of you and the field it was opened for missing from it, is the
+   * state that reads as the canvas being broken.
+   *
+   * The placement lands rather than glides. A pick is a jump to somewhere else,
+   * not the continuation of a gesture, so there is no motion to preserve — and
+   * the frame the click just focused is liable to be scrolled back into view by
+   * the browser, which an animation in flight loses to and a landing does not.
    */
   const onPicked = useCallback(() => {
     if (!isPicking) return;
     onViewChange("fields");
-    if (!isPhone || pane === "editor") return;
-    /*
-     * See `placePaneInstantly`: a glide here is cancelled by the focus the
-     * click just gave the frame.
-     *
-     * Only when the pane is actually MOVING. `setPane` to the pane you are
-     * already on is not a state change, so the effect that consumes this flag
-     * never runs — and the flag would sit there until the next pane change,
-     * whoever made it, and turn that one into a jump with 400ms of held
-     * position. A swipe answered that way feels like the switch fighting back.
-     */
-    placePaneInstantly.current = true;
-    setPane("editor");
-  }, [isPicking, onViewChange, isPhone, pane]);
+    if (!isPhone) return;
+    goToPane("editor", { animate: false });
+  }, [isPicking, onViewChange, isPhone, goToPane]);
 
   /**
    * Whether the page is re-rendering because of an edit.
@@ -944,8 +837,7 @@ export function PageWorkspace({
     return (
       <div className="absolute inset-0 bg-bg-canvas">
         <div
-          ref={paneScrollRef}
-          onScroll={onPaneScroll}
+          ref={panes.ref}
           className={cn(
             "flex h-full snap-x snap-mandatory overflow-x-auto overscroll-x-contain",
             !open && "overflow-x-hidden",
@@ -988,7 +880,7 @@ export function PageWorkspace({
             <span className="ml-auto">
               <PaneToggle
                 pane={pane}
-                onChange={setPane}
+                onChange={goToPane}
                 animate={!reducedMotion}
               />
             </span>
@@ -1105,9 +997,6 @@ function SplitDivider({
     </div>
   );
 }
-
-/** Which half of the workspace a phone is showing. */
-export type WorkspacePane = "editor" | "canvas";
 
 /** Where the thumb sits, in pixels from the inside of the control's border. */
 type SegmentedThumb = { left: number; width: number };

--- a/packages/ui/spa/components/shell/canvas/canvasPick.test.tsx
+++ b/packages/ui/spa/components/shell/canvas/canvasPick.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, render } from "@testing-library/react";
+import { SourcePath } from "@valbuild/core";
+import {
+  VAL_CANVAS_MESSAGE,
+  type ValCanvasPageMessage,
+  type ValCanvasStudioMessage,
+} from "@valbuild/shared/internal";
+import { CanvasFrame } from "./CanvasFrame";
+
+/**
+ * What the studio asks the page for after a pick.
+ *
+ * A pick is followed by a highlight of the field that was picked, and the
+ * highlight used to carry `scrollIntoView: true` unconditionally — including for
+ * the field the person had just put their finger on, which is by definition
+ * already in front of them.
+ *
+ * Asking for it anyway was not merely redundant. The page's scroll does not stop
+ * at the page: `scrollIntoView` inside a same-origin frame walks out of the
+ * frame and scrolls the EMBEDDER's scroll containers too (measured in Chromium).
+ * On a phone the embedder is the pane scroller, so the studio's answer to "I
+ * picked this" was to switch to the fields column and then have the page drag it
+ * back to the canvas — or, since what is being revealed is an element rather
+ * than a pane, to somewhere between the two.
+ *
+ * `ValCanvasBridge` no longer calls `scrollIntoView` at all, and the pane
+ * scroller now corrects anything that moves it. This is the third of the three:
+ * do not ask for a scroll there was never a reason to ask for.
+ */
+describe("a pick on the page", () => {
+  let posted: ValCanvasStudioMessage[];
+  let frame: HTMLIFrameElement;
+
+  const PICKED = '/content/page.val.ts?p="title"' as SourcePath;
+  const ELSEWHERE = '/content/page.val.ts?p="body"' as SourcePath;
+
+  const renderFrame = (highlightedPath: SourcePath | null) => {
+    const rendered = render(
+      <CanvasFrame
+        url="/"
+        width={800}
+        height={600}
+        reloadKey={0}
+        isPicking
+        highlightedPath={highlightedPath}
+        onRequestReload={() => {}}
+      />,
+    );
+    const found = rendered.container.querySelector("iframe");
+    if (found === null) throw new Error("the frame did not render");
+    frame = found;
+    const target = frame.contentWindow;
+    if (target === null) throw new Error("the frame has no content window");
+    posted = [];
+    jest
+      .spyOn(target, "postMessage")
+      .mockImplementation((message: unknown) =>
+        posted.push(message as ValCanvasStudioMessage),
+      );
+    return rendered;
+  };
+
+  /** The page saying an element was clicked. */
+  const click = (path: SourcePath) => {
+    const message: ValCanvasPageMessage = {
+      val: VAL_CANVAS_MESSAGE,
+      type: "clicked",
+      paths: [path],
+    };
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          source: frame.contentWindow,
+          data: message,
+        }),
+      );
+    });
+  };
+
+  /** The last thing the studio asked the page to outline. */
+  const lastHighlight = () =>
+    posted.filter((message) => message.type === "highlight").at(-1);
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("does not ask the page to scroll to the thing that was just clicked", () => {
+    const rendered = renderFrame(null);
+    click(PICKED);
+    // The shell answers a pick by navigating, which comes back here as the
+    // highlighted path.
+    rendered.rerender(
+      <CanvasFrame
+        url="/"
+        width={800}
+        height={600}
+        reloadKey={0}
+        isPicking
+        highlightedPath={PICKED}
+        onRequestReload={() => {}}
+      />,
+    );
+
+    expect(lastHighlight()).toEqual({
+      val: VAL_CANVAS_MESSAGE,
+      type: "highlight",
+      path: PICKED,
+      scrollIntoView: false,
+    });
+  });
+
+  it("still asks for a field opened from anywhere else", () => {
+    // A row in the fields column, a search hit, a validation error: the field is
+    // not necessarily on screen, and finding it on the page is the whole point.
+    const rendered = renderFrame(null);
+    rendered.rerender(
+      <CanvasFrame
+        url="/"
+        width={800}
+        height={600}
+        reloadKey={0}
+        isPicking
+        highlightedPath={ELSEWHERE}
+        onRequestReload={() => {}}
+      />,
+    );
+    expect(lastHighlight()).toEqual({
+      val: VAL_CANVAS_MESSAGE,
+      type: "highlight",
+      path: ELSEWHERE,
+      scrollIntoView: true,
+    });
+  });
+
+  it("asks again once the selection moves off the picked field", () => {
+    const rendered = renderFrame(null);
+    click(PICKED);
+    rendered.rerender(
+      <CanvasFrame
+        url="/"
+        width={800}
+        height={600}
+        reloadKey={0}
+        isPicking
+        highlightedPath={ELSEWHERE}
+        onRequestReload={() => {}}
+      />,
+    );
+
+    expect(lastHighlight()?.scrollIntoView).toBe(true);
+  });
+
+  it("asks again when the picked field is opened from the column later", () => {
+    const rendered = renderFrame(null);
+    const on = (path: SourcePath | null) =>
+      rendered.rerender(
+        <CanvasFrame
+          url="/"
+          width={800}
+          height={600}
+          reloadKey={0}
+          isPicking
+          highlightedPath={path}
+          onRequestReload={() => {}}
+        />,
+      );
+    click(PICKED);
+    on(PICKED);
+    on(ELSEWHERE);
+    // Back to the same field, this time from a row in the fields column. The
+    // finger is nowhere near it now, and where it is on the page is exactly what
+    // is being asked.
+    on(PICKED);
+
+    expect(lastHighlight()?.scrollIntoView).toBe(true);
+  });
+});

--- a/packages/ui/spa/components/shell/canvas/paneScroller.test.tsx
+++ b/packages/ui/spa/components/shell/canvas/paneScroller.test.tsx
@@ -54,6 +54,8 @@ describe("the phone's pane scroller", () => {
     foreignScrollTo(left: number): void;
     /** A finger, and where it left the scroller. */
     swipeTo(left: number): void;
+    /** A finger down and up again, having moved nothing. */
+    tap(): void;
     /** Let everything that was going to settle, settle. */
     settle(): void;
   };
@@ -112,6 +114,12 @@ describe("the phone's pane scroller", () => {
         act(() => {
           element.dispatchEvent(new Event("touchstart"));
           element.scrollLeft = left;
+          element.dispatchEvent(new Event("touchend"));
+        });
+      },
+      tap: () => {
+        act(() => {
+          element.dispatchEvent(new Event("touchstart"));
           element.dispatchEvent(new Event("touchend"));
         });
       },
@@ -182,14 +190,17 @@ describe("the phone's pane scroller", () => {
     panes.goTo("editor");
     panes.settle();
 
-    // A tap on the canvas pane is a `touchstart` and a `touchend` with no
-    // scroll between them. What follows is the browser revealing the frame the
-    // tap focused — which must not be read as the tap having chosen a pane.
-    act(() => {
-      const el = document.querySelector("[data-testid=scroller]");
-      el?.dispatchEvent(new Event("touchstart"));
-      el?.dispatchEvent(new Event("touchend"));
-    });
+    /*
+     * A tap on the canvas pane is a `touchstart` and a `touchend` with no
+     * scroll between them. What follows is the browser revealing the frame the
+     * tap focused — which must not be read as the tap having chosen a pane.
+     *
+     * Through the harness rather than a fresh `document.querySelector`: the
+     * query would have to be null-checked, and a `?.` that skipped the dispatch
+     * would leave this test asserting that nothing happens when nothing is
+     * done.
+     */
+    panes.tap();
     panes.settle();
     panes.foreignScrollTo(PANE_WIDTH);
     panes.settle();

--- a/packages/ui/spa/components/shell/canvas/paneScroller.test.tsx
+++ b/packages/ui/spa/components/shell/canvas/paneScroller.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, render } from "@testing-library/react";
+import { usePaneScroller } from "./usePaneScroller";
+
+/**
+ * The phone's panes, and the one thing that must always be true of them.
+ *
+ * The bug these are about is not a wrong pane — it is NO pane: the scroller
+ * resting between the two, showing half the editor and half the canvas, with
+ * nothing in the studio able to recover from it. Selecting a different page did
+ * not fix it, because nothing re-asserted the position; only closing the canvas
+ * did, because that removed the pane it was half way to.
+ *
+ * It got there because the canvas pane holds an iframe on the customer's site,
+ * and a browser scrolls an ancestor scroll container for reasons of its own: to
+ * reveal a frame that has just been focused by a click, and — measured, in
+ * Chromium — because `scrollIntoView` inside a same-origin frame walks out of
+ * the frame and scrolls the embedder's containers too. Those reveal an ELEMENT,
+ * not a pane, so where they leave the scroller is arbitrary.
+ *
+ * So these tests do not check that any particular cause is handled. They check
+ * the invariant: whenever the panes come to rest, they are on a pane.
+ */
+describe("the phone's pane scroller", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    // jsdom has no layout, so nothing here ever resizes. The hook only uses the
+    // observer to re-place the panes when the pane WIDTH changes, which these
+    // tests hold fixed.
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  });
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  const PANE_WIDTH = 390;
+
+  /** Everything a test can do to the panes, and everything it can read. */
+  type Panes = {
+    /** Where the scroller is, as the browser would report it. */
+    at(): number;
+    /** Which pane the switch says. */
+    pane(): string;
+    /** The studio asking for a pane, as the switch and a pick both do. */
+    goTo(pane: "editor" | "canvas"): void;
+    /** Something other than the studio moving the scroller. */
+    foreignScrollTo(left: number): void;
+    /** A finger, and where it left the scroller. */
+    swipeTo(left: number): void;
+    /** Let everything that was going to settle, settle. */
+    settle(): void;
+  };
+
+  function mount(paneCount = 2): Panes {
+    let pane = "editor";
+    let goTo: (next: "editor" | "canvas") => void = () => undefined;
+    let scrollLeft = 0;
+    let element: HTMLDivElement | null = null;
+
+    function Harness() {
+      const panes = usePaneScroller({
+        enabled: true,
+        paneCount,
+        // The glide is not what is under test, and a jsdom `scrollTo` lands
+        // instantly either way.
+        animate: false,
+      });
+      pane = panes.pane;
+      goTo = panes.goTo;
+      return <div ref={panes.ref} data-testid="scroller" />;
+    }
+
+    const rendered = render(<Harness />);
+    element = rendered.getByTestId("scroller") as HTMLDivElement;
+    /*
+     * jsdom has no layout and no scrolling, so the scroller is given both.
+     *
+     * Writing `scrollLeft` fires a `scroll` event, which is the one piece of
+     * browser behaviour this hook is built on: it is how it learns that
+     * something moved the panes, whoever that something was.
+     */
+    Object.defineProperty(element, "clientWidth", {
+      value: PANE_WIDTH,
+      configurable: true,
+    });
+    Object.defineProperty(element, "scrollLeft", {
+      configurable: true,
+      get: () => scrollLeft,
+      set: (next: number) => {
+        scrollLeft = next;
+        element?.dispatchEvent(new Event("scroll"));
+      },
+    });
+    element.scrollTo = ((options: ScrollToOptions) => {
+      if (typeof options?.left === "number") element.scrollLeft = options.left;
+    }) as HTMLElement["scrollTo"];
+
+    const settle = () => act(() => void jest.runOnlyPendingTimers());
+    return {
+      at: () => scrollLeft,
+      pane: () => pane,
+      goTo: (next) => act(() => goTo(next)),
+      foreignScrollTo: (left) => act(() => void (element.scrollLeft = left)),
+      swipeTo: (left) => {
+        act(() => {
+          element.dispatchEvent(new Event("touchstart"));
+          element.scrollLeft = left;
+          element.dispatchEvent(new Event("touchend"));
+        });
+      },
+      settle,
+    };
+  }
+
+  it("puts a scroller that came to rest between the panes back on one", () => {
+    const panes = mount();
+    panes.goTo("canvas");
+    panes.settle();
+    panes.goTo("editor");
+    panes.settle();
+    expect(panes.at()).toBe(0);
+
+    // The shape of every cause: something revealed an element inside the canvas
+    // pane, and the scroller stopped part of the way there.
+    panes.foreignScrollTo(PANE_WIDTH * 0.4);
+    panes.settle();
+
+    expect(panes.at()).toBe(0);
+    expect(panes.pane()).toBe("editor");
+  });
+
+  it("undoes a foreign scroll that landed exactly on the other pane", () => {
+    const panes = mount();
+    panes.goTo("editor");
+    panes.settle();
+
+    // The browser revealing the newly focused frame is a scroll all the way to
+    // the canvas pane, and reads as a perfectly ordinary pane change. It is not
+    // one: nobody asked for it.
+    panes.foreignScrollTo(PANE_WIDTH);
+    panes.settle();
+
+    expect(panes.at()).toBe(0);
+    expect(panes.pane()).toBe("editor");
+  });
+
+  it("keeps correcting, however long after the move", () => {
+    const panes = mount();
+    panes.goTo("editor");
+    panes.settle();
+
+    // The version this replaces held the position for 400ms and then let go, so
+    // anything slow enough — a phone busy mounting a column of fields — won.
+    act(() => void jest.advanceTimersByTime(60_000));
+    panes.foreignScrollTo(PANE_WIDTH * 0.6);
+    panes.settle();
+
+    expect(panes.at()).toBe(0);
+  });
+
+  it("adopts the pane a swipe ended on", () => {
+    const panes = mount();
+
+    panes.swipeTo(PANE_WIDTH * 0.8);
+    panes.settle();
+
+    expect(panes.pane()).toBe("canvas");
+    // And exactly on it: a swipe that stopped short is still a swipe to the
+    // canvas, and half a pane is not a place to be left.
+    expect(panes.at()).toBe(PANE_WIDTH);
+  });
+
+  it("does not adopt a foreign scroll that follows a tap", () => {
+    const panes = mount();
+    panes.goTo("editor");
+    panes.settle();
+
+    // A tap on the canvas pane is a `touchstart` and a `touchend` with no
+    // scroll between them. What follows is the browser revealing the frame the
+    // tap focused — which must not be read as the tap having chosen a pane.
+    act(() => {
+      const el = document.querySelector("[data-testid=scroller]");
+      el?.dispatchEvent(new Event("touchstart"));
+      el?.dispatchEvent(new Event("touchend"));
+    });
+    panes.settle();
+    panes.foreignScrollTo(PANE_WIDTH);
+    panes.settle();
+
+    expect(panes.pane()).toBe("editor");
+    expect(panes.at()).toBe(0);
+  });
+
+  it("has nowhere but the editor to be when the canvas is closed", () => {
+    const panes = mount(1);
+
+    panes.foreignScrollTo(PANE_WIDTH);
+    panes.settle();
+
+    expect(panes.pane()).toBe("editor");
+    expect(panes.at()).toBe(0);
+  });
+});

--- a/packages/ui/spa/components/shell/canvas/usePaneScroller.ts
+++ b/packages/ui/spa/components/shell/canvas/usePaneScroller.ts
@@ -1,0 +1,350 @@
+import { RefObject, useCallback, useEffect, useRef, useState } from "react";
+
+/** Which half of the workspace a phone is showing. */
+export type WorkspacePane = "editor" | "canvas";
+
+/**
+ * How long the panes have to be still before their position means anything.
+ *
+ * A scroll — anybody's — is a stream of events, and the only one worth reading
+ * is the last. Short enough that a correction is never seen as a second
+ * animation, long enough to sit out a momentum flick's tail.
+ */
+const SETTLE_MS = 120;
+
+/**
+ * How far off a pane boundary counts as being on it.
+ *
+ * Not zero: a scroll offset is a fraction on a device with a fractional pixel
+ * ratio, and rubber-banding on iOS leaves one behind on purpose. An exact
+ * comparison would find a deviation on every scroll and correct a container
+ * that is already exactly where it should be, forever.
+ */
+const ON_PANE_PX = 1;
+
+export type PaneScroller = {
+  /** Goes on the element that scrolls between the panes. */
+  ref: RefObject<HTMLDivElement | null>;
+  /** Which pane is current. */
+  pane: WorkspacePane;
+  /**
+   * Show a pane, and keep showing it.
+   *
+   * `animate` is about this placement only; the invariant is the same either
+   * way. Left out, a placement glides once one has already been made — the
+   * first one is where the panes START, and nothing should be seen sliding
+   * into a position it was always in.
+   */
+  goTo: (pane: WorkspacePane, options?: { animate?: boolean }) => void;
+};
+
+/**
+ * The phone's two panes, and the one rule that keeps them whole.
+ *
+ * ## The rule
+ *
+ * **Whenever the panes have been still for {@link SETTLE_MS}, the scroller is
+ * exactly on a pane** — the one the person swiped to if they were swiping, and
+ * otherwise the one {@link PaneScroller.goTo} last asked for. There is no third
+ * outcome, and no window of time in which there is.
+ *
+ * That is the whole hook, and it is stated as an invariant rather than as a
+ * sequence of steps on purpose: the failure it exists to prevent is not one bug
+ * but a shape of bug, and the shape is always the same — something other than
+ * this component moves the scroller, and nothing puts it back.
+ *
+ * ## What moves it
+ *
+ * The canvas pane holds an iframe on the customer's site, and a browser scrolls
+ * a scroll container for reasons that have nothing to do with whoever wrote it:
+ *
+ * - Focusing an element scrolls every ancestor scroller to reveal it, and
+ *   clicking inside an iframe focuses the iframe.
+ * - `scrollIntoView` **inside a same-origin frame walks out of the frame** and
+ *   scrolls the embedder's scrollers too. Measured, not assumed: with the panes
+ *   placed on the editor, one `scrollIntoView` in the framed page pulls them
+ *   back onto the canvas. (`ValCanvasBridge` no longer calls it — see there —
+ *   but that fix lives in a different package, shipped separately, and this one
+ *   must hold against an older page.)
+ * - A scroll-snap container re-snaps to the area it last considered current
+ *   whenever its contents change, and the editor pane's contents change
+ *   constantly as fields resolve.
+ * - `scrollTo` from the browser's own UI: find-in-page, an anchor, a
+ *   restoration on rotate.
+ *
+ * The version of this that held the position for 400ms after each placement
+ * covered the first three when they were quick and none of them when they were
+ * not — and what it left behind when it lost was a scroller resting BETWEEN the
+ * panes, showing half of each. Nothing recovered from that: the switch reads
+ * the position back, agreed with the half it was nearest, found the state it
+ * already had, and changed nothing. The panes then stayed split until the
+ * canvas was closed, through any number of navigations.
+ *
+ * So: no window, no deadline, no counting of the ways it can be moved. It is
+ * put back every time it comes to rest anywhere else.
+ *
+ * ## Why the pane lives here
+ *
+ * Because it and the scroll position are the same fact, and the split version
+ * of that fact is exactly what got stuck: the state said "editor", the
+ * scroller said "somewhere between", and each was consistent with itself.
+ *
+ * ## What it does not try to do
+ *
+ * Tell a swipe from a browser scroll that happens to coincide with a finger
+ * being down somewhere on the panes. Nothing distinguishes them, and it does
+ * not matter: both branches of the rule end with the scroller exactly on a
+ * pane, so the worst such a coincidence can produce is the wrong pane — which
+ * one swipe undoes — rather than no pane, which nothing undid.
+ */
+export function usePaneScroller({
+  enabled,
+  paneCount,
+  animate,
+}: {
+  /** Off where there are no panes to scroll — every layout but the phone. */
+  enabled: boolean;
+  /** How many panes exist. One while the canvas is closed. */
+  paneCount: number;
+  /** Whether a placement may glide. Off for reduced motion and for tests. */
+  animate: boolean;
+}): PaneScroller {
+  const ref = useRef<HTMLDivElement>(null);
+  const [pane, setPane] = useState<WorkspacePane>("editor");
+
+  /**
+   * The current pane, readable from a listener.
+   *
+   * Written next to every `setPane` rather than in an effect: the settle below
+   * runs on a timer and must see the pane that has been ASKED for, not the one
+   * the last render happened to commit.
+   */
+  const paneRef = useRef(pane);
+  const paneCountRef = useRef(paneCount);
+  paneCountRef.current = paneCount;
+  const animateRef = useRef(animate);
+  animateRef.current = animate;
+
+  /**
+   * Whether the person is moving the panes themselves.
+   *
+   * The one thing that makes the scroller's position an ANSWER rather than a
+   * deviation, so it is set as narrowly as it can be: a pointer has to be down
+   * ON the scroller AND the scroller has to actually move while it is. A tap
+   * scrolls nothing, and neither does a click on a field in the editor column —
+   * so neither leaves the scroller willing to adopt whatever moves it next,
+   * which is the whole failure this hook exists to prevent.
+   */
+  const userDriven = useRef(false);
+  /** Whether a pointer is down on the scroller. See {@link userDriven}. */
+  const pointerDown = useRef(false);
+  /** Whether a pane has ever been placed. See {@link PaneScroller.goTo}. */
+  const hasPlaced = useRef(false);
+  const settleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const offsetOf = useCallback(
+    (container: HTMLElement, target: WorkspacePane) =>
+      target === "canvas" && paneCountRef.current > 1
+        ? container.clientWidth
+        : 0,
+    [],
+  );
+
+  /**
+   * Which pane the scroller is nearest.
+   *
+   * Rounded rather than compared against the half-way mark, so it says the same
+   * thing for two panes as it would for five — and so a scroller resting a
+   * third of the way across resolves to a pane rather than to an argument.
+   */
+  const nearestPane = useCallback((container: HTMLElement): WorkspacePane => {
+    if (paneCountRef.current < 2 || container.clientWidth === 0)
+      return "editor";
+    return Math.round(container.scrollLeft / container.clientWidth) >= 1
+      ? "canvas"
+      : "editor";
+  }, []);
+
+  /** Put the scroller exactly on `target`. */
+  const place = useCallback(
+    (target: WorkspacePane, smooth: boolean) => {
+      const container = ref.current;
+      if (container === null || container.clientWidth === 0) return;
+      const left = offsetOf(container, target);
+      if (smooth) {
+        container.scrollTo({ left, behavior: "smooth" });
+        return;
+      }
+      container.scrollTo({ left, behavior: "auto" });
+      // Asserted as well as asked for: a snap container mid-gesture can decline
+      // a `scrollTo`, and this one has to land.
+      if (Math.abs(container.scrollLeft - left) > ON_PANE_PX) {
+        container.scrollLeft = left;
+      }
+    },
+    [offsetOf],
+  );
+
+  /**
+   * The invariant, applied.
+   *
+   * Runs when the panes have been still for {@link SETTLE_MS}, and is the only
+   * thing that ever changes the pane in response to a position.
+   */
+  const settle = useCallback(() => {
+    settleTimer.current = null;
+    const container = ref.current;
+    // Nothing to hold in place, and no size to hold it at. The observer below
+    // brings it back the moment there is one.
+    if (container === null || container.clientWidth === 0) return;
+    const wasUserDriven = userDriven.current;
+    userDriven.current = false;
+    const target = wasUserDriven ? nearestPane(container) : paneRef.current;
+    if (target !== paneRef.current) {
+      paneRef.current = target;
+      setPane(target);
+    }
+    const left = offsetOf(container, target);
+    if (Math.abs(container.scrollLeft - left) > ON_PANE_PX) {
+      // Never smooth: this is a correction, not a move. Something else already
+      // put the scroller somewhere it should not be, and animating back from
+      // there draws attention to a position nobody chose.
+      container.scrollLeft = left;
+    }
+  }, [nearestPane, offsetOf]);
+
+  const armSettle = useCallback(() => {
+    if (settleTimer.current !== null) clearTimeout(settleTimer.current);
+    settleTimer.current = setTimeout(settle, SETTLE_MS);
+  }, [settle]);
+
+  const goTo = useCallback<PaneScroller["goTo"]>(
+    (target, options) => {
+      const smooth =
+        options?.animate ?? (animateRef.current && hasPlaced.current);
+      hasPlaced.current = true;
+      // A placement is this component speaking, so whatever gesture the
+      // scroller thought it was in the middle of is over.
+      userDriven.current = false;
+      pointerDown.current = false;
+      if (target !== paneRef.current) {
+        paneRef.current = target;
+        setPane(target);
+      }
+      place(target, smooth);
+      // Even a placement that moved nothing arms the settle: it is what proves
+      // the scroller ended up where it was told, and a `scrollTo` that the
+      // browser quietly declined produces no scroll event to notice.
+      armSettle();
+    },
+    [place, armSettle],
+  );
+
+  /**
+   * Every scroll re-arms the settle, and nothing else reads the position.
+   *
+   * Deliberately indifferent to who scrolled and why. A gesture, a momentum
+   * tail, a glide of our own, a browser revealing a focused frame — they all
+   * produce the same stream of events, and the only question worth asking is
+   * what the position is once they stop.
+   */
+  useEffect(() => {
+    if (!enabled) return;
+    const container = ref.current;
+    if (container === null) return;
+    /**
+     * A scroll while a finger is down is the person moving the panes.
+     *
+     * The two halves have to be taken separately. A pointer alone is not a
+     * choice — most of them are taps and clicks on things inside the panes — and
+     * a scroll alone is not one either, since that is exactly what the browser
+     * does when it reveals a focused frame. Together they are.
+     */
+    const onScroll = () => {
+      if (pointerDown.current) userDriven.current = true;
+      armSettle();
+    };
+    const onPointerDown = () => {
+      pointerDown.current = true;
+    };
+    /**
+     * And the end of one, whether or not anything moved.
+     *
+     * A settle is armed here as well because a tap produces no scroll at all,
+     * and the flag it leaves down has to be cleared by something.
+     */
+    const onPointerUp = () => {
+      pointerDown.current = false;
+      armSettle();
+    };
+    // A wheel IS the gesture, with no pointer to be down: a trackpad swipe
+    // across the panes arrives as nothing else.
+    const onWheel = (event: WheelEvent) => {
+      if (event.deltaX !== 0) userDriven.current = true;
+    };
+    container.addEventListener("scroll", onScroll, { passive: true });
+    container.addEventListener("touchstart", onPointerDown, { passive: true });
+    container.addEventListener("touchend", onPointerUp, { passive: true });
+    container.addEventListener("touchcancel", onPointerUp, { passive: true });
+    container.addEventListener("pointerdown", onPointerDown);
+    container.addEventListener("pointerup", onPointerUp);
+    container.addEventListener("pointercancel", onPointerUp);
+    container.addEventListener("wheel", onWheel, { passive: true });
+    return () => {
+      container.removeEventListener("scroll", onScroll);
+      container.removeEventListener("touchstart", onPointerDown);
+      container.removeEventListener("touchend", onPointerUp);
+      container.removeEventListener("touchcancel", onPointerUp);
+      container.removeEventListener("pointerdown", onPointerDown);
+      container.removeEventListener("pointerup", onPointerUp);
+      container.removeEventListener("pointercancel", onPointerUp);
+      container.removeEventListener("wheel", onWheel);
+    };
+  }, [enabled, armSettle]);
+
+  /**
+   * A pane offset is a width, so a resize moves it.
+   *
+   * Rotating a phone changes `clientWidth` and leaves the scroller on the old
+   * pane's old offset, which is the same split view by another route. Also
+   * covers the first size the container ever has: on mount it is measured at
+   * zero, where there is nothing to place.
+   */
+  useEffect(() => {
+    if (!enabled) return;
+    const container = ref.current;
+    if (container === null) return;
+    const observer = new ResizeObserver(() => place(paneRef.current, false));
+    observer.observe(container);
+    place(paneRef.current, false);
+    return () => observer.disconnect();
+  }, [enabled, place]);
+
+  /**
+   * The canvas closing takes its pane with it.
+   *
+   * Not merely a placement: with one pane there is no canvas to be on, so the
+   * pane the switch reports has to come back too.
+   */
+  useEffect(() => {
+    if (!enabled) return;
+    if (paneCount > 1) {
+      place(paneRef.current, false);
+      return;
+    }
+    if (paneRef.current !== "editor") {
+      paneRef.current = "editor";
+      setPane("editor");
+    }
+    place("editor", false);
+  }, [enabled, paneCount, place]);
+
+  useEffect(
+    () => () => {
+      if (settleTimer.current !== null) clearTimeout(settleTimer.current);
+    },
+    [],
+  );
+
+  return { ref, pane, goTo };
+}

--- a/packages/ui/spa/components/shell/canvasPageScope.test.ts
+++ b/packages/ui/spa/components/shell/canvasPageScope.test.ts
@@ -1,0 +1,113 @@
+import { ModuleFilePath, SourcePath } from "@valbuild/core";
+import {
+  canvasModulesFromKey,
+  canvasModulesKey,
+  canvasShowsEditedContent,
+} from "./canvasPageScope";
+
+/**
+ * When the canvas closes itself.
+ *
+ * The rule it replaces was "the selection is a page, or the canvas closes", and
+ * the case it got wrong is the one the canvas exists for: clicking an element on
+ * the page it is showing. Most content on a real page lives outside the page's
+ * own route module, so picking a footer or an author's name resolved to a data
+ * module — not a page — and shut the canvas. On a phone that is the whole
+ * workspace rearranging itself in answer to a tap on some text, which is what
+ * "it opens a broken page" looks like from the outside.
+ */
+describe("whether the canvas is still showing what is being edited", () => {
+  const PAGE = "/app/page.val.ts" as ModuleFilePath;
+  const AUTHORS = "/content/authors.val.ts" as ModuleFilePath;
+  const SETTINGS = "/content/settings.val.ts" as ModuleFilePath;
+  const onPage = canvasModulesFromKey(
+    canvasModulesKey([
+      `${PAGE}?p="/"."hero"."title"` as SourcePath,
+      `${PAGE}?p="/"."text"` as SourcePath,
+      `${AUTHORS}?p="freekh"."name"` as SourcePath,
+    ]),
+  );
+
+  test("a page selection always keeps it", () => {
+    expect(
+      canvasShowsEditedContent({
+        selectionKind: "page",
+        editedPath: `${PAGE}?p="/"` as SourcePath,
+        canvasModules: onPage,
+      }),
+    ).toBe(true);
+  });
+
+  test("keeps it for a module the page reported content from", () => {
+    // The regression: an author's name is on the page, and the navigation files
+    // its module under Data.
+    expect(
+      canvasShowsEditedContent({
+        selectionKind: "data",
+        editedPath: `${AUTHORS}?p="freekh"."name"` as SourcePath,
+        canvasModules: onPage,
+      }),
+    ).toBe(true);
+  });
+
+  test("keeps it for a module with no row in the navigation at all", () => {
+    expect(
+      canvasShowsEditedContent({
+        selectionKind: null,
+        editedPath: `${AUTHORS}?p="freekh"` as SourcePath,
+        canvasModules: onPage,
+      }),
+    ).toBe(true);
+  });
+
+  test("closes it for a module that is not on the page", () => {
+    expect(
+      canvasShowsEditedContent({
+        selectionKind: "data",
+        editedPath: `${SETTINGS}?p="siteName"` as SourcePath,
+        canvasModules: onPage,
+      }),
+    ).toBe(false);
+  });
+
+  test("closes it where the route names nothing", () => {
+    // The compare and errors views, and the empty state.
+    expect(
+      canvasShowsEditedContent({
+        selectionKind: null,
+        editedPath: null,
+        canvasModules: onPage,
+      }),
+    ).toBe(false);
+  });
+
+  test("closes it while the page has reported nothing yet", () => {
+    expect(
+      canvasShowsEditedContent({
+        selectionKind: "media",
+        editedPath: `${AUTHORS}?p="freekh"` as SourcePath,
+        canvasModules: canvasModulesFromKey(canvasModulesKey(undefined)),
+      }),
+    ).toBe(false);
+  });
+
+  /**
+   * The key is what everything downstream is keyed on, so equal page contents
+   * must produce an equal key — the page re-reports its elements whenever
+   * anything on it moves, several times a second while it is being scrolled.
+   */
+  test("is the same key for the same modules, whatever the paths", () => {
+    expect(
+      canvasModulesKey([
+        `${AUTHORS}?p="a"` as SourcePath,
+        `${PAGE}?p="/"."b"` as SourcePath,
+      ]),
+    ).toBe(
+      canvasModulesKey([
+        `${PAGE}?p="/"."c"` as SourcePath,
+        `${AUTHORS}?p="d"` as SourcePath,
+        `${PAGE}?p="/"."b"` as SourcePath,
+      ]),
+    );
+  });
+});

--- a/packages/ui/spa/components/shell/canvasPageScope.ts
+++ b/packages/ui/spa/components/shell/canvasPageScope.ts
@@ -1,0 +1,71 @@
+import { Internal, ModuleFilePath, SourcePath } from "@valbuild/core";
+import { ShellSelection } from "./Shell";
+
+/**
+ * Whether the canvas is still showing the thing being edited.
+ *
+ * The canvas closes itself when the editor moves somewhere the page on it has
+ * nothing to do with: a canvas showing a page you are no longer editing is
+ * merely stale in the normal view, and in the fields view it is worse than that
+ * — the editor column IS the page's fields, so the module you navigated to does
+ * not appear at all and the navigation looks like it did nothing.
+ *
+ * ## "On the page" is not the same as "is a page"
+ *
+ * This used to be `selection.kind === "page"` and nothing else, which closed the
+ * canvas on the one navigation that most obviously belongs to it: clicking an
+ * element on the page it is showing. Most content on a real page lives outside
+ * its route module — a footer, a settings record, an author — so picking any of
+ * those resolved to a data module, which is not a page, which shut the canvas
+ * and dropped you into a module editor. On a phone that is the entire workspace
+ * rearranging itself in answer to a tap on some text.
+ *
+ * So the question is whether the editor is on content the CANVAS PAGE ITSELF
+ * reported, which is exactly what its reported paths are a list of. Derived
+ * rather than flagged: there is no "this navigation came from the canvas" bit to
+ * set and forget, and a deep link into the footer while the canvas happens to be
+ * showing a page that contains it is the same situation by a different route.
+ */
+export function canvasShowsEditedContent({
+  selectionKind,
+  editedPath,
+  canvasModules,
+}: {
+  /** What the navigation resolved the route to, or `null` for no row. */
+  selectionKind: ShellSelection["kind"] | null;
+  /** The path the editor is on, or `null` when the route names none. */
+  editedPath: SourcePath | null;
+  /** The modules the page on the canvas reported content from. */
+  canvasModules: ReadonlySet<ModuleFilePath>;
+}): boolean {
+  if (selectionKind === "page") return true;
+  if (editedPath === null) return false;
+  const [moduleFilePath] =
+    Internal.splitModuleFilePathAndModulePath(editedPath);
+  return canvasModules.has(moduleFilePath);
+}
+
+/**
+ * The modules a page's reported paths belong to, as a stable key.
+ *
+ * A sorted string rather than the set itself, and that is load-bearing: the page
+ * re-reports its elements whenever anything on it moves, so the path list is a
+ * fresh array several times a second while the canvas is being scrolled. Keyed
+ * on the array, everything downstream recomputes constantly and an effect that
+ * depends on it runs constantly; keyed on what it MEANS, it changes when the
+ * answer changes.
+ */
+export function canvasModulesKey(
+  paths: readonly SourcePath[] | undefined,
+): string {
+  const modules = new Set<string>();
+  for (const path of paths ?? []) {
+    modules.add(Internal.splitModuleFilePathAndModulePath(path)[0]);
+  }
+  return Array.from(modules).sort().join("\n");
+}
+
+/** The set {@link canvasModulesKey} stands for. */
+export function canvasModulesFromKey(key: string): ReadonlySet<ModuleFilePath> {
+  return new Set(key === "" ? [] : (key.split("\n") as ModuleFilePath[]));
+}


### PR DESCRIPTION
## Summary

Fixes a critical bug where tapping a field on the mobile canvas would leave the workspace resting between the editor and canvas panes, showing half of each. The fix involves three coordinated changes across the page, studio, and pane scroller.

## Key Changes

### 1. New Pane Scroller Hook (`usePaneScroller`)
- Introduces `usePaneScroller` hook that enforces an invariant: **whenever the panes come to rest, they are exactly on a pane**
- Replaces ad-hoc pane positioning logic in `PageWorkspace` with a single source of truth that owns both the pane state and scroll position
- Uses a settle timer (120ms) to detect when scrolling has stopped, then corrects any off-pane positions
- Distinguishes between user-driven swipes (adopts nearest pane) and programmatic placements (goes to requested pane)
- Handles edge cases like snap containers, fractional pixels, and rubber-banding on iOS

### 2. Page Scroll Containment (`ValCanvasBridge`)
- Replaces `Element.scrollIntoView()` with new `scrollWithinPage()` function that scrolls only within the page document
- Prevents `scrollIntoView` from walking out of the same-origin iframe and scrolling the studio's containers
- Measured in Chromium: a single `scrollIntoView` in the framed page was pulling the panes back to canvas mid-transition
- New function scrolls each scrollport minimally (except document which centers vertically) and stops at document boundary

### 3. Smart Canvas Closure (`canvasPageScope`)
- Adds `canvasShowsEditedContent()` to determine if canvas should close based on what content is being edited
- Replaces simple "selection is a page" check with "is the edited content on the page the canvas is showing"
- Fixes regression where picking a footer or author (data module) would close canvas even though that content was on the page
- Canvas now only closes when editing something genuinely unrelated to the displayed page

### 4. Pick Error Reporting
- Adds `resolveNavPath()` that returns detailed resolution status instead of just `null`
- Distinguishes between: schemas not loaded, module not loaded, and unresolvable paths
- Allows `openPickedPath()` to report why a pick failed instead of silently doing nothing
- Prevents workspace rearrangement when a pick cannot be opened

### 5. Highlight Optimization (`CanvasFrame`)
- Tracks the most recently picked path to suppress unnecessary scroll requests
- Avoids asking page to scroll to a field the user's finger is still on
- Reduces redundant scroll operations that could interfere with pane positioning

## Implementation Details

- **Invariant-based design**: The pane scroller is stated as an invariant rather than a sequence of steps, making it resilient to any code that moves the scroller
- **No window, no deadline**: Unlike previous 400ms hold approach, the scroller corrects itself whenever it comes to rest anywhere else
- **Comprehensive test coverage**: Added tests for pane scroller behavior, canvas picks, and navigation resolution
- **E2E validation**: Added mobile canvas pick test that verifies the fields column lands whole on screen after a pick

The three changes are independent but compound: the page no longer scrolls the studio, the studio no longer asks it to for picked fields, and the pane scroller corrects anything that moves it anyway.

https://claude.ai/code/session_01NaxL7oZaViaLfsmRjHxyWd