### PR TITLE
Warm the SPA and both workers, not just Next's routes

### DIFF
--- a/e2e/warmup.setup.ts
+++ b/e2e/warmup.setup.ts
@@ -49,6 +49,12 @@ import {
  */
 
 /**
+ * A module to validate, chosen because the example app always has it and it is
+ * small enough that validating it costs nothing beyond building the worker.
+ */
+const VALIDATED_MODULE = "/content/authors.val.ts";
+
+/**
  * Generous, and deliberately so. This is the wait for a cold compile on a loaded
  * CI runner — the thing every other timeout in the suite is trying not to be.
  */
@@ -135,9 +141,7 @@ test("the app has compiled the routes the suite visits", async ({
   }
 });
 
-test("the Studio's bundle and the patch-sets worker are built", async ({
-  page,
-}) => {
+test("the Studio's bundle and both workers are built", async ({ page }) => {
   test.setTimeout(COMPILE_TIMEOUT * 2);
 
   /**
@@ -168,28 +172,52 @@ test("the Studio's bundle and the patch-sets worker are built", async ({
   await waitForIntake(page, "the Studio");
 
   /**
-   * The validation worker is NOT warmed, and that is a known gap.
+   * The validation worker, forced by invalidating first.
    *
-   * Two attempts failed, both for reasons worth recording so the next person
-   * does not repeat them:
-   *
-   * 1. Driving `ValStoreProbe` reached `useModuleValidation` and reported
-   *    `"validated"` without building anything: `ValidationStore.validate`
-   *    returns a cached result unless the module is stale, and on a clean
-   *    checkout every module is already validated from intake. This looked like
-   *    it worked locally ONLY because the local `.val/patches` had leftover
-   *    patches from earlier runs marking modules stale — the clean chain a CI
-   *    runner starts with has none.
-   * 2. `validationStore.invalidate([m])` followed by `validate(m)` also built
-   *    nothing, so `run()` is not reaching `schemaValidationBridge.validate` —
-   *    which calls `ensureWorker()` on its first line, so the worker would have
-   *    been recorded if it had. Where that path actually stops is not yet known.
-   *
-   * The cost is real (`studio.spec.ts` records the validation worker's first use
-   * turning a fixed wait into a flake) but it is one first-use compile, and a
-   * warmup that gates all six shards is the wrong place to keep guessing. What
-   * IS warmed below is asserted, so this file cannot quietly stop working.
+   * `ValidationStore.validate` returns a cached result unless the module is
+   * stale, and on a clean checkout intake has already validated everything — so
+   * asking it to validate does nothing. `invalidate` drops the cached result and
+   * marks the module stale, which makes the `validate` below do real work and
+   * reach `schemaValidationBridge`'s `ensureWorker()`. It writes no patch and
+   * touches no content, which is what a warmup must not do.
    */
+  await page.evaluate(async (moduleFilePath) => {
+    const bag = window as unknown as {
+      __VAL_STORES__?: {
+        system: {
+          validationStore: {
+            invalidate(modules: string[]): void;
+            validate(moduleFilePath: string): Promise<unknown>;
+          };
+        };
+      };
+    };
+    const store = bag.__VAL_STORES__?.system.validationStore;
+    if (store === undefined) {
+      throw new Error("the Studio's store system is not on window");
+    }
+    store.invalidate([moduleFilePath]);
+    await store.validate(moduleFilePath);
+  }, VALIDATED_MODULE);
+
+  /**
+   * Asserted HERE, before navigating — the log does not survive a navigation.
+   *
+   * `addInitScript` runs on every document, so the `goto` below re-runs it and
+   * resets `__WARMUP_WORKERS__` to a fresh array. An assertion made after it can
+   * only see what the compare document built, which is why the first version of
+   * this file reported "no validation worker" and sent me chasing two wrong
+   * explanations in `ValidationStore` and the bridge. The worker was almost
+   * certainly being built; the evidence was being thrown away one line later.
+   */
+  await expect
+    .poll(() => workersBuilt(page), {
+      timeout: COMPILE_TIMEOUT,
+      message: "the validation worker was never constructed",
+    })
+    .toEqual(
+      expect.arrayContaining([expect.stringContaining("validation.worker")]),
+    );
 
   /**
    * The patch-sets worker, by going to the compare view.

--- a/e2e/warmup.setup.ts
+++ b/e2e/warmup.setup.ts
@@ -1,37 +1,51 @@
-import { expect, test, type APIRequestContext } from "@playwright/test";
+import {
+  expect,
+  test,
+  type APIRequestContext,
+  type Page,
+} from "@playwright/test";
 
 /**
- * Compile the app's routes before the suite starts timing anything.
+ * Pay the app's first-use costs before the suite starts timing anything.
  *
- * `next dev` compiles a route the first time it is requested, and the SPA is a
- * Vite dev server that transforms its modules on the same terms. So the first
- * test to touch a route pays for a build — while its own `expect` timeout is
- * running. That cost is real work the app has to do, but it is not the app's
- * behaviour, and charging it to whichever test happens to go first is what made
- * this suite flaky in a way that moved around between runs:
+ * `next dev` compiles a route the first time it is requested, Vite transforms the
+ * SPA's modules on the same terms, and two of the Studio's workers are built the
+ * first time something needs them. So whichever test goes first pays for a build
+ * — while its own `expect` timeout is running. That cost is real work the app has
+ * to do, but it is not the app's behaviour, and charging it to whichever test
+ * happens to be first is what made this suite flaky in a way that moved between
+ * runs:
  *
  * - `canvas.spec.ts` waits for the canvas frame to render `/blogs/blog1`. It is
- *   the only spec that loads a blog route, so it is always the one paying for
- *   that compile. It was given 20s, then 60s, and still failed on a loaded
- *   runner — because the number was never the thing that was wrong.
- * - `list-diff.spec.ts` opens the Studio and waits 30s for a field. Whether that
- *   is enough depends on whether an earlier spec already warmed the route, which
- *   depends on the order Playwright happened to pick.
+ *   the only spec that loads a blog route, so it always paid for that compile. It
+ *   was given 20s, then 60s, and still failed on a loaded runner — because the
+ *   number was never the thing that was wrong.
+ * - `list-diff.spec.ts` and `compare.spec.ts` wait 30s for the first diff line,
+ *   which is the first construction of the patch-sets worker.
+ * - `studio.spec.ts`'s own comment records the validation worker doing this
+ *   already: "A fixed wait was long enough while validation ran in-process and
+ *   became a flake the moment it moved to a thread."
  *
  * A test's timeout should be a statement about the app being responsive, not a
- * bet on how fast a compiler is on the box the run landed on. Warming here makes
- * every later timeout mean what it says, and moves the one legitimately slow
- * wait somewhere that being slow is expected — and where being BROKEN is
- * reported as a setup failure naming the route, rather than as a locator that
- * found nothing.
+ * bet on how fast a compiler is on the box the run landed on.
+ *
+ * ## Two halves, because HTTP is not enough
+ *
+ * The first version of this file warmed routes with `request.get`, which compiles
+ * Next's routes and nothing else: a bare HTML GET never runs the page, so the
+ * SPA's module graph is never fetched from Vite and neither worker is ever
+ * constructed. `openStudio`'s 60s intake poll and `diffLines`' 30s were still
+ * absorbing all of it. So the second half drives a real browser.
  *
  * A project dependency rather than a `globalSetup`, because `globalSetup` runs
  * before `webServer` does: there would be nothing up to warm. As a project it
- * runs after the servers are ready, and Playwright reports it like a test.
+ * runs after the servers are ready, Playwright reports it like a test, and it
+ * runs in EVERY shard — verified with `--list` — which is what a sharded CI run
+ * needs, since each shard is its own cold checkout.
  *
  * Only the `fs`-mode app is warmed. `chromium-http` gets its own servers and
- * would want the same treatment, but it is not currently flaky, and warming it
- * on an `fs`-only run would mean compiling an app that run never visits.
+ * would want the same treatment, but it is not currently flaky and warming it on
+ * an `fs`-only run would mean compiling an app that run never visits.
  */
 
 /**
@@ -43,13 +57,12 @@ const COMPILE_TIMEOUT = 180_000;
 /**
  * The routes to build, cheapest first.
  *
- * `/val` first, because everything else in the suite goes through it and it
- * drags in the SPA bundle. Then the app routes the canvas specs point a frame
- * at, which are otherwise compiled inside an assertion about the canvas.
+ * `/val` first, because everything else in the suite goes through it. Then the
+ * app routes the canvas specs point a frame at, which are otherwise compiled
+ * inside an assertion about the canvas.
  *
  * Query strings are left off: `next dev` compiles a route, not a URL, so
- * `/val/~/content/lists.val.ts?p=…` and `/val` are the same build. What differs
- * per URL is the Studio's own client-side work, which is not what this is for.
+ * `/val/~/content/lists.val.ts?p=…` and `/val` are the same build.
  */
 const ROUTES = [
   "/val",
@@ -58,6 +71,12 @@ const ROUTES = [
   "/blogs/blog2",
   "/support/getting-started",
 ] as const;
+
+/**
+ * A module and path the probe can read, chosen because the example app always
+ * has it and `studio.spec.ts` already relies on it.
+ */
+const PROBE_PATH = '/content/authors.val.ts?p="teddy"."name"';
 
 /**
  * Request a route until the server answers, and name the route if it never does.
@@ -86,6 +105,33 @@ async function warm(request: APIRequestContext, url: string): Promise<void> {
     .toBe(200);
 }
 
+/** The store system has taken the project in. See `openStudio`. */
+async function waitForIntake(page: Page, what: string): Promise<void> {
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          const bag = window as unknown as {
+            __VAL_STORES__?: { received: boolean };
+          };
+          return bag.__VAL_STORES__?.received === true;
+        }),
+      {
+        timeout: COMPILE_TIMEOUT,
+        message: `${what} never took the project in`,
+      },
+    )
+    .toBe(true);
+}
+
+/** Every worker script this page has constructed, in order. */
+function workersBuilt(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const bag = window as unknown as { __WARMUP_WORKERS__?: string[] };
+    return bag.__WARMUP_WORKERS__ ?? [];
+  });
+}
+
 test("the app has compiled the routes the suite visits", async ({
   request,
 }) => {
@@ -93,4 +139,98 @@ test("the app has compiled the routes the suite visits", async ({
   for (const route of ROUTES) {
     await warm(request, route);
   }
+});
+
+test("the Studio's bundle and both workers are built", async ({ page }) => {
+  test.setTimeout(COMPILE_TIMEOUT * 2);
+
+  /**
+   * Record every `new Worker(...)`, so this can assert it did its job.
+   *
+   * Without it the warmup would be a sequence of navigations that LOOK like they
+   * build the workers, and a refactor moving either construction — behind a
+   * condition, into a lazier component — would silently take the warmup away
+   * while every test kept passing, slower and closer to its timeout again. The
+   * subclass calls `super`, so the page behaves exactly as it would have.
+   */
+  await page.addInitScript(() => {
+    const built: string[] = [];
+    (window as unknown as { __WARMUP_WORKERS__: string[] }).__WARMUP_WORKERS__ =
+      built;
+    const Original = window.Worker;
+    window.Worker = class extends Original {
+      constructor(scriptURL: string | URL, options?: WorkerOptions) {
+        built.push(String(scriptURL));
+        super(scriptURL, options);
+      }
+    };
+  });
+
+  // The SPA itself: Vite transforms its module graph on this first load, which
+  // is what `openStudio`'s 60s intake poll has been absorbing.
+  await page.goto("/val");
+  await waitForIntake(page, "the Studio");
+
+  /**
+   * The validation worker, through the hook a real field uses.
+   *
+   * `ValStoreProbe` mounts on a path handed to it at runtime and calls
+   * `useModuleValidation`, which is what reaches `schemaValidationBridge`'s
+   * `ensureWorker()`. Driving the probe needs no patch and leaves no state
+   * behind — which matters, because a warmup that dirtied the chain would break
+   * every spec that reads the fixture's own content.
+   */
+  await page.evaluate((path) => {
+    const bag = window as unknown as {
+      __VAL_STORE_PROBE__?: (next: string) => void;
+    };
+    if (bag.__VAL_STORE_PROBE__ === undefined) {
+      throw new Error("the Studio's test probe is not on window");
+    }
+    bag.__VAL_STORE_PROBE__(path);
+  }, PROBE_PATH);
+
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          const root = document.getElementById("val-shadow-root");
+          const scope = root?.shadowRoot ?? document;
+          const raw = scope
+            .querySelector("[data-val-store-probe]")
+            ?.getAttribute("data-val-store-probe");
+          return raw === null || raw === undefined
+            ? null
+            : (JSON.parse(raw) as { validation: string }).validation;
+        }),
+      {
+        timeout: COMPILE_TIMEOUT,
+        message: "validation never completed, so its worker is not warm",
+      },
+    )
+    .toBe("validated");
+
+  /**
+   * The patch-sets worker, by going to the compare view.
+   *
+   * Straight to the route rather than through Quick actions: that panel's
+   * "Review N changes" item only exists once there IS a change, and the warmup
+   * deliberately makes none. `usePatchSetsWorker` builds its worker in an effect
+   * on mount, and `ValShell` mounts `ComparePatchSets` as soon as the patch sets
+   * have loaded — empty or not — so an empty chain still pays the construction.
+   */
+  await page.goto("/val/compare");
+  await waitForIntake(page, "the compare view");
+
+  await expect
+    .poll(() => workersBuilt(page), {
+      timeout: COMPILE_TIMEOUT,
+      message: "the Studio's workers were never constructed",
+    })
+    .toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("validation.worker"),
+        expect.stringContaining("patchsets.worker"),
+      ]),
+    );
 });

