### PR TITLE
Give the canvas frame time for a first-request compile

### DIFF
--- a/e2e/canvas.spec.ts
+++ b/e2e/canvas.spec.ts
@@ -87,7 +87,23 @@ test.describe("the canvas", () => {
       .frames()
       .find((candidate) => candidate.url().includes("/blogs/blog1"));
     expect(frame, "the canvas frame went away").toBeTruthy();
-    await expect(frame!.locator("body")).toContainText("Blog 1");
+    /*
+     * A first-request compile, not a slow assertion.
+     *
+     * This is the first time anything in the suite asks for `/blogs/blog1`,
+     * and `next dev` compiles a route the first time it is requested — the
+     * same reason the test timeout here is 90s. The poll above waited for the
+     * frame to COMMIT its navigation, which happens long before the server has
+     * anything to send, so this is the wait for the compile and the render.
+     *
+     * `expect`'s default is 20s (see `playwright.config.ts`), which is enough
+     * on a warm developer machine and is not on a cold CI runner: this
+     * assertion was the last red test in the suite's first real CI run, while
+     * passing locally every time.
+     */
+    await expect(frame!.locator("body")).toContainText("Blog 1", {
+      timeout: 60_000,
+    });
 
     // Closing puts the editor back at full width, and leaves it on the same
     // page: the way out lands where the way in started.


### PR DESCRIPTION
## Summary

The last red test in the e2e suite's first real CI run (#539). With #535 merged, `E2E (chromium)` went from **10 failed / 75 passed** to **1 failed / 88 passed** — this is that one.

## The failure

`canvas.spec.ts:45` fails at:

```ts
await expect(frame!.locator("body")).toContainText("Blog 1");
```

The frame has already navigated — the `expect.poll` above it waits for the URL to contain `/blogs/blog1` and that passes — but its body is still empty when the assertion times out.

## Why

This is the first spec in the suite (alphabetically) to request `/blogs/blog1`, and `next dev` compiles a route the first time it is asked for. That is not incidental: it is the same fact the file's own 90s test timeout exists for, and the config comments on it directly ("`next dev` compiles the route on first request, so the first test pays for a build").

Committing a navigation happens long before the server has anything to send, so this assertion is what actually waits out the compile — against `expect`'s default budget of 20s, not the test's 90s. That is enough on a warm developer machine and is not on a cold CI runner, which is why it passed locally every time and failed only in CI.

## The change

One assertion gets a 60s timeout, with the reasoning recorded inline. It stays event-driven — `toContainText` retries — so this is a deadline that reflects what is being waited for, not a sleep.

## Verified

`pnpm exec playwright test canvas.spec.ts --project=chromium` → **18 passed** locally. The CI run on this branch is the real check.

https://claude.ai/code/session_01DEwy4V5s5BSJQmasskbj4M

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEwy4V5s5BSJQmasskbj4M)_