### PR TITLE
Fix validation crash on .jsonValues() entries with files

### DIFF
--- a/.changeset/jsonvalues-validate-fix.md
+++ b/.changeset/jsonvalues-validate-fix.md
@@ -1,0 +1,29 @@
+---
+"@valbuild/server": patch
+---
+
+Fix `val validate` crashing on a `.jsonValues()` entry that contains a file
+
+A module using `.jsonValues()` keeps its entry content in separate `*.val.json`
+files, so the `.val.ts` holds a `c.json(() => import(...))` marker where the
+value would be. Validation loads those files and reports errors at paths INSIDE
+an entry — but the fix handlers resolved such a path against the module source,
+which still had the marker, and resolving into a marker throws.
+
+An `s.image()` or `s.file()` inside an entry hits this every time: whether the
+stored dimensions match the bytes can only be answered by reading the file, so
+every image validation ends in a fix. The result was that a single image in a
+jsonValues entry aborted the whole run:
+
+```
+❌Error: Cannot resolve path into a jsonValues entry until its content is loaded. Path: "/jobb/student"."pageImage"
+```
+
+No report, no exit code, nothing fixable — and `--fix` could not get out of it,
+because the crash came before any fix ran.
+
+The loaded entry content is now substituted back into the source before anything
+resolves a path against it, and `Service.patch` routes an op that lands inside an
+entry to that entry's `*.val.json` instead of the `.val.ts` — the same routing
+the Studio's publish already does. So `val validate --fix` writes image metadata
+into the entry file, and the next run is clean.

--- a/.changeset/jsonvalues-validate-fix.md
+++ b/.changeset/jsonvalues-validate-fix.md
@@ -10,9 +10,10 @@ value would be. Validation loads those files and reports errors at paths INSIDE
 an entry — but the fix handlers resolved such a path against the module source,
 which still had the marker, and resolving into a marker throws.
 
