### PR TITLE
Warm the app's routes before the suite, and fix list-diff's stale wait

### DIFF
--- a/docs/flaky-tests-audit.md
+++ b/docs/flaky-tests-audit.md
@@ -34,6 +34,15 @@ failed**, in 19.9 minutes. The full jest suite (2660 tests, 213 suites),
 same tree. The sections below are kept as the record of what was wrong and
 why; each now ends with what changed.
 
+**Update 2 — that green run did not hold in CI, and §5 says what was still
+wrong.** A later CI run of the same fs-mode code produced 5 failures where its
+immediate predecessor had produced 0. Three distinct causes came out of it, all
+now fixed and reproduced first (§5a–§5c) — including one spec that this audit
+had filed as flaky and which was in fact failing on every single run. Read §5
+before trusting the paragraph above: a single green full run is not evidence
+that a suite is stable, and treating it as such is what put the wrong verdict
+in §1c.
+
 ---
 
 ## 1. The e2e suite is the problem, and mostly for one reason: shared disk state
@@ -120,6 +129,11 @@ reading the ids and the discard returning (`e2e/studio.ts:92-99`).
 flushing (`patchSync.flush()`) before returning, so nothing bleeds into the next
 test. The "operations compose" property is better pinned where it already is
 deterministic — the store suites (`patchSync.test.ts`, `systemFlow.test.ts`).
+
+> **Partly wrong — see §5c.** The missing flush was real and is fixed, but the
+> failure that survived into CI was not residue at all: this test discarded
+> `createPatch`'s return value, so a refused write presented as the previous
+> test's value still being on screen. Composition was not the cause.
 
 ### 1d. Make clean state impossible to forget
 
@@ -394,3 +408,73 @@ left for a deliberate follow-up decision rather than a mechanical fix.
     `.github/workflows/check.yml` is rejected outright. The job's YAML is in
     this branch's history (before the revert commit that follows it) for
     someone with the right permissions to apply.
