### PR TITLE
Wait for the mock to accept the page's socket, not just for the browser to open one

### DIFF
--- a/e2e/http/httpMode.ts
+++ b/e2e/http/httpMode.ts
@@ -129,6 +129,23 @@ export async function openHttpStudio(
   const sockets: string[] = [];
   page.on("websocket", (socket) => sockets.push(socket.url()));
 
+  /*
+   * What the mock had accepted BEFORE this page existed.
+   *
+   * The page-side check below proves this page opened a socket, but Playwright
+   * fires `websocket` when the browser INITIATES one — the mock has not
+   * necessarily accepted and registered it yet. Broadcasts only reach sockets
+   * already in the mock's set, so a test that fires an event the instant
+   * `openHttpStudio` returns can lose it entirely and then sit on "No deploys"
+   * until the next `/stat` rescues it. That is a real flake: it took the
+   * `deployments.spec.ts` "publish the site is serving is live" test from green
+   * to red between two CI runs with no change to `http` mode at all.
+   *
+   * A count going UP is what distinguishes this page's socket from one an
+   * earlier test left open, which a plain `subscribers > 0` could not.
+   */
+  const acceptedBefore = (await mock.state()).socketsAccepted;
+
   await page.goto(route);
   await expect
     .poll(
@@ -151,6 +168,13 @@ export async function openHttpStudio(
       message: "this page never opened a socket to the content service",
     })
     .toContain(`ws://localhost:${MOCK_CONTENT_PORT}/ws`);
+  // And the mock has it, so anything broadcast from here on actually arrives.
+  await expect
+    .poll(async () => (await mock.state()).socketsAccepted, {
+      timeout: INTAKE_TIMEOUT,
+      message: "the content service never accepted this page's socket",
+    })
+    .toBeGreaterThan(acceptedBefore);
 }
 
 // #region the mock's control plane
@@ -204,6 +228,8 @@ export type MockState = {
   remoteFiles: string[];
   headCommitSha: string;
   subscribers: number;
+  /** How many sockets the mock has ever accepted. Only ever increases. */
+  socketsAccepted: number;
 };
 
 /**

--- a/e2e/mock-content-host/server.ts
+++ b/e2e/mock-content-host/server.ts
@@ -312,6 +312,8 @@ let state = emptyState();
 
 /** Every subscribed browser. Written to by the control plane and by commits. */
 const sockets = new Set<WebSocket>();
+/** How many sockets have ever been accepted. Only ever increases. */
+let socketsAccepted = 0;
 
 /**
  * The `Origin` of the request each response belongs to.
@@ -1309,6 +1311,7 @@ const controlPlane: Handler = async (req, res, url) => {
       remoteFiles: [...state.remoteFiles.keys()],
       headCommitSha: state.headCommitSha,
       subscribers: sockets.size,
+      socketsAccepted,
     });
     return;
   }
@@ -1595,6 +1598,16 @@ wss.on("connection", (socket) => {
       return;
     }
     sockets.add(socket);
+    /*
+     * Counted, not just held.
+     *
+     * `subscribers` is a live size, so it cannot tell "this page's socket is
+     * registered" from "a socket some earlier test left open". A broadcast only
+     * reaches sockets already in this set, so a test that fires an event before
+     * its own page is in here loses it — see `openHttpStudio`, which waits on
+     * this number going up.
+     */
+    socketsAccepted += 1;
     socket.send(JSON.stringify({ type: "subscribed" }));
   });
   socket.on("close", () => {


### PR DESCRIPTION
## Summary

A real race in the `http`-mode harness, caught by the new E2E job in #539: `chromium-http` went from **green to red between two consecutive CI runs** with no change to `http` mode at all. Chased rather than re-run.

## The evidence

`e2e/http/deployments.spec.ts:321` — "a publish the site is serving is live, with no build ever reported":

```
Expected: "Deployed"
Received: "No deploys"
- Timeout 20000ms exceeded while waiting on the predicate
```

`"No deploys"` is the tell. Not "Queued", not "Building" — the Studio saw *no deployment at all* for 20 seconds. The event never reached the browser.

## The cause

```ts
page.on("websocket", (socket) => sockets.push(socket.url()));
```

Playwright fires `websocket` when the browser **initiates** a connection. The mock content host has not necessarily accepted and registered it yet, and it broadcasts only to sockets already in its set:

```ts
for (const socket of sockets) {
  if (socket.readyState === socket.OPEN) socket.send(payload);
}
```

So a test that fires an event the instant `openHttpStudio` returns can land in the window between "browser opened it" and "mock registered it", and the event goes nowhere. Recovery is then the next `/stat` — which this very file documents as the fallback path — and if that does not arrive inside the 20s `expect` budget, the test fails having seen nothing.

## The fix

The mock counts sockets it has ever accepted; `openHttpStudio` records that count before `goto` and waits for it to **rise**.

A count going up is what distinguishes *this page's* socket from one an earlier test left open. That distinction matters: the existing comment in `openHttpStudio` had explicitly rejected counting subscribers on the mock precisely because a leftover socket would satisfy a `> 0` check and the assertion would then prove nothing. A monotonic counter keeps that property while closing the window.

The page-side check stays exactly as it was — it is what proves this page is in proxy mode at all.

## Verified

- `deployments.spec.ts` → **13 passed**, including the previously flaky one
- full `chromium-http` project → **44 passed** (8.6m)

https://claude.ai/code/session_01DEwy4V5s5BSJQmasskbj4M

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEwy4V5s5BSJQmasskbj4M)_