### PR TITLE
Offer editor quick fixes inside a .jsonValues() entry

### DIFF
--- a/.changeset/lsp-jsonvalues-quick-fix.md
+++ b/.changeset/lsp-jsonvalues-quick-fix.md
@@ -1,0 +1,26 @@
+---
+"@valbuild/language-server": patch
+"@valbuild/server": patch
+---
+
+Offer editor quick fixes inside a `.jsonValues()` entry
+
+An error inside a `.jsonValues()` entry — an `s.image()` with stale dimensions,
+say — got no quick fix in the editor, and no explanation either. The action was
+computed and then silently dropped.
+
+Two things were wrong. The entry's value is not in the `.val.ts`, which holds
+only `c.json(() => import("./x.val.json"))`, so applying the fix patch to that
+file walked into the thunk and failed. And the diagnostic had nowhere to sit:
+nothing in the `.val.ts` matches a path that continues below the entry key, so
+every error inside every entry collapsed onto line 1 — for a record with
+hundreds of entries, hundreds of diagnostics stacked on the first line, none of
+them naming an entry.
+
+Now the diagnostic is reported at the entry's key, and the quick fix edits the
+entry's own `*.val.json` as a cross-file workspace edit, routing the patch the
+same way the Studio's publish and `val validate --fix` do. The entry file is
+read through the editor's buffers, so an unsaved entry is fixed as the editor
+has it rather than as the disk has it, and `*.val.json` is now watched — editing
+one, or having a quick fix write one, revalidates the module that reads it
+instead of leaving a diagnostic that nothing can clear.

--- a/architecture/quirks.md
+++ b/architecture/quirks.md
@@ -234,6 +234,18 @@ before it did, one `s.image()` inside an entry aborted the entire run, because
 image metadata can only be checked by reading the bytes and therefore ALWAYS ends
 in a fix.
 
+**In an editor, both halves of an entry error land somewhere surprising.** The
+diagnostic has no range to sit on — the `.val.ts` contains the entry key and
+nothing below it — so it is reported on the KEY, via the longest prefix of the
+path that the file's own AST knows (`longestResolvedPrefixRange` in
+`diagnostics.ts`); without that it fell through to line 1, and a record with
+hundreds of entries stacked hundreds of diagnostics there. The quick fix then
+edits a **different file** from the one it was requested on, as a cross-file
+workspace edit into the entry's `*.val.json`. And because nothing validates a
+`*.val.json` on its own, it has to be watched explicitly: editing one — or
+applying that quick fix — invalidates the whole project, since the parsed JSON
+is cached inside the `Service`.
+
 **A patch into an entry does not touch the `.val.ts`.** The value being edited is
 not in that file, so an op whose path descends into an entry is rebased and
 replayed against the entry's `*.val.json` instead — `classifyJsonValuesOp` +

--- a/examples/next/content/jsonEntryMedia.val.ts
+++ b/examples/next/content/jsonEntryMedia.val.ts
@@ -1,0 +1,21 @@
+import { c, s } from "../val.config";
+
+/**
+ * A `.jsonValues()` record whose entry content contains an `s.image()`.
+ *
+ * The point of the fixture: the image — and therefore everything a metadata fix
+ * has to edit — is in `jsonEntryMedia/hero.val.json`, not in this file. This
+ * file only says which file to read. Editor tooling that assumes the value is
+ * here has nothing to work with.
+ *
+ * What is on disk is CORRECT, so the example app gains no new validation error;
+ * the language-server tests supply a wrong-metadata version as an unsaved
+ * buffer.
+ */
+export default c.define(
+  "/content/jsonEntryMedia.val.ts",
+  s.record(s.object({ image: s.image() })).jsonValues(),
+  {
+    hero: c.json(() => import("./jsonEntryMedia/hero.val.json")),
+  },
+);

--- a/examples/next/content/jsonEntryMedia/hero.val.json
+++ b/examples/next/content/jsonEntryMedia/hero.val.json
@@ -1,0 +1,8 @@
+{
+  "image": {
+    "path": "/public/val/images/logo.png",
+    "width": 944,
+    "height": 944,
+    "mimeType": "image/png"
+  }
+}

