### PR TITLE
Add explicit .render({ as: "inline" }) to every field, plus a dense sortable-list prototype

### DIFF
--- a/.changeset/inline-render.md
+++ b/.changeset/inline-render.md
@@ -4,7 +4,33 @@
 "@valbuild/ui": minor
 ---
 
-Explicit inline rendering: `.render({ as: "inline" })` on every field
+Explicit inline rendering (`.render({ as: "inline" })`) and item-level `.preview(...)` on every field
+
+**`.preview(...)` moved from containers to the value being previewed.** Every
+schema now has `.preview(({ val }) => ({ title, subtitle?, image? }))`, and an
+array/record reifies its rows by running each ITEM's closure:
+
+```ts
+const author = s
+  .object({ name: s.string() })
+  .preview(({ val }) => ({ title: val.name }));
+const authors = s.array(author);
+```
+
+A tagged union without a preview of its own dispatches to the variant the
+value takes, so blocks in a page-builder list preview per block type. `render`
+and `preview` never intersect: `render` is how the FIELD is laid out when you
+are looking at it, `preview` is how the VALUE shows wherever a preview is
+needed (list rows, keyOf dropdowns, search, references) — see
+`architecture/render-and-preview.md`. A second `.render(...)` (or
+`.preview(...)`) on the same schema replaces the first.
+
+**Breaking (preview):** a `.preview` on `s.array(...)`/`s.record(...)` now
+describes the container ITSELF as a value (for when it is someone else's
+item), not its rows — move the closure onto the item schema. The record
+closure no longer receives `key` (derive the title from `val`). A null entry
+is skipped rather than passed to the closure. `.jsonValues()` must come before
+`.preview(...)`, like `.validate(...)`.
 
 Every schema now has a `.render({ as: "inline" })` method. When the item of an
 array or record carries it, the Studio edits that item IN PLACE inside the

--- a/.changeset/inline-render.md
+++ b/.changeset/inline-render.md
@@ -1,0 +1,39 @@
+---
+"@valbuild/core": minor
+"@valbuild/shared": minor
+"@valbuild/ui": minor
+---
+
+Explicit inline rendering: `.render({ as: "inline" })` on every field
+
+Every schema now has a `.render({ as: "inline" })` method. When the item of an
+array or record carries it, the Studio edits that item IN PLACE inside the
+(sortable) list row instead of showing a clickable preview row that navigates
+to it — which is what a page builder is made of:
+
+```ts
+s.array(
+  s.object({ title: s.string(), body: s.richtext() }).render({ as: "inline" }),
+);
+```
+
+Like the existing string renders (`textarea`, `code`), it is static
+configuration carried whole in the serialized schema, and it survives
+serialize → deserialize and chaining (`nullable`, `readonly`, `hidden`,
+`describe`, `validate`).
+
+**Breaking (behavior):** strings in arrays are no longer inlined implicitly.
+`s.array(s.string())` now renders preview rows and its items become navigation
+stops, like every other item type; add `.render({ as: "inline" })` to the
+string schema to get the old editing-in-the-list behavior back. The nav-stop
+rule (`getNavPath`), the add-button's "navigate into new item" rule, and the
+sortable list row all key on the new flag instead of `item.type === "string"`.
+
+An inlined `s.keyOf(...)` also renders the CONTENT of the referenced entry
+below the key selector (the shared entry itself — edits go to the referenced
+module).
+
+Also adds a Storybook-only prototype of a denser sortable list
+(`BlockList`, working name) aimed at page-builder trees: three nested list
+levels on one laptop screen, rows collapse, nested rows share their parent's
+left border. Not wired into `ArrayFields` yet.

--- a/.changeset/inline-render.md
+++ b/.changeset/inline-render.md
@@ -59,6 +59,15 @@ An inlined `s.keyOf(...)` also renders the CONTENT of the referenced entry
 below the key selector (the shared entry itself — edits go to the referenced
 module).
 
+A value that HAS a preview now looks unlike one that does not. `ListPreviewItem`
+is a compact media row — thumbnail left, title and subtitle stacked beside it,
+one line each, truncated rather than wrapped — laid out for the shape the
+preview told us the row has, instead of the generic per-type fallback. Rows are
+roughly 56px instead of ~96px, which is what puts several list levels on one
+laptop screen. `PreviewItem.image` now distinguishes `null` (the preview
+declares an image this value does not have — the column stays, so rows in a
+list stay aligned) from `undefined` (no image declared — no column).
+
 Also adds a Storybook-only prototype of a denser sortable list
 (`BlockList`, working name) aimed at page-builder trees: three nested list
 levels on one laptop screen, rows collapse, nested rows share their parent's

--- a/architecture/README.md
+++ b/architecture/README.md
@@ -3,14 +3,15 @@
 How Val's parts are meant to fit together, and the quirks that bite when they
 don't. Written for a human reading it once, not as a reference to be exhaustive.
 
-| file                                 | what it covers                                                                                                    |
-| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
-| [media.md](./media.md)               | `s.images()`, `s.files()`, `s.image()`, `s.file()` — collections vs fields, where bytes land, how a URL is chosen |
-| [stores.md](./stores.md)             | The Studio's client state: ten stores, two realms, and the one rule the whole design turns on                     |
-| [quirks.md](./quirks.md)             | Things that are true, surprising, and cost someone an afternoon                                                   |
-| [patch-store.md](./patch-store.md)   | Where unpublished edits live in `fs` mode: the log, the lock, and the failure that decided the shape              |
-| [known-issues.md](./known-issues.md) | Problems that are understood but not fixed, and the evidence behind each                                          |
-| [logo.md](./logo.md)                 | What the Val mark is of — a terminal caret over the brand dot, and why it is always green                         |
+| file                                             | what it covers                                                                                                           |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| [media.md](./media.md)                           | `s.images()`, `s.files()`, `s.image()`, `s.file()` — collections vs fields, where bytes land, how a URL is chosen        |
+| [stores.md](./stores.md)                         | The Studio's client state: ten stores, two realms, and the one rule the whole design turns on                            |
+| [quirks.md](./quirks.md)                         | Things that are true, surprising, and cost someone an afternoon                                                          |
+| [patch-store.md](./patch-store.md)               | Where unpublished edits live in `fs` mode: the log, the lock, and the failure that decided the shape                     |
+| [render-and-preview.md](./render-and-preview.md) | `.render(...)` vs `.preview(...)`: one is the field's own layout, the other is how the value shows where it is navigable |
+| [known-issues.md](./known-issues.md)             | Problems that are understood but not fixed, and the evidence behind each                                                 |
+| [logo.md](./logo.md)                             | What the Val mark is of — a terminal caret over the brand dot, and why it is always green                                |
 
 ## What belongs here
 

--- a/architecture/render-and-preview.md
+++ b/architecture/render-and-preview.md
@@ -48,3 +48,21 @@ A `preview` is a user closure over source, so only the host can run it: the
 serialized schema carries just a `preview: true` marker, and the Studio asks
 the host on demand, scoped to what is on screen (`core/src/preview.ts`,
 `ui/spa/stores/PreviewStore.ts`).
+
+## What a declared preview buys, visually
+
+A value that HAS a preview is drawn by `ListPreviewItem`: a compact media row —
+thumbnail left, title and subtitle stacked beside it, one line each, truncated
+rather than wrapped. It can be laid out that tightly precisely because the
+preview told us what the row is made of.
+
+A value with no preview falls back to `Preview`, which renders whatever the
+value happens to be, per type. `RefPreview` picks between the two, and pads
+both the same so a list does not change density row by row depending on which
+branch each row took — callers must not add their own padding on top.
+
+`PreviewItem.image` has three states and they are all load-bearing: an
+`ImageSource` draws the thumbnail, `null` means the preview declares an image
+this particular value does not have (the column is still reserved, so rows in
+a list stay aligned), and `undefined` means no image is declared at all (no
+column). Coalescing `null` and `undefined` is what left mixed lists ragged.

--- a/architecture/render-and-preview.md
+++ b/architecture/render-and-preview.md
@@ -1,0 +1,50 @@
+# Render and preview
+
+Two schema methods decide how content looks in the Studio, and they answer
+different questions. Conflating them is the mistake this note exists to
+prevent — it has already been undone once, when the two shared a pipeline.
+
+## The rule
+
+- **`render` is how the FIELD ITSELF is laid out, and applies only when you
+  are looking at the field.** `s.string().render({ as: "textarea" })` is a
+  textarea instead of an input; `.render({ as: "code", language })` a code
+  editor; `.render({ as: "inline" })` on an array/record item edits the item
+  inside the (sortable) list row instead of behind a clickable row.
+- **`preview` is how the VALUE is shown wherever a preview of it is needed** —
+  a list row, a reference (`keyOf`) dropdown, a search hit, the references
+  view. A preview is needed exactly where the value is NAVIGABLE to rather
+  than open. It is never how the field itself is edited.
+
+So the two never intersect: a schema can carry both, `render` is read where
+the field is drawn, `preview` where the value is previewed. Declaring another
+`.render(...)` on the same schema REPLACES the earlier one (last wins), and a
+second `.preview(...)` replaces the earlier preview the same way — they do not
+merge.
+
+## Where each is declared
+
+A `preview` is declared on the schema of the value being previewed — the
+ITEM, not the container:
+
+```ts
+const author = s
+  .object({ name: s.string() })
+  .preview(({ val }) => ({ title: val.name }));
+const authors = s.array(author);
+```
+
+The array reifies its rows by running each item's closure (`executePreviewItem`
+in `core/src/schema/index.ts`). A tagged union without a preview of its own
+dispatches to the variant the value takes, so page-builder blocks preview per
+block type. A `.preview` on the array/record itself describes the CONTAINER as
+a value, for when it is the item of something else.
+
+## Why the plumbing differs
+
+A `render` is static data — no closure, no source — so it travels whole in the
+serialized schema and is read where the field is drawn (`core/src/render.ts`).
+A `preview` is a user closure over source, so only the host can run it: the
+serialized schema carries just a `preview: true` marker, and the Studio asks
+the host on demand, scoped to what is on screen (`core/src/preview.ts`,
+`ui/spa/stores/PreviewStore.ts`).