+
+---
+
+## 5. What the first real CI runs found
+
+The job above (PR #539) went red on `chromium` after everything in §4 was
+fixed, and the three failures it kept producing are worth recording, because
+two of them say something about this audit's method rather than about the
+tests.
+
+### 5a. `list-diff.spec.ts` was never flaky — it was broken, every run
+
+All three of its tests failed waiting 30s for
+`getByRole("textbox").first()`, which reads exactly like the intermittent
+timeouts elsewhere in this document. It is not intermittent: it reproduces
+100% locally and has since `e5a7aa5` made `.render({ as: "inline" })` opt-in.
+`s.array(s.string())` no longer inlines implicitly, so a list of strings
+renders as rows you navigate into and there is no textbox on that screen at
+all.
+
+The lesson is about diagnosis, not about lists. **A timeout is not evidence of
+a race.** Every failure in a browser suite arrives as "waited, did not
+appear", so the shape of the symptom carries almost no information about the
+cause — and this audit twice reached for "flaky" on the strength of that shape
+alone (the other time was `gallery-backed-image`, item 1, which was also plain
+test rot). The cheap check that settles it is running the spec on its own: a
+race passes in isolation, and rot does not.
+
+That wait was also incidental — scaffolding for "the field is on screen"
+before patching through the store — so it now counts the list's rows, which is
+what the tests actually depend on and is indifferent to how a row is drawn.
+
+**Left open**: after `e5a7aa5` nothing in the example app opts into
+`.render({ as: "inline" })` on a primitive list, so the inline-editing path for
+list items has no e2e coverage. Adding it to one field of `lists.val.ts` would
+restore it.
+
+### 5b. `canvas.spec.ts:45` — the timeout was never the problem
+
+It waits for the canvas frame to render `/blogs/blog1`, and it is the only spec
+that loads a blog route, so it is always the one paying for `next dev`'s first
+compile of it — inside its own assertion. It was given 20s, then 60s, and
+failed again on a loaded runner.
+
+Raising a timeout to cover a compile is not a fix, it is a bet on the runner.
+`e2e/warmup.setup.ts` is now a Playwright project that `chromium` depends on;
+it requests the routes the suite visits so they are built before any test
+starts. A project dependency rather than a `globalSetup`, which runs _before_
+`webServer` and so would have nothing to warm. Every remaining timeout in the
+suite can now be read as a claim about the app rather than about the box.
+
+### 5c. `studio.spec.ts:219` — a silent write, not a residue problem
+
+§1c above blamed cross-test residue and item 9 fixed a missing flush. The
+failure that survived was simpler and was in this test's own body: it threw
+away `createPatch`'s return value. `createPatch` reports a refused write by
+returning, not by throwing, so a write that never happened was
+indistinguishable from one still in flight — the probe kept showing the
+previous test's value and the poll ran out its 20s with no mention of the store
+having said no. It now checks the result, and writes a value unique to the run
+so that "the old value is still here" cannot be confused with "my value
+arrived".
+
+### 5d. And the honest caveat
+
+Two consecutive CI runs of identical fs-mode code gave 0 failures and then 5.
+The three above have real, reproduced causes and real fixes, but that pair of
+runs is the reason the `e2e` job should land with `continue-on-error: true` and
+have it removed only after the suite has been green across several runs — not
+after one.

--- a/e2e/list-diff.spec.ts
+++ b/e2e/list-diff.spec.ts
@@ -4,6 +4,49 @@ import type { Locator, Page } from "@playwright/test";
 
 const MODULE = "/content/lists.val.ts";
 
+/** The fixture's `keywords`, in the order `lists.val.ts` defines them. */
+const KEYWORDS = [
+  "content",
+  "editing",
+  "preview",
+  "publish",
+  "validation",
+] as const;
+
+/**
+ * Open the `keywords` list and wait until it has rendered every item.
+ *
+ * `openStudio` returns once the store system has taken the PROJECT in, which is
+ * earlier than this module's own field being on screen — so each of these tests
+ * needs a second wait before it patches, or it races the render.
+ *
+ * That wait used to be for `getByRole("textbox").first()`, on the assumption
+ * that a list of strings is a column of inputs. It was, until `.render({ as:
+ * "inline" })` became opt-in: `s.array(s.string())` now renders each item as a
+ * row you navigate into, so there is no textbox on this screen at all and all
+ * three tests failed identically, every run, waiting 30s for an element the app
+ * had stopped drawing. Not a flake — a stale assumption that only looked like
+ * one because it surfaced as a timeout.
+ *
+ * Counting the rows instead says what these tests actually need: the list is
+ * rendered, with the items the fixture defines, so a patch against it is a patch
+ * against something real. It is also indifferent to how a row is drawn, which is
+ * the part that changed — while still failing loudly, and with a count, if the
+ * fixture or the list stops rendering rather than timing out on an element that
+ * was never the point.
+ */
+async function openKeywords(page: Page): Promise<Locator> {
+  await openStudio(page, `/val/~${MODULE}?p=%22keywords%22`);
+  const studio = page.locator("#val-shadow-root");
+  await expect(
+    studio.getByRole("button", {
+      name: new RegExp(`^(${KEYWORDS.join("|")})$`),
+    }),
+    "the keywords list never rendered its items",
+  ).toHaveCount(KEYWORDS.length, { timeout: 30000 });
+  return studio;
+}
+
 /** Reach the compare view the way an editor does — see compare.spec.ts. */
 async function openCompare(page: Page, studio: Locator): Promise<void> {
   await studio.getByLabel("Quick actions").click();
@@ -45,11 +88,7 @@ test.describe("the compare view diffs a list of primitives", () => {
   test("reports a reorder as a move, naming where it came from", async ({
     page,
   }) => {
-    await openStudio(page, `/val/~${MODULE}?p=%22keywords%22`);
-    const studio = page.locator("#val-shadow-root");
-    await expect(studio.getByRole("textbox").first()).toBeVisible({
-      timeout: 30000,
-    });
+    const studio = await openKeywords(page);
 
     // Move the last item to the front, through the store, because a drag in
     // Playwright is a different test than this one.
@@ -81,11 +120,7 @@ test.describe("the compare view diffs a list of primitives", () => {
   test("an insert plus an edit stays one insert plus one edit", async ({
     page,
   }) => {
-    await openStudio(page, `/val/~${MODULE}?p=%22keywords%22`);
-    const studio = page.locator("#val-shadow-root");
-    await expect(studio.getByRole("textbox").first()).toBeVisible({
-      timeout: 30000,
-    });
+    const studio = await openKeywords(page);
 
     await patchThroughStore(page, MODULE, [
       { op: "add", path: ["keywords", "1"], value: "inserted" },
@@ -113,11 +148,7 @@ test.describe("the compare view diffs a list of primitives", () => {
 
   /** A deletion says removed, in the place the item used to be. */
   test("reports a deletion where it was", async ({ page }) => {
-    await openStudio(page, `/val/~${MODULE}?p=%22keywords%22`);
-    const studio = page.locator("#val-shadow-root");
-    await expect(studio.getByRole("textbox").first()).toBeVisible({
-      timeout: 30000,
-    });
+    const studio = await openKeywords(page);
 
     await patchThroughStore(page, MODULE, [
       { op: "remove", path: ["keywords", "2"] },

--- a/e2e/studio.spec.ts
+++ b/e2e/studio.spec.ts
@@ -219,25 +219,66 @@ test.describe("the Studio runs on the store system", () => {
   test("shows the written value through the hooks", async ({ page }) => {
     await openStudio(page);
 
-    await page.evaluate(async () => {
+    /**
+     * Unique per run, so the assertion cannot be satisfied by anything already
+     * in the chain.
+     *
+     * This suite composes on purpose, and the test before this one writes to the
+     * same field. A fixed string would still be the right assertion — the two
+     * values differ — but it makes the FAILURE ambiguous: seeing the earlier
+     * test's value here could mean this write never landed, or that it landed
+     * and was somehow undone. A value no earlier run could have produced settles
+     * that: whatever the probe shows instead, it is a value that was already
+     * there.
+     */
+    const written = `Shown by e2e ${Date.now()}`;
+
+    await page.evaluate(async (value) => {
       const bag = window as unknown as {
         __VAL_STORE_PROBE__: (path: string) => void;
         __VAL_STORES__: {
           system: {
             patchStore: {
-              createPatch(mfp: string, patch: unknown[]): Promise<unknown>;
+              /**
+               * Declared as one shape rather than as a union of the success and
+               * failure results, for the reason the sibling test above spells
+               * out: the failure branch's `status` is a plain `string`, so it
+               * overlaps `"created"` and TypeScript cannot narrow on it — a
+               * union here would only make `message` unreachable on the branch
+               * that carries it.
+               */
+              createPatch(
+                mfp: string,
+                patch: unknown[],
+              ): Promise<{ status: string; message?: string }>;
             };
           };
         };
       };
-      await bag.__VAL_STORES__.system.patchStore.createPatch(
+      const res = await bag.__VAL_STORES__.system.patchStore.createPatch(
         "/content/authors.val.ts",
-        [{ op: "replace", path: ["teddy", "name"], value: "Shown by e2e" }],
+        [{ op: "replace", path: ["teddy", "name"], value }],
       );
+      /**
+       * Checked, because the alternative is a twenty-second silence.
+       *
+       * `createPatch` reports a refused write in its return value rather than by
+       * throwing. Ignoring it meant a write that never happened was indis-
+       * tinguishable from one still in flight: the probe kept showing whatever
+       * was there before, the poll below ran out its timeout, and the report was
+       * a value mismatch with no mention of the store having said no. The
+       * message it carries is the actual diagnosis, so it belongs in the
+       * failure.
+       */
+      if (res.status !== "created") {
+        throw new Error(
+          `the store refused the write: ${res.message ?? res.status}`,
+        );
+      }
       // Drive the probe component, which reads through `useSourceAtPath` — the
       // same hook a real field uses.
       bag.__VAL_STORE_PROBE__('/content/authors.val.ts?p="teddy"."name"');
-    });
+    }, written);
 
     /**
      * Polled, not slept on.
@@ -266,7 +307,7 @@ test.describe("the Studio runs on the store system", () => {
       .poll(async () => (await read())?.source, {
         message: "the probe never rendered the written value",
       })
-      .toMatchObject({ status: "success", data: "Shown by e2e" });
+      .toMatchObject({ status: "success", data: written });
     // And the module validated, which is the other half of a field being ready.
     await expect
       .poll(async () => (await read())?.validation, {

--- a/e2e/warmup.setup.ts
+++ b/e2e/warmup.setup.ts
@@ -1,0 +1,96 @@
+import { expect, test, type APIRequestContext } from "@playwright/test";
+
+/**
+ * Compile the app's routes before the suite starts timing anything.
+ *
+ * `next dev` compiles a route the first time it is requested, and the SPA is a
+ * Vite dev server that transforms its modules on the same terms. So the first
+ * test to touch a route pays for a build — while its own `expect` timeout is
+ * running. That cost is real work the app has to do, but it is not the app's
+ * behaviour, and charging it to whichever test happens to go first is what made
+ * this suite flaky in a way that moved around between runs:
+ *
+ * - `canvas.spec.ts` waits for the canvas frame to render `/blogs/blog1`. It is
+ *   the only spec that loads a blog route, so it is always the one paying for
+ *   that compile. It was given 20s, then 60s, and still failed on a loaded
+ *   runner — because the number was never the thing that was wrong.
+ * - `list-diff.spec.ts` opens the Studio and waits 30s for a field. Whether that
+ *   is enough depends on whether an earlier spec already warmed the route, which
+ *   depends on the order Playwright happened to pick.
+ *
+ * A test's timeout should be a statement about the app being responsive, not a
+ * bet on how fast a compiler is on the box the run landed on. Warming here makes
+ * every later timeout mean what it says, and moves the one legitimately slow
+ * wait somewhere that being slow is expected — and where being BROKEN is
+ * reported as a setup failure naming the route, rather than as a locator that
+ * found nothing.
+ *
+ * A project dependency rather than a `globalSetup`, because `globalSetup` runs
+ * before `webServer` does: there would be nothing up to warm. As a project it
+ * runs after the servers are ready, and Playwright reports it like a test.
+ *
+ * Only the `fs`-mode app is warmed. `chromium-http` gets its own servers and
+ * would want the same treatment, but it is not currently flaky, and warming it
+ * on an `fs`-only run would mean compiling an app that run never visits.
+ */
+
+/**
+ * Generous, and deliberately so. This is the wait for a cold compile on a loaded
+ * CI runner — the thing every other timeout in the suite is trying not to be.
+ */
+const COMPILE_TIMEOUT = 180_000;
+
+/**
+ * The routes to build, cheapest first.
+ *
+ * `/val` first, because everything else in the suite goes through it and it
+ * drags in the SPA bundle. Then the app routes the canvas specs point a frame
+ * at, which are otherwise compiled inside an assertion about the canvas.
+ *
+ * Query strings are left off: `next dev` compiles a route, not a URL, so
+ * `/val/~/content/lists.val.ts?p=…` and `/val` are the same build. What differs
+ * per URL is the Studio's own client-side work, which is not what this is for.
+ */
+const ROUTES = [
+  "/val",
+  "/",
+  "/blogs/blog1",
+  "/blogs/blog2",
+  "/support/getting-started",
+] as const;
+
+/**
+ * Request a route until the server answers, and name the route if it never does.
+ *
+ * A plain `request.get` would already wait, but a route that fails to build
+ * answers quickly with a 500 — so this polls the status rather than the request
+ * completing, and a route that cannot compile fails here, named, instead of
+ * surfacing later as a missing element in a test about something else.
+ */
+async function warm(request: APIRequestContext, url: string): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        try {
+          return (
+            await request.get(url, { timeout: COMPILE_TIMEOUT })
+          ).status();
+        } catch (err) {
+          // The dev server can still be binding its port when the first request
+          // goes out; report it rather than throwing out of the poll.
+          return `unreachable: ${err instanceof Error ? err.message : err}`;
+        }
+      },
+      { timeout: COMPILE_TIMEOUT, message: `${url} never compiled` },
+    )
+    .toBe(200);
+}
+
+test("the app has compiled the routes the suite visits", async ({
+  request,
+}) => {
+  test.setTimeout(COMPILE_TIMEOUT * 2);
+  for (const route of ROUTES) {
+    await warm(request, route);
+  }
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -79,7 +79,27 @@ export default defineConfig({
   },
   projects: [
     {
+      // Not a test: it asks the dev server to build the routes the suite is
+      // about to visit, so no later test is the one paying for a compile inside
+      // its own timeout. See `e2e/warmup.setup.ts`.
+      name: "warmup",
+      testMatch: "warmup.setup.ts",
+      use: {
+        launchOptions: {
+          ...(existsSync(PREINSTALLED_CHROMIUM)
+            ? { executablePath: PREINSTALLED_CHROMIUM }
+            : {}),
+          args: ["--no-sandbox", "--disable-dev-shm-usage"],
+        },
+      },
+    },
+    {
       name: "chromium",
+      // Every fs-mode test starts against an app that has already compiled its
+      // routes, rather than against whichever route the run happened to hit
+      // first. This is why the timeouts below can be read as claims about the
+      // app rather than about the runner.
+      dependencies: ["warmup"],
       // The `fs`-mode suites. `e2e/http/` is excluded because those tests need
       // the other app, on the other port. `screens.spec.ts` is excluded because
       // it is not a test — it takes screenshots for a human to look at, on a


### PR DESCRIPTION
Three separate things were showing up as the same symptom -- a locator
timing out -- and only one of them was actually about timing.

list-diff was not flaky at all: it failed on every run, all three tests,
and had done since .render({ as: "inline" }) became opt-in. s.array(s.string())
no longer inlines implicitly, so a list of strings renders as rows you
navigate into and there is no textbox on that screen to wait for. The wait
was incidental scaffolding for "the field is on screen", so it now counts
the list's rows instead: indifferent to how a row is drawn, and it fails
with a count rather than by timing out on an element that was never the
point.

canvas.spec.ts:45 was the one paying for next dev's first compile of
/blogs/blog1, inside its own assertion. It has been given 20s, then 60s,
and still failed on a loaded runner, because the number was never the
problem. A warmup project now builds the routes the suite visits before
any test starts, so every later timeout is a claim about the app rather
than a bet on the compiler. A project dependency, not globalSetup, which
runs before webServer and would have nothing to warm.

studio.spec.ts:219 threw away createPatch's return value, so a refused
write was indistinguishable from one still in flight: the probe kept
showing the previous test's value and the poll ran out its timeout with
no mention of the store having said no. It now checks the result and
writes a value unique to the run, so the failure names the cause.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DEwy4V5s5BSJQmasskbj4M