--- a/e2e/warmup.setup.ts
+++ b/e2e/warmup.setup.ts
@@ -73,12 +73,6 @@ const ROUTES = [
 ] as const;
 
 /**
- * A module and path the probe can read, chosen because the example app always
- * has it and `studio.spec.ts` already relies on it.
- */
-const PROBE_PATH = '/content/authors.val.ts?p="teddy"."name"';
-
-/**
  * Request a route until the server answers, and name the route if it never does.
  *
  * A plain `request.get` would already wait, but a route that fails to build
@@ -141,7 +135,9 @@ test("the app has compiled the routes the suite visits", async ({
   }
 });
 
-test("the Studio's bundle and both workers are built", async ({ page }) => {
+test("the Studio's bundle and the patch-sets worker are built", async ({
+  page,
+}) => {
   test.setTimeout(COMPILE_TIMEOUT * 2);
 
   /**
@@ -172,43 +168,28 @@ test("the Studio's bundle and both workers are built", async ({ page }) => {
   await waitForIntake(page, "the Studio");
 
   /**
-   * The validation worker, through the hook a real field uses.
+   * The validation worker is NOT warmed, and that is a known gap.
    *
-   * `ValStoreProbe` mounts on a path handed to it at runtime and calls
-   * `useModuleValidation`, which is what reaches `schemaValidationBridge`'s
-   * `ensureWorker()`. Driving the probe needs no patch and leaves no state
-   * behind — which matters, because a warmup that dirtied the chain would break
-   * every spec that reads the fixture's own content.
+   * Two attempts failed, both for reasons worth recording so the next person
+   * does not repeat them:
+   *
+   * 1. Driving `ValStoreProbe` reached `useModuleValidation` and reported
+   *    `"validated"` without building anything: `ValidationStore.validate`
+   *    returns a cached result unless the module is stale, and on a clean
+   *    checkout every module is already validated from intake. This looked like
+   *    it worked locally ONLY because the local `.val/patches` had leftover
+   *    patches from earlier runs marking modules stale — the clean chain a CI
+   *    runner starts with has none.
+   * 2. `validationStore.invalidate([m])` followed by `validate(m)` also built
+   *    nothing, so `run()` is not reaching `schemaValidationBridge.validate` —
+   *    which calls `ensureWorker()` on its first line, so the worker would have
+   *    been recorded if it had. Where that path actually stops is not yet known.
+   *
+   * The cost is real (`studio.spec.ts` records the validation worker's first use
+   * turning a fixed wait into a flake) but it is one first-use compile, and a
+   * warmup that gates all six shards is the wrong place to keep guessing. What
+   * IS warmed below is asserted, so this file cannot quietly stop working.
    */
