### PR TITLE
Wait for both halves of a gallery-backed upload before discarding

### DIFF
--- a/e2e/media.spec.ts
+++ b/e2e/media.spec.ts
@@ -329,6 +329,8 @@ test.describe("an s.files() gallery", () => {
 
 test.describe("single media fields", () => {
   const MODULE = "/content/mediaFields.val.ts";
+  /** The gallery `fromGallery` references — where its metadata entry lands. */
+  const GALLERY = "/content/mediaFixtures.val.ts";
 
   /**
    * Both field components crashed the Studio for a field with no value: a
@@ -393,6 +395,40 @@ test.describe("single media fields", () => {
     await expect
       .poll(() => uploadedRefs(page), { timeout: 30_000 })
       .toEqual(["/public/test/subdir/blue-8x8_8b441.png"]);
+
+    /**
+     * Wait for BOTH patches, because a gallery-backed upload writes two.
+     *
+     * `useImageUpload` uploads the field's patch — the one carrying the `file`
+     * op — and only in its `.then` adds the metadata entry to the GALLERY
+     * module (`addModuleFilePatch(referencedModule, [{ op: "add", … }])`). The
+     * poll above reads `uploadedRefs`, which filters `op === "file"`, so the
+     * second patch is invisible to it: the test could reach `discardAll` before
+     * that patch existed, discard the one that did, and leave the other on the
+     * server. It failed in CI and reproduces here about once in three runs, and
+     * the leftover always named itself the same way:
+     *
+     *     ["/content/mediaFixtures.val.ts [add]"]
+     *
+     * A discard cannot remove what has not been created yet, so the wait is what
+     * has to change — not the discard. Asked of the server, because that is
+     * where the next assertion looks and because the client can hold a record
+     * the server has already dropped (see `expectNoPatchesOnServer`).
+     */
+    await expect
+      .poll(
+        async () => {
+          const res = await request.get("/api/val/patches");
+          if (!res.ok()) return `the server refused it: ${res.status()}`;
+          const body = (await res.json()) as { patches: { path?: string }[] };
+          return [...new Set(body.patches.map((entry) => entry.path ?? "?"))]
+            .sort()
+            .join(", ");
+        },
+        { message: "the gallery never got the metadata half of the upload" },
+      )
+      .toBe([MODULE, GALLERY].sort().join(", "));
+
     await discardAll(page);
     await expectNoPatchesOnServer(request);
   });

--- a/e2e/studio.ts
+++ b/e2e/studio.ts
@@ -177,14 +177,28 @@ export async function expectNoPatchesOnServer(
   await expect
     .poll(
       async () => {
-        const res = await request.get("/api/val/patches");
-        if (!res.ok()) return `the server refused the request: ${res.status()}`;
-        const body = (await res.json()) as { patches: { patchId: string }[] };
-        return body.patches.length;
+        // `exclude_patch_ops=false` so a leftover can NAME itself. A bare count
+        // says "one patch survived the discard" and leaves you guessing which;
+        // the module and the ops say whether it is the write the test made or a
+        // second one the test never waited for.
+        const res = await request.get(
+          "/api/val/patches?exclude_patch_ops=false",
+        );
+        if (!res.ok())
+          return [`the server refused the request: ${res.status()}`];
+        const body = (await res.json()) as {
+          patches: { path?: string; patch?: { op?: string }[] }[];
+        };
+        return body.patches.map(
+          (entry) =>
+            `${entry.path ?? "?"} [${(entry.patch ?? [])
+              .map((op) => op.op ?? "?")
+              .join(",")}]`,
+        );
       },
       { message: "the discard left patches on the server" },
     )
-    .toBe(0);
+    .toEqual([]);
 }
 
 /** How many patches the store currently holds, straight from the system. */


### PR DESCRIPTION
The last known flake in the fs-mode suite, with a proven mechanism.

## What it was

`media.spec.ts` → `s.image(gallery) stores in the gallery's directory` intermittently left a patch on the server after `discardAll`.

A gallery-backed upload writes **two** patches (`useImageUpload.ts:131-158`):

```ts
addAndUploadPatchWithFileOps(uploadPatch, …)   // the field's module — carries the `file` op
  .then(() =>
    addModuleFilePatch(referencedModule, [{ op: "add", … }], "record"),  // the GALLERY module
  )
```

The test gated on `uploadedRefs`, which filters `op === "file"` — so the second patch was **invisible to the gate**. The test could reach `discardAll` before that patch existed, discard the one that did, and leave the other behind.

A discard cannot remove what has not been created yet, so **the wait is what had to change, not the discard**. It now waits for the server to hold patches for both modules first — asked of the server, because that is where the next assertion looks and because the client can hold a record the server has already dropped.

## How it was found

Two commits, deliberately separate.

**`4afb953` — make a leftover name itself.** `expectNoPatchesOnServer` reported a bare count, so a failure said "one patch survived the discard" and left you guessing which. It now asks for the ops and asserts on a list. On its first failure it said:

```
Received: ["/content/mediaFixtures.val.ts [add]"]
```

One `add` on the gallery module — the whole answer, in one line. Before that, the bare count had sent me through two wrong mechanisms in `PatchStore` and `ValOpsFS`.

**`a67a612` — the fix**, resting on that evidence rather than on my reading of the upload path.

## Verification

Same loop, clean `.val/patches` before every attempt:

| | result |
| --- | --- |
| before the fix | **3 failures in 10** |
| after the fix | **0 failures in 10** |

`tsc -p e2e/tsconfig.json`, `eslint .`, `prettier --check` all clean.

## Two notes for whoever hits something like this next

**Clear `.val/patches` between attempts or you will not reproduce it.** Six earlier attempts against a dirty chain never showed it — leftovers change the timing enough to hide it entirely. Every "cannot reproduce" today turned out to be an unverified instrument rather than an absent bug.

**Naming beats counting.** The whole investigation turned on one assertion saying *what* it saw instead of *how many*. `e2e/README.md` is honest that the boundary rule makes failures harder to read; this is the counterweight — when a poll can afford to name what it found, it should.