-An `s.image()` or `s.file()` inside an entry hits this every time: whether the
-stored dimensions match the bytes can only be answered by reading the file, so
-every image validation ends in a fix. The result was that a single image in a
+An `s.image()` or `s.file()` inside an entry hits this every time. Media metadata
+can only be checked against the bytes themselves — an image's stored width and
+height, a file's mime type — which is something the schema deliberately cannot
+do, so it is always handed on as a fix rather than settled during validation. The result was that a single image in a
 jsonValues entry aborted the whole run:
 
 ```

--- a/architecture/quirks.md
+++ b/architecture/quirks.md
@@ -216,6 +216,32 @@ appends socket messages. Both feed the same fold, which keeps the last entry per
 commit sha — so anything reading that list has to sort before folding, or a
 finished build gets overwritten by the pending one it replaced.
 
+## `.jsonValues()`
+
+**A validation error can point where the module source cannot go.** A
+`.jsonValues()` record keeps each entry's value in its own `*.val.json`, so the
+source the server evaluates holds a `c.json(() => import(...))` marker in its
+place. Validation loads those files and reports errors at paths INSIDE an entry
+(`?p="/jobb/student"."pageImage"`), which means the error paths and the source
+they nominally belong to disagree: `Internal.resolvePath` refuses to walk into a
+marker and throws `Cannot resolve path into a jsonValues entry until its content
+is loaded`.
+
+So anything holding an `(errors, source)` pair for a jsonValues module has to
+substitute the loaded entry content back in first. `Service.get` does that on the
+validate path, which is what the `val validate --fix` handlers resolve against —
+before it did, one `s.image()` inside an entry aborted the entire run, because
+image metadata can only be checked by reading the bytes and therefore ALWAYS ends
+in a fix.
+
+**A patch into an entry does not touch the `.val.ts`.** The value being edited is
+not in that file, so an op whose path descends into an entry is rebased and
+replayed against the entry's `*.val.json` instead — `classifyJsonValuesOp` +
+`rebaseContentOp`, in both `ValOps.prepare` (publish) and `Service.patch`
+(`val validate --fix`). Which file an entry key maps to is read from the
+`import(...)` specifier in the `.val.ts`, not derived from the key: entries may be
+hand-placed, and deriving would write a file the module does not read.
+
 ## Patches
 
 **`GET /patches` with no `patch_id` returns every patch.** The filter is applied

--- a/packages/cli/src/__fixtures__/basic/app/jobb/[slug]/page.val.ts
+++ b/packages/cli/src/__fixtures__/basic/app/jobb/[slug]/page.val.ts
@@ -1,0 +1,20 @@
+import { c, nextAppRouter, s } from "../../../val.config";
+
+/**
+ * The shape the `.jsonValues()` path bug was reported on: a ROUTER whose entry
+ * content — including an `s.image()` — lives in a `*.val.json` next to the
+ * module. A router serializes as a record, so it takes the same jsonValues code
+ * path, but nothing pinned that until this fixture.
+ */
+export default c.define(
+  "/app/jobb/[slug]/page.val.ts",
+  s
+    .router(
+      nextAppRouter,
+      s.object({ header: s.string(), pageImage: s.image() }),
+    )
+    .jsonValues(),
+  {
+    "/jobb/student": c.json(() => import("./page/jobb/student.val.json")),
+  },
+);

--- a/packages/cli/src/__fixtures__/basic/app/jobb/[slug]/page/jobb/student.val.json
+++ b/packages/cli/src/__fixtures__/basic/app/jobb/[slug]/page/jobb/student.val.json
@@ -1,0 +1,6 @@
+{
+  "header": "Student",
+  "pageImage": {
+    "path": "/public/val/image.png"
+  }
+}

--- a/packages/cli/src/__fixtures__/basic/content/basic-json-values-image.val.ts
+++ b/packages/cli/src/__fixtures__/basic/content/basic-json-values-image.val.ts
@@ -1,0 +1,16 @@
+import { c, s } from "../val.config";
+
+/**
+ * A `.jsonValues()` record whose entry content contains an `s.image()`. Image
+ * metadata can only be checked by reading the bytes, so validating an image
+ * ALWAYS produces a fix — which means every fix handler has to cope with a
+ * source path that points inside an entry whose content is not in the
+ * `.val.ts`.
+ */
+export default c.define(
+  "/content/basic-json-values-image.val.ts",
+  s.record(s.object({ title: s.string(), image: s.image() })).jsonValues(),
+  {
+    "/with-image": c.json(() => import("./json-entries/with-image.val.json")),
+  },
+);

--- a/packages/cli/src/__fixtures__/basic/content/json-entries/with-image.val.json
+++ b/packages/cli/src/__fixtures__/basic/content/json-entries/with-image.val.json
@@ -1,0 +1,6 @@
+{
+  "title": "An entry with an image",
+  "image": {
+    "path": "/public/val/image.png"
+  }
+}

--- a/packages/cli/src/__fixtures__/basic/val.config.ts
+++ b/packages/cli/src/__fixtures__/basic/val.config.ts
@@ -1,7 +1,11 @@
-import { initVal } from "@valbuild/core";
+import { initVal, Internal } from "@valbuild/core";
 
 // NOTE: initVal() must be called with an options object for `config` to be
 // defined - the CLI requires val.config to export a config object.
 const { s, c, config } = initVal({});
 
-export { s, c, config };
+// `@valbuild/next` is what a real project takes its routers from; this fixture
+// only depends on core, so it reads the same router off `Internal`.
+const { nextAppRouter } = Internal;
+
+export { s, c, config, nextAppRouter };

--- a/packages/cli/src/__fixtures__/basic/val.modules.ts
+++ b/packages/cli/src/__fixtures__/basic/val.modules.ts
@@ -16,6 +16,8 @@ export default modules(config, [
   { def: () => import("./content/basic-gallery-remote.val") },
   { def: () => import("./content/basic-gallery-remote-existing.val") },
   { def: () => import("./content/basic-json-values.val") },
+  { def: () => import("./content/basic-json-values-image.val") },
+  { def: () => import("./app/jobb/[slug]/page.val") },
   { def: () => import("./content/basic-nested-json-values.val") },
   { def: () => import("./content/basic-inline-json-values.val") },
   { def: () => import("./content/basic-inline-json-values-invalid.val") },

--- a/packages/cli/src/runValidation.test.ts
+++ b/packages/cli/src/runValidation.test.ts
@@ -735,6 +735,130 @@ describe("runValidation", () => {
       expect(events.at(-1)).toEqual({ type: "summary-errors", count: 2 });
     });
 
+    test("reports a fixable error INSIDE an entry instead of throwing", async () => {
+      // Regression: every image validation ends in a fix (whether the stored
+      // dimensions match the bytes can only be answered by reading the file), and
+      // the fix handlers resolved the reported path against the module source —
+      // which for a jsonValues module holds a `c.json(...)` marker where the
+      // entry content should be. `Internal.resolvePath` refuses to walk into a
+      // marker, so a single `s.image()` inside an entry aborted the whole run
+      // with "Cannot resolve path into a jsonValues entry until its content is
+      // loaded" — no report, no exit code, nothing fixable.
+      const events = await runOn(["content/basic-json-values-image.val.ts"]);
+
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "validation-fixable-error",
+            sourcePath:
+              '/content/basic-json-values-image.val.ts?p="/with-image"."image"',
+            fixable: true,
+          }),
+        ]),
+      );
+      expect(events.at(-1)).toEqual({ type: "summary-errors", count: 1 });
+    });
+
+    test("--fix writes the entry's metadata into its *.val.json", async () => {
+      const events: ValidationEvent[] = [];
+      for await (const event of runValidation({
+        root: tmpDir,
+        fix: true,
+        valFiles: ["content/basic-json-values-image.val.ts"],
+        project: undefined,
+        remote: mockRemote,
+        fs: createDefaultValFSHost(),
+      })) {
+        events.push(event);
+      }
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "fix-applied",
+            sourcePath:
+              '/content/basic-json-values-image.val.ts?p="/with-image"."image"',
+          }),
+        ]),
+      );
+
+      // The metadata belongs in the entry's own file: the `.val.ts` has no place
+      // to put it, and a patch applied there would either fail or corrupt the
+      // `c.json(...)` reference.
+      const jsonPath = path.join(
+        tmpDir,
+        "content/json-entries/with-image.val.json",
+      );
+      expect(JSON.parse(fs.readFileSync(jsonPath, "utf8"))).toEqual({
+        title: "An entry with an image",
+        image: {
+          path: "/public/val/image.png",
+          width: 1,
+          height: 1,
+          mimeType: "image/png",
+        },
+      });
+      const valTs = fs.readFileSync(
+        path.join(tmpDir, "content/basic-json-values-image.val.ts"),
+        "utf8",
+      );
+      expect(valTs).toContain(
+        'c.json(() => import("./json-entries/with-image.val.json"))',
+      );
+      expect(valTs).not.toContain("mimeType");
+
+      // The bug the user hit was the SECOND run: fixing once and then failing
+      // forever is the same as never fixing at all.
+      const afterFix = await runOn(["content/basic-json-values-image.val.ts"]);
+      expect(afterFix.at(-1)).toEqual({ type: "summary-success" });
+    });
+
+    test("--fix reaches into a ROUTER's entry file too", async () => {
+      // The reported bug was on a router (`s.router(nextAppRouter, ...).jsonValues()`),
+      // not a plain record. A router serializes as a record so it takes the same
+      // path, but nothing covered it — and a router's entry keys are URL paths,
+      // which is what the failing report showed: `"/jobb/student"."pageImage"`.
+      const before = await runOn(["app/jobb/[slug]/page.val.ts"]);
+      expect(before).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "validation-fixable-error",
+            sourcePath:
+              '/app/jobb/[slug]/page.val.ts?p="/jobb/student"."pageImage"',
+          }),
+        ]),
+      );
+
+      const events: ValidationEvent[] = [];
+      for await (const event of runValidation({
+        root: tmpDir,
+        fix: true,
+        valFiles: ["app/jobb/[slug]/page.val.ts"],
+        project: undefined,
+        remote: mockRemote,
+        fs: createDefaultValFSHost(),
+      })) {
+        events.push(event);
+      }
+      expect(events.at(-1)).toEqual({ type: "summary-success" });
+
+      const jsonPath = path.join(
+        tmpDir,
+        "app/jobb/[slug]/page/jobb/student.val.json",
+      );
+      expect(JSON.parse(fs.readFileSync(jsonPath, "utf8"))).toEqual({
+        header: "Student",
+        pageImage: {
+          path: "/public/val/image.png",
+          width: 1,
+          height: 1,
+          mimeType: "image/png",
+        },
+      });
+      expect((await runOn(["app/jobb/[slug]/page.val.ts"])).at(-1)).toEqual({
+        type: "summary-success",
+      });
+    });
+
     test("rejects a nested .jsonValues() instead of reporting it valid", async () => {
       // Root-only is a hard contract: a nested one would silently get NO content
       // validation. The Studio refuses to load such a project, so the CLI saying

--- a/packages/server/src/Service.test.ts
+++ b/packages/server/src/Service.test.ts
@@ -6,6 +6,12 @@ import { createService } from "./Service";
 import { IValFSHost } from "./ValFSHost";
 
 const BASIC_FIXTURE = path.resolve(__dirname, "__fixtures__/basic");
+const JSON_VALUES_FIXTURE = path.resolve(
+  __dirname,
+  "..",
+  "test",
+  "jsonValues-fixture",
+);
 const PATHS_ALIAS_FIXTURE = path.resolve(__dirname, "__fixtures__/paths-alias");
 
 function createTestHost(overrides?: Partial<IValFSHost>): IValFSHost {
@@ -179,5 +185,81 @@ export default c.define("/content/basic-valid.val.ts", s.string(), "Patched by h
     await expect(createService(BASIC_FIXTURE, host)).rejects.toThrow(
       /Could not find 'val.modules.ts' nor 'val.modules.js'/,
     );
+  });
+});
+
+describe("Service.patch with .jsonValues()", () => {
+  const ENTRY_JSON = "page/blogs/test.val.json";
+  const MODULE = "/blogs.val.ts" as ModuleFilePath;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    const tmpBase = path.join(__dirname, ".tmp");
+    nodeFs.mkdirSync(tmpBase, { recursive: true });
+    tmpDir = nodeFs.mkdtempSync(path.join(tmpBase, "service-jsonvalues-"));
+    nodeFs.cpSync(JSON_VALUES_FIXTURE, tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    nodeFs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const readEntry = () =>
+    JSON.parse(nodeFs.readFileSync(path.join(tmpDir, ENTRY_JSON), "utf8"));
+
+  test("writes an edit inside an entry to the entry's own *.val.json", async () => {
+    const service = await createService(tmpDir, createTestHost());
+    const valTsBefore = nodeFs.readFileSync(
+      path.join(tmpDir, "blogs.val.ts"),
+      "utf8",
+    );
+
+    await service.patch(MODULE, [
+      { op: "replace", path: ["/blogs/test", "title"], value: "Edited" },
+    ]);
+
+    expect(readEntry()).toEqual({ title: "Edited" });
+    // The `.val.ts` only references the entry, so it has no business changing.
+    expect(nodeFs.readFileSync(path.join(tmpDir, "blogs.val.ts"), "utf8")).toBe(
+      valTsBefore,
+    );
+  });
+
+  test("refuses a copy into an entry from outside it", async () => {
+    // `rebaseContentOp` slices `from` by the same prefix as `path`, so an op
+    // whose ends are in different places is not unsupported but silently WRONG:
+    // the source would be re-read as a path inside the destination's file.
+    const service = await createService(tmpDir, createTestHost());
+
+    await expect(
+      service.patch(MODULE, [
+        { op: "copy", from: ["elsewhere"], path: ["/blogs/test", "title"] },
+      ]),
+    ).rejects.toThrow(/from outside it/);
+    expect(readEntry()).toEqual({ title: "Hello from JSON" });
+  });
+
+  test("allows a move WITHIN one entry", async () => {
+    // The guard above must reject only what crosses a file boundary: both ends
+    // inside the same entry rebase consistently and are a normal edit.
+    const service = await createService(tmpDir, createTestHost());
+
+    await service.patch(MODULE, [
+      {
+        op: "move",
+        from: ["/blogs/test", "title"],
+        path: ["/blogs/test", "heading"],
+      },
+    ]);
+
+    expect(readEntry()).toEqual({ heading: "Hello from JSON" });
+  });
+
+  test("refuses an op that adds or removes a whole entry", async () => {
+    const service = await createService(tmpDir, createTestHost());
+
+    await expect(
+      service.patch(MODULE, [{ op: "remove", path: ["/blogs/test"] }]),
+    ).rejects.toThrow(/only edits INSIDE an entry/);
   });
 });

--- a/packages/server/src/Service.ts
+++ b/packages/server/src/Service.ts
@@ -1,5 +1,12 @@
 import { patchValFile } from "./patchValFile";
-import { Patch } from "@valbuild/core/patch";
+import {
+  applyPatch,
+  deepClone,
+  JSONOps,
+  JSONValue,
+  Patch,
+} from "@valbuild/core/patch";
+import { result } from "@valbuild/core/fp";
 import { ValSourceFileHandler } from "./ValSourceFileHandler";
 import ts from "typescript";
 import { getCompilerOptions } from "./getCompilerOptions";
@@ -7,6 +14,7 @@ import { IValFSHost } from "./ValFSHost";
 import fs from "fs";
 import { SerializedModuleContent } from "./SerializedModuleContent";
 import {
+  type Json,
   ModuleFilePath,
   ModulePath,
   Internal,
@@ -15,13 +23,52 @@ import {
   SelectorSource,
   SerializedSchema,
   Source,
+  SourceObject,
   extractValModules,
   ValidationError,
 } from "@valbuild/core";
 import path from "path";
 import { loadValModules } from "./loadValModules";
-import { findNestedJsonValuesRecords } from "./patch/jsonValuesPatch";
+import {
+  classifyJsonValuesOp,
+  findNestedJsonValuesRecords,
+  rebaseContentOp,
+  type JsonValuesOpClass,
+} from "./patch/jsonValuesPatch";
 import { validateJsonValuesEntries } from "./validateJsonValues";
+import { findJsonEntryFilePath } from "./jsonEntryLocation";
+import { getSyntheticContainingPath } from "./getSyntheticContainingPath";
+
+const jsonOps = new JSONOps();
+
+/**
+ * Substitutes loaded `.jsonValues()` entry content back into a module's root
+ * record, in place of the `c.json(...)` markers the `.val.ts` holds.
+ *
+ * Only entries that actually loaded are replaced: an entry whose file is missing
+ * or unparseable keeps its marker, so the failure stays visible as the
+ * validation error it already produced rather than becoming a silent `undefined`
+ * further down.
+ */
+function withLoadedJsonEntries(
+  source: Source,
+  loadedEntries: Record<string, Json>,
+): Source {
+  if (Object.keys(loadedEntries).length === 0) {
+    return source;
+  }
+  if (!isSourceObject(source)) {
+    return source;
+  }
+  return { ...source, ...loadedEntries };
+}
+
+/** A non-null, non-array source object: the shape a record/router source has. */
+function isSourceObject(source: Source): source is SourceObject {
+  return (
+    typeof source === "object" && source !== null && !Array.isArray(source)
+  );
+}
 
 export async function createService(
   projectRoot: string,
@@ -78,6 +125,14 @@ export class Service {
     return Object.keys(this.extracted.sources) as ModuleFilePath[];
   }
 
+  private serializedSchemaOf(
+    moduleFilePath: ModuleFilePath,
+  ): SerializedSchema | undefined {
+    return this.extracted.serializedSchemas[moduleFilePath] as
+      | SerializedSchema
+      | undefined;
+  }
+
   async get(
     moduleFilePath: ModuleFilePath,
     modulePath: ModulePath,
@@ -88,9 +143,7 @@ export class Service {
     const schema = this.extracted.schemas[moduleFilePath] as
       | Schema<SelectorSource>
       | undefined;
-    const serializedSchema = this.extracted.serializedSchemas[
-      moduleFilePath
-    ] as SerializedSchema | undefined;
+    const serializedSchema = this.serializedSchemaOf(moduleFilePath);
 
     const moduleError = this.extracted.moduleErrors.find(
       (e) => e.path === moduleFilePath,
@@ -141,6 +194,12 @@ export class Service {
     // entry content, or an unsupported nested `.jsonValues()`, as VALID, and CI
     // gates on that.
     let jsonValuesModuleError: string | undefined;
+    // The source as it is on disk holds a `c.json(...)` marker for every
+    // `.jsonValues()` entry, and validation reports errors at paths INSIDE those
+    // entries. Resolving such a path against the marker source is impossible —
+    // it throws — so the loaded content is substituted back in before anything
+    // downstream (the `val validate --fix` handlers, chiefly) tries.
+    let resolvedFromSource = source;
     if (opts.validate) {
       const nested = findNestedJsonValuesRecords(serializedSchema);
       if (nested.length > 0) {
@@ -157,11 +216,9 @@ export class Service {
         // accepted cost of having no revalidation token (locked decision #3):
         // validation is allowed to be slower at scale, but it is not allowed to
         // silently skip content.
-        const entryErrors = await validateJsonValuesEntries(
-          schema,
-          source,
-          moduleFilePath,
-        );
+        const { errors: entryErrors, loadedEntries } =
+          await validateJsonValuesEntries(schema, source, moduleFilePath);
+        resolvedFromSource = withLoadedJsonEntries(source, loadedEntries);
         if (Object.keys(entryErrors).length > 0) {
           // Concatenate per path, never overwrite: an entry written inline is
           // reported BOTH by the record-level validation (which checks the
@@ -180,7 +237,11 @@ export class Service {
       }
     }
 
-    const resolved = Internal.resolvePath(modulePath, source, serializedSchema);
+    const resolved = Internal.resolvePath(
+      modulePath,
+      resolvedFromSource,
+      serializedSchema,
+    );
     const sourcePath = (
       resolved.path ? [moduleFilePath, resolved.path].join(".") : moduleFilePath
     ) as SourcePath;
@@ -211,12 +272,143 @@ export class Service {
     };
   }
 
+  /**
+   * Applies a patch to a module's files.
+   *
+   * A `.jsonValues()` entry's content is not in the `.val.ts` — that file holds
+   * only `c.json(() => import("./x.val.json"))` — so an op whose path descends
+   * into an entry has to be replayed against the backing `*.val.json` instead.
+   * That routing is the same one the Studio's commit flow does in
+   * `ValOps.prepare`; both classify with {@link classifyJsonValuesOp} and rebase
+   * with {@link rebaseContentOp}, so a CLI fix and a Studio publish write the
+   * same file the same way.
+   */
   async patch(moduleFilePath: ModuleFilePath, patch: Patch): Promise<void> {
-    await patchValFile(
+    const serializedSchema = this.serializedSchemaOf(moduleFilePath);
+    const valTsOps: Patch = [];
+    const entryOps = new Map<string, Patch>();
+    for (const op of patch) {
+      const cls: JsonValuesOpClass = serializedSchema
+        ? classifyJsonValuesOp(serializedSchema, op.path)
+        : { kind: "normal" };
+      if (cls.kind === "normal") {
+        valTsOps.push(op);
+        continue;
+      }
+      if (cls.recordPath.length > 0) {
+        // Nested `.jsonValues()` is rejected as a module error before any fix
+        // runs, so reaching here means the contract moved without this moving
+        // with it. Refuse rather than write to the wrong file.
+        throw Error(
+          `Cannot patch a nested .jsonValues() record in ${moduleFilePath}: only a root record/router is supported`,
+        );
+      }
+      if (cls.subPath.length === 0) {
+        // Adding, removing or replacing a whole entry means writing the
+        // `*.val.json` AND rewriting the `c.json(...)` reference in the
+        // `.val.ts`. Nothing that reaches `Service.patch` produces those today
+        // (`val validate --fix` only ever corrects values inside an entry), and
+        // silently applying it to the `.val.ts` alone would leave the module
+        // pointing at a file that does not exist.
+        throw Error(
+          `Cannot ${op.op} the whole .jsonValues() entry '${cls.entryKey}' of ${moduleFilePath} through Service.patch: only edits INSIDE an entry are supported`,
+        );
+      }
+      const ops = entryOps.get(cls.entryKey);
+      if (ops) {
+        ops.push(op);
+      } else {
+        entryOps.set(cls.entryKey, [op]);
+      }
+    }
+    // When nothing is routed away, hand the patch over untouched: an empty
+    // `valTsOps` would otherwise rewrite the `.val.ts` for no reason.
+    if (entryOps.size === 0) {
+      await patchValFile(
+        moduleFilePath,
+        this.projectRoot,
+        patch,
+        this.sourceFileHandler,
+      );
+      return;
+    }
+    if (valTsOps.length > 0) {
+      await patchValFile(
+        moduleFilePath,
+        this.projectRoot,
+        valTsOps,
+        this.sourceFileHandler,
+      );
+    }
+    for (const [entryKey, ops] of entryOps) {
+      this.patchJsonValuesEntry(moduleFilePath, entryKey, ops);
+    }
+  }
+
+  /** Replays content ops against one `.jsonValues()` entry's `*.val.json`. */
+  private patchJsonValuesEntry(
+    moduleFilePath: ModuleFilePath,
+    entryKey: string,
+    ops: Patch,
+  ): void {
+    const valTsPath = this.sourceFileHandler.resolveSourceModulePath(
+      getSyntheticContainingPath(this.projectRoot),
+      `.${moduleFilePath
+        .replace(".val.ts", ".val")
+        .replace(".val.js", ".val")
+        .replace(".val.jsx", ".val")
+        .replace(".val.tsx", ".val")}`,
+    );
+    const sourceFile = this.sourceFileHandler.getSourceFile(valTsPath);
+    if (!sourceFile) {
+      throw Error(`Source file ${valTsPath} not found`);
+    }
+    // The import specifier is authoritative, not the derived path: entries may
+    // be hand-placed (hybrid authoring), so deriving would write a file the
+    // module does not read.
+    const jsonPath = findJsonEntryFilePath(
       moduleFilePath,
-      this.projectRoot,
-      patch,
-      this.sourceFileHandler,
+      sourceFile,
+      entryKey,
+    );
+    if (!jsonPath) {
+      throw Error(
+        `Could not find the '*.val.json' backing .jsonValues() entry '${entryKey}' of ${moduleFilePath}`,
+      );
+    }
+    const absoluteJsonPath = path.join(this.projectRoot, jsonPath);
+    const text = this.sourceFileHandler.host.readFile(absoluteJsonPath);
+    if (text === undefined) {
+      throw Error(`Could not read jsonValues entry file: ${jsonPath}`);
+    }
+    let content: JSONValue;
+    try {
+      content = JSON.parse(text);
+    } catch (err) {
+      throw new Error(`Could not parse jsonValues entry file ${jsonPath}`, {
+        cause: err,
+      });
+    }
+    for (const op of ops) {
+      // Root record / router only, so the prefix is exactly the entry key.
+      const rebased = rebaseContentOp(op, 1);
+      if (result.isErr(rebased)) {
+        throw Error(
+          `Could not apply ${op.op} to jsonValues entry '${entryKey}' of ${moduleFilePath}: ${rebased.error.message}`,
+        );
+      }
+      const applied = applyPatch(deepClone(content), jsonOps, [rebased.value]);
+      if (result.isErr(applied)) {
+        throw Error(
+          `Could not apply ${op.op} to ${jsonPath}: ${applied.error.message}`,
+        );
+      }
+      content = applied.value;
+    }
+    this.sourceFileHandler.writeFile(
+      absoluteJsonPath,
+      JSON.stringify(content, null, 2) + "\n",
+      "utf8",
     );
   }
 

--- a/packages/server/src/Service.ts
+++ b/packages/server/src/Service.ts
@@ -287,11 +287,32 @@ export class Service {
     const serializedSchema = this.serializedSchemaOf(moduleFilePath);
     const valTsOps: Patch = [];
     const entryOps = new Map<string, Patch>();
-    for (const op of patch) {
-      const cls: JsonValuesOpClass = serializedSchema
-        ? classifyJsonValuesOp(serializedSchema, op.path)
+    const classify = (opPath: string[]): JsonValuesOpClass =>
+      serializedSchema
+        ? classifyJsonValuesOp(serializedSchema, opPath)
         : { kind: "normal" };
+    for (const op of patch) {
+      const cls = classify(op.path);
+      // `move` and `copy` read a SECOND path, and `rebaseContentOp` slices
+      // `from` by the same prefix it slices `path` by. So an op whose two ends
+      // are not in the same place is not merely unsupported, it is silently
+      // wrong: a copy INTO an entry from anywhere else gets its `from`
+      // reinterpreted as a path inside the destination's `*.val.json` and reads
+      // the wrong value. `ValOps.prepare` guards this on the publish path; both
+      // ends have to be classified here for the same reason.
+      const fromCls =
+        op.op === "move" || op.op === "copy" ? classify(op.from) : undefined;
       if (cls.kind === "normal") {
+        // Unreachable while `.jsonValues()` is root-only -- every top-level path
+        // in such a module IS an entry key, so a normal destination means the
+        // module has no jsonValues record and the source cannot be in one
+        // either. Kept because it is the half of the guard that stops being
+        // theoretical the moment root-only is relaxed.
+        if (fromCls && fromCls.kind !== "normal") {
+          throw Error(
+            `Cannot ${op.op} out of the .jsonValues() entry '${fromCls.entryKey}' of ${moduleFilePath}: the entry's content is not in the .val.ts`,
+          );
+        }
         valTsOps.push(op);
         continue;
       }