-  await page.evaluate((path) => {
-    const bag = window as unknown as {
-      __VAL_STORE_PROBE__?: (next: string) => void;
-    };
-    if (bag.__VAL_STORE_PROBE__ === undefined) {
-      throw new Error("the Studio's test probe is not on window");
-    }
-    bag.__VAL_STORE_PROBE__(path);
-  }, PROBE_PATH);
-
-  await expect
-    .poll(
-      () =>
-        page.evaluate(() => {
-          const root = document.getElementById("val-shadow-root");
-          const scope = root?.shadowRoot ?? document;
-          const raw = scope
-            .querySelector("[data-val-store-probe]")
-            ?.getAttribute("data-val-store-probe");
-          return raw === null || raw === undefined
-            ? null
-            : (JSON.parse(raw) as { validation: string }).validation;
-        }),
-      {
-        timeout: COMPILE_TIMEOUT,
-        message: "validation never completed, so its worker is not warm",
-      },
-    )
-    .toBe("validated");
 
   /**
    * The patch-sets worker, by going to the compare view.
@@ -225,12 +206,9 @@ test("the Studio's bundle and both workers are built", async ({ page }) => {
   await expect
     .poll(() => workersBuilt(page), {
       timeout: COMPILE_TIMEOUT,
-      message: "the Studio's workers were never constructed",
+      message: "the patch-sets worker was never constructed",
     })
     .toEqual(
-      expect.arrayContaining([
-        expect.stringContaining("validation.worker"),
-        expect.stringContaining("patchsets.worker"),
-      ]),
+      expect.arrayContaining([expect.stringContaining("patchsets.worker")]),
     );
 });


### PR DESCRIPTION
Closes the gap in the warmup added by #546.

## What was missing

That warmup used `request.get`, which compiles Next's routes and nothing else. A bare HTML GET never runs the page, so Vite never transformed the SPA's module graph and neither of the Studio's workers was ever constructed:

- `schemaValidationBridge.ts:61` — `new Worker(new URL("./validation.worker.ts", import.meta.url))` inside `ensureWorker()`, on the first validation
- `usePatchSetsWorker.ts:58` — the same shape, when the compare view first mounts

So `openStudio`'s 60s intake poll and `diffLines`' 30s were still absorbing all of it — which is the cost those numbers exist for, and the reason `canvas.spec.ts` was given 20s, then 60s, and still failed on a loaded runner.

## What it does now

Three steps, each paying one cost:

1. **`page.goto("/val")` + intake** — Vite transforms the SPA's module graph.
2. **`validationStore.invalidate([m])` then `validate(m)`** — `validate` returns a cached result unless the module is stale, and a clean checkout has everything validated from intake, so the invalidate is what makes it do real work and reach `ensureWorker()`. It writes no patch and touches no content.
3. **`page.goto("/val/compare")`** — `usePatchSetsWorker` builds its worker in an effect on mount, and `ValShell` mounts `ComparePatchSets` as soon as patch sets load, empty or not.

Straight to `/val/compare` rather than through Quick actions, because that panel's "Review N changes" item only exists once there *is* a change, and the warmup deliberately makes none.

## It proves it worked

An init script subclasses `window.Worker` to record every construction, and each worker is asserted **in the document that builds it**. Without the recording the warmup would be a sequence of navigations that merely *look* like they build the workers, and a refactor moving either construction behind a condition would silently remove the warmup while every test kept passing, slower and closer to its timeout again.

## What went wrong first, since it is instructive

The first version asserted both workers once, at the end. `addInitScript` runs on **every** document, so `goto("/val/compare")` reset `__WARMUP_WORKERS__` to a fresh array and the assertion could only see what the compare document built — `[patchsets, patchsets]`. All six chromium shards failed, since the warmup is a project dependency.

I then wrote two explanations for the "missing" validation worker into the file — a cache hit in `ValidationStore.validate`, then `run()` not reaching the bridge — and **both were wrong**. The worker was being built all along; the evidence was being discarded one line later. Caught in review by Copilot (thread resolved); the lesson is that a measurement is a hypothesis too.

Also worth recording: my first local verification was worthless, because `.val/patches` held leftovers from earlier runs that marked modules stale. Every verification since clears the chain first.

## Verification

- `--project=warmup` on a **cleared** chain: **2 passed** (51.8s), both workers recorded. `arrayContaining` fails on an empty array, so the pass is real evidence.
- Earlier, fully cold — all ports down and `.next` / `.next-http` removed — `canvas` + `list-diff` + `compare` + `studio`: **23 passed**.
- `tsc -p e2e/tsconfig.json`, `prettier --check`, `eslint .` clean.

## Deliberately not included

The 60s and 30s timeouts are left alone. Lowering them is a separate judgement that should be made against a few CI runs with this in place, not on the same day it lands.