--- a/examples/next/app/blogs/[blog]/page.val.ts
+++ b/examples/next/app/blogs/[blog]/page.val.ts
@@ -18,16 +18,16 @@ const blogSchema = s.object({
 
 export default c.define(
   "/app/blogs/[blog]/page.val.ts",
-  s
-    .router(
-      nextAppRouter,
-      s.string().describe("The URL of the blog post"),
-      blogSchema,
-    )
-    .preview(({ val }) => ({
+  s.router(
+    nextAppRouter,
+    s.string().describe("The URL of the blog post"),
+    // The preview lives on the BLOG POST (the value being previewed): the
+    // router's rows, search and references all read it from there.
+    blogSchema.preview(({ val }) => ({
       title: val.title,
       subtitle: val.author,
     })),
+  ),
   {
     "/blogs/blog2": {
       title: "Blog 2",

--- a/examples/next/app/notes/[note]/page.val.ts
+++ b/examples/next/app/notes/[note]/page.val.ts
@@ -15,16 +15,16 @@ import { c, nextAppRouter, s } from "../../../val.config";
  */
 export default c.define(
   "/app/notes/[note]/page.val.ts",
-  s
-    .router(
-      nextAppRouter,
-      s.string().describe("The URL of the note"),
-      s.object({
+  s.router(
+    nextAppRouter,
+    s.string().describe("The URL of the note"),
+    s
+      .object({
         title: s.string(),
         body: s.string(),
-      }),
-    )
-    .preview(({ val }) => ({ title: val.title, subtitle: val.body })),
+      })
+      .preview(({ val }) => ({ title: val.title, subtitle: val.body })),
+  ),
   {
     "/notes/first": {
       title: "First note",

--- a/examples/next/content/authors.val.ts
+++ b/examples/next/content/authors.val.ts
@@ -1,10 +1,10 @@
 import { s, c, type t } from "../val.config";
 import mediaVal from "./media.val";
 
-export const schema = s
-  .record(
-    s.string().describe("Unique identifier for the author"),
-    s.object({
+export const schema = s.record(
+  s.string().describe("Unique identifier for the author"),
+  s
+    .object({
       name: s.string().minLength(2),
       birthdate: s
         .date()
@@ -14,13 +14,16 @@ export const schema = s
         .describe("Author's birthdate"),
       joinedAt: s.datetime().nullable(),
       image: s.image(mediaVal).nullable(),
-    }),
-  )
-  .preview(({ val }) => ({
-    title: val.name,
-    subtitle: val.birthdate,
-    image: val.image,
-  }));
+    })
+    // The preview lives on the AUTHOR (the value being previewed), so it is
+    // used everywhere an author shows up: the record's rows, a keyOf dropdown,
+    // search. See architecture/render-and-preview.md.
+    .preview(({ val }) => ({
+      title: val.name,
+      subtitle: val.birthdate,
+      image: val.image,
+    })),
+);
 
 export type Author = t.inferSchema<typeof schema>;
 export default c.define("/content/authors.val.ts", schema, {

--- a/examples/next/content/handbook.val.ts
+++ b/examples/next/content/handbook.val.ts
@@ -5,10 +5,12 @@ import authorsVal from "./authors.val";
 // Regenerate with a different size: pnpm handbook generate 4 3
 
 /**
- * A handbook: chapters of sections, with a `preview` at BOTH array levels.
+ * A handbook: chapters of sections, with a `preview` at BOTH list levels —
+ * declared on the ITEM schemas (the section and the chapter), which is where a
+ * preview lives: the containers reify their rows from it.
  *
  * This is the shape the store benchmark exists to measure. Two nested
- * `.preview()` calls mean an UNSCOPED preview of one visible section has to walk
+ * previews mean an UNSCOPED preview of one visible section has to walk
  * every chapter and every section and run the user's closure for each — which is
  * exactly the worst case `packages/ui/spa/stores/architecture.md` names, and the
  * reason `PreviewScope` was added to `packages/core`.
@@ -18,29 +20,36 @@ import authorsVal from "./authors.val";
  * `s.route()` for the reference scan, and an image per chapter for the file
  * reference scan.
  */
-export const handbookSectionSchema = s.object({
-  heading: s.string().minLength(2),
-  body: s.richtext({
-    style: { bold: true, italic: true },
-    block: { h2: true, ul: true },
-    inline: { a: true },
-  }),
-  /** A route this section points at, so route references have something to find. */
-  seeAlso: s.route().nullable(),
-});
-
-export const handbookChapterSchema = s.object({
-  title: s.string().minLength(2),
-  slug: s.string().regexp(/^[a-z0-9-]+$/),
-  summary: s.string().render({ as: "textarea" }),
-  owner: s.keyOf(authorsVal),
-  sections: s.array(handbookSectionSchema).preview(({ val }) => ({
+export const handbookSectionSchema = s
+  .object({
+    heading: s.string().minLength(2),
+    body: s.richtext({
+      style: { bold: true, italic: true },
+      block: { h2: true, ul: true },
+      inline: { a: true },
+    }),
+    /** A route this section points at, so route references have something to find. */
+    seeAlso: s.route().nullable(),
+  })
+  .preview(({ val }) => ({
     title: val.heading,
     // Deliberately reads INTO the richtext: a preview that only returned a
     // string would be cheap in a way a real one is not.
     subtitle: firstText(val.body) ?? null,
-  })),
-});
+  }));
+
+export const handbookChapterSchema = s
+  .object({
+    title: s.string().minLength(2),
+    slug: s.string().regexp(/^[a-z0-9-]+$/),
+    summary: s.string().render({ as: "textarea" }),
+    owner: s.keyOf(authorsVal),
+    sections: s.array(handbookSectionSchema),
+  })
+  .preview(({ val }) => ({
+    title: val.title,
+    subtitle: `${val.sections.length} sections`,
+  }));
 
 export type HandbookChapter = t.inferSchema<typeof handbookChapterSchema>;
 
@@ -64,10 +73,7 @@ function firstText(body: unknown): string | null {
 
 export default c.define(
   "/content/handbook.val.ts",
-  s.array(handbookChapterSchema).preview(({ val }) => ({
-    title: val.title,
-    subtitle: `${val.sections.length} sections`,
-  })),
+  s.array(handbookChapterSchema),
   [
     {
       title: "Onboarding",

--- a/examples/next/content/kb.val.ts
+++ b/examples/next/content/kb.val.ts
@@ -39,12 +39,13 @@ export type KbArticle = t.inferSchema<typeof kbArticleSchema>;
 export default c.define(
   "/content/kb.val.ts",
   s
-    .record(kbArticleSchema)
-    .jsonValues()
-    .preview(({ val }) => ({
-      title: val.title,
-      subtitle: val.body,
-    })),
+    .record(
+      kbArticleSchema.preview(({ val }) => ({
+        title: val.title,
+        subtitle: val.body,
+      })),
+    )
+    .jsonValues(),
   {
     "kb-000": c.json(() => import("./kb/entry-000.val.json")),
     "kb-001": c.json(() => import("./kb/entry-001.val.json")),

--- a/examples/next/scripts/handbook-fixture.mjs
+++ b/examples/next/scripts/handbook-fixture.mjs
@@ -226,10 +226,12 @@ import authorsVal from "./authors.val";
 // Regenerate with a different size: pnpm handbook generate ${chapterCount} ${sectionCount}
 
 /**
- * A handbook: chapters of sections, with a \`preview\` at BOTH array levels.
+ * A handbook: chapters of sections, with a \`preview\` at BOTH list levels —
+ * declared on the ITEM schemas (the section and the chapter), which is where a
+ * preview lives: the containers reify their rows from it.
  *
  * This is the shape the store benchmark exists to measure. Two nested
- * \`.preview()\` calls mean an UNSCOPED preview of one visible section has to walk
+ * previews mean an UNSCOPED preview of one visible section has to walk
  * every chapter and every section and run the user's closure for each — which is
  * exactly the worst case \`packages/ui/spa/stores/architecture.md\` names, and the
  * reason \`PreviewScope\` was added to \`packages/core\`.
@@ -239,29 +241,36 @@ import authorsVal from "./authors.val";
  * \`s.route()\` for the reference scan, and an image per chapter for the file
  * reference scan.
  */
-export const handbookSectionSchema = s.object({
-  heading: s.string().minLength(2),
-  body: s.richtext({
-    style: { bold: true, italic: true },
-    block: { h2: true, ul: true },
-    inline: { a: true },
-  }),
-  /** A route this section points at, so route references have something to find. */
-  seeAlso: s.route().nullable(),
-});
-
-export const handbookChapterSchema = s.object({
-  title: s.string().minLength(2),
-  slug: s.string().regexp(/^[a-z0-9-]+$/),
-  summary: s.string().render({ as: "textarea" }),
-  owner: s.keyOf(authorsVal),
-  sections: s.array(handbookSectionSchema).preview(({ val }) => ({
+export const handbookSectionSchema = s
+  .object({
+    heading: s.string().minLength(2),
+    body: s.richtext({
+      style: { bold: true, italic: true },
+      block: { h2: true, ul: true },
+      inline: { a: true },
+    }),
+    /** A route this section points at, so route references have something to find. */
+    seeAlso: s.route().nullable(),
+  })
+  .preview(({ val }) => ({
     title: val.heading,
     // Deliberately reads INTO the richtext: a preview that only returned a
     // string would be cheap in a way a real one is not.
     subtitle: firstText(val.body) ?? null,
-  })),
-});
+  }));
+
+export const handbookChapterSchema = s
+  .object({
+    title: s.string().minLength(2),
+    slug: s.string().regexp(/^[a-z0-9-]+$/),
+    summary: s.string().render({ as: "textarea" }),
+    owner: s.keyOf(authorsVal),
+    sections: s.array(handbookSectionSchema),
+  })
+  .preview(({ val }) => ({
+    title: val.title,
+    subtitle: \`\${val.sections.length} sections\`,
+  }));
 
 export type HandbookChapter = t.inferSchema<typeof handbookChapterSchema>;
 
@@ -285,10 +294,7 @@ function firstText(body: unknown): string | null {
 
 export default c.define(
   "/content/handbook.val.ts",
-  s.array(handbookChapterSchema).preview(({ val }) => ({
-    title: val.title,
-    subtitle: \`\${val.sections.length} sections\`,
-  })),
+  s.array(handbookChapterSchema),
   ${literal(chapters, 2)},
 );
 `;

--- a/examples/next/scripts/jsonvalues-fixtures.mjs
+++ b/examples/next/scripts/jsonvalues-fixtures.mjs
@@ -131,12 +131,13 @@ export type KbArticle = t.inferSchema<typeof kbArticleSchema>;
 export default c.define(
   "/content/kb.val.ts",
   s
-    .record(kbArticleSchema)
-    .jsonValues()
-    .preview(({ val }) => ({
-      title: val.title,
-      subtitle: val.body,
-    })),
+    .record(
+      kbArticleSchema.preview(({ val }) => ({
+        title: val.title,
+        subtitle: val.body,
+      })),
+    )
+    .jsonValues(),
   {
 ${entries.join("\n")}
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -174,7 +174,13 @@ export {
   type PreviewScope,
   previewScope,
 } from "./preview";
-export { type CodeLanguage, type StringRender, CODE_LANGUAGES } from "./render";
+export {
+  type CodeLanguage,
+  type StringRender,
+  type InlineRender,
+  type FieldRender,
+  CODE_LANGUAGES,
+} from "./render";
 export type { ValRouter, RouteValidationError } from "./router";
 export { getSourcePathFromRoute } from "./getSourcePathFromRoute";
 import { nextAppRouter, externalPageRouter } from "./router";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -168,6 +168,7 @@ export { type SerializedLiteralSchema, LiteralSchema } from "./schema/literal";
 export { deserializeSchema } from "./schema/deserialize";
 export {
   type PreviewItem,
+  type ItemPreviewInput,
   type RecordPreview,
   type ArrayPreview,
   type ReifiedPreview,

--- a/packages/core/src/preview.test.ts
+++ b/packages/core/src/preview.test.ts
@@ -80,10 +80,13 @@ describe("scoped executePreview", () => {
 
   function listSchema() {
     let calls = 0;
-    const schema = array(object({ name: string() })).preview(({ val }) => {
-      calls++;
-      return { title: val.name };
-    });
+    // The preview is declared on the ITEM: the container reifies rows from it.
+    const schema = array(
+      object({ name: string() }).preview(({ val }) => {
+        calls++;
+        return { title: val.name };
+      }),
+    );
     return { schema, calls: () => calls };
   }
 
@@ -147,12 +150,14 @@ describe("scoped executePreview", () => {
    * loop the natural place for the try.
    */
   it("keeps the rows a throwing preview did not touch", () => {
-    const schema = array(object({ name: string() })).preview(({ val }) => {
-      if (val.name === "Grace") {
-        throw new Error("nope");
-      }
-      return { title: val.name };
-    });
+    const schema = array(
+      object({ name: string() }).preview(({ val }) => {
+        if (val.name === "Grace") {
+          throw new Error("nope");
+        }
+        return { title: val.name };
+      }),
+    );
 
     const res = schema["executePreview"](sp("/test.val.ts"), rows);
 
@@ -169,11 +174,11 @@ describe("scoped executePreview", () => {
 
   it("windows a record to the wanted entry", () => {
     let calls = 0;
-    const schema = record(object({ name: string() })).preview(
-      ({ key, val }) => {
+    const schema = record(
+      object({ name: string() }).preview(({ val }) => {
         calls++;
-        return { title: `${key}: ${val.name}` };
-      },
+        return { title: val.name };
+      }),
     );
     const src = { a: { name: "Ada" }, b: { name: "Grace" } };
 
@@ -202,15 +207,17 @@ describe("scoped executePreview", () => {
     const schema = array(
       object({
         title: string(),
-        sections: array(object({ heading: string() })).preview(({ val }) => {
-          inner++;
-          return { title: val.heading };
-        }),
+        sections: array(
+          object({ heading: string() }).preview(({ val }) => {
+            inner++;
+            return { title: val.heading };
+          }),
+        ),
+      }).preview(({ val }) => {
+        outer++;
+        return { title: val.title };
       }),
-    ).preview(({ val }) => {
-      outer++;
-      return { title: val.title };
-    });
+    );
     const src = [
       { title: "One", sections: [{ heading: "1.1" }, { heading: "1.2" }] },
       { title: "Two", sections: [{ heading: "2.1" }, { heading: "2.2" }] },

--- a/packages/core/src/preview.ts
+++ b/packages/core/src/preview.ts
@@ -5,8 +5,29 @@ import { splitModuleFilePathAndModulePath, splitModulePath } from "./module";
 import { ModuleFilePath, SourcePath } from "./val";
 
 /**
- * What a container shows for ONE of its items: the user's `preview` callback
- * returns this, and the Studio draws a row from it.
+ * A PREVIEW is how a VALUE is shown wherever a preview of it is needed — a row
+ * in a sortable list, a key in a reference dropdown, a search hit, a
+ * reference — which is everywhere the value is NAVIGABLE to rather than open.
+ * It is never how the field itself is edited: that is a RENDER (`render.ts`),
+ * which applies only when you are looking at the field. The two do not
+ * intersect — a schema can carry both, and each is read in its own places.
+ *
+ * A preview is declared on the schema of the VALUE being previewed:
+ *
+ * ```ts
+ * const author = s.object({ name: s.string() })
+ *   .preview(({ val }) => ({ title: val.name }));
+ * const authors = s.array(author);
+ * ```
+ *
+ * The container reifies its rows by running each ITEM's preview closure — see
+ * {@link ArrayPreview} / {@link RecordPreview}. (Previews used to be declared
+ * on the container instead; a `.preview` on an array/record now previews the
+ * array/record itself as a value, for when IT is the item of something.)
+ */
+/**
+ * What a preview shows for one value: the user's `preview` callback returns
+ * this, and the Studio draws a row from it.
  *
  * NB: {@link ArrayPreview} / {@link RecordPreview} name the DATA a container
  * previews with. The Studio also has React components called `ArrayPreview` /
@@ -20,6 +41,22 @@ export type PreviewItem = {
   subtitle?: string | null;
   image?: ImageSource | null;
 };
+
+/**
+ * What `.preview(...)` takes, on every schema: the value's own source in, a
+ * {@link PreviewItem} out. `NonNullable` because a container skips null items
+ * rather than previewing them.
+ *
+ * Declared through method syntax deliberately (the same bivariance shape
+ * React's event handler types use): `nullable()` copies a schema's closure
+ * into the `Src | null` variant of the same class, and with a plain function
+ * type the checker cannot see that `NonNullable<Src | null>` IS
+ * `NonNullable<Src>` while `Src` is still a type parameter — every schema's
+ * `nullable()` would need a cast instead.
+ */
+export type ItemPreviewInput<Src> = {
+  bivarianceHack(input: { val: NonNullable<Src> }): PreviewItem;
+}["bivarianceHack"];
 
 export type RecordPreview = {
   parent: "record";

--- a/packages/core/src/render.ts
+++ b/packages/core/src/render.ts
@@ -47,9 +47,32 @@ export const CODE_LANGUAGES = [
 export type CodeLanguage = (typeof CODE_LANGUAGES)[number];
 
 /**
+ * `{ as: "inline" }` on a field that is the ITEM of an array or record: the
+ * container renders the field itself inside each (sortable) row, instead of a
+ * clickable preview row that navigates to it. This is what a page-builder list
+ * is made of: `s.array(s.object({...}).render({ as: "inline" }))`.
+ *
+ * On a field that is not directly under an array or record it is inert — an
+ * object's fields are already laid out in place.
+ *
+ * Like every render it is static configuration (see the top of this file): it
+ * travels whole in the serialized schema and the editor reads it straight off
+ * the item schema it already has.
+ */
+export type InlineRender = { as: "inline" };
+
+/**
+ * What `.render(...)` takes on every field except `s.string()`, and what the
+ * serialized schema carries verbatim.
+ */
+export type FieldRender = InlineRender;
+
+/**
  * What `s.string().render(...)` takes, and what the serialized schema carries
- * verbatim.
+ * verbatim. A string has editor layouts of its own (textarea, code) in
+ * addition to the container-facing `inline`.
  */
 export type StringRender =
   | { as: "textarea" }
-  | { as: "code"; language: CodeLanguage };
+  | { as: "code"; language: CodeLanguage }
+  | InlineRender;

--- a/packages/core/src/render.ts
+++ b/packages/core/src/render.ts
@@ -1,9 +1,19 @@
 /**
- * A RENDER is how one field is laid out in the editor: `s.string().render({ as:
- * "textarea" })`, `.render({ as: "code", language })`.
+ * A RENDER is how the FIELD ITSELF is laid out in the editor, and it applies
+ * only when you are looking at the field: `s.string().render({ as: "textarea"
+ * })`, `.render({ as: "code", language })`, `.render({ as: "inline" })` on an
+ * array/record item.
  *
- * It is static configuration - plain data, with no closure behind it and no
- * dependency on source - which is why it lives in the SERIALIZED schema
+ * A PREVIEW (`preview.ts`) is the other thing: how the VALUE is shown wherever
+ * a preview of it is needed — a list row, a reference dropdown, a search hit —
+ * that is, wherever the value is navigable to rather than open. The two never
+ * intersect: a schema can carry both, a `render` is read where the field is
+ * edited and a `preview` where the value is previewed. A second `.render(...)`
+ * on the same schema REPLACES the first (last one wins), exactly like a second
+ * `.preview(...)` replaces the first — they do not merge.
+ *
+ * A render is static configuration - plain data, with no closure behind it and
+ * no dependency on source - which is why it lives in the SERIALIZED schema
  * (`SerializedStringSchema.render`) and is read straight off it where the field
  * is drawn. There is no render pipeline, no store and no host round-trip.
  *
@@ -13,9 +23,6 @@
  * the shape it needs back is `executePreview`'s, and the honest move is to give
  * `render` its own execute/store pair again. It is NOT to re-merge the two:
  * conflating them is what this file was split up to undo.
- *
- * The dynamic, source-dependent, demand-scoped thing - what a container shows
- * for its items - is a PREVIEW. See `preview.ts`.
  */
 /**
  * The list is the declaration and {@link CodeLanguage} is derived from it, so

--- a/packages/core/src/schema/array.test.ts
+++ b/packages/core/src/schema/array.test.ts
@@ -20,9 +20,11 @@ describe("ArraySchema", () => {
     );
   });
   test("preview: preview is kept when chaining after preview", () => {
-    const base = array(object({ name: string() })).preview(({ val }) => ({
-      title: val.name,
-    }));
+    const base = array(
+      object({ name: string() }).preview(({ val }) => ({
+        title: val.name,
+      })),
+    );
     const src = [{ name: "Ada" }];
     const expected = {
       "/test.val.ts": {
@@ -51,10 +53,12 @@ describe("ArraySchema", () => {
   });
 
   test("preview: does not mutate the schema it was called on", () => {
-    const base = array(object({ name: string() }));
-    base.preview(({ val }) => ({ title: val.name }));
+    const item = object({ name: string() });
+    item.preview(({ val }) => ({ title: val.name }));
     expect(
-      base["executePreview"]("/test.val.ts" as SourcePath, [{ name: "Ada" }]),
+      array(item)["executePreview"]("/test.val.ts" as SourcePath, [
+        { name: "Ada" },
+      ]),
     ).toEqual({});
   });
 });

--- a/packages/core/src/schema/array.ts
+++ b/packages/core/src/schema/array.ts
@@ -11,6 +11,7 @@ import {
   ReifiedPreview,
   PreviewScope,
 } from "../preview";
+import { FieldRender } from "../render";
 import { SelectorSource } from "../selector";
 import { unsafeCreateSourcePath } from "../selector/SelectorProxy";
 import { ModuleFilePath, SourcePath } from "../val";
@@ -21,6 +22,8 @@ import {
 
 export type SerializedArraySchema = {
   type: "array";
+  /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
+  render?: FieldRender;
   item: SerializedSchema;
   opt: boolean;
   /**
@@ -57,6 +60,7 @@ export class ArraySchema<
     private readonly isHidden: boolean = false,
     private readonly description?: string,
     private readonly previewInput: ArrayPreviewInput<T> | null = null,
+    private readonly renderInput: FieldRender | null = null,
   ) {
     super();
   }
@@ -70,6 +74,7 @@ export class ArraySchema<
       this.isHidden,
       description ?? undefined,
       this.previewInput,
+      this.renderInput,
     );
   }
 
@@ -84,6 +89,7 @@ export class ArraySchema<
       this.isHidden,
       this.description,
       this.previewInput,
+      this.renderInput,
     );
   }
 
@@ -162,6 +168,7 @@ export class ArraySchema<
       this.isHidden,
       this.description,
       this.previewInput,
+      this.renderInput,
     );
   }
 
@@ -174,6 +181,7 @@ export class ArraySchema<
       this.isHidden,
       this.description,
       this.previewInput,
+      this.renderInput,
     );
   }
 
@@ -186,6 +194,7 @@ export class ArraySchema<
       true,
       this.description,
       this.previewInput,
+      this.renderInput,
     );
   }
 
@@ -203,6 +212,7 @@ export class ArraySchema<
   protected executeSerialize(): SerializedArraySchema {
     return {
       type: "array",
+      render: this.renderInput ?? undefined,
       item: this.item["executeSerialize"](),
       opt: this.opt,
       preview: this.previewInput ? true : undefined,
@@ -301,6 +311,27 @@ export class ArraySchema<
       this.isHidden,
       this.description,
       select,
+      this.renderInput,
+    );
+  }
+
+  /**
+   * How this field is laid out in the editor when it is the item of an array
+   * or record: `{ as: "inline" }` renders the field itself inside each row,
+   * instead of a preview row that navigates to it.
+   *
+   * Static configuration, not a callback — see `render.ts`.
+   */
+  render(input: FieldRender): ArraySchema<T, Src> {
+    return new ArraySchema(
+      this.item,
+      this.opt,
+      this.customValidateFunctions,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      this.previewInput,
+      input,
     );
   }
 }

--- a/packages/core/src/schema/array.ts
+++ b/packages/core/src/schema/array.ts
@@ -6,8 +6,8 @@ import {
 } from ".";
 import {
   ArrayPreview,
+  ItemPreviewInput,
   PreviewItem,
-  PreviewSelector,
   ReifiedPreview,
   PreviewScope,
 } from "../preview";
@@ -27,7 +27,10 @@ export type SerializedArraySchema = {
   item: SerializedSchema;
   opt: boolean;
   /**
-   * Set when this schema declares a `preview`.
+   * Set when this schema declares a `preview` — of the ARRAY ITSELF as a
+   * value, for when it is the item of another container. Whether this array's
+   * ROWS preview is carried by the ITEM's serialized schema, where the closure
+   * is declared.
    *
    * The preview itself cannot be serialized — it is a user closure — but whether
    * one EXISTS can be, and that is worth carrying: it lets the non-host side
@@ -42,10 +45,6 @@ export type SerializedArraySchema = {
   description?: string;
 };
 
-type ArrayPreviewInput<T extends Schema<SelectorSource>> = (input: {
-  val: PreviewSelector<T>;
-}) => PreviewItem;
-
 export class ArraySchema<
   T extends Schema<SelectorSource>,
   Src extends SelectorOfSchema<T>[] | null,
@@ -59,7 +58,7 @@ export class ArraySchema<
     private readonly isReadonly: boolean = false,
     private readonly isHidden: boolean = false,
     private readonly description?: string,
-    private readonly previewInput: ArrayPreviewInput<T> | null = null,
+    private readonly previewInput: ItemPreviewInput<Src> | null = null,
     private readonly renderInput: FieldRender | null = null,
   ) {
     super();
@@ -160,7 +159,8 @@ export class ArraySchema<
   }
 
   nullable(): ArraySchema<T, Src | null> {
-    return new ArraySchema(
+    // Explicit type args: `previewInput` would otherwise pin inference to `Src`.
+    return new ArraySchema<T, Src | null>(
       this.item,
       true,
       [],
@@ -250,8 +250,10 @@ export class ArraySchema<
         res[key] = itemResult[key];
       }
     }
-    if (this.previewInput) {
-      const select = this.previewInput;
+    // The rows preview comes from the ITEM schema's own `preview` — the
+    // container just runs it per row. Asked as a fact rather than by running
+    // the closure, so an empty list still previews as an empty list.
+    if (this.item["declaresItemPreview"]()) {
       // The whole list when the LIST is what is being shown; only the wanted
       // rows when it is not. The user's closure is the real expense — a list
       // view asks for the container and gets every row, a single field asks for
@@ -263,20 +265,27 @@ export class ArraySchema<
         scope !== undefined && !scope.wants(sourcePath) ? scope : null;
       const items: ArrayPreview["items"] = [];
       for (let index = 0; index < src.length; index++) {
+        const itemSrc = src[index];
+        if (itemSrc === null || itemSrc === undefined) {
+          continue;
+        }
         if (
           window !== null &&
           !window.wantsUnder(unsafeCreateSourcePath(sourcePath, index))
         ) {
           continue;
         }
-        // Per ITEM, not per list, matching what `record` already does: the
-        // closure is user code, and one row whose data trips it up must not take
-        // out the whole list. Before scoping, one throwing row produced an error
-        // at the container and no items at all.
+        // Per ITEM, not per list: the closure is user code, and one row whose
+        // data trips it up must not take out the whole list. Before scoping,
+        // one throwing row produced an error at the container and no items at
+        // all.
         try {
           // NB NB: display is actually defined by the user
-          const { title, subtitle, image } = select({ val: src[index] });
-          items.push([index, { title, subtitle, image }]);
+          const item = this.item["executePreviewItem"](itemSrc);
+          if (item !== null) {
+            const { title, subtitle, image } = item;
+            items.push([index, { title, subtitle, image }]);
+          }
         } catch (e) {
           res[unsafeCreateSourcePath(sourcePath, index)] = {
             status: "error",
@@ -295,14 +304,26 @@ export class ArraySchema<
     return res;
   }
 
+  protected override executePreviewItem(
+    src: NonNullable<Src>,
+  ): PreviewItem | null {
+    if (this.previewInput === null) {
+      return null;
+    }
+    return this.previewInput({ val: src });
+  }
+
+  protected override declaresItemPreview(): boolean {
+    return this.previewInput !== null;
+  }
+
   /**
-   * What the editor shows for each ITEM of this array: a title, and optionally a
-   * subtitle and an image.
-   *
-   * `select` is your own code over the item's source, so it is run on demand for
-   * the rows that are actually being looked at — see `PreviewScope`.
+   * How this ARRAY ITSELF is shown where a preview of it is needed — when it
+   * is the item of another container, in search, in references. What its rows
+   * show is the ITEM schema's `preview`, not this. Never how the field is
+   * edited (that is `render`). See `preview.ts`.
    */
-  preview(select: ArrayPreviewInput<T>): ArraySchema<T, Src> {
+  preview(select: ItemPreviewInput<Src>): ArraySchema<T, Src> {
     return new ArraySchema(
       this.item,
       this.opt,

--- a/packages/core/src/schema/boolean.ts
+++ b/packages/core/src/schema/boolean.ts
@@ -6,6 +6,7 @@ import {
   SerializedSchema,
 } from ".";
 import { ReifiedPreview } from "../preview";
+import { FieldRender } from "../render";
 import { ModuleFilePath, SourcePath } from "../val";
 import {
   ValidationError,
@@ -14,6 +15,8 @@ import {
 
 export type SerializedBooleanSchema = {
   type: "boolean";
+  /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
+  render?: FieldRender;
   opt: boolean;
   customValidate?: boolean;
   readonly?: boolean;
@@ -28,6 +31,7 @@ export class BooleanSchema<Src extends boolean | null> extends Schema<Src> {
     private readonly isReadonly: boolean = false,
     private readonly isHidden: boolean = false,
     private readonly description?: string,
+    private readonly renderInput: FieldRender | null = null,
   ) {
     super();
   }
@@ -39,6 +43,7 @@ export class BooleanSchema<Src extends boolean | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       description ?? undefined,
+      this.renderInput,
     );
   }
 
@@ -51,6 +56,7 @@ export class BooleanSchema<Src extends boolean | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -117,6 +123,7 @@ export class BooleanSchema<Src extends boolean | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -127,6 +134,7 @@ export class BooleanSchema<Src extends boolean | null> extends Schema<Src> {
       true,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -137,6 +145,7 @@ export class BooleanSchema<Src extends boolean | null> extends Schema<Src> {
       this.isReadonly,
       true,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -151,9 +160,28 @@ export class BooleanSchema<Src extends boolean | null> extends Schema<Src> {
     );
   }
 
+  /**
+   * How this field is laid out in the editor when it is the item of an array
+   * or record: `{ as: "inline" }` renders the field itself inside each row,
+   * instead of a preview row that navigates to it.
+   *
+   * Static configuration, not a callback — see `render.ts`.
+   */
+  render(input: FieldRender): BooleanSchema<Src> {
+    return new BooleanSchema(
+      this.opt,
+      this.customValidateFunctions,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      input,
+    );
+  }
+
   protected executeSerialize(): SerializedSchema {
     return {
       type: "boolean",
+      render: this.renderInput ?? undefined,
       opt: this.opt,
       customValidate:
         this.customValidateFunctions &&

--- a/packages/core/src/schema/boolean.ts
+++ b/packages/core/src/schema/boolean.ts
@@ -5,7 +5,7 @@ import {
   SchemaAssertResult,
   SerializedSchema,
 } from ".";
-import { ReifiedPreview } from "../preview";
+import { ItemPreviewInput, PreviewItem, ReifiedPreview } from "../preview";
 import { FieldRender } from "../render";
 import { ModuleFilePath, SourcePath } from "../val";
 import {
@@ -17,6 +17,8 @@ export type SerializedBooleanSchema = {
   type: "boolean";
   /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
   render?: FieldRender;
+  /** Set when this schema declares a `preview`. The closure itself cannot serialize. */
+  preview?: true;
   opt: boolean;
   customValidate?: boolean;
   readonly?: boolean;
@@ -32,6 +34,7 @@ export class BooleanSchema<Src extends boolean | null> extends Schema<Src> {
     private readonly isHidden: boolean = false,
     private readonly description?: string,
     private readonly renderInput: FieldRender | null = null,
+    private readonly previewInput: ItemPreviewInput<Src> | null = null,
   ) {
     super();
   }
@@ -44,6 +47,7 @@ export class BooleanSchema<Src extends boolean | null> extends Schema<Src> {
       this.isHidden,
       description ?? undefined,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -57,6 +61,7 @@ export class BooleanSchema<Src extends boolean | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -124,6 +129,7 @@ export class BooleanSchema<Src extends boolean | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -135,6 +141,7 @@ export class BooleanSchema<Src extends boolean | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -146,6 +153,7 @@ export class BooleanSchema<Src extends boolean | null> extends Schema<Src> {
       true,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -175,13 +183,45 @@ export class BooleanSchema<Src extends boolean | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       input,
+      this.previewInput,
     );
+  }
+
+  /**
+   * How this VALUE is shown where a preview of it is needed — a row in a
+   * sortable list, a reference dropdown, a search hit. Never how the field
+   * itself is edited (that is `render`). See `preview.ts`.
+   */
+  preview(select: ItemPreviewInput<Src>): BooleanSchema<Src> {
+    return new BooleanSchema(
+      this.opt,
+      this.customValidateFunctions,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      this.renderInput,
+      select,
+    );
+  }
+
+  protected override executePreviewItem(
+    src: NonNullable<Src>,
+  ): PreviewItem | null {
+    if (this.previewInput === null) {
+      return null;
+    }
+    return this.previewInput({ val: src });
+  }
+
+  protected override declaresItemPreview(): boolean {
+    return this.previewInput !== null;
   }
 
   protected executeSerialize(): SerializedSchema {
     return {
       type: "boolean",
       render: this.renderInput ?? undefined,
+      preview: this.previewInput ? true : undefined,
       opt: this.opt,
       customValidate:
         this.customValidateFunctions &&

--- a/packages/core/src/schema/color.ts
+++ b/packages/core/src/schema/color.ts
@@ -4,7 +4,7 @@ import {
   SchemaAssertResult,
   SerializedSchema,
 } from ".";
-import { ReifiedPreview } from "../preview";
+import { ItemPreviewInput, PreviewItem, ReifiedPreview } from "../preview";
 import { FieldRender } from "../render";
 import { SourcePath } from "../val";
 import {
@@ -48,6 +48,8 @@ export type SerializedColorSchema = {
   type: "color";
   /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
   render?: FieldRender;
+  /** Set when this schema declares a `preview`. The closure itself cannot serialize. */
+  preview?: true;
   options?: ColorOptions;
   opt: boolean;
   customValidate?: boolean;
@@ -76,6 +78,7 @@ export class ColorSchema<Src extends string | null> extends Schema<Src> {
     private readonly isHidden: boolean = false,
     private readonly description?: string,
     private readonly renderInput: FieldRender | null = null,
+    private readonly previewInput: ItemPreviewInput<Src> | null = null,
   ) {
     super();
   }
@@ -89,6 +92,7 @@ export class ColorSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       description ?? undefined,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -101,6 +105,7 @@ export class ColorSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -219,6 +224,7 @@ export class ColorSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -231,6 +237,7 @@ export class ColorSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -243,6 +250,7 @@ export class ColorSchema<Src extends string | null> extends Schema<Src> {
       true,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -262,13 +270,46 @@ export class ColorSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       input,
+      this.previewInput,
     );
+  }
+
+  /**
+   * How this VALUE is shown where a preview of it is needed — a row in a
+   * sortable list, a reference dropdown, a search hit. Never how the field
+   * itself is edited (that is `render`). See `preview.ts`.
+   */
+  preview(select: ItemPreviewInput<Src>): ColorSchema<Src> {
+    return new ColorSchema<Src>(
+      this.options,
+      this.opt,
+      this.customValidateFunctions,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      this.renderInput,
+      select,
+    );
+  }
+
+  protected override executePreviewItem(
+    src: NonNullable<Src>,
+  ): PreviewItem | null {
+    if (this.previewInput === null) {
+      return null;
+    }
+    return this.previewInput({ val: src });
+  }
+
+  protected override declaresItemPreview(): boolean {
+    return this.previewInput !== null;
   }
 
   protected executeSerialize(): SerializedSchema {
     return {
       type: "color",
       render: this.renderInput ?? undefined,
+      preview: this.previewInput ? true : undefined,
       opt: this.opt,
       options: this.options,
       customValidate:

--- a/packages/core/src/schema/color.ts
+++ b/packages/core/src/schema/color.ts
@@ -5,6 +5,7 @@ import {
   SerializedSchema,
 } from ".";
 import { ReifiedPreview } from "../preview";
+import { FieldRender } from "../render";
 import { SourcePath } from "../val";
 import {
   ColorFormat,
@@ -45,6 +46,8 @@ export type ColorOptions = {
 
 export type SerializedColorSchema = {
   type: "color";
+  /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
+  render?: FieldRender;
   options?: ColorOptions;
   opt: boolean;
   customValidate?: boolean;
@@ -72,6 +75,7 @@ export class ColorSchema<Src extends string | null> extends Schema<Src> {
     private readonly isReadonly: boolean = false,
     private readonly isHidden: boolean = false,
     private readonly description?: string,
+    private readonly renderInput: FieldRender | null = null,
   ) {
     super();
   }
@@ -84,6 +88,7 @@ export class ColorSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       description ?? undefined,
+      this.renderInput,
     );
   }
 
@@ -95,6 +100,7 @@ export class ColorSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -212,6 +218,7 @@ export class ColorSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -223,6 +230,7 @@ export class ColorSchema<Src extends string | null> extends Schema<Src> {
       true,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -234,12 +242,33 @@ export class ColorSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       true,
       this.description,
+      this.renderInput,
+    );
+  }
+
+  /**
+   * How this field is laid out in the editor when it is the item of an array
+   * or record: `{ as: "inline" }` renders the field itself inside each row,
+   * instead of a preview row that navigates to it.
+   *
+   * Static configuration, not a callback — see `render.ts`.
+   */
+  render(input: FieldRender): ColorSchema<Src> {
+    return new ColorSchema<Src>(
+      this.options,
+      this.opt,
+      this.customValidateFunctions,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      input,
     );
   }
 
   protected executeSerialize(): SerializedSchema {
     return {
       type: "color",
+      render: this.renderInput ?? undefined,
       opt: this.opt,
       options: this.options,
       customValidate:

--- a/packages/core/src/schema/date.ts
+++ b/packages/core/src/schema/date.ts
@@ -4,7 +4,7 @@ import {
   SchemaAssertResult,
   SerializedSchema,
 } from ".";
-import { ReifiedPreview } from "../preview";
+import { ItemPreviewInput, PreviewItem, ReifiedPreview } from "../preview";
 import { FieldRender } from "../render";
 import { SourcePath } from "../val";
 import { RawString } from "./string";
@@ -34,6 +34,8 @@ export type SerializedDateSchema = {
   type: "date";
   /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
   render?: FieldRender;
+  /** Set when this schema declares a `preview`. The closure itself cannot serialize. */
+  preview?: true;
   options?: DateOptions;
   opt: boolean;
   customValidate?: boolean;
@@ -51,6 +53,7 @@ export class DateSchema<Src extends string | null> extends Schema<Src> {
     private readonly isHidden: boolean = false,
     private readonly description?: string,
     private readonly renderInput: FieldRender | null = null,
+    private readonly previewInput: ItemPreviewInput<Src> | null = null,
   ) {
     super();
   }
@@ -64,6 +67,7 @@ export class DateSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       description ?? undefined,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -76,6 +80,7 @@ export class DateSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -181,6 +186,7 @@ export class DateSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -193,6 +199,7 @@ export class DateSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -205,6 +212,7 @@ export class DateSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -217,6 +225,7 @@ export class DateSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -229,6 +238,7 @@ export class DateSchema<Src extends string | null> extends Schema<Src> {
       true,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -259,13 +269,46 @@ export class DateSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       input,
+      this.previewInput,
     );
+  }
+
+  /**
+   * How this VALUE is shown where a preview of it is needed — a row in a
+   * sortable list, a reference dropdown, a search hit. Never how the field
+   * itself is edited (that is `render`). See `preview.ts`.
+   */
+  preview(select: ItemPreviewInput<Src>): DateSchema<Src> {
+    return new DateSchema<Src>(
+      this.options,
+      this.opt,
+      this.customValidateFunctions,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      this.renderInput,
+      select,
+    );
+  }
+
+  protected override executePreviewItem(
+    src: NonNullable<Src>,
+  ): PreviewItem | null {
+    if (this.previewInput === null) {
+      return null;
+    }
+    return this.previewInput({ val: src });
+  }
+
+  protected override declaresItemPreview(): boolean {
+    return this.previewInput !== null;
   }
 
   protected executeSerialize(): SerializedSchema {
     return {
       type: "date",
       render: this.renderInput ?? undefined,
+      preview: this.previewInput ? true : undefined,
       opt: this.opt,
       options: this.options,
       customValidate:

--- a/packages/core/src/schema/date.ts
+++ b/packages/core/src/schema/date.ts
@@ -5,6 +5,7 @@ import {
   SerializedSchema,
 } from ".";
 import { ReifiedPreview } from "../preview";
+import { FieldRender } from "../render";
 import { SourcePath } from "../val";
 import { RawString } from "./string";
 import {
@@ -31,6 +32,8 @@ type DateOptions = {
 
 export type SerializedDateSchema = {
   type: "date";
+  /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
+  render?: FieldRender;
   options?: DateOptions;
   opt: boolean;
   customValidate?: boolean;
@@ -47,6 +50,7 @@ export class DateSchema<Src extends string | null> extends Schema<Src> {
     private readonly isReadonly: boolean = false,
     private readonly isHidden: boolean = false,
     private readonly description?: string,
+    private readonly renderInput: FieldRender | null = null,
   ) {
     super();
   }
@@ -59,6 +63,7 @@ export class DateSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       description ?? undefined,
+      this.renderInput,
     );
   }
 
@@ -70,6 +75,7 @@ export class DateSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -174,6 +180,7 @@ export class DateSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -185,6 +192,7 @@ export class DateSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -196,6 +204,7 @@ export class DateSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -207,6 +216,7 @@ export class DateSchema<Src extends string | null> extends Schema<Src> {
       true,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -218,6 +228,7 @@ export class DateSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       true,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -232,9 +243,29 @@ export class DateSchema<Src extends string | null> extends Schema<Src> {
     );
   }
 
+  /**
+   * How this field is laid out in the editor when it is the item of an array
+   * or record: `{ as: "inline" }` renders the field itself inside each row,
+   * instead of a preview row that navigates to it.
+   *
+   * Static configuration, not a callback — see `render.ts`.
+   */
+  render(input: FieldRender): DateSchema<Src> {
+    return new DateSchema<Src>(
+      this.options,
+      this.opt,
+      this.customValidateFunctions,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      input,
+    );
+  }
+
   protected executeSerialize(): SerializedSchema {
     return {
       type: "date",
+      render: this.renderInput ?? undefined,
       opt: this.opt,
       options: this.options,
       customValidate:

--- a/packages/core/src/schema/datetime.ts
+++ b/packages/core/src/schema/datetime.ts
@@ -4,7 +4,7 @@ import {
   SchemaAssertResult,
   SerializedSchema,
 } from ".";
-import { ReifiedPreview } from "../preview";
+import { ItemPreviewInput, PreviewItem, ReifiedPreview } from "../preview";
 import { FieldRender } from "../render";
 import { SourcePath } from "../val";
 import { RawString } from "./string";
@@ -38,6 +38,8 @@ export type SerializedDateTimeSchema = {
   type: "dateTime";
   /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
   render?: FieldRender;
+  /** Set when this schema declares a `preview`. The closure itself cannot serialize. */
+  preview?: true;
   options?: DateTimeOptions;
   opt: boolean;
   customValidate?: boolean;
@@ -55,6 +57,7 @@ export class DateTimeSchema<Src extends string | null> extends Schema<Src> {
     private readonly isHidden: boolean = false,
     private readonly description?: string,
     private readonly renderInput: FieldRender | null = null,
+    private readonly previewInput: ItemPreviewInput<Src> | null = null,
   ) {
     super();
   }
@@ -68,6 +71,7 @@ export class DateTimeSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       description ?? undefined,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -82,6 +86,7 @@ export class DateTimeSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -217,6 +222,7 @@ export class DateTimeSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -229,6 +235,7 @@ export class DateTimeSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -241,6 +248,7 @@ export class DateTimeSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -253,6 +261,7 @@ export class DateTimeSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -265,6 +274,7 @@ export class DateTimeSchema<Src extends string | null> extends Schema<Src> {
       true,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -295,13 +305,46 @@ export class DateTimeSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       input,
+      this.previewInput,
     );
+  }
+
+  /**
+   * How this VALUE is shown where a preview of it is needed — a row in a
+   * sortable list, a reference dropdown, a search hit. Never how the field
+   * itself is edited (that is `render`). See `preview.ts`.
+   */
+  preview(select: ItemPreviewInput<Src>): DateTimeSchema<Src> {
+    return new DateTimeSchema<Src>(
+      this.options,
+      this.opt,
+      this.customValidateFunctions,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      this.renderInput,
+      select,
+    );
+  }
+
+  protected override executePreviewItem(
+    src: NonNullable<Src>,
+  ): PreviewItem | null {
+    if (this.previewInput === null) {
+      return null;
+    }
+    return this.previewInput({ val: src });
+  }
+
+  protected override declaresItemPreview(): boolean {
+    return this.previewInput !== null;
   }
 
   protected executeSerialize(): SerializedSchema {
     return {
       type: "dateTime",
       render: this.renderInput ?? undefined,
+      preview: this.previewInput ? true : undefined,
       opt: this.opt,
       options: this.options,
       customValidate:

--- a/packages/core/src/schema/datetime.ts
+++ b/packages/core/src/schema/datetime.ts
@@ -5,6 +5,7 @@ import {
   SerializedSchema,
 } from ".";
 import { ReifiedPreview } from "../preview";
+import { FieldRender } from "../render";
 import { SourcePath } from "../val";
 import { RawString } from "./string";
 import {
@@ -35,6 +36,8 @@ type DateTimeOptions = {
 
 export type SerializedDateTimeSchema = {
   type: "dateTime";
+  /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
+  render?: FieldRender;
   options?: DateTimeOptions;
   opt: boolean;
   customValidate?: boolean;
@@ -51,6 +54,7 @@ export class DateTimeSchema<Src extends string | null> extends Schema<Src> {
     private readonly isReadonly: boolean = false,
     private readonly isHidden: boolean = false,
     private readonly description?: string,
+    private readonly renderInput: FieldRender | null = null,
   ) {
     super();
   }
@@ -63,6 +67,7 @@ export class DateTimeSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       description ?? undefined,
+      this.renderInput,
     );
   }
 
@@ -76,6 +81,7 @@ export class DateTimeSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -210,6 +216,7 @@ export class DateTimeSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -221,6 +228,7 @@ export class DateTimeSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -232,6 +240,7 @@ export class DateTimeSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -243,6 +252,7 @@ export class DateTimeSchema<Src extends string | null> extends Schema<Src> {
       true,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -254,6 +264,7 @@ export class DateTimeSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       true,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -268,9 +279,29 @@ export class DateTimeSchema<Src extends string | null> extends Schema<Src> {
     );
   }
 
+  /**
+   * How this field is laid out in the editor when it is the item of an array
+   * or record: `{ as: "inline" }` renders the field itself inside each row,
+   * instead of a preview row that navigates to it.
+   *
+   * Static configuration, not a callback — see `render.ts`.
+   */
+  render(input: FieldRender): DateTimeSchema<Src> {
+    return new DateTimeSchema<Src>(
+      this.options,
+      this.opt,
+      this.customValidateFunctions,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      input,
+    );
+  }
+
   protected executeSerialize(): SerializedSchema {
     return {
       type: "dateTime",
+      render: this.renderInput ?? undefined,
       opt: this.opt,
       options: this.options,
       customValidate:

--- a/packages/core/src/schema/deserialize.ts
+++ b/packages/core/src/schema/deserialize.ts
@@ -67,6 +67,7 @@ function deserializeSchemaImpl(
         false,
         false,
         serialized.description,
+        serialized.render ?? null,
       );
     case "boolean":
       return new BooleanSchema(
@@ -75,6 +76,7 @@ function deserializeSchemaImpl(
         false,
         false,
         serialized.description,
+        serialized.render ?? null,
       );
     case "number":
       return new NumberSchema(
@@ -84,6 +86,7 @@ function deserializeSchemaImpl(
         false,
         false,
         serialized.description,
+        serialized.render ?? null,
       );
     case "object":
       return new ObjectSchema(
@@ -97,6 +100,7 @@ function deserializeSchemaImpl(
         false,
         false,
         serialized.description,
+        serialized.render ?? null,
       );
     case "array":
       return new ArraySchema(
@@ -106,6 +110,9 @@ function deserializeSchemaImpl(
         false,
         false,
         serialized.description,
+        // The preview closure cannot survive serialization; the render can.
+        null,
+        serialized.render ?? null,
       );
     case "union":
       return new UnionSchema(
@@ -120,6 +127,7 @@ function deserializeSchemaImpl(
         false,
         false,
         serialized.description,
+        serialized.render ?? null,
       );
     case "richtext": {
       const deserializedOptions = {
@@ -155,6 +163,7 @@ function deserializeSchemaImpl(
         false,
         false,
         serialized.description,
+        serialized.render ?? null,
       );
     }
     case "record":
@@ -181,6 +190,9 @@ function deserializeSchemaImpl(
         false,
         serialized.description,
         serialized.jsonValues ?? false,
+        // The preview closure cannot survive serialization; the render can.
+        null,
+        serialized.render ?? null,
       );
     case "keyOf":
       return new KeyOfSchema(
@@ -191,6 +203,7 @@ function deserializeSchemaImpl(
         false,
         false,
         serialized.description,
+        serialized.render ?? null,
       );
     case "route": {
       const routeOptions = serialized.options
@@ -216,6 +229,7 @@ function deserializeSchemaImpl(
         false,
         false,
         serialized.description,
+        serialized.render ?? null,
       );
     }
     case "file":
@@ -228,6 +242,7 @@ function deserializeSchemaImpl(
         false,
         false,
         serialized.description,
+        serialized.render ?? null,
       );
     case "image":
       return new ImageSchema(
@@ -239,6 +254,7 @@ function deserializeSchemaImpl(
         false,
         false,
         serialized.description,
+        serialized.render ?? null,
       );
     case "date":
       return new DateSchema(
@@ -248,6 +264,7 @@ function deserializeSchemaImpl(
         false,
         false,
         serialized.description,
+        serialized.render ?? null,
       );
     case "dateTime":
       return new DateTimeSchema(
@@ -257,6 +274,7 @@ function deserializeSchemaImpl(
         false,
         false,
         serialized.description,
+        serialized.render ?? null,
       );
     case "color":
       return new ColorSchema(
@@ -266,6 +284,7 @@ function deserializeSchemaImpl(
         false,
         false,
         serialized.description,
+        serialized.render ?? null,
       );
     default: {
       const exhaustiveCheck: never = serialized;

--- a/packages/core/src/schema/file.ts
+++ b/packages/core/src/schema/file.ts
@@ -17,7 +17,7 @@ import {
   ValidationErrors,
 } from "./validation/ValidationError";
 import { Internal, ValModule } from "..";
-import { ReifiedPreview } from "../preview";
+import { ItemPreviewInput, PreviewItem, ReifiedPreview } from "../preview";
 import { FieldRender } from "../render";
 import { FilesEntryMetadata } from "./files";
 import { getSource } from "../module";
@@ -30,6 +30,8 @@ export type SerializedFileSchema = {
   type: "file";
   /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
   render?: FieldRender;
+  /** Set when this schema declares a `preview`. The closure itself cannot serialize. */
+  preview?: true;
   options?: FileOptions;
   remote?: boolean;
   opt: boolean;
@@ -54,6 +56,7 @@ export class FileSchema<Src extends FileSource | null> extends Schema<Src> {
     private readonly isHidden: boolean = false,
     private readonly description?: string,
     private readonly renderInput: FieldRender | null = null,
+    private readonly previewInput: ItemPreviewInput<Src> | null = null,
   ) {
     super();
   }
@@ -69,6 +72,7 @@ export class FileSchema<Src extends FileSource | null> extends Schema<Src> {
       this.isHidden,
       description ?? undefined,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -83,6 +87,7 @@ export class FileSchema<Src extends FileSource | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -97,6 +102,7 @@ export class FileSchema<Src extends FileSource | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -371,6 +377,7 @@ export class FileSchema<Src extends FileSource | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -385,6 +392,7 @@ export class FileSchema<Src extends FileSource | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -399,6 +407,7 @@ export class FileSchema<Src extends FileSource | null> extends Schema<Src> {
       true,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -431,7 +440,41 @@ export class FileSchema<Src extends FileSource | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       input,
+      this.previewInput,
     );
+  }
+
+  /**
+   * How this VALUE is shown where a preview of it is needed — a row in a
+   * sortable list, a reference dropdown, a search hit. Never how the field
+   * itself is edited (that is `render`). See `preview.ts`.
+   */
+  preview(select: ItemPreviewInput<Src>): FileSchema<Src> {
+    return new FileSchema(
+      this.options,
+      this.opt,
+      this.isRemote,
+      this.customValidateFunctions,
+      this.moduleMetadata,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      this.renderInput,
+      select,
+    );
+  }
+
+  protected override executePreviewItem(
+    src: NonNullable<Src>,
+  ): PreviewItem | null {
+    if (this.previewInput === null) {
+      return null;
+    }
+    return this.previewInput({ val: src });
+  }
+
+  protected override declaresItemPreview(): boolean {
+    return this.previewInput !== null;
   }
 
   protected executeSerialize(): SerializedSchema {
@@ -441,6 +484,7 @@ export class FileSchema<Src extends FileSource | null> extends Schema<Src> {
     return {
       type: "file",
       render: this.renderInput ?? undefined,
+      preview: this.previewInput ? true : undefined,
       options: this.options,
       opt: this.opt,
       remote: this.isRemote,

--- a/packages/core/src/schema/file.ts
+++ b/packages/core/src/schema/file.ts
@@ -18,6 +18,7 @@ import {
 } from "./validation/ValidationError";
 import { Internal, ValModule } from "..";
 import { ReifiedPreview } from "../preview";
+import { FieldRender } from "../render";
 import { FilesEntryMetadata } from "./files";
 import { getSource } from "../module";
 
@@ -27,6 +28,8 @@ export type FileOptions = {
 
 export type SerializedFileSchema = {
   type: "file";
+  /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
+  render?: FieldRender;
   options?: FileOptions;
   remote?: boolean;
   opt: boolean;
@@ -50,6 +53,7 @@ export class FileSchema<Src extends FileSource | null> extends Schema<Src> {
     private readonly isReadonly: boolean = false,
     private readonly isHidden: boolean = false,
     private readonly description?: string,
+    private readonly renderInput: FieldRender | null = null,
   ) {
     super();
   }
@@ -64,6 +68,7 @@ export class FileSchema<Src extends FileSource | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       description ?? undefined,
+      this.renderInput,
     );
   }
 
@@ -77,6 +82,7 @@ export class FileSchema<Src extends FileSource | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -90,6 +96,7 @@ export class FileSchema<Src extends FileSource | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -363,6 +370,7 @@ export class FileSchema<Src extends FileSource | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -376,6 +384,7 @@ export class FileSchema<Src extends FileSource | null> extends Schema<Src> {
       true,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -389,6 +398,7 @@ export class FileSchema<Src extends FileSource | null> extends Schema<Src> {
       this.isReadonly,
       true,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -403,12 +413,34 @@ export class FileSchema<Src extends FileSource | null> extends Schema<Src> {
     );
   }
 
+  /**
+   * How this field is laid out in the editor when it is the item of an array
+   * or record: `{ as: "inline" }` renders the field itself inside each row,
+   * instead of a preview row that navigates to it.
+   *
+   * Static configuration, not a callback — see `render.ts`.
+   */
+  render(input: FieldRender): FileSchema<Src> {
+    return new FileSchema(
+      this.options,
+      this.opt,
+      this.isRemote,
+      this.customValidateFunctions,
+      this.moduleMetadata,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      input,
+    );
+  }
+
   protected executeSerialize(): SerializedSchema {
     const modulePaths = this.moduleMetadata
       ? Object.keys(this.moduleMetadata)
       : [];
     return {
       type: "file",
+      render: this.renderInput ?? undefined,
       options: this.options,
       opt: this.opt,
       remote: this.isRemote,

--- a/packages/core/src/schema/image.ts
+++ b/packages/core/src/schema/image.ts
@@ -16,6 +16,7 @@ import {
 } from "./validation/ValidationError";
 import { Internal, ValModule } from "..";
 import { ReifiedPreview } from "../preview";
+import { FieldRender } from "../render";
 import { ImagesEntryMetadata } from "./images";
 import { getSource } from "../module";
 
@@ -28,6 +29,8 @@ export type ImageOptions = {
 
 export type SerializedImageSchema = {
   type: "image";
+  /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
+  render?: FieldRender;
   options?: ImageOptions;
   opt: boolean;
   remote?: boolean;
@@ -61,6 +64,7 @@ export class ImageSchema<Src extends ImageSource | null> extends Schema<Src> {
     private readonly isReadonly: boolean = false,
     private readonly isHidden: boolean = false,
     private readonly description?: string,
+    private readonly renderInput: FieldRender | null = null,
   ) {
     super();
   }
@@ -75,6 +79,7 @@ export class ImageSchema<Src extends ImageSource | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       description ?? undefined,
+      this.renderInput,
     );
   }
 
@@ -88,6 +93,7 @@ export class ImageSchema<Src extends ImageSource | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -101,6 +107,7 @@ export class ImageSchema<Src extends ImageSource | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -406,6 +413,7 @@ export class ImageSchema<Src extends ImageSource | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -419,6 +427,7 @@ export class ImageSchema<Src extends ImageSource | null> extends Schema<Src> {
       true,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -432,6 +441,7 @@ export class ImageSchema<Src extends ImageSource | null> extends Schema<Src> {
       this.isReadonly,
       true,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -446,12 +456,34 @@ export class ImageSchema<Src extends ImageSource | null> extends Schema<Src> {
     );
   }
 
+  /**
+   * How this field is laid out in the editor when it is the item of an array
+   * or record: `{ as: "inline" }` renders the field itself inside each row,
+   * instead of a preview row that navigates to it.
+   *
+   * Static configuration, not a callback — see `render.ts`.
+   */
+  render(input: FieldRender): ImageSchema<Src> {
+    return new ImageSchema(
+      this.options,
+      this.opt,
+      this.isRemote,
+      this.customValidateFunctions,
+      this.moduleMetadata,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      input,
+    );
+  }
+
   protected executeSerialize(): SerializedSchema {
     const modulePaths = this.moduleMetadata
       ? Object.keys(this.moduleMetadata)
       : [];
     return {
       type: "image",
+      render: this.renderInput ?? undefined,
       options: this.options,
       opt: this.opt,
       remote: this.isRemote,

--- a/packages/core/src/schema/image.ts
+++ b/packages/core/src/schema/image.ts
@@ -15,7 +15,7 @@ import {
   ValidationErrors,
 } from "./validation/ValidationError";
 import { Internal, ValModule } from "..";
-import { ReifiedPreview } from "../preview";
+import { ItemPreviewInput, PreviewItem, ReifiedPreview } from "../preview";
 import { FieldRender } from "../render";
 import { ImagesEntryMetadata } from "./images";
 import { getSource } from "../module";
@@ -31,6 +31,8 @@ export type SerializedImageSchema = {
   type: "image";
   /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
   render?: FieldRender;
+  /** Set when this schema declares a `preview`. The closure itself cannot serialize. */
+  preview?: true;
   options?: ImageOptions;
   opt: boolean;
   remote?: boolean;
@@ -65,6 +67,7 @@ export class ImageSchema<Src extends ImageSource | null> extends Schema<Src> {
     private readonly isHidden: boolean = false,
     private readonly description?: string,
     private readonly renderInput: FieldRender | null = null,
+    private readonly previewInput: ItemPreviewInput<Src> | null = null,
   ) {
     super();
   }
@@ -80,6 +83,7 @@ export class ImageSchema<Src extends ImageSource | null> extends Schema<Src> {
       this.isHidden,
       description ?? undefined,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -94,6 +98,7 @@ export class ImageSchema<Src extends ImageSource | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -108,6 +113,7 @@ export class ImageSchema<Src extends ImageSource | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -414,6 +420,7 @@ export class ImageSchema<Src extends ImageSource | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -428,6 +435,7 @@ export class ImageSchema<Src extends ImageSource | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -442,6 +450,7 @@ export class ImageSchema<Src extends ImageSource | null> extends Schema<Src> {
       true,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -474,7 +483,41 @@ export class ImageSchema<Src extends ImageSource | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       input,
+      this.previewInput,
     );
+  }
+
+  /**
+   * How this VALUE is shown where a preview of it is needed — a row in a
+   * sortable list, a reference dropdown, a search hit. Never how the field
+   * itself is edited (that is `render`). See `preview.ts`.
+   */
+  preview(select: ItemPreviewInput<Src>): ImageSchema<Src> {
+    return new ImageSchema(
+      this.options,
+      this.opt,
+      this.isRemote,
+      this.customValidateFunctions,
+      this.moduleMetadata,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      this.renderInput,
+      select,
+    );
+  }
+
+  protected override executePreviewItem(
+    src: NonNullable<Src>,
+  ): PreviewItem | null {
+    if (this.previewInput === null) {
+      return null;
+    }
+    return this.previewInput({ val: src });
+  }
+
+  protected override declaresItemPreview(): boolean {
+    return this.previewInput !== null;
   }
 
   protected executeSerialize(): SerializedSchema {
@@ -484,6 +527,7 @@ export class ImageSchema<Src extends ImageSource | null> extends Schema<Src> {
     return {
       type: "image",
       render: this.renderInput ?? undefined,
+      preview: this.previewInput ? true : undefined,
       options: this.options,
       opt: this.opt,
       remote: this.isRemote,

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -23,7 +23,7 @@ import {
 } from "./validation/ValidationError";
 import { FileSource } from "../source/media";
 import { GenericRichTextSourceNode, RichTextSource } from "../source/richtext";
-import { ReifiedPreview, PreviewScope } from "../preview";
+import { ReifiedPreview, PreviewScope, PreviewItem } from "../preview";
 // import { SerializedI18nSchema } from "./future/i18n";
 // import { SerializedOneOfSchema } from "./future/oneOf";
 
@@ -184,6 +184,31 @@ export abstract class Schema<Src extends SelectorSource> {
     src: Src,
     scope?: PreviewScope,
   ): ReifiedPreview;
+  /**
+   * This value AS A PREVIEW — what a container's row, a reference dropdown or
+   * a search hit shows for it. Runs the schema's own `preview` closure;
+   * `null` when none is declared (the consumer falls back to a generic
+   * preview). A union dispatches to the matching member's closure.
+   *
+   * Containers call this on their ITEM schema per item — that is how
+   * `executePreview` reifies an {@link ArrayPreview} / {@link RecordPreview}
+   * from item-level declarations.
+   */
+  protected executePreviewItem(src: NonNullable<Src>): PreviewItem | null {
+    // Default for schemas without a closure; every class that stores a
+    // `previewInput` overrides both this and {@link declaresItemPreview}.
+    void src;
+    return null;
+  }
+  /**
+   * Could {@link executePreviewItem} ever answer? A container reifies a rows
+   * preview only when its item schema says yes — asked here rather than by
+   * running the closure, so an EMPTY list still previews as an empty list
+   * instead of not at all.
+   */
+  protected declaresItemPreview(): boolean {
+    return false;
+  }
   // remote(): Src extends RemoteCompatibleSource
   //   ? Schema<RemoteSource<Src>>
   //   : never {

--- a/packages/core/src/schema/itemPreview.test.ts
+++ b/packages/core/src/schema/itemPreview.test.ts
@@ -1,0 +1,251 @@
+import { Schema } from ".";
+import { initVal } from "../initVal";
+import { SelectorSource } from "../selector";
+import { SourcePath } from "../val";
+
+const { s, c } = initVal();
+
+const authors = c.define(
+  "/content/authors.val.ts",
+  s.record(s.object({ name: s.string() })),
+  { fredrik: { name: "Fredrik" } },
+);
+
+/**
+ * `preview` is declared on the schema of the VALUE being previewed — the item,
+ * not the container — and the container reifies its rows from it. See
+ * `preview.ts` and `architecture/render-and-preview.md`.
+ */
+describe("item-level preview", () => {
+  test("simple: an array previews rows from its item's preview", () => {
+    const schema = s.array(
+      s
+        .object({ name: s.string() })
+        .preview(({ val }) => ({ title: val.name })),
+    );
+    expect(
+      schema["executePreview"]("/test.val.ts" as SourcePath, [
+        { name: "Ada" },
+        { name: "Grace" },
+      ]),
+    ).toStrictEqual({
+      "/test.val.ts": {
+        status: "success",
+        data: {
+          parent: "array",
+          items: [
+            [0, { title: "Ada", subtitle: undefined, image: undefined }],
+            [1, { title: "Grace", subtitle: undefined, image: undefined }],
+          ],
+        },
+      },
+    });
+  });
+
+  test("simple: a record previews entries from its item's preview", () => {
+    const schema = s.record(
+      s
+        .object({ name: s.string() })
+        .preview(({ val }) => ({ title: val.name })),
+    );
+    expect(
+      schema["executePreview"]("/test.val.ts" as SourcePath, {
+        ada: { name: "Ada" },
+      }),
+    ).toStrictEqual({
+      "/test.val.ts": {
+        status: "success",
+        data: {
+          parent: "record",
+          items: [
+            ["ada", { title: "Ada", subtitle: undefined, image: undefined }],
+          ],
+        },
+      },
+    });
+  });
+
+  test("an item without a preview produces no rows preview", () => {
+    const schema = s.array(s.object({ name: s.string() }));
+    expect(
+      schema["executePreview"]("/test.val.ts" as SourcePath, [{ name: "Ada" }]),
+    ).toStrictEqual({});
+  });
+
+  test("preview serializes as a marker across every schema type", () => {
+    const p = () => ({ title: "t" });
+    const schemas: Schema<SelectorSource>[] = [
+      s.string().preview(p),
+      s.number().preview(p),
+      s.boolean().preview(p),
+      s.literal("a").preview(p),
+      s.date().preview(p),
+      s.datetime().preview(p),
+      s.color().preview(p),
+      s.route().preview(p),
+      s.richtext().preview(p),
+      s.image().preview(p),
+      s.file().preview(p),
+      s.array(s.string()).preview(p),
+      s.object({ a: s.string() }).preview(p),
+      s.record(s.string()).preview(p),
+      s.union("type", s.object({ type: s.literal("a") })).preview(p),
+      s.keyOf(authors).preview(p),
+    ];
+    for (const schema of schemas) {
+      expect(schema["executeSerialize"]().preview).toBe(true);
+    }
+    expect(s.string()["executeSerialize"]().preview).toBe(undefined);
+  });
+
+  test("preview is kept when chaining, including through render", () => {
+    const base = s
+      .object({ name: s.string() })
+      .preview(({ val }) => ({ title: val.name }));
+    for (const item of [
+      base,
+      base.nullable(),
+      base.readonly(),
+      base.hidden(),
+      base.describe("desc"),
+      base.validate(() => false),
+      base.render({ as: "inline" }),
+    ]) {
+      expect(item["executeSerialize"]().preview).toBe(true);
+    }
+  });
+
+  test("a second preview replaces the first (last wins)", () => {
+    const schema = s.array(
+      s
+        .object({ name: s.string() })
+        .preview(({ val }) => ({ title: `first: ${val.name}` }))
+        .preview(({ val }) => ({ title: `second: ${val.name}` })),
+    );
+    const res = schema["executePreview"]("/test.val.ts" as SourcePath, [
+      { name: "Ada" },
+    ]);
+    const at = res["/test.val.ts" as SourcePath];
+    if (at?.status !== "success" || at.data.parent !== "array") {
+      throw new Error("expected an array preview");
+    }
+    expect(at.data.items).toEqual([
+      [0, { title: "second: Ada", subtitle: undefined, image: undefined }],
+    ]);
+  });
+
+  test("a string item previews with its own closure", () => {
+    const schema = s.array(s.string().preview(({ val }) => ({ title: val })));
+    const res = schema["executePreview"]("/test.val.ts" as SourcePath, [
+      "hello",
+    ]);
+    const at = res["/test.val.ts" as SourcePath];
+    if (at?.status !== "success" || at.data.parent !== "array") {
+      throw new Error("expected an array preview");
+    }
+    expect(at.data.items).toEqual([
+      [0, { title: "hello", subtitle: undefined, image: undefined }],
+    ]);
+  });
+
+  describe("unions", () => {
+    const blocks = s.array(
+      s.union(
+        "type",
+        s
+          .object({ type: s.literal("hero"), heading: s.string() })
+          .preview(({ val }) => ({ title: `Hero: ${val.heading}` })),
+        s
+          .object({ type: s.literal("quote"), text: s.string() })
+          .preview(({ val }) => ({ title: `Quote: ${val.text}` })),
+        s.object({ type: s.literal("spacer"), size: s.number() }),
+      ),
+    );
+    const src = [
+      { type: "quote" as const, text: "Make it work" },
+      { type: "spacer" as const, size: 8 },
+      { type: "hero" as const, heading: "Welcome" },
+    ];
+
+    test("a union item previews as the variant the value takes", () => {
+      const res = blocks["executePreview"]("/test.val.ts" as SourcePath, src);
+      const at = res["/test.val.ts" as SourcePath];
+      if (at?.status !== "success" || at.data.parent !== "array") {
+        throw new Error("expected an array preview");
+      }
+      // The spacer variant declares no preview, so its row is simply absent —
+      // the consumer falls back to a generic preview for it.
+      expect(at.data.items).toEqual([
+        [
+          0,
+          {
+            title: "Quote: Make it work",
+            subtitle: undefined,
+            image: undefined,
+          },
+        ],
+        [2, { title: "Hero: Welcome", subtitle: undefined, image: undefined }],
+      ]);
+    });
+
+    test("a union's own preview wins over its variants'", () => {
+      const schema = s.array(
+        s
+          .union(
+            "type",
+            s
+              .object({ type: s.literal("hero"), heading: s.string() })
+              .preview(({ val }) => ({ title: `Hero: ${val.heading}` })),
+            s.object({ type: s.literal("spacer"), size: s.number() }),
+          )
+          .preview(() => ({ title: "block" })),
+      );
+      const res = schema["executePreview"]("/test.val.ts" as SourcePath, [
+        { type: "hero" as const, heading: "Welcome" },
+      ]);
+      const at = res["/test.val.ts" as SourcePath];
+      if (at?.status !== "success" || at.data.parent !== "array") {
+        throw new Error("expected an array preview");
+      }
+      expect(at.data.items).toEqual([
+        [0, { title: "block", subtitle: undefined, image: undefined }],
+      ]);
+    });
+
+    test("a preview nested deep within a union variant still reifies", () => {
+      // The corner case: the previewing container lives inside a variant of a
+      // union inside an array — the walk has to dispatch through the union to
+      // reach it.
+      const schema = s.array(
+        s.union(
+          "type",
+          s.object({
+            type: s.literal("gallery"),
+            images: s.record(
+              s
+                .object({ alt: s.string() })
+                .preview(({ val }) => ({ title: val.alt })),
+            ),
+          }),
+          s.object({ type: s.literal("spacer") }),
+        ),
+      );
+      const res = schema["executePreview"]("/test.val.ts" as SourcePath, [
+        { type: "spacer" as const },
+        {
+          type: "gallery" as const,
+          images: { a: { alt: "A cat" } },
+        },
+      ]);
+      expect(res['/test.val.ts?p=1."images"' as SourcePath]).toStrictEqual({
+        status: "success",
+        data: {
+          parent: "record",
+          items: [
+            ["a", { title: "A cat", subtitle: undefined, image: undefined }],
+          ],
+        },
+      });
+    });
+  });
+});

--- a/packages/core/src/schema/keyOf.ts
+++ b/packages/core/src/schema/keyOf.ts
@@ -15,11 +15,14 @@ import {
 } from "./validation/ValidationError";
 import { RawString } from "./string";
 import { ReifiedPreview } from "../preview";
+import { FieldRender } from "../render";
 import { ObjectSchema } from "./object";
 import { RecordSchema } from "./record";
 
 export type SerializedKeyOfSchema = {
   type: "keyOf";
+  /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
+  render?: FieldRender;
   path: SourcePath;
   schema?: SerializedRefSchema | undefined;
   opt: boolean;
@@ -65,6 +68,7 @@ export class KeyOfSchema<
     private readonly isReadonly: boolean = false,
     private readonly isHidden: boolean = false,
     private readonly description?: string,
+    private readonly renderInput: FieldRender | null = null,
   ) {
     super();
   }
@@ -78,6 +82,7 @@ export class KeyOfSchema<
       this.isReadonly,
       this.isHidden,
       description ?? undefined,
+      this.renderInput,
     );
   }
 
@@ -92,6 +97,7 @@ export class KeyOfSchema<
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -299,6 +305,7 @@ export class KeyOfSchema<
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -311,6 +318,7 @@ export class KeyOfSchema<
       true,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -323,6 +331,7 @@ export class KeyOfSchema<
       this.isReadonly,
       true,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -334,6 +343,26 @@ export class KeyOfSchema<
       src,
       this.customValidateFunctions,
       { path },
+    );
+  }
+
+  /**
+   * How this field is laid out in the editor when it is the item of an array
+   * or record: `{ as: "inline" }` renders the field itself inside each row,
+   * instead of a preview row that navigates to it.
+   *
+   * Static configuration, not a callback — see `render.ts`.
+   */
+  render(input: FieldRender): KeyOfSchema<Sel, Src> {
+    return new KeyOfSchema(
+      this.schema,
+      this.sourcePath,
+      this.opt,
+      this.customValidateFunctions,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      input,
     );
   }
 
@@ -365,6 +394,7 @@ export class KeyOfSchema<
     }
     return {
       type: "keyOf",
+      render: this.renderInput ?? undefined,
       path: path,
       schema: serializedSchema,
       opt: this.opt,

--- a/packages/core/src/schema/keyOf.ts
+++ b/packages/core/src/schema/keyOf.ts
@@ -14,7 +14,7 @@ import {
   ValidationErrors,
 } from "./validation/ValidationError";
 import { RawString } from "./string";
-import { ReifiedPreview } from "../preview";
+import { ItemPreviewInput, PreviewItem, ReifiedPreview } from "../preview";
 import { FieldRender } from "../render";
 import { ObjectSchema } from "./object";
 import { RecordSchema } from "./record";
@@ -23,6 +23,8 @@ export type SerializedKeyOfSchema = {
   type: "keyOf";
   /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
   render?: FieldRender;
+  /** Set when this schema declares a `preview`. The closure itself cannot serialize. */
+  preview?: true;
   path: SourcePath;
   schema?: SerializedRefSchema | undefined;
   opt: boolean;
@@ -69,6 +71,7 @@ export class KeyOfSchema<
     private readonly isHidden: boolean = false,
     private readonly description?: string,
     private readonly renderInput: FieldRender | null = null,
+    private readonly previewInput: ItemPreviewInput<Src> | null = null,
   ) {
     super();
   }
@@ -83,6 +86,7 @@ export class KeyOfSchema<
       this.isHidden,
       description ?? undefined,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -98,6 +102,7 @@ export class KeyOfSchema<
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -297,7 +302,7 @@ export class KeyOfSchema<
   }
 
   nullable(): KeyOfSchema<Sel, Src | null> {
-    return new KeyOfSchema(
+    return new KeyOfSchema<Sel, Src | null>(
       this.schema,
       this.sourcePath,
       true,
@@ -306,6 +311,7 @@ export class KeyOfSchema<
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -319,6 +325,7 @@ export class KeyOfSchema<
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -332,6 +339,7 @@ export class KeyOfSchema<
       true,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -363,7 +371,40 @@ export class KeyOfSchema<
       this.isHidden,
       this.description,
       input,
+      this.previewInput,
     );
+  }
+
+  /**
+   * How this VALUE is shown where a preview of it is needed — a row in a
+   * sortable list, a reference dropdown, a search hit. Never how the field
+   * itself is edited (that is `render`). See `preview.ts`.
+   */
+  preview(select: ItemPreviewInput<Src>): KeyOfSchema<Sel, Src> {
+    return new KeyOfSchema(
+      this.schema,
+      this.sourcePath,
+      this.opt,
+      this.customValidateFunctions,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      this.renderInput,
+      select,
+    );
+  }
+
+  protected override executePreviewItem(
+    src: NonNullable<Src>,
+  ): PreviewItem | null {
+    if (this.previewInput === null) {
+      return null;
+    }
+    return this.previewInput({ val: src });
+  }
+
+  protected override declaresItemPreview(): boolean {
+    return this.previewInput !== null;
   }
 
   protected executeSerialize(): SerializedSchema {
@@ -395,6 +436,7 @@ export class KeyOfSchema<
     return {
       type: "keyOf",
       render: this.renderInput ?? undefined,
+      preview: this.previewInput ? true : undefined,
       path: path,
       schema: serializedSchema,
       opt: this.opt,

--- a/packages/core/src/schema/literal.ts
+++ b/packages/core/src/schema/literal.ts
@@ -5,6 +5,7 @@ import {
   SerializedSchema,
 } from ".";
 import { ReifiedPreview } from "../preview";
+import { FieldRender } from "../render";
 import { SourcePath } from "../val";
 import {
   ValidationError,
@@ -13,6 +14,8 @@ import {
 
 export type SerializedLiteralSchema = {
   type: "literal";
+  /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
+  render?: FieldRender;
   value: string;
   opt: boolean;
   customValidate?: boolean;
@@ -29,6 +32,7 @@ export class LiteralSchema<Src extends string | null> extends Schema<Src> {
     private readonly isReadonly: boolean = false,
     private readonly isHidden: boolean = false,
     private readonly description?: string,
+    private readonly renderInput: FieldRender | null = null,
   ) {
     super();
   }
@@ -41,6 +45,7 @@ export class LiteralSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       description ?? undefined,
+      this.renderInput,
     );
   }
 
@@ -54,6 +59,7 @@ export class LiteralSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -144,6 +150,7 @@ export class LiteralSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -155,6 +162,7 @@ export class LiteralSchema<Src extends string | null> extends Schema<Src> {
       true,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -166,6 +174,7 @@ export class LiteralSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       true,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -180,9 +189,29 @@ export class LiteralSchema<Src extends string | null> extends Schema<Src> {
     );
   }
 
+  /**
+   * How this field is laid out in the editor when it is the item of an array
+   * or record: `{ as: "inline" }` renders the field itself inside each row,
+   * instead of a preview row that navigates to it.
+   *
+   * Static configuration, not a callback — see `render.ts`.
+   */
+  render(input: FieldRender): LiteralSchema<Src> {
+    return new LiteralSchema(
+      this.value,
+      this.opt,
+      this.customValidateFunctions,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      input,
+    );
+  }
+
   protected executeSerialize(): SerializedSchema {
     return {
       type: "literal",
+      render: this.renderInput ?? undefined,
       value: this.value,
       opt: this.opt,
       customValidate:

--- a/packages/core/src/schema/literal.ts
+++ b/packages/core/src/schema/literal.ts
@@ -4,7 +4,7 @@ import {
   SchemaAssertResult,
   SerializedSchema,
 } from ".";
-import { ReifiedPreview } from "../preview";
+import { ItemPreviewInput, PreviewItem, ReifiedPreview } from "../preview";
 import { FieldRender } from "../render";
 import { SourcePath } from "../val";
 import {
@@ -16,6 +16,8 @@ export type SerializedLiteralSchema = {
   type: "literal";
   /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
   render?: FieldRender;
+  /** Set when this schema declares a `preview`. The closure itself cannot serialize. */
+  preview?: true;
   value: string;
   opt: boolean;
   customValidate?: boolean;
@@ -33,6 +35,7 @@ export class LiteralSchema<Src extends string | null> extends Schema<Src> {
     private readonly isHidden: boolean = false,
     private readonly description?: string,
     private readonly renderInput: FieldRender | null = null,
+    private readonly previewInput: ItemPreviewInput<Src> | null = null,
   ) {
     super();
   }
@@ -46,6 +49,7 @@ export class LiteralSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       description ?? undefined,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -60,6 +64,7 @@ export class LiteralSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -151,6 +156,7 @@ export class LiteralSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -163,6 +169,7 @@ export class LiteralSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -175,6 +182,7 @@ export class LiteralSchema<Src extends string | null> extends Schema<Src> {
       true,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -205,13 +213,46 @@ export class LiteralSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       input,
+      this.previewInput,
     );
+  }
+
+  /**
+   * How this VALUE is shown where a preview of it is needed — a row in a
+   * sortable list, a reference dropdown, a search hit. Never how the field
+   * itself is edited (that is `render`). See `preview.ts`.
+   */
+  preview(select: ItemPreviewInput<Src>): LiteralSchema<Src> {
+    return new LiteralSchema(
+      this.value,
+      this.opt,
+      this.customValidateFunctions,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      this.renderInput,
+      select,
+    );
+  }
+
+  protected override executePreviewItem(
+    src: NonNullable<Src>,
+  ): PreviewItem | null {
+    if (this.previewInput === null) {
+      return null;
+    }
+    return this.previewInput({ val: src });
+  }
+
+  protected override declaresItemPreview(): boolean {
+    return this.previewInput !== null;
   }
 
   protected executeSerialize(): SerializedSchema {
     return {
       type: "literal",
       render: this.renderInput ?? undefined,
+      preview: this.previewInput ? true : undefined,
       value: this.value,
       opt: this.opt,
       customValidate:

--- a/packages/core/src/schema/number.ts
+++ b/packages/core/src/schema/number.ts
@@ -5,6 +5,7 @@ import {
   SerializedSchema,
 } from ".";
 import { ReifiedPreview } from "../preview";
+import { FieldRender } from "../render";
 import { SourcePath } from "../val";
 import {
   ValidationError,
@@ -18,6 +19,8 @@ type NumberOptions = {
 
 export type SerializedNumberSchema = {
   type: "number";
+  /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
+  render?: FieldRender;
   options?: NumberOptions;
   opt: boolean;
   customValidate?: boolean;
@@ -34,6 +37,7 @@ export class NumberSchema<Src extends number | null> extends Schema<Src> {
     private readonly isReadonly: boolean = false,
     private readonly isHidden: boolean = false,
     private readonly description?: string,
+    private readonly renderInput: FieldRender | null = null,
   ) {
     super();
   }
@@ -46,6 +50,7 @@ export class NumberSchema<Src extends number | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       description ?? undefined,
+      this.renderInput,
     );
   }
 
@@ -59,6 +64,7 @@ export class NumberSchema<Src extends number | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -160,6 +166,7 @@ export class NumberSchema<Src extends number | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -171,6 +178,7 @@ export class NumberSchema<Src extends number | null> extends Schema<Src> {
       true,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -182,6 +190,7 @@ export class NumberSchema<Src extends number | null> extends Schema<Src> {
       this.isReadonly,
       true,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -193,6 +202,7 @@ export class NumberSchema<Src extends number | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -204,6 +214,7 @@ export class NumberSchema<Src extends number | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -218,9 +229,29 @@ export class NumberSchema<Src extends number | null> extends Schema<Src> {
     );
   }
 
+  /**
+   * How this field is laid out in the editor when it is the item of an array
+   * or record: `{ as: "inline" }` renders the field itself inside each row,
+   * instead of a preview row that navigates to it.
+   *
+   * Static configuration, not a callback — see `render.ts`.
+   */
+  render(input: FieldRender): NumberSchema<Src> {
+    return new NumberSchema<Src>(
+      this.options,
+      this.opt,
+      this.customValidateFunctions,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      input,
+    );
+  }
+
   protected executeSerialize(): SerializedSchema {
     return {
       type: "number",
+      render: this.renderInput ?? undefined,
       options: this.options,
       opt: this.opt,
       customValidate:

--- a/packages/core/src/schema/number.ts
+++ b/packages/core/src/schema/number.ts
@@ -4,7 +4,7 @@ import {
   SchemaAssertResult,
   SerializedSchema,
 } from ".";
-import { ReifiedPreview } from "../preview";
+import { ItemPreviewInput, PreviewItem, ReifiedPreview } from "../preview";
 import { FieldRender } from "../render";
 import { SourcePath } from "../val";
 import {
@@ -21,6 +21,8 @@ export type SerializedNumberSchema = {
   type: "number";
   /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
   render?: FieldRender;
+  /** Set when this schema declares a `preview`. The closure itself cannot serialize. */
+  preview?: true;
   options?: NumberOptions;
   opt: boolean;
   customValidate?: boolean;
@@ -38,6 +40,7 @@ export class NumberSchema<Src extends number | null> extends Schema<Src> {
     private readonly isHidden: boolean = false,
     private readonly description?: string,
     private readonly renderInput: FieldRender | null = null,
+    private readonly previewInput: ItemPreviewInput<Src> | null = null,
   ) {
     super();
   }
@@ -51,6 +54,7 @@ export class NumberSchema<Src extends number | null> extends Schema<Src> {
       this.isHidden,
       description ?? undefined,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -65,6 +69,7 @@ export class NumberSchema<Src extends number | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -167,6 +172,7 @@ export class NumberSchema<Src extends number | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -179,6 +185,7 @@ export class NumberSchema<Src extends number | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -191,6 +198,7 @@ export class NumberSchema<Src extends number | null> extends Schema<Src> {
       true,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -203,6 +211,7 @@ export class NumberSchema<Src extends number | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -215,6 +224,7 @@ export class NumberSchema<Src extends number | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -245,13 +255,46 @@ export class NumberSchema<Src extends number | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       input,
+      this.previewInput,
     );
+  }
+
+  /**
+   * How this VALUE is shown where a preview of it is needed — a row in a
+   * sortable list, a reference dropdown, a search hit. Never how the field
+   * itself is edited (that is `render`). See `preview.ts`.
+   */
+  preview(select: ItemPreviewInput<Src>): NumberSchema<Src> {
+    return new NumberSchema<Src>(
+      this.options,
+      this.opt,
+      this.customValidateFunctions,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      this.renderInput,
+      select,
+    );
+  }
+
+  protected override executePreviewItem(
+    src: NonNullable<Src>,
+  ): PreviewItem | null {
+    if (this.previewInput === null) {
+      return null;
+    }
+    return this.previewInput({ val: src });
+  }
+
+  protected override declaresItemPreview(): boolean {
+    return this.previewInput !== null;
   }
 
   protected executeSerialize(): SerializedSchema {
     return {
       type: "number",
       render: this.renderInput ?? undefined,
+      preview: this.previewInput ? true : undefined,
       options: this.options,
       opt: this.opt,
       customValidate:

--- a/packages/core/src/schema/object.ts
+++ b/packages/core/src/schema/object.ts
@@ -8,6 +8,7 @@ import {
   SerializedSchema,
 } from ".";
 import { ReifiedPreview, PreviewScope } from "../preview";
+import { FieldRender } from "../render";
 import { SelectorSource } from "../selector";
 import {
   createValPathOfItem,
@@ -22,6 +23,8 @@ import {
 
 export type SerializedObjectSchema = {
   type: "object";
+  /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
+  render?: FieldRender;
   items: Record<string, SerializedSchema>;
   opt: boolean;
   customValidate?: boolean;
@@ -64,6 +67,7 @@ export class ObjectSchema<
     private readonly isReadonly: boolean = false,
     private readonly isHidden: boolean = false,
     private readonly description?: string,
+    private readonly renderInput: FieldRender | null = null,
   ) {
     super();
   }
@@ -76,6 +80,7 @@ export class ObjectSchema<
       this.isReadonly,
       this.isHidden,
       description ?? undefined,
+      this.renderInput,
     );
   }
 
@@ -89,6 +94,7 @@ export class ObjectSchema<
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -230,6 +236,7 @@ export class ObjectSchema<
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -241,6 +248,7 @@ export class ObjectSchema<
       true,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -252,6 +260,7 @@ export class ObjectSchema<
       this.isReadonly,
       true,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -266,9 +275,29 @@ export class ObjectSchema<
     );
   }
 
+  /**
+   * How this field is laid out in the editor when it is the item of an array
+   * or record: `{ as: "inline" }` renders the field itself inside each row,
+   * instead of a preview row that navigates to it.
+   *
+   * Static configuration, not a callback — see `render.ts`.
+   */
+  render(input: FieldRender): ObjectSchema<Props, Src> {
+    return new ObjectSchema(
+      this.items,
+      this.opt,
+      this.customValidateFunctions,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      input,
+    );
+  }
+
   protected executeSerialize(): SerializedSchema {
     return {
       type: "object",
+      render: this.renderInput ?? undefined,
       items: Object.fromEntries(
         Object.entries(this.items).map(([key, schema]) => [
           key,

--- a/packages/core/src/schema/object.ts
+++ b/packages/core/src/schema/object.ts
@@ -7,7 +7,12 @@ import {
   SelectorOfSchema,
   SerializedSchema,
 } from ".";
-import { ReifiedPreview, PreviewScope } from "../preview";
+import {
+  ItemPreviewInput,
+  PreviewItem,
+  ReifiedPreview,
+  PreviewScope,
+} from "../preview";
 import { FieldRender } from "../render";
 import { SelectorSource } from "../selector";
 import {
@@ -25,6 +30,8 @@ export type SerializedObjectSchema = {
   type: "object";
   /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
   render?: FieldRender;
+  /** Set when this schema declares a `preview`. The closure itself cannot serialize. */
+  preview?: true;
   items: Record<string, SerializedSchema>;
   opt: boolean;
   customValidate?: boolean;
@@ -68,6 +75,7 @@ export class ObjectSchema<
     private readonly isHidden: boolean = false,
     private readonly description?: string,
     private readonly renderInput: FieldRender | null = null,
+    private readonly previewInput: ItemPreviewInput<Src> | null = null,
   ) {
     super();
   }
@@ -81,6 +89,7 @@ export class ObjectSchema<
       this.isHidden,
       description ?? undefined,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -95,6 +104,7 @@ export class ObjectSchema<
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -229,7 +239,8 @@ export class ObjectSchema<
   }
 
   nullable(): ObjectSchema<Props, Src | null> {
-    return new ObjectSchema(
+    // Explicit type args: `previewInput` would otherwise pin inference to `Src`.
+    return new ObjectSchema<Props, Src | null>(
       this.items,
       true,
       [],
@@ -237,6 +248,7 @@ export class ObjectSchema<
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -249,6 +261,7 @@ export class ObjectSchema<
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -261,6 +274,7 @@ export class ObjectSchema<
       true,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -291,13 +305,46 @@ export class ObjectSchema<
       this.isHidden,
       this.description,
       input,
+      this.previewInput,
     );
+  }
+
+  /**
+   * How this VALUE is shown where a preview of it is needed — a row in a
+   * sortable list, a reference dropdown, a search hit. Never how the field
+   * itself is edited (that is `render`). See `preview.ts`.
+   */
+  preview(select: ItemPreviewInput<Src>): ObjectSchema<Props, Src> {
+    return new ObjectSchema(
+      this.items,
+      this.opt,
+      this.customValidateFunctions,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      this.renderInput,
+      select,
+    );
+  }
+
+  protected override executePreviewItem(
+    src: NonNullable<Src>,
+  ): PreviewItem | null {
+    if (this.previewInput === null) {
+      return null;
+    }
+    return this.previewInput({ val: src });
+  }
+
+  protected override declaresItemPreview(): boolean {
+    return this.previewInput !== null;
   }
 
   protected executeSerialize(): SerializedSchema {
     return {
       type: "object",
       render: this.renderInput ?? undefined,
+      preview: this.previewInput ? true : undefined,
       items: Object.fromEntries(
         Object.entries(this.items).map(([key, schema]) => [
           key,

--- a/packages/core/src/schema/record.test.ts
+++ b/packages/core/src/schema/record.test.ts
@@ -22,18 +22,20 @@ describe("RecordSchema", () => {
         bar: record(
           object({
             baz: string().nullable(),
+          }).preview(({ val }) => {
+            return {
+              title: val.baz || "No baz",
+            };
           }),
-        ).preview(({ val }) => {
+        ),
+      })
+        .nullable()
+        .preview(({ val }) => {
           return {
-            title: val.baz || "No baz",
+            title: val.title || "No item",
           };
         }),
-      }).nullable(),
-    ).preview(({ val }) => {
-      return {
-        title: val?.title || "No item",
-      };
-    });
+    );
     const src = {
       "upper-key": {
         title: "test",
@@ -60,14 +62,12 @@ describe("RecordSchema", () => {
         status: "success",
         data: {
           parent: "record",
+          // The null entry is skipped, not previewed: an item preview closure
+          // receives NonNullable values.
           items: [
             [
               "upper-key",
               { title: "test", subtitle: undefined, image: undefined },
-            ],
-            [
-              "nullable-key",
-              { title: "No item", subtitle: undefined, image: undefined },
             ],
           ],
         },
@@ -80,9 +80,9 @@ describe("RecordSchema", () => {
     // rather than fed to the user's closure — and the result must still cover the
     // keys that ARE loaded, which is what makes a windowed list work: the caller
     // shows a placeholder for the keys missing from `items`.
-    const schema = record(object({ title: string() }))
-      .jsonValues()
-      .preview(({ val }) => ({ title: val.title }));
+    const schema = record(
+      object({ title: string() }).preview(({ val }) => ({ title: val.title })),
+    ).jsonValues();
     const res = schema["executePreview"](
       "/test.val.ts" as SourcePath,
       {
@@ -106,12 +106,14 @@ describe("RecordSchema", () => {
   });
 
   test("preview: one key whose closure throws is one error, not a dead preview", () => {
-    const schema = record(object({ title: string() })).preview(({ val }) => {
-      if (val.title === "boom") {
-        throw new Error("user select blew up");
-      }
-      return { title: val.title };
-    });
+    const schema = record(
+      object({ title: string() }).preview(({ val }) => {
+        if (val.title === "boom") {
+          throw new Error("user select blew up");
+        }
+        return { title: val.title };
+      }),
+    );
     const res = schema["executePreview"]("/test.val.ts" as SourcePath, {
       ok: { title: "fine" },
       bad: { title: "boom" },
@@ -595,17 +597,20 @@ describe("RecordSchema", () => {
     }
   });
   test("record: preview is kept when chaining after preview", () => {
-    const base = record(object({ name: string() })).preview(({ key, val }) => ({
-      title: val.name,
-      subtitle: key,
-    }));
+    const base = record(
+      object({ name: string() }).preview(({ val }) => ({
+        title: val.name,
+      })),
+    );
     const src = { ada: { name: "Ada" } };
     const expected = {
       "/test.val.ts": {
         status: "success",
         data: {
           parent: "record",
-          items: [["ada", { title: "Ada", subtitle: "ada", image: undefined }]],
+          items: [
+            ["ada", { title: "Ada", subtitle: undefined, image: undefined }],
+          ],
         },
       },
     };
@@ -625,10 +630,10 @@ describe("RecordSchema", () => {
   });
 
   test("record: preview does not mutate the schema it was called on", () => {
-    const base = record(object({ name: string() }));
-    base.preview(({ val }) => ({ title: val.name }));
+    const item = object({ name: string() });
+    item.preview(({ val }) => ({ title: val.name }));
     expect(
-      base["executePreview"]("/test.val.ts" as SourcePath, {
+      record(item)["executePreview"]("/test.val.ts" as SourcePath, {
         ada: { name: "Ada" },
       }),
     ).toEqual({});

--- a/packages/core/src/schema/record.ts
+++ b/packages/core/src/schema/record.ts
@@ -13,6 +13,7 @@ import {
   PreviewScope,
 } from "../preview";
 import { splitModuleFilePathAndModulePath } from "../module";
+import { FieldRender } from "../render";
 import { ValRouter } from "../router";
 import { SelectorSource } from "../selector";
 import {
@@ -42,6 +43,8 @@ export type SerializedRecordSchema = {
   opt: boolean;
   /** Set when this schema declares a `preview`. See `SerializedArraySchema`. */
   preview?: true;
+  /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
+  render?: FieldRender;
   router?: string;
   customValidate?: boolean;
   // Optional media collection marker for files/images that are backed by a record
@@ -105,6 +108,7 @@ export class RecordSchema<
     /** When true, entry values are lazily loaded {@link JsonSource} thunks. */
     private readonly isJsonValues: boolean = false,
     private readonly previewInput: RecordPreviewInput<T> | null = null,
+    private readonly renderInput: FieldRender | null = null,
   ) {
     super();
   }
@@ -122,6 +126,7 @@ export class RecordSchema<
       description ?? undefined,
       this.isJsonValues,
       this.previewInput,
+      this.renderInput,
     );
   }
 
@@ -140,6 +145,7 @@ export class RecordSchema<
       this.description,
       this.isJsonValues,
       this.previewInput,
+      this.renderInput,
     );
   }
 
@@ -586,6 +592,7 @@ export class RecordSchema<
       this.description,
       this.isJsonValues,
       this.previewInput,
+      this.renderInput,
     ) as RecordSchema<T, K, Src | null>;
   }
 
@@ -602,6 +609,7 @@ export class RecordSchema<
       this.description,
       this.isJsonValues,
       this.previewInput,
+      this.renderInput,
     );
   }
 
@@ -618,6 +626,7 @@ export class RecordSchema<
       this.description,
       this.isJsonValues,
       this.previewInput,
+      this.renderInput,
     );
   }
 
@@ -634,6 +643,7 @@ export class RecordSchema<
       this.description,
       this.isJsonValues,
       this.previewInput,
+      this.renderInput,
     );
   }
 
@@ -650,6 +660,7 @@ export class RecordSchema<
       this.description,
       this.isJsonValues,
       this.previewInput,
+      this.renderInput,
     );
   }
 
@@ -695,6 +706,7 @@ export class RecordSchema<
       this.description,
       true,
       this.previewInput,
+      this.renderInput,
     ) as RecordSchema<T, K, JsonValuesRecordSrc<T, K>>;
   }
 
@@ -774,6 +786,7 @@ export class RecordSchema<
   protected executeSerialize(): SerializedRecordSchema {
     const result: SerializedRecordSchema = {
       type: "record",
+      render: this.renderInput ?? undefined,
       item: this.item["executeSerialize"](),
       key: this.keySchema?.["executeSerialize"](),
       opt: this.opt,
@@ -908,6 +921,31 @@ export class RecordSchema<
       this.description,
       this.isJsonValues,
       select,
+      this.renderInput,
+    );
+  }
+
+  /**
+   * How this field is laid out in the editor when it is the item of an array
+   * or record: `{ as: "inline" }` renders the field itself inside each row,
+   * instead of a preview row that navigates to it.
+   *
+   * Static configuration, not a callback — see `render.ts`.
+   */
+  render(input: FieldRender): RecordSchema<T, K, Src> {
+    return new RecordSchema(
+      this.item,
+      this.opt,
+      this.customValidateFunctions,
+      this.currentRouter,
+      this.keySchema,
+      this.mediaOptions,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      this.isJsonValues,
+      this.previewInput,
+      input,
     );
   }
 }

--- a/packages/core/src/schema/record.ts
+++ b/packages/core/src/schema/record.ts
@@ -7,8 +7,8 @@ import {
 } from ".";
 import {
   RecordPreview,
+  ItemPreviewInput,
   PreviewItem,
-  PreviewSelector,
   ReifiedPreview,
   PreviewScope,
 } from "../preview";
@@ -41,7 +41,11 @@ export type SerializedRecordSchema = {
   item: SerializedSchema;
   key?: SerializedSchema;
   opt: boolean;
-  /** Set when this schema declares a `preview`. See `SerializedArraySchema`. */
+  /**
+   * Set when this schema declares a `preview` — of the RECORD ITSELF as a
+   * value. Whether its ENTRIES preview is carried by the item's serialized
+   * schema. See `SerializedArraySchema`.
+   */
   preview?: true;
   /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
   render?: FieldRender;
@@ -82,11 +86,6 @@ export type JsonValuesRecordSrc<
   JsonSource<JsonOf<SelectorOfSchema<T>>> | SelectorOfSchema<T>
 >;
 
-type RecordPreviewInput<T extends Schema<SelectorSource>> = (input: {
-  key: string;
-  val: PreviewSelector<T>;
-}) => PreviewItem;
-
 export class RecordSchema<
   T extends Schema<SelectorSource>,
   K extends Schema<string>,
@@ -107,7 +106,7 @@ export class RecordSchema<
     private readonly description?: string,
     /** When true, entry values are lazily loaded {@link JsonSource} thunks. */
     private readonly isJsonValues: boolean = false,
-    private readonly previewInput: RecordPreviewInput<T> | null = null,
+    private readonly previewInput: ItemPreviewInput<Src> | null = null,
     private readonly renderInput: FieldRender | null = null,
   ) {
     super();
@@ -693,7 +692,17 @@ export class RecordSchema<
         ".jsonValues() must come BEFORE .validate(): a validator added first is typed against the un-lazy source shape and cannot be carried over. Write s.record(...).jsonValues().validate(...) instead.",
       );
     }
-    return new RecordSchema(
+    if (this.previewInput !== null) {
+      // Same reasoning as the validator guard above: the record's own preview
+      // closure is typed against the un-lazy source shape.
+      throw new Error(
+        ".jsonValues() must come BEFORE .preview(): a preview added first is typed against the un-lazy source shape and cannot be carried over. Write s.record(...).jsonValues().preview(...) instead.",
+      );
+    }
+    // Explicit type args instead of a cast on the result: `previewInput` would
+    // otherwise pin inference to `Src`, and the two record source shapes no
+    // longer overlap enough for the old assertion.
+    return new RecordSchema<T, K, JsonValuesRecordSrc<T, K>>(
       this.item,
       this.opt,
       // Empty by construction: the guard above rejects any that were registered.
@@ -705,9 +714,10 @@ export class RecordSchema<
       this.isHidden,
       this.description,
       true,
-      this.previewInput,
+      // Null by construction: the guard above rejects any that was declared.
+      null,
       this.renderInput,
-    ) as RecordSchema<T, K, JsonValuesRecordSrc<T, K>>;
+    );
   }
 
   private getRouterValidations(path: SourcePath, src: Src): ValidationErrors {
@@ -856,8 +866,10 @@ export class RecordSchema<
         res[key] = itemResult[key];
       }
     }
-    if (this.previewInput) {
-      const prepare = this.previewInput;
+    // The entries preview comes from the ITEM schema's own `preview` — the
+    // container just runs it per entry. Asked as a fact rather than by running
+    // the closure, so an empty record still previews as an empty record.
+    if (this.item["declaresItemPreview"]()) {
       // See the same block in `array`: the whole record when the record is what
       // is being shown, only the wanted entries when it is not.
       const window =
@@ -866,6 +878,9 @@ export class RecordSchema<
       for (const [key, val] of Object.entries(src)) {
         if (isJson(val)) {
           continue; // as above: nothing to select from an un-loaded entry
+        }
+        if (val === null || val === undefined) {
+          continue;
         }
         if (
           window !== null &&
@@ -877,11 +892,13 @@ export class RecordSchema<
         // data trips it up must not take out the whole list.
         try {
           // NB NB: display is actually defined by the user
-          const { title, subtitle, image } = prepare({
-            key,
-            val: val as SelectorOfSchema<T>,
-          });
-          items.push([key, { title, subtitle, image }]);
+          const item = this.item["executePreviewItem"](
+            val as NonNullable<SelectorOfSchema<T>>,
+          );
+          if (item !== null) {
+            const { title, subtitle, image } = item;
+            items.push([key, { title, subtitle, image }]);
+          }
         } catch (e) {
           res[unsafeCreateSourcePath(sourcePath, key)] = {
             status: "error",
@@ -900,15 +917,26 @@ export class RecordSchema<
     return res;
   }
 
+  protected override executePreviewItem(
+    src: NonNullable<Src>,
+  ): PreviewItem | null {
+    if (this.previewInput === null) {
+      return null;
+    }
+    return this.previewInput({ val: src });
+  }
+
+  protected override declaresItemPreview(): boolean {
+    return this.previewInput !== null;
+  }
+
   /**
-   * What the editor shows for each ENTRY of this record: a title, and optionally
-   * a subtitle and an image.
-   *
-   * `select` is your own code over the entry's key and source, so it is run on
-   * demand for the entries that are actually being looked at — see
-   * `PreviewScope`.
+   * How this RECORD ITSELF is shown where a preview of it is needed — when it
+   * is the item of another container, in search, in references. What its
+   * entries show is the ITEM schema's `preview`, not this. Never how the field
+   * is edited (that is `render`). See `preview.ts`.
    */
-  preview(select: RecordPreviewInput<T>): RecordSchema<T, K, Src> {
+  preview(select: ItemPreviewInput<Src>): RecordSchema<T, K, Src> {
     return new RecordSchema(
       this.item,
       this.opt,

--- a/packages/core/src/schema/render.test.ts
+++ b/packages/core/src/schema/render.test.ts
@@ -1,0 +1,158 @@
+import { Schema } from ".";
+import { initVal } from "../initVal";
+import { SelectorSource } from "../selector";
+import { SourcePath } from "../val";
+import { deserializeSchema } from "./deserialize";
+
+const { s, c } = initVal();
+
+const authors = c.define(
+  "/content/authors.val.ts",
+  s.record(s.object({ name: s.string() })),
+  { fredrik: { name: "Fredrik" } },
+);
+
+describe("Schema.render({ as: 'inline' })", () => {
+  test("serialize: defaults to no render", () => {
+    const serialized = s.object({ a: s.string() })["executeSerialize"]();
+    expect(serialized.render).toBe(undefined);
+  });
+
+  test("serialize: render({ as: 'inline' }) is carried in the serialized schema", () => {
+    const serialized = s
+      .object({ a: s.string() })
+      .render({ as: "inline" })
+      ["executeSerialize"]();
+    expect(serialized.render).toEqual({ as: "inline" });
+  });
+
+  test("inline render serializes across every schema type", () => {
+    const schemas: Schema<SelectorSource>[] = [
+      s.string().render({ as: "inline" }),
+      s.number().render({ as: "inline" }),
+      s.boolean().render({ as: "inline" }),
+      s.literal("a").render({ as: "inline" }),
+      s.date().render({ as: "inline" }),
+      s.datetime().render({ as: "inline" }),
+      s.color().render({ as: "inline" }),
+      s.route().render({ as: "inline" }),
+      s.richtext().render({ as: "inline" }),
+      s.image().render({ as: "inline" }),
+      s.file().render({ as: "inline" }),
+      s.array(s.string()).render({ as: "inline" }),
+      s.object({ a: s.string() }).render({ as: "inline" }),
+      s.record(s.string()).render({ as: "inline" }),
+      s
+        .union("type", s.object({ type: s.literal("a") }))
+        .render({ as: "inline" }),
+      s.keyOf(authors).render({ as: "inline" }),
+    ];
+    for (const schema of schemas) {
+      expect(schema["executeSerialize"]().render).toEqual({ as: "inline" });
+    }
+  });
+
+  test("render is preserved regardless of chaining order", () => {
+    const before = s
+      .object({ a: s.string() })
+      .render({ as: "inline" })
+      .describe("desc")
+      ["executeSerialize"]();
+    const after = s
+      .object({ a: s.string() })
+      .describe("desc")
+      .render({ as: "inline" })
+      ["executeSerialize"]();
+    expect(before.render).toEqual({ as: "inline" });
+    expect(after.render).toEqual({ as: "inline" });
+  });
+
+  test("render is preserved through nullable(), readonly(), hidden() and validate()", () => {
+    const base = s.object({ a: s.string() }).render({ as: "inline" });
+    for (const schema of [
+      base.nullable(),
+      base.readonly(),
+      base.hidden(),
+      base.validate(() => false),
+    ]) {
+      expect(schema["executeSerialize"]().render).toEqual({ as: "inline" });
+    }
+  });
+
+  test("render does not mutate the schema it was called on", () => {
+    const base = s.object({ a: s.string() });
+    base.render({ as: "inline" });
+    expect(base["executeSerialize"]().render).toBe(undefined);
+  });
+
+  test("render survives a serialize -> deserialize -> serialize round-trip on a nested page-builder shape", () => {
+    // The motivating shape: sortable lists of inline objects, nested.
+    const schema = s.array(
+      s
+        .object({
+          title: s.string(),
+          sections: s.array(
+            s
+              .object({
+                title: s.string(),
+                content: s.richtext(),
+              })
+              .render({ as: "inline" }),
+          ),
+        })
+        .render({ as: "inline" }),
+    );
+    const serialized = schema["executeSerialize"]();
+    const roundTripped = deserializeSchema(serialized)["executeSerialize"]();
+    expect(roundTripped).toEqual(serialized);
+    if (roundTripped.type !== "array" || roundTripped.item.type !== "object") {
+      throw new Error("expected array of object schema");
+    }
+    expect(roundTripped.item.render).toEqual({ as: "inline" });
+    const sections = roundTripped.item.items.sections;
+    if (sections.type !== "array") {
+      throw new Error("expected array schema");
+    }
+    expect(sections.item.render).toEqual({ as: "inline" });
+  });
+
+  test("string keeps its own render layouts alongside inline", () => {
+    expect(
+      s.string().render({ as: "textarea" })["executeSerialize"]().render,
+    ).toEqual({ as: "textarea" });
+    expect(
+      s.string().render({ as: "inline" })["executeSerialize"]().render,
+    ).toEqual({ as: "inline" });
+    const roundTripped = deserializeSchema(
+      s.string().render({ as: "inline" })["executeSerialize"](),
+    )["executeSerialize"]();
+    expect(roundTripped.render).toEqual({ as: "inline" });
+  });
+
+  test("an inline item does not change the container's preview", () => {
+    const plain = s
+      .array(s.object({ name: s.string() }))
+      .preview(({ val }) => ({ title: val.name }));
+    const inline = s
+      .array(s.object({ name: s.string() }).render({ as: "inline" }))
+      .preview(({ val }) => ({ title: val.name }));
+    const src = [{ name: "Ada" }];
+    expect(inline["executePreview"]("/test.val.ts" as SourcePath, src)).toEqual(
+      plain["executePreview"]("/test.val.ts" as SourcePath, src),
+    );
+  });
+
+  test("render does not change validation results", () => {
+    const path = "/test" as SourcePath;
+    const plain = s.object({ a: s.string().minLength(3) });
+    const inline = s
+      .object({ a: s.string().minLength(3) })
+      .render({ as: "inline" });
+    expect(inline["executeValidate"](path, { a: "ok" })).toEqual(
+      plain["executeValidate"](path, { a: "ok" }),
+    );
+    expect(inline["executeValidate"](path, { a: "abc" })).toEqual(
+      plain["executeValidate"](path, { a: "abc" }),
+    );
+  });
+});

--- a/packages/core/src/schema/render.test.ts
+++ b/packages/core/src/schema/render.test.ts
@@ -79,6 +79,23 @@ describe("Schema.render({ as: 'inline' })", () => {
     }
   });
 
+  test("a second render replaces the first (last wins)", () => {
+    expect(
+      s
+        .string()
+        .render({ as: "textarea" })
+        .render({ as: "inline" })
+        ["executeSerialize"]().render,
+    ).toEqual({ as: "inline" });
+    expect(
+      s
+        .string()
+        .render({ as: "inline" })
+        .render({ as: "textarea" })
+        ["executeSerialize"]().render,
+    ).toEqual({ as: "textarea" });
+  });
+
   test("render does not mutate the schema it was called on", () => {
     const base = s.object({ a: s.string() });
     base.render({ as: "inline" });
@@ -130,12 +147,17 @@ describe("Schema.render({ as: 'inline' })", () => {
   });
 
   test("an inline item does not change the container's preview", () => {
-    const plain = s
-      .array(s.object({ name: s.string() }))
-      .preview(({ val }) => ({ title: val.name }));
-    const inline = s
-      .array(s.object({ name: s.string() }).render({ as: "inline" }))
-      .preview(({ val }) => ({ title: val.name }));
+    const plain = s.array(
+      s.object({ name: s.string() }).preview(({ val }) => ({
+        title: val.name,
+      })),
+    );
+    const inline = s.array(
+      s
+        .object({ name: s.string() })
+        .preview(({ val }) => ({ title: val.name }))
+        .render({ as: "inline" }),
+    );
     const src = [{ name: "Ada" }];
     expect(inline["executePreview"]("/test.val.ts" as SourcePath, src)).toEqual(
       plain["executePreview"]("/test.val.ts" as SourcePath, src),

--- a/packages/core/src/schema/richtext.ts
+++ b/packages/core/src/schema/richtext.ts
@@ -6,6 +6,7 @@ import {
   SerializedSchema,
 } from ".";
 import { ReifiedPreview } from "../preview";
+import { FieldRender } from "../render";
 import { unsafeCreateSourcePath } from "../selector/SelectorProxy";
 import { ImageSource } from "../source/media";
 import {
@@ -28,6 +29,8 @@ type ValidationOptions = {
 };
 export type SerializedRichTextSchema = {
   type: "richtext";
+  /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
+  render?: FieldRender;
   opt: boolean;
   options?: SerializedRichTextOptions & ValidationOptions;
   customValidate?: boolean;
@@ -47,6 +50,7 @@ export class RichTextSchema<
     private readonly isReadonly: boolean = false,
     private readonly isHidden: boolean = false,
     private readonly description?: string,
+    private readonly renderInput: FieldRender | null = null,
   ) {
     super();
   }
@@ -59,6 +63,7 @@ export class RichTextSchema<
       this.isReadonly,
       this.isHidden,
       description ?? undefined,
+      this.renderInput,
     );
   }
 
@@ -73,6 +78,7 @@ export class RichTextSchema<
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -87,6 +93,7 @@ export class RichTextSchema<
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -100,6 +107,7 @@ export class RichTextSchema<
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -653,6 +661,7 @@ export class RichTextSchema<
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -664,6 +673,7 @@ export class RichTextSchema<
       true,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -675,6 +685,7 @@ export class RichTextSchema<
       this.isReadonly,
       true,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -686,6 +697,25 @@ export class RichTextSchema<
       src,
       this.customValidateFunctions,
       { path },
+    );
+  }
+
+  /**
+   * How this field is laid out in the editor when it is the item of an array
+   * or record: `{ as: "inline" }` renders the field itself inside each row,
+   * instead of a preview row that navigates to it.
+   *
+   * Static configuration, not a callback — see `render.ts`.
+   */
+  render(input: FieldRender): RichTextSchema<O, Src> {
+    return new RichTextSchema(
+      this.options,
+      this.opt,
+      this.customValidateFunctions,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      input,
     );
   }
 
@@ -724,6 +754,7 @@ export class RichTextSchema<
     };
     return {
       type: "richtext",
+      render: this.renderInput ?? undefined,
       opt: this.opt,
       options: serializedOptions,
       customValidate:

--- a/packages/core/src/schema/richtext.ts
+++ b/packages/core/src/schema/richtext.ts
@@ -5,7 +5,7 @@ import {
   SchemaAssertResult,
   SerializedSchema,
 } from ".";
-import { ReifiedPreview } from "../preview";
+import { ItemPreviewInput, PreviewItem, ReifiedPreview } from "../preview";
 import { FieldRender } from "../render";
 import { unsafeCreateSourcePath } from "../selector/SelectorProxy";
 import { ImageSource } from "../source/media";
@@ -31,6 +31,8 @@ export type SerializedRichTextSchema = {
   type: "richtext";
   /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
   render?: FieldRender;
+  /** Set when this schema declares a `preview`. The closure itself cannot serialize. */
+  preview?: true;
   opt: boolean;
   options?: SerializedRichTextOptions & ValidationOptions;
   customValidate?: boolean;
@@ -51,6 +53,7 @@ export class RichTextSchema<
     private readonly isHidden: boolean = false,
     private readonly description?: string,
     private readonly renderInput: FieldRender | null = null,
+    private readonly previewInput: ItemPreviewInput<Src> | null = null,
   ) {
     super();
   }
@@ -64,6 +67,7 @@ export class RichTextSchema<
       this.isHidden,
       description ?? undefined,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -79,6 +83,7 @@ export class RichTextSchema<
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -94,6 +99,7 @@ export class RichTextSchema<
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -108,6 +114,7 @@ export class RichTextSchema<
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -654,7 +661,7 @@ export class RichTextSchema<
   }
 
   nullable(): RichTextSchema<O, Src | null> {
-    return new RichTextSchema(
+    return new RichTextSchema<O, Src | null>(
       this.options,
       true,
       [],
@@ -662,6 +669,7 @@ export class RichTextSchema<
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -674,6 +682,7 @@ export class RichTextSchema<
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -686,6 +695,7 @@ export class RichTextSchema<
       true,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -716,7 +726,39 @@ export class RichTextSchema<
       this.isHidden,
       this.description,
       input,
+      this.previewInput,
     );
+  }
+
+  /**
+   * How this VALUE is shown where a preview of it is needed — a row in a
+   * sortable list, a reference dropdown, a search hit. Never how the field
+   * itself is edited (that is `render`). See `preview.ts`.
+   */
+  preview(select: ItemPreviewInput<Src>): RichTextSchema<O, Src> {
+    return new RichTextSchema(
+      this.options,
+      this.opt,
+      this.customValidateFunctions,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      this.renderInput,
+      select,
+    );
+  }
+
+  protected override executePreviewItem(
+    src: NonNullable<Src>,
+  ): PreviewItem | null {
+    if (this.previewInput === null) {
+      return null;
+    }
+    return this.previewInput({ val: src });
+  }
+
+  protected override declaresItemPreview(): boolean {
+    return this.previewInput !== null;
   }
 
   protected executeSerialize(): SerializedSchema {
@@ -755,6 +797,7 @@ export class RichTextSchema<
     return {
       type: "richtext",
       render: this.renderInput ?? undefined,
+      preview: this.previewInput ? true : undefined,
       opt: this.opt,
       options: serializedOptions,
       customValidate:

--- a/packages/core/src/schema/route.ts
+++ b/packages/core/src/schema/route.ts
@@ -1,6 +1,6 @@
 import { Schema, SchemaAssertResult, SerializedSchema } from ".";
 import { SourcePath } from "../val";
-import { ReifiedPreview } from "../preview";
+import { ItemPreviewInput, PreviewItem, ReifiedPreview } from "../preview";
 import { FieldRender } from "../render";
 import {
   ValidationError,
@@ -16,6 +16,8 @@ export type SerializedRouteSchema = {
   type: "route";
   /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
   render?: FieldRender;
+  /** Set when this schema declares a `preview`. The closure itself cannot serialize. */
+  preview?: true;
   options?: {
     include?: {
       source: string;
@@ -45,6 +47,7 @@ export class RouteSchema<Src extends string | null> extends Schema<Src> {
     private readonly isHidden: boolean = false,
     private readonly description?: string,
     private readonly renderInput: FieldRender | null = null,
+    private readonly previewInput: ItemPreviewInput<Src> | null = null,
   ) {
     super();
   }
@@ -58,6 +61,7 @@ export class RouteSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       description ?? undefined,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -82,6 +86,7 @@ export class RouteSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -106,6 +111,7 @@ export class RouteSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -118,6 +124,7 @@ export class RouteSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -194,6 +201,7 @@ export class RouteSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     ) as unknown as RouteSchema<Src | null>;
   }
 
@@ -206,6 +214,7 @@ export class RouteSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -218,6 +227,7 @@ export class RouteSchema<Src extends string | null> extends Schema<Src> {
       true,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -248,13 +258,46 @@ export class RouteSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       input,
+      this.previewInput,
     );
+  }
+
+  /**
+   * How this VALUE is shown where a preview of it is needed — a row in a
+   * sortable list, a reference dropdown, a search hit. Never how the field
+   * itself is edited (that is `render`). See `preview.ts`.
+   */
+  preview(select: ItemPreviewInput<Src>): RouteSchema<Src> {
+    return new RouteSchema<Src>(
+      this.options,
+      this.opt,
+      this.customValidateFunctions,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      this.renderInput,
+      select,
+    );
+  }
+
+  protected override executePreviewItem(
+    src: NonNullable<Src>,
+  ): PreviewItem | null {
+    if (this.previewInput === null) {
+      return null;
+    }
+    return this.previewInput({ val: src });
+  }
+
+  protected override declaresItemPreview(): boolean {
+    return this.previewInput !== null;
   }
 
   protected executeSerialize(): SerializedSchema {
     return {
       type: "route",
       render: this.renderInput ?? undefined,
+      preview: this.previewInput ? true : undefined,
       options: {
         include: this.options?.include && {
           source: this.options.include.source,

--- a/packages/core/src/schema/route.ts
+++ b/packages/core/src/schema/route.ts
@@ -1,6 +1,7 @@
 import { Schema, SchemaAssertResult, SerializedSchema } from ".";
 import { SourcePath } from "../val";
 import { ReifiedPreview } from "../preview";
+import { FieldRender } from "../render";
 import {
   ValidationError,
   ValidationErrors,
@@ -13,6 +14,8 @@ type RouteOptions = {
 
 export type SerializedRouteSchema = {
   type: "route";
+  /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
+  render?: FieldRender;
   options?: {
     include?: {
       source: string;
@@ -41,6 +44,7 @@ export class RouteSchema<Src extends string | null> extends Schema<Src> {
     private readonly isReadonly: boolean = false,
     private readonly isHidden: boolean = false,
     private readonly description?: string,
+    private readonly renderInput: FieldRender | null = null,
   ) {
     super();
   }
@@ -53,6 +57,7 @@ export class RouteSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       description ?? undefined,
+      this.renderInput,
     );
   }
 
@@ -76,6 +81,7 @@ export class RouteSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -99,6 +105,7 @@ export class RouteSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -110,6 +117,7 @@ export class RouteSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -185,6 +193,7 @@ export class RouteSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     ) as unknown as RouteSchema<Src | null>;
   }
 
@@ -196,6 +205,7 @@ export class RouteSchema<Src extends string | null> extends Schema<Src> {
       true,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -207,6 +217,7 @@ export class RouteSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       true,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -221,9 +232,29 @@ export class RouteSchema<Src extends string | null> extends Schema<Src> {
     );
   }
 
+  /**
+   * How this field is laid out in the editor when it is the item of an array
+   * or record: `{ as: "inline" }` renders the field itself inside each row,
+   * instead of a preview row that navigates to it.
+   *
+   * Static configuration, not a callback — see `render.ts`.
+   */
+  render(input: FieldRender): RouteSchema<Src> {
+    return new RouteSchema<Src>(
+      this.options,
+      this.opt,
+      this.customValidateFunctions,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      input,
+    );
+  }
+
   protected executeSerialize(): SerializedSchema {
     return {
       type: "route",
+      render: this.renderInput ?? undefined,
       options: {
         include: this.options?.include && {
           source: this.options.include.source,

--- a/packages/core/src/schema/string.ts
+++ b/packages/core/src/schema/string.ts
@@ -1,5 +1,5 @@
 import { Schema, SchemaAssertResult, SerializedSchema } from ".";
-import { ReifiedPreview } from "../preview";
+import { ItemPreviewInput, PreviewItem, ReifiedPreview } from "../preview";
 import { StringRender } from "../render";
 import { SourcePath } from "../val";
 import {
@@ -26,6 +26,8 @@ export type SerializedStringSchema = {
    * buys, and what to do if a render ever needs to stop being static.
    */
   render?: StringRender;
+  /** Set when this schema declares a `preview`. The closure itself cannot serialize. */
+  preview?: true;
   options?: {
     maxLength?: number;
     minLength?: number;
@@ -59,6 +61,7 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
     private readonly isReadonly: boolean = false,
     private readonly isHidden: boolean = false,
     private readonly description?: string,
+    private readonly previewInput: ItemPreviewInput<Src> | null = null,
   ) {
     super();
   }
@@ -73,6 +76,7 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       description ?? undefined,
+      this.previewInput,
     );
   }
 
@@ -93,6 +97,7 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.previewInput,
     );
   }
 
@@ -113,6 +118,7 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.previewInput,
     );
   }
 
@@ -126,6 +132,7 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.previewInput,
     );
   }
 
@@ -141,6 +148,7 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.previewInput,
     );
   }
 
@@ -237,6 +245,7 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.previewInput,
     ) as unknown as StringSchema<Src | null>;
   }
 
@@ -250,6 +259,7 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
       true,
       this.isHidden,
       this.description,
+      this.previewInput,
     );
   }
 
@@ -263,6 +273,7 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       true,
       this.description,
+      this.previewInput,
     );
   }
 
@@ -276,6 +287,7 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.previewInput,
     ) as unknown as StringSchema<
       Src extends null ? RawString | null : RawString
     >;
@@ -296,6 +308,7 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
     return {
       type: "string",
       render: this.renderInput ?? undefined,
+      preview: this.previewInput ? true : undefined,
       options: {
         maxLength: this.options?.maxLength,
         minLength: this.options?.minLength,
@@ -336,7 +349,40 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.previewInput,
     );
+  }
+
+  /**
+   * How this VALUE is shown where a preview of it is needed — a row in a
+   * sortable list, a reference dropdown, a search hit. Never how the field
+   * itself is edited (that is `render`). See `preview.ts`.
+   */
+  preview(select: ItemPreviewInput<Src>): StringSchema<Src> {
+    return new StringSchema<Src>(
+      this.options,
+      this.opt,
+      this.isRaw,
+      this.customValidateFunctions,
+      this.renderInput,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      select,
+    );
+  }
+
+  protected override executePreviewItem(
+    src: NonNullable<Src>,
+  ): PreviewItem | null {
+    if (this.previewInput === null) {
+      return null;
+    }
+    return this.previewInput({ val: src });
+  }
+
+  protected override declaresItemPreview(): boolean {
+    return this.previewInput !== null;
   }
 
   /**

--- a/packages/core/src/schema/union.test.ts
+++ b/packages/core/src/schema/union.test.ts
@@ -65,12 +65,12 @@ describe("UnionSchema", () => {
         innerObject: record(
           object({
             value: string(),
+          }).preview(({ val }) => {
+            return {
+              title: val.value,
+            };
           }),
-        ).preview(({ val }) => {
-          return {
-            title: val.value,
-          };
-        }),
+        ),
       }),
       object({ type: literal("value2"), innerString: string() }),
     );

--- a/packages/core/src/schema/union.ts
+++ b/packages/core/src/schema/union.ts
@@ -6,7 +6,12 @@ import {
   SchemaAssertResult,
   SerializedSchema,
 } from ".";
-import { ReifiedPreview, PreviewScope } from "../preview";
+import {
+  ItemPreviewInput,
+  PreviewItem,
+  ReifiedPreview,
+  PreviewScope,
+} from "../preview";
 import { FieldRender } from "../render";
 import {
   createValPathOfItem,
@@ -29,6 +34,8 @@ export type SerializedStringUnionSchema = {
   type: "union";
   /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
   render?: FieldRender;
+  /** Set when this schema declares a `preview`. The closure itself cannot serialize. */
+  preview?: true;
   key: SerializedLiteralSchema;
   items: SerializedLiteralSchema[];
   opt: boolean;
@@ -41,6 +48,8 @@ export type SerializedObjectUnionSchema = {
   type: "union";
   /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
   render?: FieldRender;
+  /** Set when this schema declares a `preview`. The closure itself cannot serialize. */
+  preview?: true;
   key: string;
   items: SerializedObjectSchema[];
   opt: boolean;
@@ -86,6 +95,7 @@ export class UnionSchema<
       this.isHidden,
       description ?? undefined,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -101,6 +111,7 @@ export class UnionSchema<
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -496,7 +507,8 @@ export class UnionSchema<
   }
 
   nullable(): UnionSchema<Key, T, Src | null> {
-    return new UnionSchema(
+    // Explicit type args: `previewInput` would otherwise pin inference to `Src`.
+    return new UnionSchema<Key, T, Src | null>(
       this.key,
       this.items,
       true,
@@ -505,6 +517,7 @@ export class UnionSchema<
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -518,6 +531,7 @@ export class UnionSchema<
       this.isHidden,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -531,6 +545,7 @@ export class UnionSchema<
       true,
       this.description,
       this.renderInput,
+      this.previewInput,
     );
   }
 
@@ -607,6 +622,54 @@ export class UnionSchema<
       this.isHidden,
       this.description,
       input,
+      this.previewInput,
+    );
+  }
+
+  /**
+   * How this VALUE is shown where a preview of it is needed — a row in a
+   * sortable list, a reference dropdown, a search hit. Never how the field
+   * itself is edited (that is `render`). See `preview.ts`.
+   *
+   * Without one of its own, a tagged union previews as the VARIANT the value
+   * takes — declare `preview` on the member objects and the union dispatches.
+   */
+  preview(select: ItemPreviewInput<Src>): UnionSchema<Key, T, Src> {
+    return new UnionSchema<Key, T, Src>(
+      this.key,
+      this.items,
+      this.opt,
+      this.customValidateFunctions,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      this.renderInput,
+      select,
+    );
+  }
+
+  protected override executePreviewItem(
+    src: NonNullable<Src>,
+  ): PreviewItem | null {
+    if (this.previewInput !== null) {
+      return this.previewInput({ val: src });
+    }
+    // Only the union knows which variant the value takes; the variant's own
+    // `preview` is what it previews as.
+    const matched = this.matchedVariant(src);
+    if (matched) {
+      return matched["executePreviewItem"](src);
+    }
+    return null;
+  }
+
+  protected override declaresItemPreview(): boolean {
+    if (this.previewInput !== null) {
+      return true;
+    }
+    return (
+      Array.isArray(this.items) &&
+      this.items.some((item) => item["declaresItemPreview"]())
     );
   }
 
@@ -615,6 +678,7 @@ export class UnionSchema<
       return {
         type: "union",
         render: this.renderInput ?? undefined,
+        preview: this.previewInput ? true : undefined,
         key: this.key,
         items: this.items.map((o) => o["executeSerialize"]()),
         opt: this.opt,
@@ -629,6 +693,7 @@ export class UnionSchema<
     return {
       type: "union",
       render: this.renderInput ?? undefined,
+      preview: this.previewInput ? true : undefined,
       key: this.key["executeSerialize"](),
       items: this.items.map((o) => o["executeSerialize"]()),
       opt: this.opt,
@@ -650,6 +715,7 @@ export class UnionSchema<
     private readonly isHidden: boolean = false,
     private readonly description?: string,
     private readonly renderInput: FieldRender | null = null,
+    private readonly previewInput: ItemPreviewInput<Src> | null = null,
   ) {
     super();
   }

--- a/packages/core/src/schema/union.ts
+++ b/packages/core/src/schema/union.ts
@@ -7,6 +7,7 @@ import {
   SerializedSchema,
 } from ".";
 import { ReifiedPreview, PreviewScope } from "../preview";
+import { FieldRender } from "../render";
 import {
   createValPathOfItem,
   unsafeCreateSourcePath,
@@ -26,6 +27,8 @@ export type SerializedUnionSchema =
   | SerializedObjectUnionSchema;
 export type SerializedStringUnionSchema = {
   type: "union";
+  /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
+  render?: FieldRender;
   key: SerializedLiteralSchema;
   items: SerializedLiteralSchema[];
   opt: boolean;
@@ -36,6 +39,8 @@ export type SerializedStringUnionSchema = {
 };
 export type SerializedObjectUnionSchema = {
   type: "union";
+  /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
+  render?: FieldRender;
   key: string;
   items: SerializedObjectSchema[];
   opt: boolean;
@@ -80,6 +85,7 @@ export class UnionSchema<
       this.isReadonly,
       this.isHidden,
       description ?? undefined,
+      this.renderInput,
     );
   }
 
@@ -94,6 +100,7 @@ export class UnionSchema<
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -497,6 +504,7 @@ export class UnionSchema<
       this.isReadonly,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -509,6 +517,7 @@ export class UnionSchema<
       true,
       this.isHidden,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -521,6 +530,7 @@ export class UnionSchema<
       this.isReadonly,
       true,
       this.description,
+      this.renderInput,
     );
   }
 
@@ -580,10 +590,31 @@ export class UnionSchema<
     return null;
   }
 
+  /**
+   * How this field is laid out in the editor when it is the item of an array
+   * or record: `{ as: "inline" }` renders the field itself inside each row,
+   * instead of a preview row that navigates to it.
+   *
+   * Static configuration, not a callback — see `render.ts`.
+   */
+  render(input: FieldRender): UnionSchema<Key, T, Src> {
+    return new UnionSchema<Key, T, Src>(
+      this.key,
+      this.items,
+      this.opt,
+      this.customValidateFunctions,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      input,
+    );
+  }
+
   protected executeSerialize(): SerializedSchema {
     if (typeof this.key === "string") {
       return {
         type: "union",
+        render: this.renderInput ?? undefined,
         key: this.key,
         items: this.items.map((o) => o["executeSerialize"]()),
         opt: this.opt,
@@ -597,6 +628,7 @@ export class UnionSchema<
     }
     return {
       type: "union",
+      render: this.renderInput ?? undefined,
       key: this.key["executeSerialize"](),
       items: this.items.map((o) => o["executeSerialize"]()),
       opt: this.opt,
@@ -617,6 +649,7 @@ export class UnionSchema<
     private readonly isReadonly: boolean = false,
     private readonly isHidden: boolean = false,
     private readonly description?: string,
+    private readonly renderInput: FieldRender | null = null,
   ) {
     super();
   }

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -522,42 +522,53 @@ export default async function MyPage({ params }: { params:
 
 ### Previews
 
-A **preview** is what the Val editor shows for each ITEM of a container — the row
-you see in a list of records, or of array items. Declare one with `.preview()` on
-a `record` or an `array`, and return a `title`, and optionally a `subtitle` and an
-`image`.
+A **preview** is how a VALUE is shown wherever the Val editor shows a preview of
+it rather than opening it: a row in a list, an entry in a `keyOf` dropdown, a
+search hit, a reference. Declare one with `.preview()` on the schema of the value
+being previewed, and return a `title`, and optionally a `subtitle` and an `image`.
 
 #### Example
 
 ```ts
-const pagesSchema = s
-  .record(s.object({ title: s.string(), image: s.image() }))
-  .router(nextAppRouter)
-  .preview(({ key, val }) => ({
-    // Capitalize the first letter of the key for display
-    title: key?.[0]?.toUpperCase() + key?.slice(1),
-    // Show the image from the record
-    image: val.image,
-  }));
+const pageSchema = s
+  .object({ title: s.string(), image: s.image() })
+  .preview(({ val }) => ({ title: val.title, image: val.image }));
+
+// Every row of this record previews with the closure above
+const pagesSchema = s.record(pageSchema).router(nextAppRouter);
 ```
 
-An array's preview gets the item alone, since there is no key:
+The container reifies its rows by running each ITEM's closure, so an array works
+the same way:
 
 ```ts
-const sectionsSchema = s
-  .array(s.object({ heading: s.string(), body: s.string() }))
-  .preview(({ val }) => ({ title: val.heading, subtitle: val.body }));
+const sectionsSchema = s.array(
+  s
+    .object({ heading: s.string(), body: s.string() })
+    .preview(({ val }) => ({ title: val.heading, subtitle: val.body })),
+);
 ```
 
+A tagged union with no preview of its own previews as the VARIANT the value
+takes, so a page-builder list previews each block by its own block type.
+
 Your function is run on demand, for the rows actually on screen, so it is fine
-for it to read into the item's content.
+for it to read into the value's content.
+
+> **Changed in the release that added `.render({ as: "inline" })`.** A
+> `.preview()` on `s.array(...)` / `s.record(...)` used to describe the
+> container's ROWS; it now describes the container ITSELF as a value, for when
+> it is someone else's item. Move the closure onto the item schema. The record
+> closure no longer receives `key` — derive the title from `val`. And
+> `.jsonValues()` must come before `.preview(...)`, like `.validate(...)`.
 
 ### Field rendering
 
-A **render** is how ONE field is laid out in the editor. It is static
-configuration rather than a function, and it is a different thing from a
-preview: a preview describes a container's items, a render describes a single
-field.
+A **render** is how ONE field is laid out in the editor when you are LOOKING at
+that field. It is static configuration rather than a function, and it is a
+different thing from a preview: a render is the field's own layout, a preview is
+how the value shows where it is navigable to. A schema can carry both, and a
+second `.render(...)` replaces the first rather than merging with it.
 
 ```ts
 const articleSchema = s.object({
@@ -572,6 +583,28 @@ const articleSchema = s.object({
 `as: "code"` takes a `language` — `typescript`, `javascript`, `json`, `html`,
 `css`, `markdown`, `python`, `sql` and others; see `CodeLanguage` in
 `@valbuild/core` for the full list.
+
+#### Editing list items in place
+
+Every field takes `.render({ as: "inline" })`. On the ITEM of an array or record
+it means: edit the item right there in the (sortable) list row, instead of
+showing a preview row that navigates into it. This is what a page-builder list is
+made of.
+
+```ts
+const sectionsSchema = s.array(
+  s.object({ title: s.string(), body: s.richtext() }).render({ as: "inline" }),
+);
+```
+
+> **Breaking.** Strings in arrays are no longer inlined implicitly.
+> `s.array(s.string())` now renders preview rows and its items are navigation
+> stops, like every other item type. Add `.render({ as: "inline" })` to the
+> string schema for the old behavior:
+>
+> ```ts
+> s.array(s.string().render({ as: "inline" }));
+> ```
 
 ## RichText
 

--- a/packages/server/src/ValRouter.test.ts
+++ b/packages/server/src/ValRouter.test.ts
@@ -9,12 +9,11 @@ import { encodeJwt } from "./jwt";
 describe("ValRouter", () => {
   const route = "/api/val";
   const { c, s, config } = initVal();
-  const authorsSchema = s.record(
-    s.object({
-      name: s.string(),
-      birthdate: s.date().from("1900-01-01").to("2024-01-01"),
-    }),
-  );
+  const authorItemSchema = s.object({
+    name: s.string(),
+    birthdate: s.date().from("1900-01-01").to("2024-01-01"),
+  });
+  const authorsSchema = s.record(authorItemSchema);
   const authorsSource = {
     teddy: {
       name: "Theodor René Carlsen",
@@ -136,10 +135,12 @@ describe("ValRouter", () => {
       const onRouteWithPreview = createOnRoute(
         c.define(
           "/content/authors.val.ts",
-          authorsSchema.preview(({ val }) => ({
-            title: val.name,
-            subtitle: val.birthdate,
-          })),
+          s.record(
+            authorItemSchema.preview(({ val }) => ({
+              title: val.name,
+              subtitle: val.birthdate,
+            })),
+          ),
           authorsSource,
         ),
       );

--- a/packages/shared/src/internal/zod/SerializedSchema.ts
+++ b/packages/shared/src/internal/zod/SerializedSchema.ts
@@ -22,15 +22,23 @@ import {
 } from "@valbuild/core";
 import { SourcePath } from "./SourcePath";
 
+// A render is static config, so unlike a `preview` it travels WHOLE — this
+// is the field the editor reads the layout from. See `core/src/render.ts`.
+// Every field can carry `{ as: "inline" }`; strings have layouts of their own
+// on top. NB: these z.objects STRIP unknown keys, so a render variant that is
+// not declared here is silently dropped in transit — add it here when it is
+// added to `render.ts`.
+const InlineRender = z.object({ as: z.literal("inline") });
+const FieldRender = InlineRender.optional();
+
 export const SerializedStringSchema: z.ZodType<SerializedStringSchemaT> =
   z.object({
     type: z.literal("string"),
-    // A render is static config, so unlike a `preview` it travels WHOLE — this
-    // is the field the editor reads the layout from. See `core/src/render.ts`.
     render: z
       .union([
         z.object({ as: z.literal("textarea") }),
         z.object({ as: z.literal("code"), language: z.enum(CODE_LANGUAGES) }),
+        InlineRender,
       ])
       .optional(),
     options: z
@@ -54,6 +62,7 @@ export const SerializedStringSchema: z.ZodType<SerializedStringSchemaT> =
 export const SerializedLiteralSchema: z.ZodType<SerializedLiteralSchemaT> =
   z.object({
     type: z.literal("literal"),
+    render: FieldRender,
     value: z.string(),
     opt: z.boolean(),
     readonly: z.boolean().optional(),
@@ -63,6 +72,7 @@ export const SerializedLiteralSchema: z.ZodType<SerializedLiteralSchemaT> =
 export const SerializedBooleanSchema: z.ZodType<SerializedBooleanSchemaT> =
   z.object({
     type: z.literal("boolean"),
+    render: FieldRender,
     opt: z.boolean(),
     readonly: z.boolean().optional(),
     hidden: z.boolean().optional(),
@@ -71,6 +81,7 @@ export const SerializedBooleanSchema: z.ZodType<SerializedBooleanSchemaT> =
 export const SerializedNumberSchema: z.ZodType<SerializedNumberSchemaT> =
   z.object({
     type: z.literal("number"),
+    render: FieldRender,
     options: z
       .object({
         max: z.number().optional(),
@@ -86,6 +97,7 @@ export const SerializedObjectSchema: z.ZodType<SerializedObjectSchemaT> =
   z.lazy(() => {
     return z.object({
       type: z.literal("object"),
+      render: FieldRender,
       items: z.record(z.string(), SerializedSchema),
       opt: z.boolean(),
       readonly: z.boolean().optional(),
@@ -97,6 +109,7 @@ export const SerializedArraySchema: z.ZodType<SerializedArraySchemaT> = z.lazy(
   () => {
     return z.object({
       type: z.literal("array"),
+      render: FieldRender,
       item: SerializedSchema,
       opt: z.boolean(),
       // Only whether a preview EXISTS: the closure itself cannot be serialized.
@@ -112,6 +125,7 @@ export const SerializedUnionSchema: z.ZodType<SerializedUnionSchemaT> = z.lazy(
     return z.union([
       z.object({
         type: z.literal("union"),
+        render: FieldRender,
         key: SerializedLiteralSchema,
         items: z.array(SerializedLiteralSchema),
         opt: z.boolean(),
@@ -120,6 +134,7 @@ export const SerializedUnionSchema: z.ZodType<SerializedUnionSchemaT> = z.lazy(
       }),
       z.object({
         type: z.literal("union"),
+        render: FieldRender,
         key: z.string(),
         items: z.array(SerializedObjectSchema),
         opt: z.boolean(),
@@ -141,6 +156,7 @@ export const ImageOptions = z.object({
 export const SerializedImageSchema: z.ZodType<SerializedImageSchemaT> =
   z.object({
     type: z.literal("image"),
+    render: FieldRender,
     options: ImageOptions.optional(),
     opt: z.boolean(),
     readonly: z.boolean().optional(),
@@ -182,6 +198,7 @@ export const RichTextOptions: z.ZodType<SerializedRichTextOptionsT> = z.lazy(
 export const SerializedRichTextSchema: z.ZodType<SerializedRichTextSchemaT> =
   z.object({
     type: z.literal("richtext"),
+    render: FieldRender,
     options: RichTextOptions.optional(),
     opt: z.boolean(),
     readonly: z.boolean().optional(),
@@ -193,6 +210,7 @@ export const SerializedRecordSchema: z.ZodType<SerializedRecordSchemaT> =
     return z
       .object({
         type: z.literal("record"),
+        render: FieldRender,
         item: SerializedSchema,
         opt: z.boolean(),
         // Only whether a preview EXISTS: the closure itself cannot be serialized.
@@ -219,6 +237,7 @@ export const SerializedKeyOfSchema: z.ZodType<SerializedKeyOfSchemaT> = z.lazy(
   () => {
     return z.object({
       type: z.literal("keyOf"),
+      render: FieldRender,
       path: SourcePath,
       schema: z
         .union([
@@ -243,6 +262,7 @@ export const FileOptions = z.object({
 });
 export const SerializedFileSchema: z.ZodType<SerializedFileSchemaT> = z.object({
   type: z.literal("file"),
+  render: FieldRender,
   options: FileOptions.optional(),
   opt: z.boolean(),
   readonly: z.boolean().optional(),
@@ -256,6 +276,7 @@ export const DateOptions = z.object({
 
 export const SerializedDateSchema: z.ZodType<SerializedDateSchemaT> = z.object({
   type: z.literal("date"),
+  render: FieldRender,
   options: DateOptions.optional(),
   opt: z.boolean(),
   customValidate: z.boolean().optional(),
@@ -267,6 +288,7 @@ export const SerializedDateSchema: z.ZodType<SerializedDateSchemaT> = z.object({
 export const SerializedDateTimeSchema: z.ZodType<SerializedDateTimeSchemaT> =
   z.object({
     type: z.literal("dateTime"),
+    render: FieldRender,
     options: DateOptions.optional(),
     opt: z.boolean(),
     customValidate: z.boolean().optional(),
@@ -283,6 +305,7 @@ export const ColorOptions = z.object({
 export const SerializedColorSchema: z.ZodType<SerializedColorSchemaT> =
   z.object({
     type: z.literal("color"),
+    render: FieldRender,
     options: ColorOptions.optional(),
     opt: z.boolean(),
     customValidate: z.boolean().optional(),
@@ -294,6 +317,7 @@ export const SerializedColorSchema: z.ZodType<SerializedColorSchemaT> =
 export const SerializedRouteSchema: z.ZodType<SerializedRouteSchemaT> =
   z.object({
     type: z.literal("route"),
+    render: FieldRender,
     options: z
       .object({
         include: z

--- a/packages/shared/src/internal/zod/SerializedSchema.ts
+++ b/packages/shared/src/internal/zod/SerializedSchema.ts
@@ -41,6 +41,7 @@ export const SerializedStringSchema: z.ZodType<SerializedStringSchemaT> =
         InlineRender,
       ])
       .optional(),
+    preview: z.literal(true).optional(),
     options: z
       .object({
         maxLength: z.number().optional(),
@@ -63,6 +64,7 @@ export const SerializedLiteralSchema: z.ZodType<SerializedLiteralSchemaT> =
   z.object({
     type: z.literal("literal"),
     render: FieldRender,
+    preview: z.literal(true).optional(),
     value: z.string(),
     opt: z.boolean(),
     readonly: z.boolean().optional(),
@@ -73,6 +75,7 @@ export const SerializedBooleanSchema: z.ZodType<SerializedBooleanSchemaT> =
   z.object({
     type: z.literal("boolean"),
     render: FieldRender,
+    preview: z.literal(true).optional(),
     opt: z.boolean(),
     readonly: z.boolean().optional(),
     hidden: z.boolean().optional(),
@@ -82,6 +85,7 @@ export const SerializedNumberSchema: z.ZodType<SerializedNumberSchemaT> =
   z.object({
     type: z.literal("number"),
     render: FieldRender,
+    preview: z.literal(true).optional(),
     options: z
       .object({
         max: z.number().optional(),
@@ -98,6 +102,7 @@ export const SerializedObjectSchema: z.ZodType<SerializedObjectSchemaT> =
     return z.object({
       type: z.literal("object"),
       render: FieldRender,
+      preview: z.literal(true).optional(),
       items: z.record(z.string(), SerializedSchema),
       opt: z.boolean(),
       readonly: z.boolean().optional(),
@@ -110,10 +115,9 @@ export const SerializedArraySchema: z.ZodType<SerializedArraySchemaT> = z.lazy(
     return z.object({
       type: z.literal("array"),
       render: FieldRender,
+      preview: z.literal(true).optional(),
       item: SerializedSchema,
       opt: z.boolean(),
-      // Only whether a preview EXISTS: the closure itself cannot be serialized.
-      preview: z.literal(true).optional(),
       readonly: z.boolean().optional(),
       hidden: z.boolean().optional(),
     });
@@ -126,6 +130,7 @@ export const SerializedUnionSchema: z.ZodType<SerializedUnionSchemaT> = z.lazy(
       z.object({
         type: z.literal("union"),
         render: FieldRender,
+        preview: z.literal(true).optional(),
         key: SerializedLiteralSchema,
         items: z.array(SerializedLiteralSchema),
         opt: z.boolean(),
@@ -135,6 +140,7 @@ export const SerializedUnionSchema: z.ZodType<SerializedUnionSchemaT> = z.lazy(
       z.object({
         type: z.literal("union"),
         render: FieldRender,
+        preview: z.literal(true).optional(),
         key: z.string(),
         items: z.array(SerializedObjectSchema),
         opt: z.boolean(),
@@ -157,6 +163,7 @@ export const SerializedImageSchema: z.ZodType<SerializedImageSchemaT> =
   z.object({
     type: z.literal("image"),
     render: FieldRender,
+    preview: z.literal(true).optional(),
     options: ImageOptions.optional(),
     opt: z.boolean(),
     readonly: z.boolean().optional(),
@@ -199,6 +206,7 @@ export const SerializedRichTextSchema: z.ZodType<SerializedRichTextSchemaT> =
   z.object({
     type: z.literal("richtext"),
     render: FieldRender,
+    preview: z.literal(true).optional(),
     options: RichTextOptions.optional(),
     opt: z.boolean(),
     readonly: z.boolean().optional(),
@@ -211,10 +219,9 @@ export const SerializedRecordSchema: z.ZodType<SerializedRecordSchemaT> =
       .object({
         type: z.literal("record"),
         render: FieldRender,
+        preview: z.literal(true).optional(),
         item: SerializedSchema,
         opt: z.boolean(),
-        // Only whether a preview EXISTS: the closure itself cannot be serialized.
-        preview: z.literal(true).optional(),
         // Optional gallery marker for files/images
         mediaType: z
           .union([z.literal("files"), z.literal("images")])
@@ -238,6 +245,7 @@ export const SerializedKeyOfSchema: z.ZodType<SerializedKeyOfSchemaT> = z.lazy(
     return z.object({
       type: z.literal("keyOf"),
       render: FieldRender,
+      preview: z.literal(true).optional(),
       path: SourcePath,
       schema: z
         .union([
@@ -263,6 +271,7 @@ export const FileOptions = z.object({
 export const SerializedFileSchema: z.ZodType<SerializedFileSchemaT> = z.object({
   type: z.literal("file"),
   render: FieldRender,
+  preview: z.literal(true).optional(),
   options: FileOptions.optional(),
   opt: z.boolean(),
   readonly: z.boolean().optional(),
@@ -277,6 +286,7 @@ export const DateOptions = z.object({
 export const SerializedDateSchema: z.ZodType<SerializedDateSchemaT> = z.object({
   type: z.literal("date"),
   render: FieldRender,
+  preview: z.literal(true).optional(),
   options: DateOptions.optional(),
   opt: z.boolean(),
   customValidate: z.boolean().optional(),
@@ -289,6 +299,7 @@ export const SerializedDateTimeSchema: z.ZodType<SerializedDateTimeSchemaT> =
   z.object({
     type: z.literal("dateTime"),
     render: FieldRender,
+    preview: z.literal(true).optional(),
     options: DateOptions.optional(),
     opt: z.boolean(),
     customValidate: z.boolean().optional(),
@@ -306,6 +317,7 @@ export const SerializedColorSchema: z.ZodType<SerializedColorSchemaT> =
   z.object({
     type: z.literal("color"),
     render: FieldRender,
+    preview: z.literal(true).optional(),
     options: ColorOptions.optional(),
     opt: z.boolean(),
     customValidate: z.boolean().optional(),
@@ -318,6 +330,7 @@ export const SerializedRouteSchema: z.ZodType<SerializedRouteSchemaT> =
   z.object({
     type: z.literal("route"),
     render: FieldRender,
+    preview: z.literal(true).optional(),
     options: z
       .object({
         include: z

--- a/packages/ui/spa/bench/generateProject.ts
+++ b/packages/ui/spa/bench/generateProject.ts
@@ -13,8 +13,9 @@ import { initVal, type SelectorSource, type ValModule } from "@valbuild/core";
  *
  * - **plain modules** — objects of strings with `minLength` validators, so schema
  *   validation has real work to do rather than returning `false` immediately;
- * - **list modules** — `s.array(...).preview(select)`, where `select` is a user
- *   closure invoked per row. This is the expensive thing;
+ * - **list modules** — `s.array(item.preview(select))`, where `select` is a user
+ *   closure declared on the item schema and invoked per row. This is the
+ *   expensive thing;
  * - **one nested list** — a list whose items each contain a list, both with a
  *   `preview`. This is the `handboka` shape, the worst case named throughout
  *   `architecture.md`, and the reason path-scoped previews were built.
@@ -199,12 +200,14 @@ export function generateProject(size: ProjectSize): GeneratedProject {
     modules.push(
       c.define(
         path,
-        s
-          .array(s.object({ title: s.string().minLength(2), body: s.string() }))
-          .preview(({ val }) => {
-            selectCalls++;
-            return { title: val.title, subtitle: val.body };
-          }),
+        s.array(
+          s
+            .object({ title: s.string().minLength(2), body: s.string() })
+            .preview(({ val }) => {
+              selectCalls++;
+              return { title: val.title, subtitle: val.body };
+            }),
+        ),
         rows,
       ),
     );
@@ -219,22 +222,24 @@ export function generateProject(size: ProjectSize): GeneratedProject {
   modules.push(
     c.define(
       nestedModule,
-      s
-        .array(
-          s.object({
+      s.array(
+        s
+          .object({
             title: s.string().minLength(2),
-            sections: s
-              .array(s.object({ heading: s.string().minLength(2) }))
-              .preview(({ val }) => {
-                selectCalls++;
-                return { title: val.heading };
-              }),
+            sections: s.array(
+              s
+                .object({ heading: s.string().minLength(2) })
+                .preview(({ val }) => {
+                  selectCalls++;
+                  return { title: val.heading };
+                }),
+            ),
+          })
+          .preview(({ val }) => {
+            selectCalls++;
+            return { title: val.title };
           }),
-        )
-        .preview(({ val }) => {
-          selectCalls++;
-          return { title: val.title };
-        }),
+      ),
       Array.from({ length: size.nestedChapters }, (_unused, chapter) => ({
         title: `chapter ${chapter}`,
         sections: Array.from(

--- a/packages/ui/spa/components/AddRecordPopover.tsx
+++ b/packages/ui/spa/components/AddRecordPopover.tsx
@@ -86,12 +86,17 @@ export function AddRecordPopover({
         ],
         "record",
       );
-      navigate(
-        Internal.joinModuleFilePathAndModulePath(
-          moduleFilePath,
-          Internal.patchPathToModulePath(newPatchPath),
-        ) as SourcePath,
-      );
+      // An inline entry is edited in place in the list, so adding one should
+      // not navigate away from it — the same rule `AddArrayButton` follows,
+      // and the one `getNavPath` encodes: an inline item is not a nav stop.
+      if (schema.item.render?.as !== "inline") {
+        navigate(
+          Internal.joinModuleFilePathAndModulePath(
+            moduleFilePath,
+            Internal.patchPathToModulePath(newPatchPath),
+          ) as SourcePath,
+        );
+      }
       setOpen(false);
     },
     [addPatch, navigate, schemaAtPath, path],

--- a/packages/ui/spa/components/ArrayAndRecordTools.tsx
+++ b/packages/ui/spa/components/ArrayAndRecordTools.tsx
@@ -325,7 +325,9 @@ function AddArrayButton({
           ],
           schema.type,
         );
-        if (schema.item.type !== "string") {
+        // An inline item is edited in place in the list, so adding one should
+        // not navigate away from it. Everything else opens as its own page.
+        if (schema.item.render?.as !== "inline") {
           navigate(
             Internal.joinModuleFilePathAndModulePath(
               moduleFilePath,

--- a/packages/ui/spa/components/BlockList.stories.tsx
+++ b/packages/ui/spa/components/BlockList.stories.tsx
@@ -1,0 +1,355 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+  initVal,
+  Internal,
+  Json,
+  ModuleFilePath,
+  ReifiedPreview,
+  SerializedSchema,
+  SourcePath,
+} from "@valbuild/core";
+import { ValClient } from "@valbuild/shared/internal";
+import { useMemo, useState } from "react";
+import { BlockList } from "./BlockList";
+import { createStorySystem } from "../stores/react/storySystem";
+import { ValSystemProvider } from "../stores/react/SystemContext";
+import { ValThemeProvider, Themes } from "./ValThemeProvider";
+import { ValErrorProvider } from "./ValErrorProvider";
+import { ValPortalProvider } from "./ValPortalProvider";
+import { ValFieldProvider } from "./ValFieldProvider";
+import { ValRemoteProvider } from "./ValRemoteProvider";
+import { ValRouter } from "./ValRouter";
+import { TooltipProvider } from "./designSystem/tooltip";
+
+// Same story harness as InlineField.stories.tsx: real modules built with
+// initVal, serialized/previewed the same way the app does it.
+
+function createMockClient(): ValClient {
+  return ((path: string, method: string, req: unknown) => {
+    if (path === "/patches" && method === "PUT") {
+      const body = (req as { body?: { patches?: Record<string, unknown[]> } })
+        ?.body;
+      const newPatchIds: string[] = [];
+      if (body?.patches) {
+        for (const entries of Object.values(body.patches)) {
+          for (let i = 0; i < (entries as unknown[]).length; i++) {
+            newPatchIds.push(`mock-patch-${Date.now()}-${i}`);
+          }
+        }
+      }
+      return Promise.resolve({ status: 200, json: { newPatchIds } });
+    }
+    return Promise.resolve({
+      status: 200,
+      json: {
+        schemas: {},
+        sources: {},
+        config: { project: "storybook-test" },
+      },
+    });
+  }) as unknown as ValClient;
+}
+
+function createMockData(
+  modules: ReturnType<ReturnType<typeof initVal>["c"]["define"]>[],
+) {
+  const schemas: Record<string, SerializedSchema> = {};
+  const sources: Record<string, Json> = {};
+  const previews: Record<string, ReifiedPreview> = {};
+  for (const module of modules) {
+    const moduleFilePath = Internal.getValPath(module);
+    const schema = Internal.getSchema(module);
+    const source = Internal.getSource(module);
+    if (moduleFilePath && schema && source !== undefined) {
+      const path = moduleFilePath as unknown as ModuleFilePath;
+      schemas[path] = schema["executeSerialize"]();
+      sources[path] = source;
+      previews[path] = schema["executePreview"](path, source);
+    }
+  }
+  return {
+    schemas: schemas as Record<ModuleFilePath, SerializedSchema>,
+    sources: sources as Record<ModuleFilePath, Json>,
+    previews: previews as Record<ModuleFilePath, ReifiedPreview>,
+  };
+}
+
+function StoryProviders({
+  children,
+  mockData,
+}: {
+  children: React.ReactNode;
+  mockData: ReturnType<typeof createMockData>;
+}) {
+  const client = useMemo(() => createMockClient(), []);
+  const [theme, setTheme] = useState<Themes | null>("dark");
+  const system = useMemo(() => {
+    return createStorySystem({
+      schemas: mockData.schemas,
+      sources: mockData.sources,
+      previews: mockData.previews,
+    });
+  }, [client, mockData]);
+  const getDirectFileUploadSettings = useMemo(
+    () => async () => ({
+      status: "success" as const,
+      data: {
+        nonce: null,
+        baseUrl: "https://mock-upload.example.com",
+        contentBaseUrl: null,
+        contentAuthNonce: null,
+      },
+    }),
+    [],
+  );
+  return (
+    <ValSystemProvider system={system}>
+      <ValThemeProvider theme={theme} setTheme={setTheme} config={undefined}>
+        <TooltipProvider>
+          <ValRouter>
+            <ValErrorProvider>
+              <ValPortalProvider>
+                <ValFieldProvider
+                  getDirectFileUploadSettings={getDirectFileUploadSettings}
+                  config={undefined}
+                >
+                  <ValRemoteProvider remoteFiles={{ status: "not-asked" }}>
+                    {children}
+                  </ValRemoteProvider>
+                </ValFieldProvider>
+              </ValPortalProvider>
+            </ValErrorProvider>
+          </ValRouter>
+        </TooltipProvider>
+      </ValThemeProvider>
+    </ValSystemProvider>
+  );
+}
+
+// --- Fixtures ---
+
+const { s, c } = initVal();
+
+/**
+ * The motivating page-builder shape from the feature request, one level
+ * deeper: pages > sections > links are all sortable lists of inline objects,
+ * so three list levels have to fit on a laptop.
+ */
+const pagesModule = c.define(
+  "/content/pages.val.ts",
+  s.object({
+    blocks: s.array(
+      s
+        .object({
+          title: s.string(),
+          subtitle: s.string().render({ as: "textarea" }),
+          sections: s.array(
+            s
+              .object({
+                title: s.string(),
+                content: s.richtext(),
+                links: s.array(
+                  s
+                    .object({
+                      label: s.string(),
+                      url: s.string(),
+                    })
+                    .render({ as: "inline" }),
+                ),
+              })
+              .render({ as: "inline" }),
+          ),
+        })
+        .render({ as: "inline" }),
+    ),
+  }),
+  {
+    blocks: [
+      {
+        title: "Welcome to Val",
+        subtitle: "A CMS where your content is code.",
+        sections: [
+          {
+            title: "Why Val?",
+            content: [
+              {
+                tag: "p",
+                children: ["Content lives in git, typed end to end."],
+              },
+            ],
+            links: [
+              { label: "Docs", url: "https://val.build/docs" },
+              { label: "GitHub", url: "https://github.com/valbuild" },
+            ],
+          },
+          {
+            title: "Getting started",
+            content: [{ tag: "p", children: ["Run npm create @valbuild."] }],
+            links: [{ label: "Quickstart", url: "https://val.build/start" }],
+          },
+        ],
+      },
+      {
+        title: "Pricing",
+        subtitle: "Free while in beta.",
+        sections: [
+          {
+            title: "Plans",
+            content: [{ tag: "p", children: ["One plan: all of it."] }],
+            links: [],
+          },
+        ],
+      },
+    ],
+  },
+);
+
+const tagsModule = c.define(
+  "/content/tags.val.ts",
+  s.object({
+    tags: s.array(s.string().render({ as: "inline" })),
+  }),
+  { tags: ["design", "engineering", "content"] },
+);
+
+/** Items WITHOUT `.render({ as: "inline" })`: rows stay clickable previews. */
+const previewRowsModule = c.define(
+  "/content/testimonials.val.ts",
+  s.object({
+    testimonials: s
+      .array(
+        s.object({
+          quote: s.string(),
+          name: s.string(),
+        }),
+      )
+      .preview(({ val }) => ({ title: val.name, subtitle: val.quote })),
+  }),
+  {
+    testimonials: [
+      { quote: "Val changed how we ship content.", name: "Ada Lovelace" },
+      { quote: "The type-safety is the point.", name: "Grace Hopper" },
+    ],
+  },
+);
+
+const authorsModule = c.define(
+  "/content/authors.val.ts",
+  s.record(
+    s.object({
+      name: s.string(),
+      birthdate: s.date(),
+      bio: s.string().render({ as: "textarea" }),
+    }),
+  ),
+  {
+    fredrik: {
+      name: "Fredrik Ekholdt",
+      birthdate: "1980-01-01",
+      bio: "Building Val.",
+    },
+    erlend: {
+      name: "Erlend Hamberg",
+      birthdate: "1985-06-15",
+      bio: "Also building Val.",
+    },
+  },
+);
+
+/** An inlined keyOf shows the CONTENT of the referenced entry inside the row. */
+const articlesModule = c.define(
+  "/content/articles.val.ts",
+  s.object({
+    articles: s.array(
+      s
+        .object({
+          title: s.string(),
+          author: s.keyOf(authorsModule).render({ as: "inline" }),
+        })
+        .render({ as: "inline" }),
+    ),
+  }),
+  {
+    articles: [
+      { title: "Inline rendering deep dive", author: "fredrik" },
+      { title: "Sortable lists from scratch", author: "erlend" },
+    ],
+  },
+);
+
+const pagesData = createMockData([pagesModule]);
+const tagsData = createMockData([tagsModule]);
+const previewRowsData = createMockData([previewRowsModule]);
+const articlesData = createMockData([articlesModule, authorsModule]);
+
+// --- Storybook meta ---
+
+const meta: Meta = {
+  title: "Components/BlockList",
+  parameters: { layout: "padded" },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div className="p-6 bg-bg-primary min-h-[200px] max-w-2xl">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj;
+
+function sourcePathOf(moduleFilePath: string, key: string): SourcePath {
+  return `${moduleFilePath}?p=${JSON.stringify(key)}` as SourcePath;
+}
+
+export const ThreeLevels: Story = {
+  name: "Three levels (page builder)",
+  render: () => (
+    <StoryProviders mockData={pagesData}>
+      <BlockList path={sourcePathOf("/content/pages.val.ts", "blocks")} />
+    </StoryProviders>
+  ),
+};
+
+export const InlineStrings: Story = {
+  name: "Inline strings",
+  render: () => (
+    <StoryProviders mockData={tagsData}>
+      <BlockList path={sourcePathOf("/content/tags.val.ts", "tags")} />
+    </StoryProviders>
+  ),
+};
+
+export const PreviewRows: Story = {
+  name: "Preview rows (not inline)",
+  render: () => (
+    <StoryProviders mockData={previewRowsData}>
+      <BlockList
+        path={sourcePathOf("/content/testimonials.val.ts", "testimonials")}
+      />
+    </StoryProviders>
+  ),
+};
+
+export const InlineKeyOf: Story = {
+  name: "Inline keyOf (referenced content)",
+  render: () => (
+    <StoryProviders mockData={articlesData}>
+      <BlockList path={sourcePathOf("/content/articles.val.ts", "articles")} />
+    </StoryProviders>
+  ),
+};
+
+export const Readonly: Story = {
+  name: "Readonly",
+  render: () => (
+    <StoryProviders mockData={pagesData}>
+      <BlockList
+        path={sourcePathOf("/content/pages.val.ts", "blocks")}
+        readonly
+      />
+    </StoryProviders>
+  ),
+};

--- a/packages/ui/spa/components/BlockList.stories.tsx
+++ b/packages/ui/spa/components/BlockList.stories.tsx
@@ -216,14 +216,14 @@ const tagsModule = c.define(
 const previewRowsModule = c.define(
   "/content/testimonials.val.ts",
   s.object({
-    testimonials: s
-      .array(
-        s.object({
+    testimonials: s.array(
+      s
+        .object({
           quote: s.string(),
           name: s.string(),
-        }),
-      )
-      .preview(({ val }) => ({ title: val.name, subtitle: val.quote })),
+        })
+        .preview(({ val }) => ({ title: val.name, subtitle: val.quote })),
+    ),
   }),
   {
     testimonials: [

--- a/packages/ui/spa/components/BlockList.tsx
+++ b/packages/ui/spa/components/BlockList.tsx
@@ -1,0 +1,592 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  DndContext,
+  DragEndEvent,
+  DragOverlay,
+  closestCenter,
+  KeyboardSensor,
+  MouseSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import {
+  ChevronRight,
+  Copy,
+  EllipsisVertical,
+  GripVertical,
+  Plus,
+  Trash2,
+} from "lucide-react";
+import {
+  Json,
+  SerializedSchema,
+  SerializedArraySchema,
+  SourcePath,
+} from "@valbuild/core";
+import { array } from "@valbuild/core/fp";
+import { JSONValue } from "@valbuild/core/patch";
+import { useSourceAtPath, useValField } from "./ValFieldProvider";
+import { useValidationErrors } from "./ValErrorProvider";
+import { AnyField } from "./AnyField";
+import { RefPreview } from "./RefPreview";
+import { useNavigation } from "./ValRouter";
+import { useValPortal } from "./ValPortalProvider";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "./designSystem/popover";
+import { cn } from "./designSystem/cn";
+import { emptyOf } from "./fields/emptyOf";
+import { sourcePathOfItem } from "../utils/sourcePathOfItem";
+import { FieldValidationError } from "./FieldValidationError";
+
+/**
+ * A rebuilt sortable list for arrays, dense enough that a page-builder tree —
+ * lists of inline objects nested three levels deep — fits on a laptop screen.
+ *
+ * WORKING NAME. This is a Storybook-only prototype: `ArrayFields` still
+ * renders `SortableList` until the design (and the name) is decided.
+ *
+ * What it does differently from `SortableList`:
+ * - An item whose schema declares `.render({ as: "inline" })` is EDITED IN
+ *   PLACE inside its (sortable) row; anything else stays a clickable preview
+ *   row. The decision reads straight off the serialized item schema.
+ * - Object items get a compact header (grip, index, summary, collapse) and lay
+ *   their fields out tightly; nested inline lists recurse with a thin
+ *   indentation rail instead of another card-in-card.
+ * - Leaf items (string, number, ...) are a single row: grip, the field, menu.
+ *
+ * The optimistic-permutation-reset in the dnd wiring is the same doctrine as
+ * `SortableContainer` (see the long comment there): an array item's path is
+ * positional, so the local permutation must be re-derived from source the
+ * moment the move patch applies, or the move is applied twice and cancels out.
+ */
+/**
+ * Prototype-only density pass over the stock field controls, scoped to the
+ * list so nothing outside it changes: the design-system `Input` is `h-10 m-1`
+ * and the rich text editor `p-4`, which alone put a three-level tree far past
+ * one laptop screen. If the design lands, these become proper `compact`
+ * variants on the controls instead of descendant overrides.
+ */
+const DENSE_FIELDS = cn(
+  "[&_input]:h-7 [&_input]:m-0 [&_input]:w-full [&_input]:px-2 [&_input]:py-1 [&_input]:text-[13px]",
+  // The auto-growing textarea's height comes from its invisible ghost twin, so
+  // the ghost needs the same metrics or the box stays sized for the old ones.
+  // `field-sizing: content` stops the textarea's default `rows=2` from setting
+  // the grid row's intrinsic height (Chromium; elsewhere it stays two rows).
+  "[&_textarea]:min-h-0 [&_textarea]:m-0 [&_textarea]:px-2 [&_textarea]:py-1 [&_textarea]:text-[13px] [&_textarea]:leading-5 [&_textarea]:[field-sizing:content]",
+  "[&_[data-testid=auto-growing-textarea-ghost]]:m-0 [&_[data-testid=auto-growing-textarea-ghost]]:px-2 [&_[data-testid=auto-growing-textarea-ghost]]:py-1 [&_[data-testid=auto-growing-textarea-ghost]]:text-[13px] [&_[data-testid=auto-growing-textarea-ghost]]:leading-5",
+  // The rich text editor keeps its fixed toolbar (and the padding reserving
+  // room for it) only while focused; at rest it is one tight paragraph box.
+  "[&_.rich-text-editor:not(:focus-within)_.prose-editor]:p-2 [&_.rich-text-editor:not(:focus-within)_.prose-editor]:min-h-0",
+  "[&_.rich-text-editor:not(:focus-within)>.absolute]:hidden",
+  "[&_.prose-editor]:text-[13px]",
+);
+
+export function BlockList({
+  path,
+  readonly,
+  depth = 0,
+}: {
+  path: SourcePath;
+  readonly?: boolean;
+  /** Nesting level, used only for layout (rail indentation). */
+  depth?: number;
+}) {
+  const type = "array";
+  const { navigate } = useNavigation();
+  const sourceAtPath = useSourceAtPath(path);
+  const {
+    source: shallowSourceAtPath,
+    schema: schemaAtPath,
+    addPatch,
+    patchPath,
+  } = useValField(path, type, { watchUnsaved: true });
+
+  const [items, setItems] = useState<{ path: SourcePath; id: number }[]>([]);
+  const sourcePaths =
+    "data" in shallowSourceAtPath && shallowSourceAtPath.data
+      ? (shallowSourceAtPath.data as SourcePath[])
+      : null;
+  useEffect(() => {
+    // Re-derived from source on purpose — see the doc comment above.
+    const nextItems: { path: SourcePath; id: number }[] = [];
+    let id = 1; // 1-based: dnd-kit treats id 0 as "no active item"
+    for (const itemPath of sourcePaths ?? []) {
+      nextItems.push({ path: itemPath, id });
+      id++;
+    }
+    setItems(nextItems);
+  }, [sourcePaths]);
+
+  const sensors = useSensors(
+    useSensor(MouseSensor),
+    useSensor(TouchSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+  const [activeId, setActiveId] = useState<number | null>(null);
+  const activeItem =
+    activeId !== null ? items.find((item) => item.id === activeId) : undefined;
+
+  const onMove = useCallback(
+    (from: number, to: number) => {
+      addPatch(
+        [
+          {
+            op: "move",
+            from: patchPath.concat(
+              from.toString(),
+            ) as array.NonEmptyArray<string>,
+            path: patchPath.concat(to.toString()),
+          },
+        ],
+        type,
+      );
+    },
+    [addPatch, patchPath],
+  );
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (active?.id !== over?.id) {
+        const oldIndex = items.findIndex((i) => i.id === Number(active?.id));
+        const newIndex = items.findIndex((i) => i.id === Number(over?.id));
+        setItems((prev) => arrayMove(prev, oldIndex, newIndex));
+        onMove(oldIndex, newIndex);
+      }
+      setActiveId(null);
+    },
+    [items, onMove],
+  );
+
+  if (schemaAtPath.status === "error" || schemaAtPath.status === "not-found") {
+    return null;
+  }
+  if (schemaAtPath.status === "loading" || sourcePaths === null) {
+    return null;
+  }
+  if (schemaAtPath.data.type !== "array") {
+    return null;
+  }
+  const schema = schemaAtPath.data as SerializedArraySchema;
+
+  const renderRow = (item: { path: SourcePath; id: number }, index: number) => (
+    <BlockRow
+      key={item.id}
+      id={item.id}
+      index={index}
+      path={item.path}
+      itemSchema={schema.item}
+      depth={depth}
+      readonly={readonly}
+      onNavigate={(p) => navigate(p)}
+      onDelete={() => {
+        addPatch(
+          [
+            {
+              op: "remove",
+              path: patchPath.concat(
+                index.toString(),
+              ) as array.NonEmptyArray<string>,
+            },
+          ],
+          type,
+        );
+      }}
+      onDuplicate={() => {
+        if (
+          "data" in sourceAtPath &&
+          sourceAtPath.data &&
+          Array.isArray(sourceAtPath.data)
+        ) {
+          addPatch(
+            [
+              {
+                op: "add",
+                path: patchPath.concat(index.toString()),
+                value: (sourceAtPath.data[index] ?? null) as JSONValue,
+              },
+            ],
+            type,
+          );
+        }
+      }}
+    />
+  );
+
+  return (
+    <div id={path} className={cn("w-full", { [DENSE_FIELDS]: depth === 0 })}>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragStart={(event) => setActiveId(Number(event.active.id))}
+        onDragEnd={handleDragEnd}
+        onDragCancel={() => setActiveId(null)}
+      >
+        <SortableContext
+          items={items}
+          strategy={verticalListSortingStrategy}
+          disabled={readonly}
+        >
+          <div className="flex flex-col gap-1 w-full">
+            {items.map((item, index) => (
+              <div
+                key={item.id}
+                style={{ opacity: item.id === activeId ? 0.3 : undefined }}
+              >
+                {renderRow(item, index)}
+              </div>
+            ))}
+          </div>
+        </SortableContext>
+        {/* No drop animation — same reasoning as SortableList: the overlay
+            renders a positional path, and the content at that path changes the
+            moment the patch lands. */}
+        <DragOverlay dropAnimation={null}>
+          {activeItem ? renderRow(activeItem, items.indexOf(activeItem)) : null}
+        </DragOverlay>
+      </DndContext>
+      {!readonly && (
+        <button
+          className="flex items-center gap-1 h-6 mt-0.5 px-1 text-xs text-fg-tertiary hover:text-fg-primary"
+          onClick={() => {
+            addPatch(
+              [
+                {
+                  op: "add",
+                  path: patchPath.concat(items.length.toString()),
+                  value: emptyOf(schema.item) as JSONValue,
+                },
+              ],
+              type,
+            );
+          }}
+        >
+          <Plus size={12} />
+          <span>Add</span>
+        </button>
+      )}
+    </div>
+  );
+}
+
+function BlockRow({
+  id,
+  index,
+  path,
+  itemSchema,
+  depth,
+  readonly,
+  onNavigate,
+  onDelete,
+  onDuplicate,
+}: {
+  id: number;
+  index: number;
+  path: SourcePath;
+  itemSchema: SerializedSchema;
+  depth: number;
+  readonly?: boolean;
+  onNavigate: (path: SourcePath) => void;
+  onDelete: () => void;
+  onDuplicate: () => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id, disabled: readonly === true });
+  const [collapsed, setCollapsed] = useState(false);
+  const validationErrors = useValidationErrors(path);
+  const style = { transform: CSS.Transform.toString(transform), transition };
+  const isInline = itemSchema.render?.as === "inline";
+  // An inline object gets a header row (index, summary, collapse) above its
+  // fields; an inline leaf is a single line with the editor in it.
+  const headered = isInline && itemSchema.type === "object";
+
+  const grip = (
+    <button
+      {...attributes}
+      {...listeners}
+      className={cn("cursor-grab text-fg-quaternary hover:text-fg-primary", {
+        "opacity-30": readonly,
+      })}
+      disabled={readonly}
+    >
+      <GripVertical size={14} />
+    </button>
+  );
+  const menu = <RowMenu onDelete={onDelete} onDuplicate={onDuplicate} />;
+
+  return (
+    <div
+      touch-action="manipulation"
+      ref={setNodeRef}
+      style={style}
+      className={cn(
+        "border bg-bg-primary",
+        // A nested row shares its parent row's LEFT border instead of drawing
+        // its own: the parent's body has no left padding, so the child sits
+        // flush against that edge — one border line, and the horizontal room
+        // that a second border + padding used to cost comes back as content.
+        depth === 0 ? "rounded-md" : "rounded-r-md border-l-0",
+        {
+          "border-border-primary": validationErrors.length === 0,
+          "border-bg-warning-secondary": validationErrors.length > 0,
+        },
+      )}
+    >
+      {headered && (
+        <div className="flex items-center gap-1 h-7 px-1.5">
+          {grip}
+          <button
+            className="flex items-center gap-1 flex-1 min-w-0 text-left"
+            onClick={() => setCollapsed((prev) => !prev)}
+          >
+            <ChevronRight
+              size={12}
+              className={cn(
+                "shrink-0 text-fg-quaternary transition-transform",
+                { "rotate-90": !collapsed },
+              )}
+            />
+            <span className="w-4 shrink-0 text-[10px] text-fg-quaternary">
+              {index + 1}
+            </span>
+            <RowSummary path={path} />
+          </button>
+          {menu}
+        </div>
+      )}
+      {headered && !collapsed && (
+        // Right padding only: nested lists reach the left border (see the row
+        // class above); leaf fields add their own small left inset.
+        <div className="pr-1.5 pb-1.5 pt-0.5">
+          <InlineObjectBody
+            path={path}
+            itemSchema={itemSchema}
+            depth={depth}
+            readonly={readonly}
+          />
+        </div>
+      )}
+      {isInline && !headered && (
+        <div className="flex items-start gap-1.5 px-1.5 py-1">
+          <div className="pt-2">{grip}</div>
+          <div className="flex-1 min-w-0">
+            <AnyField
+              path={path}
+              schema={itemSchema}
+              readonly={readonly === true || itemSchema.readonly === true}
+              compact
+              errorDisplay="none"
+            />
+          </div>
+          {menu}
+        </div>
+      )}
+      {!isInline && (
+        <div className="flex items-center gap-1.5 px-1.5 py-1">
+          {grip}
+          <button
+            className="flex-1 min-w-0 overflow-y-clip rounded text-left text-xs hover:bg-bg-secondary-hover"
+            style={{ maxHeight: 96 }}
+            onClick={() => onNavigate(path)}
+          >
+            <RefPreview path={path} className="w-full p-1.5" />
+          </button>
+          {menu}
+        </div>
+      )}
+      {validationErrors.length > 0 && (
+        <div className="px-2.5 pb-1.5">
+          <FieldValidationError validationErrors={validationErrors} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The fields of one inline object item, laid out tightly. A field that is
+ * itself an array of inline items recurses into a nested `BlockList` behind a
+ * thin rail, instead of another card-in-card — that rail is most of what buys
+ * the third level on a laptop.
+ */
+function InlineObjectBody({
+  path,
+  itemSchema,
+  depth,
+  readonly,
+}: {
+  path: SourcePath;
+  itemSchema: SerializedSchema;
+  depth: number;
+  readonly?: boolean;
+}) {
+  // Which nested lists are folded away. Hiding fields is what buys clearance
+  // on the left once the rows themselves stopped indenting.
+  const [hiddenLists, setHiddenLists] = useState<Record<string, boolean>>({});
+  if (itemSchema.type !== "object") {
+    return null;
+  }
+  return (
+    <div className="flex flex-col gap-1.5">
+      {Object.entries(itemSchema.items).map(([key, fieldSchema]) => {
+        if (fieldSchema.hidden) {
+          return null;
+        }
+        const fieldPath = sourcePathOfItem(path, key);
+        const fieldReadonly =
+          readonly === true || fieldSchema.readonly === true;
+        if (
+          fieldSchema.type === "array" &&
+          fieldSchema.item.render?.as === "inline"
+        ) {
+          const hidden = hiddenLists[key] === true;
+          return (
+            <div key={key} className="flex flex-col gap-1">
+              <button
+                className="flex items-center gap-1 pl-2 text-left"
+                onClick={() =>
+                  setHiddenLists((prev) => ({ ...prev, [key]: !hidden }))
+                }
+              >
+                <ChevronRight
+                  size={10}
+                  className={cn(
+                    "shrink-0 text-fg-quaternary transition-transform",
+                    { "rotate-90": !hidden },
+                  )}
+                />
+                <FieldLabel label={key} />
+              </button>
+              {!hidden && (
+                <BlockList
+                  path={fieldPath}
+                  depth={depth + 1}
+                  readonly={fieldReadonly}
+                />
+              )}
+            </div>
+          );
+        }
+        return (
+          <div key={key} className="flex flex-col gap-0.5 pl-2">
+            <FieldLabel label={key} />
+            <AnyField
+              path={fieldPath}
+              schema={fieldSchema}
+              readonly={fieldReadonly}
+              compact
+              errorDisplay="compact"
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function FieldLabel({ label }: { label: string }) {
+  return (
+    <span className="text-[11px] leading-4 text-fg-tertiary">{label}</span>
+  );
+}
+
+/** One line of the row's own content, for the collapsed (and header) state. */
+function RowSummary({ path }: { path: SourcePath }) {
+  const sourceAtPath = useSourceAtPath(path);
+  const summary = useMemo(() => {
+    if ("data" in sourceAtPath && sourceAtPath.data !== undefined) {
+      return firstStringOf(sourceAtPath.data);
+    }
+    return null;
+  }, [sourceAtPath]);
+  return (
+    <span className="flex-1 min-w-0 truncate text-xs text-fg-tertiary">
+      {summary ?? ""}
+    </span>
+  );
+}
+
+/**
+ * Depth-first first string in a source — a cheap stand-in for a title when the
+ * schema has no `preview`. Skips `_type`-ish discriminators, which are the
+ * first field of every union item but never the row's title.
+ */
+function firstStringOf(source: Json): string | null {
+  if (typeof source === "string") {
+    return source;
+  }
+  if (Array.isArray(source)) {
+    for (const item of source) {
+      const found = firstStringOf(item);
+      if (found !== null) {
+        return found;
+      }
+    }
+    return null;
+  }
+  if (source !== null && typeof source === "object") {
+    for (const [key, value] of Object.entries(source)) {
+      if (key === "type" || key === "_type") {
+        continue;
+      }
+      if (value === undefined) {
+        continue;
+      }
+      const found = firstStringOf(value);
+      if (found !== null) {
+        return found;
+      }
+    }
+  }
+  return null;
+}
+
+function RowMenu({
+  onDelete,
+  onDuplicate,
+}: {
+  onDelete: () => void;
+  onDuplicate: () => void;
+}) {
+  const portalContainer = useValPortal();
+  return (
+    <Popover>
+      <PopoverTrigger className="shrink-0 rounded px-0.5 py-1 text-fg-quaternary hover:text-fg-primary hover:bg-bg-secondary-hover">
+        <EllipsisVertical size={14} />
+      </PopoverTrigger>
+      <PopoverContent
+        className="p-2 w-auto"
+        container={portalContainer}
+        side="top"
+      >
+        <button
+          className="flex items-center gap-x-2 text-sm"
+          onClick={onDelete}
+        >
+          <Trash2 className="w-3.5 h-3.5" />
+          <span>Delete</span>
+        </button>
+        <button
+          className="flex items-center gap-x-2 text-sm"
+          onClick={onDuplicate}
+        >
+          <Copy className="w-3.5 h-3.5" />
+          <span>Duplicate</span>
+        </button>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/ui/spa/components/BlockList.tsx
+++ b/packages/ui/spa/components/BlockList.tsx
@@ -325,7 +325,12 @@ function BlockRow({
       <GripVertical size={14} />
     </button>
   );
-  const menu = <RowMenu onDelete={onDelete} onDuplicate={onDuplicate} />;
+  // Readonly means readonly: with the menu still rendered, Delete and
+  // Duplicate stayed live and wrote patches even though the grip and every
+  // field were disabled.
+  const menu = readonly ? null : (
+    <RowMenu onDelete={onDelete} onDuplicate={onDuplicate} />
+  );
 
   return (
     <div

--- a/packages/ui/spa/components/BlockList.tsx
+++ b/packages/ui/spa/components/BlockList.tsx
@@ -407,7 +407,7 @@ function BlockRow({
             style={{ maxHeight: 96 }}
             onClick={() => onNavigate(path)}
           >
-            <RefPreview path={path} className="w-full p-1.5" />
+            <RefPreview path={path} className="w-full" />
           </button>
           {menu}
         </div>

--- a/packages/ui/spa/components/InlineAnyField.tsx
+++ b/packages/ui/spa/components/InlineAnyField.tsx
@@ -1,5 +1,5 @@
 import { SerializedSchema, SourcePath } from "@valbuild/core";
-import { AnyField } from "./AnyField";
+import { AnyField, ErrorDisplay } from "./AnyField";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { GripVertical } from "lucide-react";
@@ -9,13 +9,23 @@ export function InlineAnyField({
   path,
   schema,
   readonly,
+  errorDisplay,
 }: {
   path: SourcePath;
   schema: SerializedSchema;
   readonly: boolean;
+  /** Pass `"none"` when the row around this field shows the errors itself. */
+  errorDisplay?: ErrorDisplay;
 }) {
   return (
-    <AnyField path={path} schema={schema} readonly={readonly} compact inline />
+    <AnyField
+      path={path}
+      schema={schema}
+      readonly={readonly}
+      errorDisplay={errorDisplay}
+      compact
+      inline
+    />
   );
 }
 

--- a/packages/ui/spa/components/ListPreviewItem.stories.tsx
+++ b/packages/ui/spa/components/ListPreviewItem.stories.tsx
@@ -1,0 +1,117 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type { ImageSource } from "@valbuild/core";
+import { ListPreviewItem } from "./ListPreviewItem";
+import { placeholderImage } from "./stories/placeholderAssets";
+
+/**
+ * The row a value gets when its schema declares `.preview(...)`. Its whole job
+ * is to look unlike the fallback: we know the row is a title, maybe a subtitle
+ * and maybe an image, so it is laid out for exactly that and kept short.
+ */
+const meta: Meta<typeof ListPreviewItem> = {
+  title: "Components/ListPreviewItem",
+  component: ListPreviewItem,
+  parameters: { layout: "padded" },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div className="mx-auto w-[420px] rounded-lg border border-border-primary bg-bg-primary">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof ListPreviewItem>;
+
+// A media source is a plain object with a `path`; a data URL is not under
+// `/public`, so `mediaUrl` serves it back as-is. See `architecture/media.md`.
+const thumbnail: ImageSource = {
+  path: placeholderImage({
+    width: 80,
+    height: 80,
+    bg: "#e2e8f0",
+    fg: "#475569",
+    text: "A",
+  }),
+};
+
+export const WithImage: Story = {
+  args: {
+    title: "Ada Lovelace",
+    subtitle: "Notes on the analytical engine",
+    image: thumbnail,
+  },
+};
+
+export const WithoutImage: Story = {
+  args: {
+    title: "Grace Hopper",
+    subtitle: "A ship in port is safe, but that is not what ships are for",
+    image: null,
+  },
+};
+
+export const TitleOnly: Story = {
+  args: { title: "Katherine Johnson", subtitle: null, image: null },
+};
+
+/** Both lines are one line each: a long value is truncated, never wrapped. */
+export const Truncates: Story = {
+  args: {
+    title:
+      "A title long enough that it has nowhere left to go on a single line",
+    subtitle:
+      "And a subtitle that is likewise far too long to fit inside the row it was given",
+    image: thumbnail,
+  },
+};
+
+/** `size="compact"` — smaller thumbnail and type, for search hits. */
+export const Compact: Story = {
+  args: {
+    title: "Ada Lovelace",
+    subtitle: "Notes on the analytical engine",
+    image: thumbnail,
+    size: "compact",
+  },
+};
+
+/**
+ * Several rows together: the density a page-builder tree is aiming for, and
+ * the reason a missing image still reserves its column — the third row would
+ * otherwise start its title 52px left of the two above it.
+ */
+export const List: Story = {
+  render: () => (
+    <div className="flex flex-col">
+      <ListPreviewItem
+        title="Ada Lovelace"
+        subtitle="Notes on the analytical engine"
+        image={thumbnail}
+      />
+      <ListPreviewItem
+        title="Grace Hopper"
+        subtitle="A ship in port is safe"
+        image={thumbnail}
+      />
+      <ListPreviewItem
+        title="Katherine Johnson"
+        subtitle="Taught herself analytic geometry"
+        image={null}
+      />
+    </div>
+  ),
+};
+
+/** A list whose preview declares no image at all: no dead column anywhere. */
+export const ListWithoutImages: Story = {
+  render: () => (
+    <div className="flex flex-col">
+      <ListPreviewItem title="Ada Lovelace" subtitle="Analytical engine" />
+      <ListPreviewItem title="Grace Hopper" subtitle="COBOL" />
+      <ListPreviewItem title="Katherine Johnson" subtitle="Orbital mechanics" />
+    </div>
+  ),
+};

--- a/packages/ui/spa/components/ListPreviewItem.tsx
+++ b/packages/ui/spa/components/ListPreviewItem.tsx
@@ -2,6 +2,22 @@ import { ImageSource, Internal } from "@valbuild/core";
 import { cn } from "./designSystem/cn";
 import { useState } from "react";
 
+/**
+ * A value that HAS a preview, drawn as a compact media row: thumbnail on the
+ * left, title and subtitle stacked tight beside it, one line each.
+ *
+ * The point is that it should not look like the fallback. When a schema
+ * declares `.preview(...)` we know exactly what the row is made of — a title,
+ * maybe a subtitle, maybe an image — so the row is laid out for that shape
+ * instead of dumping whatever the value happens to contain (which is what
+ * `Preview` does, and what a reader sees when no preview is declared). Rows
+ * are deliberately short: a page-builder tree wants several list levels on one
+ * laptop screen, not three tall cards.
+ *
+ * Padding lives HERE, not in the callers: `RefPreview` picks between this and
+ * the fallback, and the two used to be padded differently by whoever wrapped
+ * them, so the same list changed density depending on which branch a row took.
+ */
 export function ListPreviewItem({
   title,
   image,
@@ -10,51 +26,80 @@ export function ListPreviewItem({
   size,
 }: {
   title: string;
-  image: ImageSource | null;
+  /**
+   * Three states, not two, because the preview tells us which it is:
+   * an `ImageSource` draws the thumbnail, `null` means the preview declares an
+   * image that this value does not have — so the column is still reserved,
+   * with a placeholder, and rows in the same list stay aligned — and
+   * `undefined` means it declares no image at all, so there is no column and
+   * the title starts at the edge.
+   */
+  image?: ImageSource | null;
   subtitle: string | null;
   className?: string;
   size?: "compact";
 }) {
+  const compact = size === "compact";
   return (
     <div
       className={cn(
-        "flex w-full items-start justify-between pl-2 flex-grow text-left",
-        size === "compact" && "h-[60px] overflow-hidden",
+        "flex items-center gap-3 p-2 w-full min-w-0 text-left",
         className,
       )}
     >
-      <div className="flex flex-col flex-shrink py-2 overflow-x-clip">
-        <div className="font-semibold">{title}</div>
+      {image !== undefined &&
+        (image === null ? (
+          <div
+            className={cn(
+              "flex-shrink-0 rounded opacity-25 bg-bg-brand-secondary",
+              compact ? "w-8 h-8" : "w-10 h-10",
+            )}
+          />
+        ) : (
+          <Thumbnail src={image} alt={title} compact={compact} />
+        ))}
+      <div className="flex flex-col flex-1 gap-0.5 min-w-0">
+        <div
+          className={cn("font-medium leading-tight truncate", {
+            "text-sm": compact,
+          })}
+        >
+          {title}
+        </div>
         {subtitle && (
-          <div className="block overflow-hidden flex-shrink max-h-5 text-sm text-gray-500 text-ellipsis">
+          <div
+            className={cn(
+              "leading-tight truncate text-fg-tertiary",
+              compact ? "text-xs" : "text-sm",
+            )}
+          >
             {subtitle}
           </div>
         )}
       </div>
-      {image && <ImageOrPlaceholder src={image} alt={title} />}
     </div>
   );
 }
 
-function ImageOrPlaceholder({
+function Thumbnail({
   src,
   alt,
+  compact,
 }: {
-  src: ImageSource | null | undefined;
+  src: ImageSource;
   alt: string;
+  compact: boolean;
 }) {
   const [isLoaded, setIsLoaded] = useState(false);
-
-  if (src === null || src === undefined) {
-    return (
-      <div className="flex-shrink-0 ml-4 w-20 h-20 opacity-25 bg-bg-brand-secondary"></div>
-    );
-  }
-
   const imageUrl = Internal.mediaUrl(src);
 
   return (
-    <div className="relative flex-shrink-0 ml-4 w-20 h-20">
+    <div
+      className={cn(
+        "flex-shrink-0 relative rounded overflow-hidden",
+        compact ? "w-8 h-8" : "w-10 h-10",
+      )}
+    >
       {!isLoaded && (
         <div className="absolute inset-0 opacity-25 bg-bg-brand-secondary animate-in"></div>
       )}
@@ -63,9 +108,10 @@ function ImageOrPlaceholder({
         alt={alt}
         onLoad={() => setIsLoaded(true)}
         onError={() => setIsLoaded(false)}
-        className={`absolute inset-0 object-cover w-full h-full rounded-r-lg ${
-          isLoaded ? "opacity-100" : "opacity-0"
-        }`}
+        className={cn(
+          "absolute inset-0 object-cover w-full h-full",
+          isLoaded ? "opacity-100" : "opacity-0",
+        )}
         style={{
           objectPosition: src.hotspot
             ? `${src.hotspot.x * 100}% ${src.hotspot.y * 100}%`

--- a/packages/ui/spa/components/RefPreview.tsx
+++ b/packages/ui/spa/components/RefPreview.tsx
@@ -1,12 +1,19 @@
 import { SourcePath } from "@valbuild/core";
+import { cn } from "./designSystem/cn";
 import { ListPreviewItem } from "./ListPreviewItem";
 import { Preview } from "./Preview";
 import { useRefPreview } from "./useRefPreview";
 
 /**
- * A container item's own preview — title, subtitle, image, as its schema's
- * `preview` produced it — falling back to the generic {@link Preview} of the
- * value when the container declares none.
+ * A value's preview — title, subtitle, image, as its schema's `preview`
+ * produced it — falling back to the generic {@link Preview} of the value when
+ * no preview is declared for it.
+ *
+ * The two branches are meant to look different: a declared preview gets the
+ * compact media row in {@link ListPreviewItem}, which is laid out for the
+ * shape we know it has, and everything else gets the generic per-type dump.
+ * Both are padded the same (`p-2`, once) so a list does not change density
+ * row by row depending on which branch each row took.
  */
 export function RefPreview({
   path,
@@ -23,24 +30,18 @@ export function RefPreview({
     return (
       <ListPreviewItem
         title={preview.title}
-        image={preview.image ?? null}
+        // Passed through rather than coalesced: `undefined` (no image in the
+        // preview) and `null` (an image this value does not have) lay the row
+        // out differently. See ListPreviewItem.
+        image={preview.image}
         subtitle={preview.subtitle ?? null}
         className={className}
         size={size}
       />
     );
   }
-  if (className) {
-    return (
-      <div className={className}>
-        <div className="p-2">
-          <Preview path={path} size={size} />
-        </div>
-      </div>
-    );
-  }
   return (
-    <div className="p-2">
+    <div className={cn("p-2", className)}>
       <Preview path={path} size={size} />
     </div>
   );

--- a/packages/ui/spa/components/Search/stories/mockData.ts
+++ b/packages/ui/spa/components/Search/stories/mockData.ts
@@ -302,21 +302,21 @@ function createMockData() {
   // Team members record with a list preview
   const team = c.define(
     "/content/team.val.ts",
-    s
-      .record(
-        s.object({
+    s.record(
+      s
+        .object({
           name: s.string(),
           position: s.string(),
           bio: s.string(),
           email: s.string(),
+        })
+        .preview(({ val }) => {
+          return {
+            title: val.name,
+            subtitle: val.position,
+          };
         }),
-      )
-      .preview(({ val }) => {
-        return {
-          title: val.name,
-          subtitle: val.position,
-        };
-      }),
+    ),
     {
       "team-1": {
         name: "Alice Johnson",
@@ -344,20 +344,21 @@ function createMockData() {
     "/app/products/[product]/page.val.ts",
     s
       .record(
-        s.object({
-          name: s.string(),
-          description: s.string().render({ as: "textarea" }),
-          price: s.number(),
-          code: s.string().render({ as: "code", language: "json" }),
-        }),
+        s
+          .object({
+            name: s.string(),
+            description: s.string().render({ as: "textarea" }),
+            price: s.number(),
+            code: s.string().render({ as: "code", language: "json" }),
+          })
+          .preview(({ val }) => {
+            return {
+              title: val.name,
+              subtitle: `$${val.price}`,
+            };
+          }),
       )
-      .router(mockRouter)
-      .preview(({ val }) => {
-        return {
-          title: val.name,
-          subtitle: `$${val.price}`,
-        };
-      }),
+      .router(mockRouter),
     {
       "/products/product-1": {
         name: "Premium Subscription",
@@ -411,20 +412,20 @@ function createMockData() {
   // Configuration array with renders on its string fields
   const config = c.define(
     "/content/config.val.ts",
-    s
-      .array(
-        s.object({
+    s.array(
+      s
+        .object({
           key: s.string(),
           value: s.string().render({ as: "code", language: "typescript" }),
           description: s.string().render({ as: "textarea" }),
+        })
+        .preview(({ val }) => {
+          return {
+            title: val.key,
+            subtitle: val.description,
+          };
         }),
-      )
-      .preview(({ val }) => {
-        return {
-          title: val.key,
-          subtitle: val.description,
-        };
-      }),
+    ),
     [
       {
         key: "customHook",

--- a/packages/ui/spa/components/SortableList.tsx
+++ b/packages/ui/spa/components/SortableList.tsx
@@ -296,6 +296,11 @@ export function SortableItemRow({
             path={path}
             schema={schema.item}
             readonly={disabled === true}
+            /* This row shows the item's errors itself, just below. Without
+               this the field shows them too whenever no `Field` wrapper above
+               has claimed them — which is every list at a module root — and
+               the same message appears twice. */
+            errorDisplay="none"
           />
           {validationErrors[path] && (
             <div className="px-2">

--- a/packages/ui/spa/components/SortableList.tsx
+++ b/packages/ui/spa/components/SortableList.tsx
@@ -326,7 +326,7 @@ export function SortableItemRow({
             onClick(path);
           }}
         >
-          <RefPreview path={path} className="flex-grow p-4 w-full" />
+          <RefPreview path={path} className="flex-grow w-full" />
           {isTruncated && (
             <div
               className="absolute bottom-0 left-0 w-full bg-gradient-to-b via-50% from-transparent via-card/90 to-card"

--- a/packages/ui/spa/components/SortableList.tsx
+++ b/packages/ui/spa/components/SortableList.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   DndContext,
   DragOverlay,
@@ -26,9 +20,8 @@ import { DragEndEvent } from "@dnd-kit/core";
 import { CSS } from "@dnd-kit/utilities";
 import { Copy, EllipsisVertical, GripVertical, Trash2 } from "lucide-react";
 import { SourcePath, SerializedArraySchema } from "@valbuild/core";
-import type { ArrayPreview } from "@valbuild/core";
 import { RefPreview } from "./RefPreview";
-import { StringField } from "./fields/StringField";
+import { InlineAnyField } from "./InlineAnyField";
 import { isParentError } from "../utils/isParentError";
 import { ErrorIndicator } from "./ErrorIndicator";
 import { useAllValidationErrors } from "./ValErrorProvider";
@@ -171,7 +164,6 @@ export function SortableContainer({
 
 export function SortableList({
   source,
-  preview,
   schema,
   disabled,
   onClick,
@@ -182,25 +174,15 @@ export function SortableList({
   source: SourcePath[];
   path: SourcePath;
   disabled?: boolean;
-  preview?: ArrayPreview;
   schema: SerializedArraySchema;
   onMove: (from: number, to: number) => void;
   onClick: (path: SourcePath) => void;
   onDelete: (item: number) => void;
   onDuplicate: (item: number) => void;
 }) {
-  /**
-   * The preview's items by index, built once per render of the list.
-   *
-   * `items` is `[index, value][]` — a windowed preview is a SHORTER array, so a
-   * row has to be found by its index rather than read at a position. Doing that
-   * with `find` per row is O(n) per row and therefore O(n²) for a full list,
-   * which is the case with the most rows on screen.
-   */
-  const previewByIndex = useMemo(
-    () => new Map(preview?.items ?? []),
-    [preview?.items],
-  );
+  // No per-row preview data here: whether a row is a preview card or an inline
+  // editor is decided by the ITEM schema (`.render({ as: "inline" })`), and a
+  // preview card resolves its own preview via `RefPreview`.
   return (
     <SortableContainer
       source={source}
@@ -211,13 +193,6 @@ export function SortableList({
           id={id}
           schema={schema}
           disabled={disabled}
-          preview={
-            /* id is 1-based because dnd kit didn't work with 0 based - surely we're doing something strange... (??) */
-            /* By index, not by position: a preview computed for a subset of paths
-               carries only those items, so items[n] would be a different row.
-               See ArrayPreview, and `previewByIndex` for why it is a Map. */
-            previewByIndex.get(id - 1)
-          }
           path={path}
           onClick={onClick}
           onDelete={(id) => {
@@ -245,14 +220,12 @@ export function SortableItemRow({
   path,
   schema,
   disabled,
-  preview,
   onClick,
   onDelete,
   onDuplicate,
 }: {
   id: number;
   path: SourcePath;
-  preview?: ArrayPreview["items"][number][1];
   schema: SerializedArraySchema;
   disabled?: boolean;
   onClick: (path: SourcePath) => void;
@@ -275,6 +248,7 @@ export function SortableItemRow({
   const { attributes, listeners, setNodeRef, transform, transition } =
     useSortable({ id: id, disabled: disabled === true });
   const validationErrors = useAllValidationErrors() || {};
+  const isInline = schema?.item?.render?.as === "inline";
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
@@ -299,20 +273,30 @@ export function SortableItemRow({
         })}
         disabled={disabled}
         onClick={() => {
-          onClick(path);
+          // An inline row is edited in place — there is no page to go to.
+          if (!isInline) {
+            onClick(path);
+          }
         }}
       >
         <GripVertical />
       </button>
-      {/** Changing this behavior means we need to change the getNavPath behavior */}
-      {!preview && schema?.item?.type === "string" && (
+      {/** Changing this behavior means we need to change the getNavPath behavior.
+       * Inlining is opt-in per item schema (`.render({ as: "inline" })`) and wins
+       * over a `.preview(...)` on the array: the explicit item-level declaration
+       * is the more specific of the two. */}
+      {isInline && (
         <div
           className={cn("flex-grow w-full", {
             "p-2 border border-bg-warning-secondary rounded-lg":
               !!validationErrors[path],
           })}
         >
-          <StringField path={path} />
+          <InlineAnyField
+            path={path}
+            schema={schema.item}
+            readonly={disabled === true}
+          />
           {validationErrors[path] && (
             <div className="px-2">
               <FieldValidationError validationErrors={validationErrors[path]} />
@@ -320,7 +304,7 @@ export function SortableItemRow({
           )}
         </div>
       )}
-      {(preview || schema?.item?.type !== "string") && (
+      {!isInline && (
         <button
           className={cn(
             "flex-grow",

--- a/packages/ui/spa/components/fields/ArrayFields.tsx
+++ b/packages/ui/spa/components/fields/ArrayFields.tsx
@@ -230,9 +230,6 @@ export function ArrayFields({
           );
         }}
         schema={schema}
-        preview={
-          previewAtPathData?.parent === "array" ? previewAtPathData : undefined
-        }
         source={shallowSourceAtPath.data || []}
       />
     </div>

--- a/packages/ui/spa/components/fields/KeyOfField.tsx
+++ b/packages/ui/spa/components/fields/KeyOfField.tsx
@@ -32,6 +32,7 @@ import { useNavigation } from "../../components/ValRouter";
 import { Link, Check, ChevronsUpDown } from "lucide-react";
 import { DropdownPreviewRow } from "../DropdownPreviewRow";
 import { ReadonlyGuard } from "./ReadonlyGuard";
+import { AnyField } from "../AnyField";
 
 export type KeyPreview = {
   title: string;
@@ -171,6 +172,13 @@ export function KeyOfField({
   const referencedPreview = usePreviewAtPath(
     (keyOf?.path ?? path) as SourcePath,
   );
+  // For `.render({ as: "inline" })` the selected entry's CONTENT is rendered
+  // below the selector, so the referenced module's schema is needed too.
+  const inlineRender =
+    "data" in schemaAtPath &&
+    schemaAtPath.data?.type === "keyOf" &&
+    schemaAtPath.data.render?.as === "inline";
+  const referencedSchemaAtPath = useSchemaAtPath(keyOf?.path ?? path);
   const sourceAtPath = useShallowSourceAtPath(path, type);
   const { patchPath, addPatch } = useAddPatch(path);
   const portalContainer = useValPortal();
@@ -268,6 +276,21 @@ export function KeyOfField({
     keyOf === undefined ||
     keys === undefined;
 
+  // The schema of the entry the key points at: a record's item schema, or the
+  // selected key's field schema when the reference is to an object.
+  const referencedItemSchema =
+    inlineRender && "data" in referencedSchemaAtPath
+      ? referencedSchemaAtPath.data?.type === "record"
+        ? referencedSchemaAtPath.data.item
+        : referencedSchemaAtPath.data?.type === "object" && source
+          ? referencedSchemaAtPath.data.items[source]
+          : undefined
+      : undefined;
+  const referencedItemPath =
+    inlineRender && keyOf?.path && source
+      ? Internal.createValPathOfItem(keyOf.path, source)
+      : undefined;
+
   const content = (
     <div id={path}>
       <div className="flex justify-between items-center">
@@ -304,6 +327,24 @@ export function KeyOfField({
           </button>
         )}
       </div>
+      {inlineRender &&
+        referencedItemPath !== undefined &&
+        referencedItemSchema !== undefined && (
+          <div className="mt-2 rounded-md border border-border-primary p-3">
+            {/* Edits here go to the referenced module (this is the SHARED
+                entry, not a copy), which is what a reference means — but it is
+                worth a label so nobody mistakes it for row-local content. */}
+            <div className="pb-2 text-xs text-fg-quaternary truncate">
+              {source}
+            </div>
+            <AnyField
+              path={referencedItemPath}
+              schema={referencedItemSchema}
+              readonly={readonly === true}
+              compact
+            />
+          </div>
+        )}
     </div>
   );
   if (readonly) {

--- a/packages/ui/spa/components/fields/KeyOfField.tsx
+++ b/packages/ui/spa/components/fields/KeyOfField.tsx
@@ -282,12 +282,15 @@ export function KeyOfField({
     inlineRender && "data" in referencedSchemaAtPath
       ? referencedSchemaAtPath.data?.type === "record"
         ? referencedSchemaAtPath.data.item
-        : referencedSchemaAtPath.data?.type === "object" && source
+        : referencedSchemaAtPath.data?.type === "object" && source !== null
           ? referencedSchemaAtPath.data.items[source]
           : undefined
       : undefined;
+  // `source !== null`, not a truthiness check: the empty string is a valid
+  // record/object key, and treating it as "nothing selected" is what left the
+  // referenced content unrendered for it.
   const referencedItemPath =
-    inlineRender && keyOf?.path && source
+    inlineRender && keyOf?.path && source !== null
       ? Internal.createValPathOfItem(keyOf.path, source)
       : undefined;
 

--- a/packages/ui/spa/components/fields/RecordFields.tsx
+++ b/packages/ui/spa/components/fields/RecordFields.tsx
@@ -90,7 +90,12 @@ export function RecordFields({
   const source = sourceAtPath.data;
   const schema = schemaAtPath.data;
 
-  if (inline) {
+  // Entries are rendered in place either because the caller asked for it
+  // (`inline` prop) or because the item schema opted in with
+  // `.render({ as: "inline" })` — the record counterpart of the inline rows in
+  // `SortableList`. Records are unordered, so there is nothing to sort; the key
+  // is the row's label.
+  if (inline || schema.item.render?.as === "inline") {
     const sourceEntries = source as Record<string, SourcePath> | null;
     if (sourceEntries === null) {
       return null;

--- a/packages/ui/spa/components/fields/RecordFields.tsx
+++ b/packages/ui/spa/components/fields/RecordFields.tsx
@@ -166,10 +166,23 @@ export function RecordFields({
   );
 }
 
-/** Row height estimate for the default card layout (`max-h-[170px]` + gap). */
-const CARD_ROW_HEIGHT = 186;
-/** Row height estimate for a `.preview(...)` row. */
-const PREVIEW_ROW_HEIGHT = 104;
+/**
+ * Row height estimate for the default card layout: gap (16) + border (2) +
+ * card padding (32) + key header (40) + {@link PREVIEW_ROW_CONTENT_HEIGHT}.
+ */
+const CARD_ROW_HEIGHT = 146;
+/**
+ * Row height estimate for a `.preview(...)` row: gap (16) + border (2) +
+ * {@link PREVIEW_ROW_CONTENT_HEIGHT}.
+ */
+const PREVIEW_ROW_HEIGHT = 74;
+/**
+ * What `ListPreviewItem` occupies: its own `p-2` (16) around a 40px thumbnail,
+ * which is also the tallest the title + subtitle column gets. The skeleton for
+ * an un-loaded entry is fixed to this so the virtualizer's measurements do not
+ * jump when the entry arrives and the row becomes a real preview.
+ */
+const PREVIEW_ROW_CONTENT_HEIGHT = 56;
 
 function RecordCardList({
   path,
@@ -236,7 +249,7 @@ function RecordCardList({
                   // spinners.
                   <RecordRowSkeleton
                     path={sourcePathOfItem(path, key)}
-                    height={96}
+                    height={PREVIEW_ROW_CONTENT_HEIGHT}
                   />
                 ) : (
                   <RefPreview path={sourcePathOfItem(path, key)} />
@@ -355,7 +368,7 @@ function RecordPreviewList({
               {unloadedKeys.has(key) ? (
                 <RecordRowSkeleton
                   path={sourcePathOfItem(path, key)}
-                  height={72}
+                  height={PREVIEW_ROW_CONTENT_HEIGHT}
                 />
               ) : (
                 <RefPreview path={sourcePathOfItem(path, key)} />

--- a/packages/ui/spa/components/getNavPath.test.ts
+++ b/packages/ui/spa/components/getNavPath.test.ts
@@ -13,6 +13,20 @@ const module = c.define(
   "/app/test.val.ts",
   s.object({
     arrayOfStrings: s.array(s.string()),
+    arrayOfInlineStrings: s.array(s.string().render({ as: "inline" })),
+    arrayOfInlineObjects: s.array(
+      s
+        .object({
+          title: s.string(),
+          sections: s.array(
+            s.object({ heading: s.string() }).render({ as: "inline" }),
+          ),
+        })
+        .render({ as: "inline" }),
+    ),
+    recordOfInlineObjects: s.record(
+      s.object({ title: s.string() }).render({ as: "inline" }),
+    ),
     objectOfRecord: s.object({
       recordA: s.record(
         s.object({
@@ -34,6 +48,13 @@ const module = c.define(
   }),
   {
     arrayOfStrings: ["a", "b", "c"],
+    arrayOfInlineStrings: ["a", "b"],
+    arrayOfInlineObjects: [
+      { title: "a", sections: [{ heading: "h1" }, { heading: "h2" }] },
+    ],
+    recordOfInlineObjects: {
+      a: { title: "a" },
+    },
     objectOfRecord: {
       recordA: {
         a: { field201: "a" },
@@ -61,13 +82,53 @@ const module = c.define(
 
 describe("getNavPath", () => {
   test("array of string", () => {
-    // NOTE: this behavior might change: maybe array of strings should not default to be shown
+    // Strings in arrays used to be inlined implicitly; inlining is now opt-in
+    // via `.render({ as: "inline" })`, so a plain string item is a nav stop.
     expect(
       testNavPath('/app/test.val.ts?p="arrayOfStrings"', module),
     ).toStrictEqual("/app/test.val.ts");
 
     expect(
       testNavPath('/app/test.val.ts?p="arrayOfStrings".0', module),
+    ).toStrictEqual('/app/test.val.ts?p="arrayOfStrings".0');
+  });
+
+  test("array of inline strings", () => {
+    expect(
+      testNavPath('/app/test.val.ts?p="arrayOfInlineStrings".0', module),
+    ).toStrictEqual("/app/test.val.ts");
+  });
+
+  test("array of inline objects", () => {
+    // The whole subtree of an inline item is edited in the parent's list, so
+    // every path inside it resolves up to the nearest non-inline ancestor —
+    // here the module root, since the nested sections are inline too.
+    expect(
+      testNavPath('/app/test.val.ts?p="arrayOfInlineObjects".0', module),
+    ).toStrictEqual("/app/test.val.ts");
+    expect(
+      testNavPath(
+        '/app/test.val.ts?p="arrayOfInlineObjects".0."title"',
+        module,
+      ),
+    ).toStrictEqual("/app/test.val.ts");
+    expect(
+      testNavPath(
+        '/app/test.val.ts?p="arrayOfInlineObjects".0."sections".0."heading"',
+        module,
+      ),
+    ).toStrictEqual("/app/test.val.ts");
+  });
+
+  test("record of inline objects", () => {
+    expect(
+      testNavPath('/app/test.val.ts?p="recordOfInlineObjects"."a"', module),
+    ).toStrictEqual("/app/test.val.ts");
+    expect(
+      testNavPath(
+        '/app/test.val.ts?p="recordOfInlineObjects"."a"."title"',
+        module,
+      ),
     ).toStrictEqual("/app/test.val.ts");
   });
 

--- a/packages/ui/spa/components/getNavPath.ts
+++ b/packages/ui/spa/components/getNavPath.ts
@@ -10,18 +10,18 @@ import { resolvePatchPath } from "../resolvePatchPath";
 /**
  * This defines the logic for when we should stop while moving up the path.
  * It must be in sync with the logic in the rest of UX - we should consider if there's a way to avoid an implicit contract
+ *
+ * An array/record item marked `.render({ as: "inline" })` is edited inside its
+ * parent's list, so it is not a place navigation can stop — we keep walking up
+ * to the nearest ancestor that is shown as its own page. (Strings in arrays
+ * used to be inlined implicitly; inlining is now opt-in via `render`.)
  */
 function isSchemaNavStop(
   schema: SerializedSchema,
   parentSchema: SerializedSchema | null,
 ): boolean {
-  if (parentSchema?.type === "array") {
-    if (schema.type === "string") {
-      return false;
-    }
-    return true;
-  } else if (parentSchema?.type === "record") {
-    return true;
+  if (parentSchema?.type === "array" || parentSchema?.type === "record") {
+    return schema.render?.as !== "inline";
   }
   return false;
 }

--- a/packages/ui/spa/components/useRefPreview.test.tsx
+++ b/packages/ui/spa/components/useRefPreview.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * @jest-environment jsdom
+ */
+import "../stores/react/testPolyfills";
+import { act, render, screen } from "@testing-library/react";
+import {
+  initVal,
+  Internal,
+  type ModuleFilePath,
+  type SourcePath,
+} from "@valbuild/core";
+import React from "react";
+import { createStorySystem } from "../stores/react/storySystem";
+import { ValSystemProvider } from "../stores/react/SystemContext";
+import { ValFieldProvider, useValField } from "./ValFieldProvider";
+import { useRefPreview } from "./useRefPreview";
+
+jest.mock("../validation/schemaValidationBridge", () => ({
+  createSchemaValidationBridge: () => ({
+    validate: async () => ({ errors: false }),
+    dispose: () => {},
+  }),
+}));
+
+const { s, c } = initVal();
+
+/**
+ * The container is deliberately NOT at the module root: its path segment is a
+ * quoted key (`?p="testimonials"`). `useParent` used to rebuild the parent
+ * path by joining UNQUOTED segments (`?p=testimonials`), so the preview lookup
+ * inside `useRefPreview` missed for every nested container while the schema
+ * lookup happened to tolerate it — rows silently fell back to the generic
+ * preview instead of the container's `.preview(...)`.
+ */
+const mod = c.define(
+  "/content/testimonials.val.ts",
+  s.object({
+    testimonials: s
+      .array(s.object({ quote: s.string(), name: s.string() }))
+      .preview(({ val }) => ({ title: val.name, subtitle: val.quote })),
+  }),
+  {
+    testimonials: [
+      { quote: "Q1", name: "Ada" },
+      { quote: "Q2", name: "Grace" },
+    ],
+  },
+);
+
+const moduleFilePath = Internal.getValPath(mod) as unknown as ModuleFilePath;
+const schema = Internal.getSchema(mod)!;
+const containerPath =
+  `${moduleFilePath}?p=${JSON.stringify("testimonials")}` as SourcePath;
+const rowPath = `${containerPath}.0` as SourcePath;
+
+function Providers({ children }: { children: React.ReactNode }) {
+  const system = createStorySystem({
+    schemas: { [moduleFilePath]: schema["executeSerialize"]() },
+    sources: { [moduleFilePath]: Internal.getSource(mod) },
+    previews: {
+      [moduleFilePath]: schema["executePreview"](
+        moduleFilePath,
+        Internal.getSource(mod),
+      ),
+    },
+  });
+  return (
+    <ValSystemProvider system={system}>
+      <ValFieldProvider
+        getDirectFileUploadSettings={async () => ({
+          status: "success" as const,
+          data: {
+            nonce: null,
+            baseUrl: "https://mock-upload.example.com",
+            contentBaseUrl: null,
+            contentAuthNonce: null,
+          },
+        })}
+        config={undefined}
+      >
+        {children}
+      </ValFieldProvider>
+    </ValSystemProvider>
+  );
+}
+
+function List() {
+  // The list field's own subscription is the demand signal that makes the
+  // preview store compute — the same shape as ArrayFields/SortableList.
+  useValField(containerPath, "array", { watchUnsaved: true });
+  return <Row />;
+}
+
+function Row() {
+  const preview = useRefPreview(rowPath);
+  return <div data-testid="row">{JSON.stringify(preview) ?? ""}</div>;
+}
+
+test("useRefPreview resolves a nested container's preview for a row", async () => {
+  render(
+    <Providers>
+      <List />
+    </Providers>,
+  );
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  });
+  expect(JSON.parse(screen.getByTestId("row").textContent || "null")).toEqual({
+    title: "Ada",
+    subtitle: "Q1",
+  });
+});

--- a/packages/ui/spa/components/useRefPreview.test.tsx
+++ b/packages/ui/spa/components/useRefPreview.test.tsx
@@ -35,9 +35,11 @@ const { s, c } = initVal();
 const mod = c.define(
   "/content/testimonials.val.ts",
   s.object({
-    testimonials: s
-      .array(s.object({ quote: s.string(), name: s.string() }))
-      .preview(({ val }) => ({ title: val.name, subtitle: val.quote })),
+    testimonials: s.array(
+      s
+        .object({ quote: s.string(), name: s.string() })
+        .preview(({ val }) => ({ title: val.name, subtitle: val.quote })),
+    ),
   }),
   {
     testimonials: [

--- a/packages/ui/spa/components/useRefPreview.test.tsx
+++ b/packages/ui/spa/components/useRefPreview.test.tsx
@@ -7,7 +7,9 @@ import {
   initVal,
   Internal,
   type ModuleFilePath,
+  type SelectorSource,
   type SourcePath,
+  type ValModule,
 } from "@valbuild/core";
 import React from "react";
 import { createStorySystem } from "../stores/react/storySystem";
@@ -50,19 +52,27 @@ const mod = c.define(
 );
 
 const moduleFilePath = Internal.getValPath(mod) as unknown as ModuleFilePath;
-const schema = Internal.getSchema(mod)!;
 const containerPath =
   `${moduleFilePath}?p=${JSON.stringify("testimonials")}` as SourcePath;
 const rowPath = `${containerPath}.0` as SourcePath;
 
-function Providers({ children }: { children: React.ReactNode }) {
+function Providers({
+  children,
+  module: forModule = mod,
+}: {
+  children: React.ReactNode;
+  /** Which fixture to build the story system from; the array one by default. */
+  module?: ValModule<SelectorSource>;
+}) {
+  const filePath = Internal.getValPath(forModule) as unknown as ModuleFilePath;
+  const forSchema = Internal.getSchema(forModule)!;
   const system = createStorySystem({
-    schemas: { [moduleFilePath]: schema["executeSerialize"]() },
-    sources: { [moduleFilePath]: Internal.getSource(mod) },
+    schemas: { [filePath]: forSchema["executeSerialize"]() },
+    sources: { [filePath]: Internal.getSource(forModule) },
     previews: {
-      [moduleFilePath]: schema["executePreview"](
-        moduleFilePath,
-        Internal.getSource(mod),
+      [filePath]: forSchema["executePreview"](
+        filePath,
+        Internal.getSource(forModule),
       ),
     },
   });
@@ -111,4 +121,56 @@ test("useRefPreview resolves a nested container's preview for a row", async () =
     title: "Ada",
     subtitle: "Q1",
   });
+});
+
+/**
+ * A record whose keys LOOK like array indices. `splitModulePath` hands back
+ * `"0"` for both an array index and this key, so a parent path rebuilt by
+ * re-quoting from the text alone (`patchPathToModulePath`) emits it unquoted
+ * and points at nothing — the row falls back to the generic preview. The
+ * parent path is sliced out of the original string instead, which keeps
+ * whatever quoting it already had.
+ */
+const numericKeyMod = c.define(
+  "/content/numericKeys.val.ts",
+  s.object({
+    entries: s.record(
+      s
+        .object({ name: s.string() })
+        .preview(({ val }) => ({ title: val.name })),
+    ),
+  }),
+  { entries: { "0": { name: "Zero" }, "1": { name: "One" } } },
+);
+
+const numericKeyFilePath = Internal.getValPath(
+  numericKeyMod,
+) as unknown as ModuleFilePath;
+const numericKeyContainerPath =
+  `${numericKeyFilePath}?p=${JSON.stringify("entries")}` as SourcePath;
+const numericKeyRowPath =
+  `${numericKeyContainerPath}.${JSON.stringify("0")}` as SourcePath;
+
+function NumericKeyList() {
+  useValField(numericKeyContainerPath, "record", { watchUnsaved: true });
+  return <NumericKeyRow />;
+}
+
+function NumericKeyRow() {
+  const preview = useRefPreview(numericKeyRowPath);
+  return <div data-testid="numeric-row">{JSON.stringify(preview) ?? ""}</div>;
+}
+
+test("useRefPreview resolves a preview for a numeric-looking record key", async () => {
+  render(
+    <Providers module={numericKeyMod}>
+      <NumericKeyList />
+    </Providers>,
+  );
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  });
+  expect(
+    JSON.parse(screen.getByTestId("numeric-row").textContent || "null"),
+  ).toEqual({ title: "Zero" });
 });

--- a/packages/ui/spa/components/useRefPreview.ts
+++ b/packages/ui/spa/components/useRefPreview.ts
@@ -38,13 +38,12 @@ export function resolveRefPreview(
   const pathParts = Internal.splitModulePath(modulePath);
   const lastPart = pathParts[pathParts.length - 1];
 
+  // `splitModulePath` has already unquoted the segment, so `lastPart` IS the
+  // key/index as written. It must not be run through `JSON.parse` again: a
+  // record key that looks like a number (`"0"`) came back as the number `0`
+  // and then matched no entry, because a record's keys are strings.
   if (parentSchema.type === "array" && previewData.parent === "array") {
-    let index: number;
-    try {
-      index = JSON.parse(lastPart);
-    } catch {
-      index = Number(lastPart);
-    }
+    const index = Number(lastPart);
     // By index, not by position: a windowed preview carries only the items that
     // were asked for. See ArrayPreview.
     const item = previewData.items.find(([itemIndex]) => itemIndex === index);
@@ -55,13 +54,7 @@ export function resolveRefPreview(
     parentSchema.type === "record" &&
     previewData.parent === "record"
   ) {
-    let key: string;
-    try {
-      key = JSON.parse(lastPart);
-    } catch {
-      key = lastPart;
-    }
-    const item = previewData.items.find(([itemKey]) => itemKey === key);
+    const item = previewData.items.find(([itemKey]) => itemKey === lastPart);
     if (item) {
       return item[1];
     }

--- a/packages/ui/spa/hooks/useParent.ts
+++ b/packages/ui/spa/hooks/useParent.ts
@@ -1,20 +1,60 @@
-import { Internal, SerializedSchema, SourcePath } from "@valbuild/core";
+import {
+  Internal,
+  ModulePath,
+  SerializedSchema,
+  SourcePath,
+} from "@valbuild/core";
 import { useSchemaAtPath } from "../components/ValFieldProvider";
+
+/**
+ * The module path with its last segment removed, cut out of the ORIGINAL
+ * string.
+ *
+ * Deliberately NOT split-and-rejoin. `splitModulePath` returns segments
+ * UNQUOTED and `patchPathToModulePath` re-quotes by guessing from the text, so
+ * a record key that merely LOOKS like a number (`"0"`) comes back as the array
+ * index `0` and the parent path is wrong. Slicing keeps whatever quoting the
+ * path already had, for every key.
+ *
+ * (`Internal.parentOfSourcePath` still round-trips and so still has that hole —
+ * see the TODO on `patchPathToModulePath`. Fixing it there is a core change of
+ * its own; this is the lookup that needs to be exact.)
+ */
+function parentOfModulePath(modulePath: ModulePath): ModulePath {
+  let lastSeparator = -1;
+  let inQuotes = false;
+  for (let i = 0; i < modulePath.length; i++) {
+    const char = modulePath[i];
+    if (inQuotes) {
+      if (char === "\\") {
+        i++; // whatever follows is escaped, never a delimiter
+      } else if (char === '"') {
+        inQuotes = false;
+      }
+    } else if (char === '"') {
+      inQuotes = true;
+    } else if (char === ".") {
+      lastSeparator = i;
+    }
+  }
+  if (lastSeparator === -1) {
+    return "" as ModulePath;
+  }
+  return modulePath.slice(0, lastSeparator) as ModulePath;
+}
 
 export function useParent(path: SourcePath) {
   const [moduleFilePath, modulePath] =
     Internal.splitModuleFilePathAndModulePath(path);
-  // `splitModulePath` returns UNQUOTED segments, so the re-join must re-quote
-  // them (`patchPathToModulePath`), not `.join(".")`: that produced
-  // `?p=testimonials` where every store keys on `?p="testimonials"`. The schema
-  // lookup happened to tolerate the unquoted form, which is what hid it — the
-  // preview lookup does not, so `useRefPreview` found nothing for any container
-  // that is not at the module root.
+  // The re-join must keep the segments quoted exactly as they came in: every
+  // store keys on `?p="testimonials"`, and `.join(".")` produced
+  // `?p=testimonials`. The schema lookup happened to tolerate the unquoted
+  // form, which is what hid it — the preview lookup does not, so
+  // `useRefPreview` found nothing for any container that is not at the module
+  // root.
   const maybeParentPath = Internal.joinModuleFilePathAndModulePath(
     moduleFilePath,
-    Internal.patchPathToModulePath(
-      Internal.splitModulePath(modulePath).slice(0, -1),
-    ),
+    parentOfModulePath(modulePath),
   );
   const parentSchemaAtPath = useSchemaAtPath(maybeParentPath);
   return {

--- a/packages/ui/spa/hooks/useParent.ts
+++ b/packages/ui/spa/hooks/useParent.ts
@@ -1,17 +1,20 @@
-import {
-  Internal,
-  ModulePath,
-  SerializedSchema,
-  SourcePath,
-} from "@valbuild/core";
+import { Internal, SerializedSchema, SourcePath } from "@valbuild/core";
 import { useSchemaAtPath } from "../components/ValFieldProvider";
 
 export function useParent(path: SourcePath) {
   const [moduleFilePath, modulePath] =
     Internal.splitModuleFilePathAndModulePath(path);
+  // `splitModulePath` returns UNQUOTED segments, so the re-join must re-quote
+  // them (`patchPathToModulePath`), not `.join(".")`: that produced
+  // `?p=testimonials` where every store keys on `?p="testimonials"`. The schema
+  // lookup happened to tolerate the unquoted form, which is what hid it — the
+  // preview lookup does not, so `useRefPreview` found nothing for any container
+  // that is not at the module root.
   const maybeParentPath = Internal.joinModuleFilePathAndModulePath(
     moduleFilePath,
-    Internal.splitModulePath(modulePath).slice(0, -1).join(".") as ModulePath,
+    Internal.patchPathToModulePath(
+      Internal.splitModulePath(modulePath).slice(0, -1),
+    ),
   );
   const parentSchemaAtPath = useSchemaAtPath(maybeParentPath);
   return {

--- a/packages/ui/spa/stores/SchemaStore.ts
+++ b/packages/ui/spa/stores/SchemaStore.ts
@@ -117,16 +117,13 @@ export class SchemaStore {
 /**
  * Does this schema, or anything under it, declare a preview?
  *
- * Only two schemas can: `array` and `record`, the containers that have items to
- * preview. Every other node is pure recursion, which is why the walk only has to
- * look for the `preview` marker and descend.
- *
- * There is deliberately NO `string` arm. `s.string().render({as:"textarea"})` is
- * a render, not a preview: static config that travels WITH the serialized schema
- * and is read where the field is drawn, so a module whose only such declaration
- * is a string layout must never be sent to the host. Restoring an arm here would
- * put that whole-module walk back for a fact the schema already carried. See
- * `core/src/render.ts`.
+ * Any node can carry the marker now that `preview` is declared on the ITEM
+ * schema (a container reifies its rows from its item's closure), so the walk
+ * checks every node and descends where there is somewhere to descend to. A
+ * `render` is deliberately NOT a hit: `s.string().render({as:"textarea"})` is
+ * static config that travels WITH the serialized schema and is read where the
+ * field is drawn, so a module whose only such declaration is a layout must
+ * never be sent to the host. See `core/src/render.ts`.
  *
  * `seen` guards a schema that refers to itself structurally, so this cannot
  * recurse forever — the same guard `collectReferences` and
@@ -138,11 +135,14 @@ function declaresPreview(
 ): boolean {
   if (seen.has(schema)) return false;
   seen.add(schema);
+  if (schema.preview === true) {
+    return true;
+  }
   switch (schema.type) {
     case "array":
-      return schema.preview === true || declaresPreview(schema.item, seen);
+      return declaresPreview(schema.item, seen);
     case "record":
-      return schema.preview === true || declaresPreview(schema.item, seen);
+      return declaresPreview(schema.item, seen);
     case "object":
       return Object.values(schema.items).some((item) =>
         declaresPreview(item, seen),

--- a/packages/ui/spa/stores/activityCost.test.ts
+++ b/packages/ui/spa/stores/activityCost.test.ts
@@ -42,9 +42,11 @@ const previewed = () => {
   const { c, s } = initVal();
   return c.define(
     "/previewed.val.ts",
-    s
-      .array(s.object({ title: s.string() }))
-      .preview(({ val }) => ({ title: val.title })),
+    s.array(
+      s
+        .object({ title: s.string() })
+        .preview(({ val }) => ({ title: val.title })),
+    ),
     [{ title: "one" }, { title: "two" }],
   );
 };

--- a/packages/ui/spa/stores/demandDriven.test.ts
+++ b/packages/ui/spa/stores/demandDriven.test.ts
@@ -32,10 +32,12 @@ function listModule(itemCount: number): {
   }));
   const module = c.define(
     "/list.val.ts",
-    s.array(s.object({ title: s.string() })).preview(({ val }) => {
-      calls++;
-      return { title: val.title };
-    }),
+    s.array(
+      s.object({ title: s.string() }).preview(({ val }) => {
+        calls++;
+        return { title: val.title };
+      }),
+    ),
     items,
   );
   return { module, selectCalls: () => calls };

--- a/packages/ui/spa/stores/workerSeam.test.ts
+++ b/packages/ui/spa/stores/workerSeam.test.ts
@@ -73,9 +73,11 @@ const project = () => {
     ),
     c.define(
       "/list.val.ts",
-      s
-        .array(s.object({ name: s.string() }))
-        .preview(({ val }) => ({ title: val.name })),
+      s.array(
+        s
+          .object({ name: s.string() })
+          .preview(({ val }) => ({ title: val.name })),
+      ),
       [{ name: "one" }, { name: "two" }],
     ),
   ];


### PR DESCRIPTION
Inlining an item in an array/record list is now opt-in per item schema
instead of implicit for strings:

- core: every schema class gains .render({ as: "inline" }) (FieldRender),
  carried whole in the serialized schema like the existing string renders,
  restored by deserializeSchema, and preserved across chaining. Exported as
  InlineRender/FieldRender. Tests in schema/render.test.ts.
- shared: the zod SerializedSchema validators accept the render field on
  every schema type (they strip unknown keys, so this is load-bearing).
- ui: the three places that keyed on `item.type === "string"` now key on
  `item.render?.as === "inline"` — SortableList rows (which render any
  inline item via InlineAnyField), getNavPath's nav-stop rule, and the add
  button's navigate-into-new-item rule. RecordFields renders inline items
  in place. An inlined keyOf also renders the referenced entry's content
  below the key selector.
- BlockList (working name): a Storybook-only prototype of a rebuilt, denser
  sortable list for page-builder trees — three nested list levels on one
  laptop screen, collapsible rows and nested lists, nested rows share the
  parent's left border. Not wired into ArrayFields yet.

BREAKING (behavior): s.array(s.string()) no longer inlines implicitly; add
.render({ as: "inline" }) on the string to edit items in the list.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0186AP2ce4KzMiUKG5NG4BYh