@@ -312,6 +333,14 @@ export class Service {
         // pointing at a file that does not exist.
         throw Error(
           `Cannot ${op.op} the whole .jsonValues() entry '${cls.entryKey}' of ${moduleFilePath} through Service.patch: only edits INSIDE an entry are supported`,
+        );
+      }
+      if (
+        fromCls &&
+        (fromCls.kind !== "entry" || fromCls.entryKey !== cls.entryKey)
+      ) {
+        throw Error(
+          `Cannot ${op.op} into the .jsonValues() entry '${cls.entryKey}' of ${moduleFilePath} from outside it: each entry is a separate file`,
         );
       }
       const ops = entryOps.get(cls.entryKey);

--- a/packages/server/src/ValOps.ts
+++ b/packages/server/src/ValOps.ts
@@ -1114,7 +1114,7 @@ export abstract class ValOps {
       );
       // For `.jsonValues()` records, executeValidate only checks the entry
       // markers; load + validate each entry's backing `*.val.json` content here.
-      const jsonValuesErrors = await validateJsonValuesEntries(
+      const { errors: jsonValuesErrors } = await validateJsonValuesEntries(
         schema,
         source,
         path,

--- a/packages/server/src/validateJsonValues.test.ts
+++ b/packages/server/src/validateJsonValues.test.ts
@@ -12,7 +12,11 @@ describe("validateJsonValuesEntries", () => {
       "/a": c.json(() => Promise.resolve({ default: { title: "ok" } })),
       "/b": c.json(() => Promise.resolve({ default: { title: "ok2" } })),
     };
-    const errors = await validateJsonValuesEntries(schema, source, modulePath);
+    const { errors } = await validateJsonValuesEntries(
+      schema,
+      source,
+      modulePath,
+    );
     expect(errors).toEqual({});
   });
 
@@ -22,7 +26,11 @@ describe("validateJsonValuesEntries", () => {
       // wrong leaf type for title — caught by the deferred content validation
       "/bad": c.json(() => Promise.resolve({ default: { title: 123 } })),
     };
-    const errors = await validateJsonValuesEntries(schema, source, modulePath);
+    const { errors } = await validateJsonValuesEntries(
+      schema,
+      source,
+      modulePath,
+    );
     const keys = Object.keys(errors);
     expect(keys.length).toBeGreaterThan(0);
     expect(keys.some((k) => k.includes("/bad"))).toBe(true);
@@ -32,7 +40,11 @@ describe("validateJsonValuesEntries", () => {
     const source = {
       "/boom": c.json(() => Promise.reject(new Error("disk gone"))),
     };
-    const errors = await validateJsonValuesEntries(schema, source, modulePath);
+    const { errors } = await validateJsonValuesEntries(
+      schema,
+      source,
+      modulePath,
+    );
     const keys = Object.keys(errors);
     expect(keys.length).toBe(1);
     expect(errors[keys[0] as keyof typeof errors][0].message).toContain(
@@ -46,7 +58,11 @@ describe("validateJsonValuesEntries", () => {
       // hand-authored inline instead of c.json(() => import(...))
       "/inline": { title: "legal shape, wrong place" },
     };
-    const errors = await validateJsonValuesEntries(schema, source, modulePath);
+    const { errors } = await validateJsonValuesEntries(
+      schema,
+      source,
+      modulePath,
+    );
     const keys = Object.keys(errors);
     expect(keys).toHaveLength(1);
     expect(keys[0]).toContain("/inline");
@@ -64,7 +80,7 @@ describe("validateJsonValuesEntries", () => {
         return Promise.resolve({ default: { title: "ok" } });
       }),
     };
-    const errors = await validateJsonValuesEntries(
+    const { errors } = await validateJsonValuesEntries(
       plainSchema,
       source,
       modulePath,
@@ -91,7 +107,7 @@ describe("validateJsonValuesEntries", () => {
         }),
       },
     };
-    const errors = await validateJsonValuesEntries(
+    const { errors } = await validateJsonValuesEntries(
       nestedSchema,
       source,
       modulePath,

--- a/packages/server/src/validateJsonValues.ts
+++ b/packages/server/src/validateJsonValues.ts
@@ -1,5 +1,6 @@
 import {
   Internal,
+  type Json,
   ModuleFilePath,
   RecordSchema,
   Schema,
@@ -7,6 +8,23 @@ import {
   SourcePath,
 } from "@valbuild/core";
 import { ValidationError } from "@valbuild/core";
+
+/**
+ * The outcome of {@link validateJsonValuesEntries}: the errors found inside the
+ * entries, plus the content of every entry that could be loaded, keyed by entry
+ * key.
+ *
+ * The content is part of the result because the errors are useless without it.
+ * They are reported at paths that point INSIDE an entry, and the module source
+ * on disk holds a `c.json(...)` marker there — so anything that has to resolve
+ * one of those paths (the `val validate --fix` handlers, chiefly) needs the very
+ * content this function has just loaded. Returning it costs nothing and is the
+ * only way to avoid loading every entry twice.
+ */
+export type JsonValuesEntriesValidation = {
+  errors: Record<SourcePath, ValidationError[]>;
+  loadedEntries: Record<string, Json>;
+};
 
 /**
  * Validates the content of every `.jsonValues()` entry in a module by loading
@@ -62,16 +80,18 @@ export async function validateJsonValuesEntries(
   schema: Schema<SelectorSource>,
   source: unknown,
   modulePath: ModuleFilePath,
-): Promise<Record<SourcePath, ValidationError[]>> {
+): Promise<JsonValuesEntriesValidation> {
   const out: Record<SourcePath, ValidationError[]> = {};
+  const loadedEntries: Record<string, Json> = {};
+  const res: JsonValuesEntriesValidation = { errors: out, loadedEntries };
   if (!(schema instanceof RecordSchema)) {
-    return out;
+    return res;
   }
   if (!schema["executeSerialize"]().jsonValues) {
-    return out;
+    return res;
   }
   if (source === null || typeof source !== "object" || Array.isArray(source)) {
-    return out;
+    return res;
   }
   for (const [key, marker] of Object.entries(source)) {
     const entryPath = Internal.createValPathOfItem(
@@ -103,9 +123,9 @@ export async function validateJsonValuesEntries(
     if (!thunk) {
       continue;
     }
-    let content: SelectorSource;
+    let content: Json;
     try {
-      content = (await thunk()).default as SelectorSource;
+      content = (await thunk()).default as Json;
     } catch (err) {
       out[entryPath] = [
         {
@@ -116,6 +136,10 @@ export async function validateJsonValuesEntries(
       ];
       continue;
     }
+    // Kept so a caller can substitute the content back into the module source:
+    // the entries have been paid for here, and a source that still holds
+    // markers cannot resolve a path INTO an entry (see the doc comment above).
+    loadedEntries[key] = content;
     const entryErrors = schema.validateJsonEntryContent(entryPath, content);
     if (entryErrors) {
       for (const [p, errs] of Object.entries(entryErrors)) {
@@ -123,5 +147,5 @@ export async function validateJsonValuesEntries(
       }
     }
   }
-  return out;
+  return res;
 }


### PR DESCRIPTION
## Summary

Fixes a crash in `val validate` when a `.jsonValues()` entry contains an `s.image()` or `s.file()`. The issue occurred because validation loads entry content from `*.val.json` files and reports errors at paths inside those entries, but the fix handlers tried to resolve those paths against the module source—which still held `c.json(...)` markers where the entry content should be. This caused `Internal.resolvePath` to throw, aborting the entire run before any fix could be applied.

## Key Changes

- **Service.get()**: Substitutes loaded `.jsonValues()` entry content back into the module source before resolving paths, so fix handlers can resolve error paths that point inside entries
- **Service.patch()**: Routes patches that land inside a `.jsonValues()` entry to that entry's `*.val.json` file instead of the `.val.ts`, using the same `classifyJsonValuesOp` + `rebaseContentOp` logic the Studio's publish flow uses
- **validateJsonValuesEntries()**: Now returns both validation errors and the loaded entry content (via new `JsonValuesEntriesValidation` type), avoiding the need to load entries twice
- **patchJsonValuesEntry()**: New private method that applies content ops to a `.jsonValues()` entry's backing `*.val.json` file, reading the import specifier from the `.val.ts` to find the correct file path
- **Test fixtures**: Added `basic-json-values-image.val.ts` (record with image entry) and `app/jobb/[slug]/page.val.ts` (router with image entry) to cover both cases
- **Documentation**: Updated `architecture/quirks.md` to explain the `.jsonValues()` path resolution quirk and the routing logic for patches

## Implementation Details

- Entry file paths are read from the `import(...)` specifier in the `.val.ts`, not derived from the entry key, to support hand-placed entries (hybrid authoring)
- Nested `.jsonValues()` records are rejected as module errors before any fix runs, so `Service.patch()` throws if it encounters one (contract violation)
- Whole-entry operations (add/remove/replace) are rejected as unsupported; only edits inside an entry are routed to the `*.val.json`
- The loaded entry content is substituted into the source only on the validate path, preserving the marker-based source for other operations

https://claude.ai/code/session_01NcwZmu3QyzmndehV1126yq