--- a/examples/next/val.modules.ts
+++ b/examples/next/val.modules.ts
@@ -34,6 +34,7 @@ export default modules(config, [
   { def: () => import("./app/external.val") },
   // Fixtures for the .jsonValues() walkthrough (docs/plans/jsonValues-walkthrough.md)
   { def: () => import("./content/kb.val") },
+  { def: () => import("./content/jsonEntryMedia.val") },
   { def: () => import("./content/tags.val") },
   { def: () => import("./content/featuredContent.val") },
   // A handbook: chapters of sections, with a `select` at BOTH array levels —

--- a/packages/language-server/src/codeActions.test.ts
+++ b/packages/language-server/src/codeActions.test.ts
@@ -213,6 +213,105 @@ describe("code actions over LSP", () => {
     expect(after.diagnostics.filter((d) => d.code === "val/fatal")).toEqual([]);
   });
 
+  // A `.jsonValues()` record: the entry's value — and so everything a metadata
+  // fix has to edit — is in `jsonEntryMedia/hero.val.json`, while the diagnostic
+  // is reported on the `.val.ts`, which holds only the `c.json(...)` thunk.
+  //
+  // Both files are opened as buffers and neither is written: what is on disk is
+  // correct (944x944), and the wrong dimensions exist only in the editor. That
+  // is also the point — the fix must read the entry as the editor has it, not as
+  // the disk has it, or it would compute its edit against text the user is not
+  // looking at.
+  const ENTRY_MODULE_FILE = path.join(
+    EXAMPLE_APP,
+    "content",
+    "jsonEntryMedia.val.ts",
+  );
+  const ENTRY_MODULE_URI = `file://${ENTRY_MODULE_FILE}`;
+  const ENTRY_MODULE_TEXT = fs.readFileSync(ENTRY_MODULE_FILE, "utf8");
+  const ENTRY_FILE = path.join(
+    EXAMPLE_APP,
+    "content",
+    "jsonEntryMedia",
+    "hero.val.json",
+  );
+  const ENTRY_URI = `file://${ENTRY_FILE}`;
+  const ENTRY_ON_DISK = fs.readFileSync(ENTRY_FILE, "utf8");
+  const ENTRY_TEXT = ENTRY_ON_DISK.replace(
+    '"width": 944',
+    '"width": 800',
+  ).replace('"height": 944', '"height": 600');
+
+  const openEntryFixture = async () => {
+    session.openDocument(ENTRY_MODULE_URI, ENTRY_MODULE_TEXT);
+    // Opening the entry buffer is what makes the module invalid: the server has
+    // to notice that a file it does not validate on its own changed what a
+    // module validates to.
+    session.openDocument(ENTRY_URI, ENTRY_TEXT);
+    const published = await session.nextDiagnostics(ENTRY_MODULE_URI, (d) =>
+      d.diagnostics.some((x) =>
+        x.data?.fixes?.some((f) => f.endsWith("check-metadata")),
+      ),
+    );
+    return {
+      published,
+      fixable: published.diagnostics.filter((d) =>
+        d.data?.fixes?.some((f) => f.endsWith("check-metadata")),
+      ),
+    };
+  };
+
+  test("the entry fixture really declares the wrong dimensions", () => {
+    expect(ENTRY_TEXT).not.toBe(ENTRY_ON_DISK);
+    expect(JSON.parse(ENTRY_TEXT).image.width).toBe(800);
+    expect(JSON.parse(ENTRY_ON_DISK).image.width).toBe(944);
+    expect(ENTRY_MODULE_TEXT).toContain("jsonValues()");
+  });
+
+  test("reports an entry error at the entry key, not at the top of the file", async () => {
+    // The value's own range is in the other file, so nothing in the `.val.ts`
+    // matches the full source path. That used to fall all the way through to
+    // line 1 — for a record with hundreds of entries, every entry's errors piled
+    // onto the first line, naming no entry at all.
+    const { fixable } = await openEntryFixture();
+    expect(fixable.length).toBeGreaterThan(0);
+
+    const keyLine = ENTRY_MODULE_TEXT.split("\n").findIndex((line) =>
+      line.includes("hero: c.json("),
+    );
+    expect(keyLine).toBeGreaterThan(0);
+    expect(fixable[0].range.start.line).toBe(keyLine);
+  });
+
+  test("offers a quick fix that edits the entry's *.val.json", async () => {
+    const { fixable } = await openEntryFixture();
+
+    const actions = await session.requestCodeActions(ENTRY_MODULE_URI, fixable);
+    expect(actions.length).toBeGreaterThan(0);
+    const action = actions[0];
+    expect(action.kind).toBe("quickfix");
+
+    // The edit belongs to the entry file, NOT to the document the fix was asked
+    // for. Before this, the patch was applied to the `.val.ts`, walked into the
+    // `c.json(...)` call, failed, and the action was silently dropped.
+    expect(action.edit?.changes?.[ENTRY_MODULE_URI]).toBeUndefined();
+    const edits = action.edit?.changes?.[ENTRY_URI];
+    expect(edits).toBeDefined();
+
+    const applied = applyEdits(ENTRY_TEXT, edits!);
+    expect(JSON.parse(applied)).toEqual({
+      image: {
+        path: "/public/val/images/logo.png",
+        width: 944,
+        height: 944,
+        mimeType: "image/png",
+      },
+    });
+    // A narrow edit: the fix corrects the dimensions, it does not rewrite the
+    // file around them.
+    expect(applied.split("\n")[0]).toBe(ENTRY_TEXT.split("\n")[0]);
+  });
+
   test("offers a quick fix that corrects gallery metadata", async () => {
     // media.val.ts is a gallery whose stored entry says 800x600 for an image
     // that is really 944x944, reported as images:check-all-files. The fix reads

--- a/packages/language-server/src/codeActions.test.ts
+++ b/packages/language-server/src/codeActions.test.ts
@@ -312,6 +312,31 @@ describe("code actions over LSP", () => {
     expect(applied.split("\n")[0]).toBe(ENTRY_TEXT.split("\n")[0]);
   });
 
+  test("stops offering the fix once the dirty entry buffer is closed", async () => {
+    // Closing an unsaved entry REMOVES an overlay. The modules that read it stay
+    // open, so without invalidating on close they keep answering from a buffer
+    // that no longer exists — here, still offering to write 944x944 over an
+    // entry that on disk already says 944x944.
+    const { fixable } = await openEntryFixture();
+    expect(
+      (await session.requestCodeActions(ENTRY_MODULE_URI, fixable)).length,
+    ).toBeGreaterThan(0);
+
+    session.closeDocument(ENTRY_URI);
+    const afterClose = await session.nextDiagnostics(ENTRY_MODULE_URI);
+    const stillFixable = afterClose.diagnostics.filter((d) =>
+      d.data?.fixes?.some((f) => f.endsWith("check-metadata")),
+    );
+    // The diagnostic itself survives — core reports check-metadata for a direct
+    // `s.image()` whether or not the metadata is right — but there is nothing
+    // left to change, so no action is offered.
+    const actions = await session.requestCodeActions(
+      ENTRY_MODULE_URI,
+      stillFixable,
+    );
+    expect(actions.filter((a) => a.edit !== undefined)).toEqual([]);
+  });
+
   test("offers a quick fix that corrects gallery metadata", async () => {
     // media.val.ts is a gallery whose stored entry says 800x600 for an image
     // that is really 944x944, reported as images:check-all-files. The fix reads

--- a/packages/language-server/src/codeActions.ts
+++ b/packages/language-server/src/codeActions.ts
@@ -32,6 +32,7 @@ import {
   valModulesEntryText,
 } from "./valModulesRegistry";
 import type { ValModuleContent } from "./ValProject";
+import { jsonEntryEditFor, type JsonEntryEdit } from "./jsonEntryEdit";
 import { minimalTextEdit } from "./textEdit";
 
 // Re-exported: it lives in its own module so that `commands.ts` can use it
@@ -107,14 +108,25 @@ export async function createValCodeActions({
   content,
   valRoot,
   moduleFilePath,
+  read,
   remoteHost = process.env.VAL_REMOTE_HOST || DEFAULT_VAL_REMOTE_HOST,
 }: {
   document: TextDocument;
   diagnostics: Diagnostic[];
   content: ValModuleContent;
   valRoot: string;
-  /** Needed to offer the remote fixes, which run as commands. */
+  /**
+   * Needed to offer the remote fixes, which run as commands -- and to fix a
+   * `.jsonValues()` entry, whose content is in a file this document only
+   * references.
+   */
   moduleFilePath?: ModuleFilePath;
+  /**
+   * Reads an open buffer for a path. A fix that edits another file must see that
+   * file as the editor has it, or the edit's ranges are computed against text
+   * the editor is not showing.
+   */
+  read?: (fsPath: string) => string | undefined;
   remoteHost?: string;
 }): Promise<CodeAction[]> {
   const actions: CodeAction[] = [];
@@ -155,7 +167,7 @@ export async function createValCodeActions({
       if (!isLocalFix(fix)) {
         continue;
       }
-      const edit = await computeFixEdit({
+      const fixEdit = await computeFixEdit({
         document,
         // A gallery check is reported on the entry but fixed against the record
         // that contains it; everything else fixes where it is reported.
@@ -169,15 +181,20 @@ export async function createValCodeActions({
         },
         content,
         valRoot,
+        moduleFilePath,
+        read,
         remoteHost,
       });
-      if (!edit) {
+      if (!fixEdit) {
         continue;
       }
       actions.push(
         CodeAction.create(
           FIX_TITLES[fix] ?? `Val: ${fix}`,
-          { changes: { [document.uri]: [edit] } },
+          // Not always `document.uri`: a fix inside a `.jsonValues()` entry
+          // edits the entry's own `*.val.json`, which is a different file from
+          // the one the diagnostic is reported on.
+          { changes: { [fixEdit.uri]: [fixEdit.edit] } },
           CodeActionKind.QuickFix,
         ),
       );
@@ -193,6 +210,8 @@ async function computeFixEdit({
   validationError,
   content,
   valRoot,
+  moduleFilePath,
+  read,
   remoteHost,
 }: {
   document: TextDocument;
@@ -200,8 +219,10 @@ async function computeFixEdit({
   validationError: ValidationError;
   content: ValModuleContent;
   valRoot: string;
+  moduleFilePath?: ModuleFilePath;
+  read?: (fsPath: string) => string | undefined;
   remoteHost: string;
-}): Promise<TextEdit | undefined> {
+}): Promise<JsonEntryEdit | undefined> {
   let fixed;
   try {
     fixed = await createFixPatch(
@@ -223,11 +244,29 @@ async function computeFixEdit({
   }
 
   const before = document.getText();
+  // The value may not be in this file at all. A `.jsonValues()` entry's content
+  // lives in its own `*.val.json`, and applying the patch to the `.val.ts` would
+  // walk into the `c.json(...)` thunk and fail -- which is exactly why no quick
+  // fix was offered inside an entry.
+  if (moduleFilePath) {
+    const entryEdit = jsonEntryEditFor({
+      patch: fixed.patch,
+      schema: content.schema,
+      moduleFilePath,
+      valTsText: before,
+      valRoot,
+      read,
+    });
+    if (entryEdit) {
+      return entryEdit;
+    }
+  }
   const patched = patchSourceFile(before, fixed.patch);
   if (result.isErr(patched)) {
     return undefined;
   }
-  return minimalTextEdit(before, patched.value.text, document);
+  const edit = minimalTextEdit(before, patched.value.text, document);
+  return edit && { uri: document.uri, edit };
 }
 
 /**

--- a/packages/language-server/src/diagnostics.ts
+++ b/packages/language-server/src/diagnostics.ts
@@ -400,7 +400,7 @@ function rangeOf(
   if (!modulePathMap) {
     return FALLBACK_RANGE;
   }
-  let modulePath: string;
+  let modulePath: ModulePath;
   try {
     [, modulePath] = Internal.splitModuleFilePathAndModulePath(
       sourcePath as never,
@@ -446,12 +446,12 @@ function rangeOf(
  * offered from.
  */
 function longestResolvedPrefixRange(
-  modulePath: string,
+  modulePath: ModulePath,
   modulePathMap: NonNullable<ReturnType<typeof createModulePathMap>>,
 ): Range | undefined {
   let segments: string[];
   try {
-    segments = Internal.splitModulePath(modulePath as ModulePath);
+    segments = Internal.splitModulePath(modulePath);
   } catch {
     return undefined;
   }

--- a/packages/language-server/src/diagnostics.ts
+++ b/packages/language-server/src/diagnostics.ts
@@ -4,6 +4,7 @@ import ts from "typescript";
 import {
   Internal,
   type ModuleFilePath,
+  type ModulePath,
   type SourcePath,
   type ValidationError,
   type ValidationFix,
@@ -422,7 +423,51 @@ function rangeOf(
     }
   }
   const range = getModulePathRange(modulePath, modulePathMap);
-  return range ? { start: range.start, end: range.end } : FALLBACK_RANGE;
+  if (range) {
+    return { start: range.start, end: range.end };
+  }
+  return (
+    longestResolvedPrefixRange(modulePath, modulePathMap) ?? FALLBACK_RANGE
+  );
+}
+
+/**
+ * The range of the longest prefix of `modulePath` this module's own text knows
+ * about.
+ *
+ * `.jsonValues()` is why this exists. An entry's value lives in a separate
+ * `*.val.json`, so the `.val.ts` contains the entry KEY and nothing below it,
+ * and every error inside an entry resolved to nothing at all -- landing on
+ * FALLBACK_RANGE, line 1. For a record with hundreds of entries that is hundreds
+ * of diagnostics stacked on the first line, none of them naming an entry.
+ *
+ * The entry key is not where the offending value is -- that is in the other file
+ * -- but it is the closest place in THIS file, and it is where the quick fix is
+ * offered from.
+ */
+function longestResolvedPrefixRange(
+  modulePath: string,
+  modulePathMap: NonNullable<ReturnType<typeof createModulePathMap>>,
+): Range | undefined {
+  let segments: string[];
+  try {
+    segments = Internal.splitModulePath(modulePath as ModulePath);
+  } catch {
+    return undefined;
+  }
+  for (let length = segments.length - 1; length > 0; length--) {
+    const range = getModulePathRange(
+      segments
+        .slice(0, length)
+        .map((segment) => JSON.stringify(segment))
+        .join("."),
+      modulePathMap,
+    );
+    if (range) {
+      return { start: range.start, end: range.end };
+    }
+  }
+  return undefined;
 }
 
 /**

--- a/packages/language-server/src/jsonEntryEdit.ts
+++ b/packages/language-server/src/jsonEntryEdit.ts
@@ -152,6 +152,15 @@ function entryOpsOf(
     if (cls.recordPath.length > 0 || cls.subPath.length === 0) {
       return undefined;
     }
+    // `move` and `copy` carry a second path, and `rebaseContentOp` slices `from`
+    // by the same prefix as `path` -- so an op reaching outside this entry would
+    // have its source silently reinterpreted as a path inside this entry's file.
+    if (op.op === "move" || op.op === "copy") {
+      const fromCls = classifyJsonValuesOp(schema, op.from);
+      if (fromCls.kind !== "entry" || fromCls.entryKey !== cls.entryKey) {
+        return undefined;
+      }
+    }
     if (entryKey !== undefined && entryKey !== cls.entryKey) {
       return undefined;
     }

--- a/packages/language-server/src/jsonEntryEdit.ts
+++ b/packages/language-server/src/jsonEntryEdit.ts
@@ -1,0 +1,173 @@
+import fs from "fs";
+import path from "path";
+import ts from "typescript";
+import type { ModuleFilePath, SerializedSchema } from "@valbuild/core";
+import {
+  applyPatch,
+  deepClone,
+  JSONOps,
+  type JSONValue,
+  type Operation,
+  type Patch,
+} from "@valbuild/core/patch";
+import { result } from "@valbuild/core/fp";
+import {
+  classifyJsonValuesOp,
+  findJsonEntryFilePath,
+  rebaseContentOp,
+} from "@valbuild/server";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import type { TextEdit } from "vscode-languageserver";
+import { minimalTextEdit } from "./textEdit";
+import { pathToUri } from "./uri";
+
+const jsonOps = new JSONOps();
+
+/**
+ * Turning a fix patch into an edit when the value it fixes is NOT in the
+ * `.val.ts` the diagnostic was reported on.
+ *
+ * A `.jsonValues()` record keeps each entry's value in its own `*.val.json`; the
+ * `.val.ts` holds `c.json(() => import("./x.val.json"))` and nothing below it.
+ * So a fix for, say, an `s.image()` inside an entry produces a patch whose path
+ * starts at the module root (`["/jobb/student", "pageImage", "width"]`) but
+ * whose target lives in another file entirely.
+ *
+ * Applying such a patch to the `.val.ts` cannot work: the walk reaches the
+ * `c.json(...)` call expression and `TSOps` refuses it ("Expression must be a
+ * literal"). That refusal is why an editor silently offered no quick fix at all
+ * for anything inside an entry — `computeFixEdit` saw an error result and
+ * dropped the action.
+ *
+ * The routing here is the same one the Studio's publish and `val validate --fix`
+ * use — {@link classifyJsonValuesOp} to find the entry, {@link rebaseContentOp}
+ * to drop the entry-key prefix — so all three write the same file the same way.
+ * What is specific to the editor is only the last step: the result comes back as
+ * a `TextEdit` against the entry's document rather than as a write to disk, so
+ * the edit goes through the editor's undo stack and respects an unsaved buffer.
+ */
+export type JsonEntryEdit = {
+  /** The `*.val.json` the edit belongs to — NOT the document the fix was asked for. */
+  uri: string;
+  edit: TextEdit;
+};
+
+export function jsonEntryEditFor({
+  patch,
+  schema,
+  moduleFilePath,
+  valTsText,
+  valRoot,
+  read,
+}: {
+  patch: Patch;
+  /** The module's root schema, which is what says whether it is `.jsonValues()`. */
+  schema: SerializedSchema | undefined;
+  moduleFilePath: ModuleFilePath;
+  /** The `.val.ts` text, as the editor currently has it. */
+  valTsText: string;
+  valRoot: string;
+  /** Reads an open buffer for a path, so an unsaved entry file is not clobbered. */
+  read?: (fsPath: string) => string | undefined;
+}): JsonEntryEdit | undefined {
+  if (!schema) {
+    return undefined;
+  }
+  const entry = entryOpsOf(patch, schema);
+  if (!entry) {
+    return undefined;
+  }
+  const jsonFilePath = findJsonEntryFilePath(
+    moduleFilePath,
+    ts.createSourceFile(moduleFilePath, valTsText, ts.ScriptTarget.ES2020),
+    entry.entryKey,
+  );
+  if (!jsonFilePath) {
+    return undefined;
+  }
+  const absolutePath = path.join(valRoot, jsonFilePath);
+  const before = read?.(absolutePath) ?? readFile(absolutePath);
+  if (before === undefined) {
+    return undefined;
+  }
+  let content: JSONValue;
+  try {
+    content = JSON.parse(before);
+  } catch {
+    // A malformed entry file is already reported as a load error; offering an
+    // edit computed from a guess at its contents would be worse than offering
+    // nothing.
+    return undefined;
+  }
+  for (const op of entry.ops) {
+    // Root-only, like the rest of the `.jsonValues()` machinery, so the prefix
+    // to drop is exactly the entry key.
+    const rebased = rebaseContentOp(op, 1);
+    if (result.isErr(rebased)) {
+      return undefined;
+    }
+    const applied = applyPatch(deepClone(content), jsonOps, [rebased.value]);
+    if (result.isErr(applied)) {
+      return undefined;
+    }
+    content = applied.value;
+  }
+  // Re-serialising the whole value and diffing it is what keeps this honest:
+  // the alternative is editing JSON text by hand, and the fix would then differ
+  // from what the CLI writes. `minimalTextEdit` narrows the result to the region
+  // that actually changed, so a two-space-indented file (what prettier and the
+  // CLI both produce) yields an edit covering the changed properties and no
+  // more. A file indented differently gets a correct but larger edit.
+  const after =
+    JSON.stringify(content, null, 2) + (before.endsWith("\n") ? "\n" : "");
+  const uri = pathToUri(absolutePath);
+  const edit = minimalTextEdit(
+    before,
+    after,
+    TextDocument.create(uri, "json", 0, before),
+  );
+  return edit && { uri, edit };
+}
+
+/**
+ * The ops of `patch`, if every one of them edits the content of ONE
+ * `.jsonValues()` entry. `undefined` for anything else — an ordinary module, a
+ * patch that also touches the `.val.ts`, or one that adds or removes a whole
+ * entry — because those either belong on the `.val.ts` (the caller's existing
+ * path) or need both files written at once, which a single `TextEdit` cannot do.
+ */
+function entryOpsOf(
+  patch: Patch,
+  schema: SerializedSchema,
+): { entryKey: string; ops: Operation[] } | undefined {
+  let entryKey: string | undefined;
+  const ops: Operation[] = [];
+  for (const op of patch) {
+    const cls = classifyJsonValuesOp(schema, op.path);
+    if (cls.kind !== "entry") {
+      return undefined;
+    }
+    // Nested `.jsonValues()` is rejected as a module error long before a fix is
+    // offered; treat it as out of scope rather than writing to a guessed file.
+    if (cls.recordPath.length > 0 || cls.subPath.length === 0) {
+      return undefined;
+    }
+    if (entryKey !== undefined && entryKey !== cls.entryKey) {
+      return undefined;
+    }
+    entryKey = cls.entryKey;
+    ops.push(op);
+  }
+  if (entryKey === undefined || ops.length === 0) {
+    return undefined;
+  }
+  return { entryKey, ops };
+}
+
+function readFile(filePath: string): string | undefined {
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -797,6 +797,19 @@ export function createValLanguageServer(connection: Connection): {
     }
     // Clear our diagnostics so they do not linger for a file the user closed.
     connection.sendDiagnostics({ uri: document.uri, diagnostics: [] });
+    // Closing an entry file REMOVES an overlay: whatever the buffer said stops
+    // being what the module reads, and the modules that read it are still open,
+    // still showing diagnostics computed from a buffer that no longer exists.
+    // (Opening one needs no case of its own -- `TextDocuments` fires
+    // onDidChangeContent for a didOpen too, which the handler above catches.)
+    if (isValJsonEntryUri(document.uri)) {
+      project?.invalidate();
+      for (const open of documents.all()) {
+        if (isValModuleUri(open.uri)) {
+          scheduleValidation(open.uri);
+        }
+      }
+    }
   });
 
   connection.onShutdown(() => {

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -57,7 +57,12 @@ import {
   type PublicValFiles,
 } from "./publicValFiles";
 import { isModuleRegistered } from "./valModulesRegistry";
-import { isValModuleUri, toModuleFilePath, uriToPath } from "./uri";
+import {
+  isValJsonEntryUri,
+  isValModuleUri,
+  toModuleFilePath,
+  uriToPath,
+} from "./uri";
 
 /**
  * How long to wait after an edit before re-evaluating.
@@ -542,6 +547,10 @@ export function createValLanguageServer(connection: Connection): {
       .register(DidChangeWatchedFilesNotification.type, {
         watchers: [
           { globPattern: "**/*.val.{ts,js}" },
+          // A `.jsonValues()` entry's content is here, not in the `.val.ts`, so
+          // this is the only thing that says an entry changed -- including when
+          // the change is a quick fix the editor just applied.
+          { globPattern: "**/*.val.json" },
           { globPattern: "**/val.modules.{ts,js}" },
           { globPattern: "**/val.config.{ts,js}" },
           // Media completions and file-not-found diagnostics both read this
@@ -672,6 +681,7 @@ export function createValLanguageServer(connection: Connection): {
           content: result.content,
           valRoot: project.valRoot,
           moduleFilePath,
+          read: readOpenDocument,
         })),
       );
       return actions;
@@ -689,7 +699,12 @@ export function createValLanguageServer(connection: Connection): {
   // per keystroke, which scheduleValidation debounces.
   documents.onDidOpen(({ document }) => scheduleValidation(document.uri));
   documents.onDidChangeContent(({ document }) => {
-    if (PROJECT_WIDE_FILE_RE.test(uriToPath(document.uri))) {
+    if (
+      PROJECT_WIDE_FILE_RE.test(uriToPath(document.uri)) ||
+      // Same reason as in the watched-files handler: an open, unsaved entry file
+      // is read through the editor overlay, but only a fresh Service sees it.
+      isValJsonEntryUri(document.uri)
+    ) {
       // A project-wide fact changed, so every module's cached result is stale --
       // not just this file's. `invalidate()` with no argument clears the content
       // cache too, which the per-module fingerprint check would not.
@@ -726,6 +741,13 @@ export function createValLanguageServer(connection: Connection): {
         continue;
       }
       if (PROJECT_WIDE_FILE_RE.test(fsPath)) {
+        projectWide = true;
+        continue;
+      }
+      // An entry file has no module of its own to invalidate: which module reads
+      // it is recorded in a `.val.ts` import specifier, and the parsed JSON is
+      // cached inside the Service, which only a project-wide invalidate discards.
+      if (isValJsonEntryUri(change.uri)) {
         projectWide = true;
         continue;
       }

--- a/packages/language-server/src/uri.ts
+++ b/packages/language-server/src/uri.ts
@@ -18,8 +18,19 @@ const FILE_URI_RE = /^file:\/\/([^/?#]*)([^?#]*)/i;
 /** A `/c:/...` prefix, i.e. a Windows drive letter as it appears in a URI. */
 const URI_DRIVE_LETTER_RE = /^\/([a-zA-Z]:)(\/|$)/;
 
+/**
+ * Matches the `*.val.json` files that hold `.jsonValues()` entry content. Not a
+ * Val module: nothing validates one on its own, but editing it changes what a
+ * module validates to, so the server has to notice.
+ */
+const VAL_JSON_ENTRY_RE = /\.val\.json$/;
+
 export function isValModuleUri(uri: string): boolean {
   return VAL_MODULE_RE.test(uri);
+}
+
+export function isValJsonEntryUri(uri: string): boolean {
+  return VAL_JSON_ENTRY_RE.test(uri);
 }
 
 /**

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -90,6 +90,14 @@ export {
   getModulePathRange,
 } from "./modulePathMap";
 export { findJsonEntryFilePath } from "./jsonEntryLocation";
+// The two halves of routing a patch op into a `.jsonValues()` entry's own
+// `*.val.json`. Exported because every writer of entry content needs them and
+// there must not be a second implementation: the Studio's publish
+// (`ValOps.prepare`), `val validate --fix` (`Service.patch`) and the editor's
+// quick fixes all classify and rebase the same way, or they disagree about
+// which file an edit belongs in.
+export { classifyJsonValuesOp, rebaseContentOp } from "./patch/jsonValuesPatch";
+export type { JsonValuesOpClass } from "./patch/jsonValuesPatch";
 export { extractJsonValuesEntry } from "./extractJsonValuesEntry";
 export type { ModulePathMap } from "./modulePathMap";
 // Exposed for the CLI's `debug` command and the snapshot replay harness, which


### PR DESCRIPTION
> **Was stacked on #537**, which has now merged; retargeted to `main`. See _Why it was stacked_ below.

## The problem

An error inside a `.jsonValues()` entry — an `s.image()` with stale dimensions, say — got **no quick fix in the editor, and no explanation either**. The action was computed and then silently dropped.

Two separate things were wrong:

**The fix could not be expressed.** The entry's value is not in the `.val.ts`; that file holds only `c.json(() => import("./x.val.json"))`. `computeFixEdit` applied the fix patch to the request document, the walk reached the `c.json(...)` call expression, `TSOps` refused a non-literal, and the error result was returned as "no action". An `s.image()` in an entry hits this every time, since whether the stored dimensions match the bytes can only be answered by reading the file — so image validation always ends in a fix.

**The diagnostic had nowhere to sit.** Nothing in the `.val.ts` matches a source path that continues below the entry key, so `rangeOf` resolved nothing and fell through to `FALLBACK_RANGE` — line 1, character 0. For a record with hundreds of entries that is hundreds of diagnostics stacked on the first line, none of them naming an entry. Even a working quick fix would have been unreachable.

## The fix

- **`diagnostics.ts`** — when the full path does not resolve, report on the longest prefix that does, which for an entry is its **key**. Not where the offending value is (that is in the other file), but the closest place in this one, and where the fix is offered from.
- **`jsonEntryEdit.ts`** (new) — builds the fix as a **cross-file workspace edit** into the entry's own `*.val.json`. Routing is `classifyJsonValuesOp` + `rebaseContentOp`, now exported from `@valbuild/server`: the same pair the Studio's publish (`ValOps.prepare`) and `val validate --fix` (`Service.patch`) use, so all three write the same file the same way rather than growing a third opinion.
- **`codeActions.ts`** — `computeFixEdit` returns `{ uri, edit }` instead of a bare `TextEdit`, and the action's `changes` key is that uri. The entry is read through the editor's open buffers (`readOpenDocument`), so an unsaved entry is fixed as the editor has it, not as the disk has it.
- **`server.ts` / `uri.ts`** — `*.val.json` is now watched and treated as a project-wide change. Nothing validates one on its own and the parsed JSON is cached inside the `Service`, so without this the quick fix wrote a file that left its own diagnostic standing until the `.val.ts` was retyped. Closing an unsaved entry buffer removes an overlay and revalidates for the same reason.

The edit is produced by re-serialising the patched value and diffing it, so it cannot drift from what the CLI writes; `minimalTextEdit` narrows it to the changed region. A file indented differently from prettier's two spaces gets a correct but larger edit.

## Why it was stacked

The test fixture is a `.jsonValues()` record holding an `s.image()` in the example app. Before #537 that fixture made `val validate` **crash** — it is exactly the bug #537 fixed — so this could not stand alone. With #537 in, the example app validates clean: `17 valid`, same 2 pre-existing errors as before.

## Tests

Four tests in `codeActions.test.ts`, driving the real server as a child process. Both files are opened as **buffers and neither is written**: disk holds the correct `944x944`, the wrong dimensions exist only in the editor — which is also what proves the fix reads the buffer, since reading disk would produce no patch at all.

- the fixture really declares the wrong dimensions (fails loudly if the example app changes shape)
- reports an entry error at the entry key, not at the top of the file
- offers a quick fix that edits the entry's `*.val.json` — asserts the module URI is **not** in `changes`, and that applying the edit yields the real dimensions
- stops offering the fix once the dirty entry buffer is closed

Every behavioural test fails without its fix.

Full CI green: 2694 tests, lint, format, recursive typecheck, `pnpm run build`, `examples/next` build.

## Review follow-ups

- `entryOpsOf` now classifies both ends of a `move`/`copy`. `rebaseContentOp` slices `from` by the same prefix as `path`, so an op reaching outside the entry would have had its source silently reinterpreted as a path inside the entry's own file. Nothing emits those today; the guard is here because this routing is shared with the publish and CLI paths and must not be the copy that disagrees.
- `ModulePath` is threaded through `rangeOf` rather than re-branded inside the prefix helper.

## Not in scope

The diagnostic is reported at the entry key in the `.val.ts`, not **inside** the `*.val.json` at the offending property. The CLI already does the latter (`sourcePathToFileLocation.ts` → `findJsonEntryFilePath` → `createJsonEntryPathMap`), so the resolution exists; what it needs here is per-diagnostic URI routing and multi-URI publishing in `server.ts`, plus accepting code-action requests on `.val.json` documents. Worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcwZmu3QyzmndehV1126yq