### PR TITLE
Add s.code() schema type and s.string().multiline()

### DIFF
--- a/.changeset/code-schema-and-multiline.md
+++ b/.changeset/code-schema-and-multiline.md
@@ -1,0 +1,46 @@
+---
+"@valbuild/core": minor
+"@valbuild/react": minor
+"@valbuild/shared": minor
+"@valbuild/ui": minor
+---
+
+`s.code()` is a schema type, and a multi-line string is `s.string().multiline()`
+
+The two string-only `render` variants are gone. Neither was about layout:
+whether a string may hold line breaks is a fact about the content, and a
+language is part of what the value is.
+
+```ts
+s.string().multiline(); // was .render({ as: "textarea" })
+s.code({ language: "typescript" }); // was .render({ as: "code", language })
+```
+
+**Breaking:** `s.string().render({ as: "textarea" })` and
+`s.string().render({ as: "code", language })` no longer type-check. `.render(...)`
+now takes only `{ as: "inline" }`, on every field alike, and `StringRender` is no
+longer exported from `@valbuild/core` (`FieldRender` is the one render type).
+
+**`s.string().multiline()`** is a growing text box instead of a single-line
+input. It is a property of the serialized schema (`multiline: true`) rather than
+a render, read the same synchronous way where the field is drawn, and it
+survives chaining (`nullable`, `readonly`, `hidden`, `describe`, `validate`,
+`raw`, `minLength`, …) and a serialize → deserialize round trip.
+
+**`s.code(options?)`** is a new schema type, backed by a plain string and edited
+in a code editor:
+
+```ts
+s.code(); // a monospaced editor, no highlighting
+s.code({ language: "json" }); // syntax highlighted
+```
+
+`language` is optional and is the same `CodeLanguage` list as before, now
+exported from `@valbuild/core` alongside `CodeSchema`, `SerializedCodeSchema` and
+`CodeOptions`. The language decides highlighting only — content is never checked
+against it, since a half-written snippet is a normal thing to save.
+
+Being its own type is what lets a code value opt out of **stega encoding**: the
+invisible characters that carry the edit tag are an edit tag in prose and
+corruption in source code, so `s.code()` values now reach your app exactly as
+written. A `s.string().render({ as: "code" })` value did not.

--- a/architecture/quirks.md
+++ b/architecture/quirks.md
@@ -90,8 +90,9 @@ what is already there. If you nest one, make it idempotent.
 stay masked.** `StringField`'s textarea worked for years while being
 uncontrolled, because the thing that decided it should BE a textarea arrived from
 the host a tick after the effect that fills `currentValue` — so by the time it
-mounted, the value was there. Making the layout synchronous (it is static schema
-config now, not something the host computes) removed that ordering, and the
+mounted, the value was there. Making the layout synchronous (it is `.multiline()`
+on the serialized schema now, not something the host computes) removed that
+ordering, and the
 textarea started mounting at `null`. `.value` still looked right, because a
 textarea's value follows `defaultValue` while it is untouched — but
 `AutoGrowingTextarea` seeds its invisible sizing ghost from props exactly once,

--- a/architecture/render-and-preview.md
+++ b/architecture/render-and-preview.md
@@ -7,10 +7,10 @@ prevent — it has already been undone once, when the two shared a pipeline.
 ## The rule
 
 - **`render` is how the FIELD ITSELF is laid out, and applies only when you
-  are looking at the field.** `s.string().render({ as: "textarea" })` is a
-  textarea instead of an input; `.render({ as: "code", language })` a code
-  editor; `.render({ as: "inline" })` on an array/record item edits the item
-  inside the (sortable) list row instead of behind a clickable row.
+  are looking at the field.** `.render({ as: "inline" })` on an array/record
+  item edits the item inside the (sortable) list row instead of behind a
+  clickable row. That is the whole of what a render says — see "What a render
+  is not" below.
 - **`preview` is how the VALUE is shown wherever a preview of it is needed** —
   a list row you click through to, a reference (`keyOf`) dropdown, a search
   hit, the references view. A preview is needed exactly where the value is
@@ -22,6 +22,32 @@ the field is drawn, `preview` where the value is previewed. Declaring another
 `.render(...)` on the same schema REPLACES the earlier one (last wins), and a
 second `.preview(...)` replaces the earlier preview the same way — they do not
 merge.
+
+## What a render is not
+
+A render used to be the answer to "how is a string edited" as well: there were
+`{ as: "textarea" }` and `{ as: "code", language }` variants on `s.string()`
+alongside `inline`. Both are gone.
+
+```ts
+s.string().multiline(); // was .render({ as: "textarea" })
+s.code({ language: "typescript" }); // was .render({ as: "code", language })
+```
+
+The reason is that neither was about layout. Whether a string may hold line
+breaks is a fact about the content, and it belongs to the schema: it is
+`.multiline()`, a property the serialized schema carries next to `render`
+(`SerializedStringSchema.multiline`) and read the same synchronous way where the
+field is drawn. Code is a step further — it is its own schema type, `s.code()`,
+because a language is not a way of drawing a string but part of what the value
+is, and being a type is what lets it opt out of stega encoding: invisible
+characters woven into source code are corruption, not an edit tag
+(`stegaEncode`'s `isCodeSchema`).
+
+What is left is one question — is this item edited in its list row — which is
+why `FieldRender` is a single variant and `isInlineRender` can answer it from
+the serialized schema alone. A render that could also mean "textarea" was a
+union whose only common trait was that it lived in the same field.
 
 ## Where they meet: a list row, and the render wins
 

--- a/docs/plans/jsonValues-walkthrough.md
+++ b/docs/plans/jsonValues-walkthrough.md
@@ -1,10 +1,11 @@
 # `.jsonValues()` manual walkthrough (V1–V20)
 
 > **2026-08-28:** `.render({ as: "list", select })` on a `record` or an `array` is
-> now `.preview(select)`. `render` still exists, but only as the static field
-> layout on `string` (`{ as: "textarea" | "code" }`). This document predates that
-> split and is left as the record of what was decided at the time; read every
-> `.render()` here as a preview.
+> now `.preview(select)`. `render` still exists, but only as `{ as: "inline" }`
+> on an array/record item — a multi-line string is `s.string().multiline()` and
+> code is `s.code({ language })`. This document predates that split and is left
+> as the record of what was decided at the time; read every `.render()` here as
+> a preview.
 
 The verification checklist for `s.record(...).jsonValues()` / `s.router(...).jsonValues()`. The
 implementation tracker is [jsonValues.md](./jsonValues.md); this file is the part a person has to run.

--- a/docs/plans/jsonValues.md
+++ b/docs/plans/jsonValues.md
@@ -1,10 +1,11 @@
 # Implementation tracker: `.jsonValues()` — lazily-loaded JSON entries
 
 > **2026-08-28:** `.render({ as: "list", select })` on a `record` or an `array` is
-> now `.preview(select)`. `render` still exists, but only as the static field
-> layout on `string` (`{ as: "textarea" | "code" }`). This document predates that
-> split and is left as the record of what was decided at the time; read every
-> `.render()` here as a preview.
+> now `.preview(select)`. `render` still exists, but only as `{ as: "inline" }`
+> on an array/record item — a multi-line string is `s.string().multiline()` and
+> code is `s.code({ language })`. This document predates that split and is left
+> as the record of what was decided at the time; read every `.render()` here as
+> a preview.
 
 > Living implementation plan for `s.record(...).jsonValues()` / `s.router(...).jsonValues()`.
 > The **design rationale + locked decisions** live in the approved design doc

--- a/docs/plans/syncStores.md
+++ b/docs/plans/syncStores.md
@@ -1,10 +1,11 @@
 # Implementation tracker: replace `ValSyncEngine` with event-driven stores
 
 > **2026-08-28:** `.render({ as: "list", select })` on a `record` or an `array` is
-> now `.preview(select)`. `render` still exists, but only as the static field
-> layout on `string` (`{ as: "textarea" | "code" }`). This document predates that
-> split and is left as the record of what was decided at the time; read every
-> `.render()` here as a preview.
+> now `.preview(select)`. `render` still exists, but only as `{ as: "inline" }`
+> on an array/record item — a multi-line string is `s.string().multiline()` and
+> code is `s.code({ language })`. This document predates that split and is left
+> as the record of what was decided at the time; read every `.render()` here as
+> a preview.
 
 > Living implementation plan for retiring `packages/ui/spa/ValSyncEngine.ts` in
 > favour of small communicating stores. Keep the "Current state" block at the top up

--- a/examples/next/app/generic/[[...path]]/page.val.ts
+++ b/examples/next/app/generic/[[...path]]/page.val.ts
@@ -15,7 +15,7 @@ const genericPageSchema = s.object({
       s
         .object({
           type: s.literal("code"),
-          code: s.string().render({ as: "code", language: "typescript" }),
+          code: s.code({ language: "typescript" }),
         })
         .render({ as: "inline" })
         // Both, on purpose: the render decides that the block is EDITED in the

--- a/examples/next/content/handbook.val.ts
+++ b/examples/next/content/handbook.val.ts
@@ -42,7 +42,7 @@ export const handbookChapterSchema = s
   .object({
     title: s.string().minLength(2),
     slug: s.string().regexp(/^[a-z0-9-]+$/),
-    summary: s.string().render({ as: "textarea" }),
+    summary: s.string().multiline(),
     owner: s.keyOf(authorsVal),
     sections: s.array(handbookSectionSchema),
   })

--- a/examples/next/content/kb.val.ts
+++ b/examples/next/content/kb.val.ts
@@ -28,7 +28,7 @@ export const kbArticleSchema = s.object({
         ? "the word 'forbidden' is not allowed in a title"
         : false,
     ),
-  body: s.string().render({ as: "textarea" }),
+  body: s.string().multiline(),
   order: s.number(),
   author: s.keyOf(authorsVal),
   related: s.route(),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -147,6 +147,13 @@ export {
   ColorSchema,
 } from "./schema/color";
 export {
+  type SerializedCodeSchema,
+  type CodeOptions,
+  type CodeLanguage,
+  CodeSchema,
+  CODE_LANGUAGES,
+} from "./schema/code";
+export {
   type ColorFormat,
   type ParsedColor,
   COLOR_FORMATS,
@@ -179,14 +186,7 @@ export {
   type PreviewScope,
   previewScope,
 } from "./preview";
-export {
-  type CodeLanguage,
-  type StringRender,
-  type InlineRender,
-  type FieldRender,
-  CODE_LANGUAGES,
-  isInlineRender,
-} from "./render";
+export { type InlineRender, type FieldRender, isInlineRender } from "./render";
 export type { ValRouter, RouteValidationError } from "./router";
 export { getSourcePathFromRoute } from "./getSourcePathFromRoute";
 import { nextAppRouter, externalPageRouter } from "./router";

--- a/packages/core/src/initSchema.ts
+++ b/packages/core/src/initSchema.ts
@@ -14,6 +14,7 @@ import { file } from "./schema/file";
 import { files } from "./schema/files";
 import { date } from "./schema/date";
 import { datetime } from "./schema/datetime";
+import { code } from "./schema/code";
 import { color } from "./schema/color";
 import { route } from "./schema/route";
 import { router } from "./schema/router";
@@ -211,6 +212,23 @@ export type InitSchema = {
    */
   readonly color: typeof color;
   /**
+   * Define a string edited in a code editor.
+   *
+   * Pass a `language` to syntax highlight it; leave it out for a plain
+   * monospaced editor. The value is a plain string, and — unlike `s.string()` —
+   * it is never stega encoded, so the code reaches your app as it was written.
+   *
+   * @example
+   * const schema = s.code({ language: "typescript" });
+   * export default c.define("/example.val.ts", schema, "const a = 1;");
+   *
+   * @example
+   * const schema = s.code();
+   * export default c.define("/example.val.ts", schema, "no highlighting here");
+   *
+   */
+  readonly code: typeof code;
+  /**
    * Define a string that references a route path in your application.
    *
    * To create router pages you can use the s.router() function.
@@ -309,6 +327,7 @@ export function initSchema() {
     date,
     datetime,
     color,
+    code,
     route,
     router,
     images,

--- a/packages/core/src/render.ts
+++ b/packages/core/src/render.ts
@@ -2,9 +2,13 @@ import type { SerializedSchema } from "./schema";
 
 /**
  * A RENDER is how the FIELD ITSELF is laid out in the editor, and it applies
- * only when you are looking at the field: `s.string().render({ as: "textarea"
- * })`, `.render({ as: "code", language })`, `.render({ as: "inline" })` on an
+ * only when you are looking at the field: `.render({ as: "inline" })` on an
  * array/record item.
+ *
+ * It is deliberately the ONE thing a render can say. What a string looks like
+ * when it holds more than a line is the schema's own business — `.multiline()`
+ * for a text box, `s.code({ language })` for a code editor — not a layout
+ * bolted onto `s.string()` from outside.
  *
  * A PREVIEW (`preview.ts`) is the other thing: how the VALUE is shown wherever
  * a preview of it is needed — a list row, a reference dropdown, a search hit —
@@ -27,35 +31,6 @@ import type { SerializedSchema } from "./schema";
  * conflating them is what this file was split up to undo.
  */
 /**
- * The list is the declaration and {@link CodeLanguage} is derived from it, so
- * that a validator elsewhere (`shared`'s zod schema) can enumerate the same
- * languages without a second copy that drifts. Same shape as `COLOR_FORMATS`.
- */
-export const CODE_LANGUAGES = [
-  "typescript",
-  "javascript",
-  "javascriptreact",
-  "typescriptreact",
-  "json",
-  "java",
-  "html",
-  "css",
-  "xml",
-  "markdown",
-  "sql",
-  "python",
-  "rust",
-  "php",
-  "go",
-  "cpp",
-  "sass",
-  "vue",
-  "angular",
-] as const;
-
-export type CodeLanguage = (typeof CODE_LANGUAGES)[number];
-
-/**
  * `{ as: "inline" }` on a field that is the ITEM of an array or record: the
  * container renders the field itself inside each (sortable) row, instead of a
  * clickable preview row that navigates to it. This is what a page-builder list
@@ -71,20 +46,10 @@ export type CodeLanguage = (typeof CODE_LANGUAGES)[number];
 export type InlineRender = { as: "inline" };
 
 /**
- * What `.render(...)` takes on every field except `s.string()`, and what the
- * serialized schema carries verbatim.
+ * What `.render(...)` takes on every field, and what the serialized schema
+ * carries verbatim.
  */
 export type FieldRender = InlineRender;
-
-/**
- * What `s.string().render(...)` takes, and what the serialized schema carries
- * verbatim. A string has editor layouts of its own (textarea, code) in
- * addition to the container-facing `inline`.
- */
-export type StringRender =
-  | { as: "textarea" }
-  | { as: "code"; language: CodeLanguage }
-  | InlineRender;
 
 /**
  * Is this item schema edited INSIDE its list row, rather than behind a

--- a/packages/core/src/schema/code.test.ts
+++ b/packages/core/src/schema/code.test.ts
@@ -1,0 +1,144 @@
+import { SourcePath } from "../val";
+import { code, CodeSchema } from "./code";
+import { deserializeSchema } from "./deserialize";
+import { RawString } from "./string";
+
+// Stored code values are raw strings; brand them for executeValidate, which is
+// typed against the schema's branded source type.
+const raw = (value: string): RawString => value as RawString;
+
+describe("CodeSchema", () => {
+  test("assert: succeeds on any string", () => {
+    expect(
+      code({ language: "typescript" })["executeAssert"](
+        "path" as SourcePath,
+        "const a = 1;",
+      ),
+    ).toEqual({ success: true, data: "const a = 1;" });
+  });
+
+  test("assert: type error on null when not optional", () => {
+    expect(code()["executeAssert"]("path" as SourcePath, null)).toEqual({
+      success: false,
+      errors: {
+        path: [{ message: "Expected 'string', got 'null'", typeError: true }],
+      },
+    });
+  });
+
+  test("assert: succeeds on null when nullable", () => {
+    expect(
+      code()
+        .nullable()
+        ["executeAssert"]("path" as SourcePath, null),
+    ).toEqual({ success: true, data: null });
+  });
+
+  test("assert: type error on a non-string", () => {
+    expect(code()["executeAssert"]("path" as SourcePath, 1)).toEqual({
+      success: false,
+      errors: {
+        path: [{ message: "Expected 'string', got 'number'", typeError: true }],
+      },
+    });
+  });
+
+  /**
+   * Code is not validated against its language: a half-written snippet is a
+   * normal state to save an editor in, and the schema is not a compiler.
+   */
+  test("validate: any string passes, whatever the language says", () => {
+    const schema = code({ language: "json" });
+    expect(
+      schema["executeValidate"]("path" as SourcePath, raw("{ not json")),
+    ).toBe(false);
+  });
+
+  test("validate: null is an error unless nullable", () => {
+    expect(
+      code()
+        .nullable()
+        ["executeValidate"]("path" as SourcePath, null),
+    ).toBe(false);
+    // Typed `string | null` so that `null` can be handed to a schema that did
+    // NOT opt in — which is the case under test.
+    const notNullable = new CodeSchema<string | null>();
+    expect(notNullable["executeValidate"]("path" as SourcePath, null)).toEqual({
+      path: [{ message: "Expected 'string', got 'null'", value: null }],
+    });
+  });
+
+  test("validate: custom validate functions run", () => {
+    const schema = code({ language: "json" }).validate((src) =>
+      src.includes("\t") ? "Use spaces, not tabs" : false,
+    );
+    expect(schema["executeValidate"]("path" as SourcePath, raw("{}"))).toBe(
+      false,
+    );
+    expect(
+      schema["executeValidate"]("path" as SourcePath, raw("{\n\t}")),
+    ).toEqual({
+      path: [{ message: "Use spaces, not tabs", value: "{\n\t}" }],
+    });
+  });
+
+  test("serialize: carries the language, and omits it when there is none", () => {
+    expect(
+      code({ language: "typescript" })["executeSerialize"](),
+    ).toMatchObject({
+      type: "code",
+      options: { language: "typescript" },
+    });
+    expect(code()["executeSerialize"]()).toMatchObject({
+      type: "code",
+      options: undefined,
+    });
+  });
+
+  test("the language survives every chained builder", () => {
+    const base = code({ language: "json" });
+    for (const schema of [
+      base,
+      base.validate(() => false),
+      base.nullable(),
+      base.readonly(),
+      base.hidden(),
+      base.describe("Some description"),
+      base.render({ as: "inline" }),
+      base.preview(({ val }) => ({ title: val })),
+    ]) {
+      expect(schema["executeSerialize"]()).toMatchObject({
+        options: { language: "json" },
+      });
+    }
+  });
+
+  test("round-trips through deserializeSchema", () => {
+    for (const base of [
+      code(),
+      code({ language: "typescript" }),
+      code({ language: "json" }).render({ as: "inline" }),
+      code().nullable().readonly().hidden().describe("desc"),
+    ]) {
+      const serialized = base["executeSerialize"]();
+      expect(deserializeSchema(serialized)["executeSerialize"]()).toStrictEqual(
+        serialized,
+      );
+    }
+  });
+
+  /** Code has no items, so it has nothing to preview of its own. */
+  test("preview: never previews", () => {
+    expect(code()["executePreview"]()).toEqual({});
+  });
+
+  test("preview: an item preview is declared and runs", () => {
+    const schema = code({ language: "json" }).preview(({ val }) => ({
+      title: val.slice(0, 4),
+    }));
+    expect(schema["executeSerialize"]()).toMatchObject({ preview: true });
+    expect(schema["executePreviewItem"](raw("{ hello: 1 }"))).toEqual({
+      title: "{ he",
+    });
+  });
+});

--- a/packages/core/src/schema/code.ts
+++ b/packages/core/src/schema/code.ts
@@ -1,0 +1,295 @@
+import {
+  CustomValidateFunction,
+  Schema,
+  SchemaAssertResult,
+  SerializedSchema,
+} from ".";
+import { ItemPreviewInput, PreviewItem, ReifiedPreview } from "../preview";
+import { FieldRender } from "../render";
+import { SourcePath } from "../val";
+import { RawString } from "./string";
+import {
+  ValidationError,
+  ValidationErrors,
+} from "./validation/ValidationError";
+
+/**
+ * The list is the declaration and {@link CodeLanguage} is derived from it, so
+ * that a validator elsewhere (`shared`'s zod schema) can enumerate the same
+ * languages without a second copy that drifts. Same shape as `COLOR_FORMATS`.
+ */
+export const CODE_LANGUAGES = [
+  "typescript",
+  "javascript",
+  "javascriptreact",
+  "typescriptreact",
+  "json",
+  "java",
+  "html",
+  "css",
+  "xml",
+  "markdown",
+  "sql",
+  "python",
+  "rust",
+  "php",
+  "go",
+  "cpp",
+  "sass",
+  "vue",
+  "angular",
+] as const;
+
+export type CodeLanguage = (typeof CODE_LANGUAGES)[number];
+
+export type CodeOptions = {
+  /**
+   * The language to syntax highlight the editor with.
+   *
+   * Omit it for a plain monospaced editor with no highlighting.
+   *
+   * @example
+   * "typescript"
+   * "json"
+   * "markdown"
+   */
+  language?: CodeLanguage;
+};
+
+export type SerializedCodeSchema = {
+  type: "code";
+  /** Static layout config, carried whole in the serialized schema — see `render.ts`. */
+  render?: FieldRender;
+  /** Set when this schema declares a `preview`. The closure itself cannot serialize. */
+  preview?: true;
+  options?: CodeOptions;
+  opt: boolean;
+  customValidate?: boolean;
+  readonly?: boolean;
+  hidden?: boolean;
+  description?: string;
+};
+
+/**
+ * A string edited in a code editor.
+ *
+ * Its own schema type rather than a layout on `s.string()`: the language is
+ * part of what the content IS, not of how one field happens to be drawn, and
+ * being a type is what lets the value stay out of stega encoding — invisible
+ * characters woven into source code are not something a consumer can render.
+ */
+export class CodeSchema<Src extends string | null> extends Schema<Src> {
+  constructor(
+    private readonly options?: CodeOptions,
+    private readonly opt: boolean = false,
+    private readonly customValidateFunctions: CustomValidateFunction<Src>[] = [],
+    private readonly isReadonly: boolean = false,
+    private readonly isHidden: boolean = false,
+    private readonly description?: string,
+    private readonly renderInput: FieldRender | null = null,
+    private readonly previewInput: ItemPreviewInput<Src> | null = null,
+  ) {
+    super();
+  }
+
+  describe(description: string | null): CodeSchema<Src> {
+    return new CodeSchema(
+      this.options,
+      this.opt,
+      this.customValidateFunctions,
+      this.isReadonly,
+      this.isHidden,
+      description ?? undefined,
+      this.renderInput,
+      this.previewInput,
+    );
+  }
+
+  validate(validationFunction: (src: Src) => false | string): CodeSchema<Src> {
+    return new CodeSchema(
+      this.options,
+      this.opt,
+      [...this.customValidateFunctions, validationFunction],
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      this.renderInput,
+      this.previewInput,
+    );
+  }
+
+  protected override executeCustomValidateAt(
+    path: SourcePath,
+    src: Src,
+  ): ValidationError[] {
+    return this.executeCustomValidateFunctions(
+      src,
+      this.customValidateFunctions,
+      { path },
+    );
+  }
+
+  protected executeValidate(path: SourcePath, src: Src): ValidationErrors {
+    const errors: ValidationError[] = this.executeCustomValidateFunctions(
+      src,
+      this.customValidateFunctions,
+      { path },
+    );
+    if (this.opt && (src === null || src === undefined)) {
+      return errors.length > 0 ? { [path]: errors } : false;
+    }
+    if (typeof src !== "string") {
+      errors.push({
+        message: `Expected 'string', got '${src === null ? "null" : typeof src}'`,
+        value: src,
+      });
+    }
+    if (errors.length > 0) {
+      return { [path]: errors } as ValidationErrors;
+    }
+    return false;
+  }
+
+  protected executeAssert(
+    path: SourcePath,
+    src: unknown,
+  ): SchemaAssertResult<Src> {
+    if (this.opt && src === null) {
+      return {
+        success: true,
+        data: src,
+      } as SchemaAssertResult<Src>;
+    }
+    if (typeof src !== "string") {
+      return {
+        success: false,
+        errors: {
+          [path]: [
+            {
+              message: `Expected 'string', got '${src === null ? "null" : typeof src}'`,
+              typeError: true,
+            },
+          ],
+        },
+      };
+    }
+    return {
+      success: true,
+      data: src,
+    } as SchemaAssertResult<Src>;
+  }
+
+  nullable(): CodeSchema<Src | null> {
+    return new CodeSchema<Src | null>(
+      this.options,
+      true,
+      [],
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      this.renderInput,
+      this.previewInput,
+    );
+  }
+
+  readonly(): CodeSchema<Src> {
+    return new CodeSchema<Src>(
+      this.options,
+      this.opt,
+      this.customValidateFunctions,
+      true,
+      this.isHidden,
+      this.description,
+      this.renderInput,
+      this.previewInput,
+    );
+  }
+
+  hidden(): CodeSchema<Src> {
+    return new CodeSchema<Src>(
+      this.options,
+      this.opt,
+      this.customValidateFunctions,
+      this.isReadonly,
+      true,
+      this.description,
+      this.renderInput,
+      this.previewInput,
+    );
+  }
+
+  /**
+   * How this field is laid out in the editor when it is the item of an array
+   * or record: `{ as: "inline" }` renders the field itself inside each row,
+   * instead of a preview row that navigates to it.
+   *
+   * Static configuration, not a callback — see `render.ts`.
+   */
+  render(input: FieldRender): CodeSchema<Src> {
+    return new CodeSchema<Src>(
+      this.options,
+      this.opt,
+      this.customValidateFunctions,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      input,
+      this.previewInput,
+    );
+  }
+
+  /**
+   * How this VALUE is shown where a preview of it is needed — a row in a
+   * sortable list, a reference dropdown, a search hit. Never how the field
+   * itself is edited (that is `render`). See `preview.ts`.
+   */
+  preview(select: ItemPreviewInput<Src>): CodeSchema<Src> {
+    return new CodeSchema<Src>(
+      this.options,
+      this.opt,
+      this.customValidateFunctions,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      this.renderInput,
+      select,
+    );
+  }
+
+  protected override executePreviewItem(
+    src: NonNullable<Src>,
+  ): PreviewItem | null {
+    if (this.previewInput === null) {
+      return null;
+    }
+    return this.previewInput({ val: src });
+  }
+
+  protected override declaresItemPreview(): boolean {
+    return this.previewInput !== null;
+  }
+
+  protected executeSerialize(): SerializedSchema {
+    return {
+      type: "code",
+      render: this.renderInput ?? undefined,
+      preview: this.previewInput ? true : undefined,
+      options: this.options,
+      opt: this.opt,
+      customValidate:
+        this.customValidateFunctions &&
+        this.customValidateFunctions?.length > 0,
+      readonly: this.isReadonly,
+      hidden: this.isHidden,
+      description: this.description,
+    };
+  }
+
+  protected executePreview(): ReifiedPreview {
+    return {};
+  }
+}
+
+export const code = (options?: CodeOptions): CodeSchema<RawString> => {
+  return new CodeSchema(options);
+};

--- a/packages/core/src/schema/code.ts
+++ b/packages/core/src/schema/code.ts
@@ -145,7 +145,7 @@ export class CodeSchema<Src extends string | null> extends Schema<Src> {
       });
     }
     if (errors.length > 0) {
-      return { [path]: errors } as ValidationErrors;
+      return { [path]: errors };
     }
     return false;
   }

--- a/packages/core/src/schema/deserialize.ts
+++ b/packages/core/src/schema/deserialize.ts
@@ -4,6 +4,7 @@ import { ImageSource } from "../source/media";
 import { SourcePath } from "../val";
 import { ArraySchema } from "./array";
 import { BooleanSchema } from "./boolean";
+import { CodeSchema } from "./code";
 import { ColorSchema } from "./color";
 import { DateSchema } from "./date";
 import { DateTimeSchema } from "./datetime";
@@ -58,6 +59,8 @@ function deserializeSchemaImpl(
         false,
         false,
         serialized.description,
+        null,
+        serialized.multiline ?? false,
       );
     case "literal":
       return new LiteralSchema(
@@ -278,6 +281,16 @@ function deserializeSchemaImpl(
       );
     case "color":
       return new ColorSchema(
+        serialized.options,
+        serialized.opt,
+        [],
+        false,
+        false,
+        serialized.description,
+        serialized.render ?? null,
+      );
+    case "code":
+      return new CodeSchema(
         serialized.options,
         serialized.opt,
         [],

--- a/packages/core/src/schema/hasRemoteFileSchema.ts
+++ b/packages/core/src/schema/hasRemoteFileSchema.ts
@@ -98,6 +98,7 @@ export function hasRemoteFileSchema(schema: SerializedSchema): boolean {
     schema.type === "date" ||
     schema.type === "dateTime" ||
     schema.type === "color" ||
+    schema.type === "code" ||
     schema.type === "keyOf" ||
     schema.type === "route"
   ) {

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -13,6 +13,7 @@ import { SerializedRecordSchema } from "./record";
 import { SerializedRichTextSchema } from "./richtext";
 import { RawString, SerializedStringSchema } from "./string";
 import { SerializedUnionSchema } from "./union";
+import { SerializedCodeSchema } from "./code";
 import { SerializedColorSchema } from "./color";
 import { SerializedDateSchema } from "./date";
 import { SerializedDateTimeSchema } from "./datetime";
@@ -44,6 +45,7 @@ export type SerializedSchema =
   | SerializedDateSchema
   | SerializedDateTimeSchema
   | SerializedColorSchema
+  | SerializedCodeSchema
   | SerializedRouteSchema
   | SerializedImageSchema;
 

--- a/packages/core/src/schema/render.test.ts
+++ b/packages/core/src/schema/render.test.ts
@@ -36,6 +36,7 @@ describe("Schema.render({ as: 'inline' })", () => {
       s.date().render({ as: "inline" }),
       s.datetime().render({ as: "inline" }),
       s.color().render({ as: "inline" }),
+      s.code().render({ as: "inline" }),
       s.route().render({ as: "inline" }),
       s.richtext().render({ as: "inline" }),
       s.image().render({ as: "inline" }),
@@ -81,20 +82,32 @@ describe("Schema.render({ as: 'inline' })", () => {
   });
 
   test("a second render replaces the first (last wins)", () => {
-    expect(
-      s
-        .string()
-        .render({ as: "textarea" })
-        .render({ as: "inline" })
-        ["executeSerialize"]().render,
-    ).toEqual({ as: "inline" });
-    expect(
-      s
-        .string()
-        .render({ as: "inline" })
-        .render({ as: "textarea" })
-        ["executeSerialize"]().render,
-    ).toEqual({ as: "textarea" });
+    const twice = s
+      .object({ a: s.string() })
+      .render({ as: "inline" })
+      .render({ as: "inline" })
+      ["executeSerialize"]();
+    expect(twice.render).toEqual({ as: "inline" });
+  });
+
+  test("multiline and an inline render are independent, in either order", () => {
+    const before = s
+      .string()
+      .multiline()
+      .render({ as: "inline" })
+      ["executeSerialize"]();
+    const after = s
+      .string()
+      .render({ as: "inline" })
+      .multiline()
+      ["executeSerialize"]();
+    for (const serialized of [before, after]) {
+      if (serialized.type !== "string") {
+        throw new Error("expected string schema");
+      }
+      expect(serialized.render).toEqual({ as: "inline" });
+      expect(serialized.multiline).toBe(true);
+    }
   });
 
   test("render does not mutate the schema it was called on", () => {
@@ -134,17 +147,26 @@ describe("Schema.render({ as: 'inline' })", () => {
     expect(sections.item.render).toEqual({ as: "inline" });
   });
 
-  test("string keeps its own render layouts alongside inline", () => {
-    expect(
-      s.string().render({ as: "textarea" })["executeSerialize"]().render,
-    ).toEqual({ as: "textarea" });
+  /**
+   * `inline` is the whole of what a render says now. A string that needs more
+   * than a line says so with `.multiline()`, and code is `s.code()` — neither
+   * is a render, so neither can be confused for one here.
+   */
+  test("inline is a string's only render; multiline is not one", () => {
+    const multiline = s.string().multiline()["executeSerialize"]();
+    if (multiline.type !== "string") {
+      throw new Error("expected string schema");
+    }
+    expect(multiline.render).toBe(undefined);
+    expect(multiline.multiline).toBe(true);
     expect(
       s.string().render({ as: "inline" })["executeSerialize"]().render,
     ).toEqual({ as: "inline" });
     const roundTripped = deserializeSchema(
-      s.string().render({ as: "inline" })["executeSerialize"](),
+      s.string().multiline().render({ as: "inline" })["executeSerialize"](),
     )["executeSerialize"]();
     expect(roundTripped.render).toEqual({ as: "inline" });
+    expect(roundTripped.type === "string" && roundTripped.multiline).toBe(true);
   });
 
   test("an inline item does not change the container's preview", () => {
@@ -186,14 +208,22 @@ describe("isInlineRender", () => {
       isInlineRender(s.string().render({ as: "inline" })["executeSerialize"]()),
     ).toBe(true);
     expect(isInlineRender(s.string()["executeSerialize"]())).toBe(false);
+    // `multiline` is a property of the schema, not a render — so it must not be
+    // mistaken for one by the question that decides how a list row is drawn.
+    expect(isInlineRender(s.string().multiline()["executeSerialize"]())).toBe(
+      false,
+    );
+    expect(
+      isInlineRender(s.code({ language: "typescript" })["executeSerialize"]()),
+    ).toBe(false);
     expect(
       isInlineRender(
         s
-          .string()
-          .render({ as: "code", language: "typescript" })
+          .code({ language: "typescript" })
+          .render({ as: "inline" })
           ["executeSerialize"](),
       ),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   test("a tagged union is inline when its VARIANTS declare it", () => {

--- a/packages/core/src/schema/string.test.ts
+++ b/packages/core/src/schema/string.test.ts
@@ -9,18 +9,10 @@ describe("StringSchema", () => {
    */
   test("render: serializes whole, not as a marker", () => {
     expect(
-      string().render({ as: "textarea" })["executeSerialize"](),
+      string().render({ as: "inline" })["executeSerialize"](),
     ).toMatchObject({
       type: "string",
-      render: { as: "textarea" },
-    });
-    expect(
-      string()
-        .render({ as: "code", language: "typescript" })
-        ["executeSerialize"](),
-    ).toMatchObject({
-      type: "string",
-      render: { as: "code", language: "typescript" },
+      render: { as: "inline" },
     });
   });
 
@@ -32,10 +24,10 @@ describe("StringSchema", () => {
    * The guard `array` and `record` have had since a render could be dropped by
    * chaining, which `string` never had despite threading `renderInput` through
    * ten builders. It matters more now: a dropped render is no longer a missing
-   * textarea in the Studio, it is a serialized schema that is wrong.
+   * inline row in the Studio, it is a serialized schema that is wrong.
    */
   test("render: survives every chained builder", () => {
-    const base = string().render({ as: "code", language: "json" });
+    const base = string().render({ as: "inline" });
     for (const schema of [
       base,
       base.minLength(1),
@@ -47,17 +39,58 @@ describe("StringSchema", () => {
       base.hidden(),
       base.raw(),
       base.describe("Some description"),
+      base.multiline(),
     ]) {
       expect(schema["executeSerialize"]()).toMatchObject({
-        render: { as: "code", language: "json" },
+        render: { as: "inline" },
       });
     }
   });
 
   test("render: does not mutate the schema it was called on", () => {
     const base = string();
-    base.render({ as: "textarea" });
+    base.render({ as: "inline" });
     expect(base["executeSerialize"]()).toMatchObject({ render: undefined });
+  });
+
+  /**
+   * `multiline` is a property of the schema, not a render variant, but it is
+   * read the same way — straight off the serialized schema — so it has to
+   * survive the same journeys.
+   */
+  test("multiline: serializes, and is absent when not declared", () => {
+    expect(string().multiline()["executeSerialize"]()).toMatchObject({
+      type: "string",
+      multiline: true,
+    });
+    expect(string()["executeSerialize"]()).toMatchObject({
+      multiline: undefined,
+    });
+  });
+
+  test("multiline: survives every chained builder", () => {
+    const base = string().multiline();
+    for (const schema of [
+      base,
+      base.minLength(1),
+      base.maxLength(10),
+      base.regexp(/x/),
+      base.validate(() => false),
+      base.nullable(),
+      base.readonly(),
+      base.hidden(),
+      base.raw(),
+      base.describe("Some description"),
+      base.render({ as: "inline" }),
+    ]) {
+      expect(schema["executeSerialize"]()).toMatchObject({ multiline: true });
+    }
+  });
+
+  test("multiline: does not mutate the schema it was called on", () => {
+    const base = string();
+    base.multiline();
+    expect(base["executeSerialize"]()).toMatchObject({ multiline: undefined });
   });
 
   /**
@@ -65,10 +98,11 @@ describe("StringSchema", () => {
    * deserialized schema has no instance behind it, so anything it drops here is
    * gone for good.
    */
-  test("render: round-trips through deserializeSchema", () => {
+  test("render and multiline: round-trip through deserializeSchema", () => {
     for (const base of [
-      string().render({ as: "textarea" }),
-      string().render({ as: "code", language: "typescript" }),
+      string().render({ as: "inline" }),
+      string().multiline(),
+      string().multiline().render({ as: "inline" }),
       string(),
     ]) {
       const serialized = base["executeSerialize"]();
@@ -80,6 +114,6 @@ describe("StringSchema", () => {
 
   /** A string has no items, so it has nothing to preview. */
   test("preview: a string never previews, render or not", () => {
-    expect(string().render({ as: "textarea" })["executePreview"]()).toEqual({});
+    expect(string().multiline()["executePreview"]()).toEqual({});
   });
 });

--- a/packages/core/src/schema/string.ts
+++ b/packages/core/src/schema/string.ts
@@ -1,6 +1,6 @@
 import { Schema, SchemaAssertResult, SerializedSchema } from ".";
 import { ItemPreviewInput, PreviewItem, ReifiedPreview } from "../preview";
-import { StringRender } from "../render";
+import { FieldRender } from "../render";
 import { SourcePath } from "../val";
 import {
   ValidationError,
@@ -25,7 +25,17 @@ export type SerializedStringSchema = {
    * off the schema it already has. See `render.ts` for what that assumption
    * buys, and what to do if a render ever needs to stop being static.
    */
-  render?: StringRender;
+  render?: FieldRender;
+  /**
+   * Set by `.multiline()`: the field is a growing text box rather than a
+   * single-line input.
+   *
+   * A property of the schema rather than a `render` variant, because it says
+   * what the string IS — text that may hold line breaks — and not merely how one
+   * field is drawn. It is read the same way a render is, straight off the
+   * serialized schema where the field is drawn.
+   */
+  multiline?: boolean;
   /** Set when this schema declares a `preview`. The closure itself cannot serialize. */
   preview?: true;
   options?: {
@@ -57,11 +67,12 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
     private readonly customValidateFunctions: ((
       src: Src,
     ) => false | string)[] = [],
-    private readonly renderInput: StringRender | null = null,
+    private readonly renderInput: FieldRender | null = null,
     private readonly isReadonly: boolean = false,
     private readonly isHidden: boolean = false,
     private readonly description?: string,
     private readonly previewInput: ItemPreviewInput<Src> | null = null,
+    private readonly isMultiline: boolean = false,
   ) {
     super();
   }
@@ -77,6 +88,7 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       description ?? undefined,
       this.previewInput,
+      this.isMultiline,
     );
   }
 
@@ -98,6 +110,7 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.previewInput,
+      this.isMultiline,
     );
   }
 
@@ -119,6 +132,7 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.previewInput,
+      this.isMultiline,
     );
   }
 
@@ -133,6 +147,7 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.previewInput,
+      this.isMultiline,
     );
   }
 
@@ -149,6 +164,7 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.previewInput,
+      this.isMultiline,
     );
   }
 
@@ -246,6 +262,7 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.previewInput,
+      this.isMultiline,
     ) as unknown as StringSchema<Src | null>;
   }
 
@@ -260,6 +277,7 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.previewInput,
+      this.isMultiline,
     );
   }
 
@@ -274,6 +292,7 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
       true,
       this.description,
       this.previewInput,
+      this.isMultiline,
     );
   }
 
@@ -288,6 +307,7 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.previewInput,
+      this.isMultiline,
     ) as unknown as StringSchema<
       Src extends null ? RawString | null : RawString
     >;
@@ -308,6 +328,7 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
     return {
       type: "string",
       render: this.renderInput ?? undefined,
+      multiline: this.isMultiline ? true : undefined,
       preview: this.previewInput ? true : undefined,
       options: {
         maxLength: this.options?.maxLength,
@@ -333,13 +354,41 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
   }
 
   /**
-   * How this field is laid out in the editor: a textarea, or a code editor for
-   * the given language.
+   * This string holds text that may run to several lines: the editor gives it a
+   * growing text box instead of a single-line input.
+   *
+   * Nothing else changes — the value is still a plain string, and no validation
+   * is added or removed. For code, use `s.code({ language })` instead, which is
+   * its own schema type.
+   *
+   * @example
+   * const schema = s.string().multiline();
+   * export default c.define("/example.val.ts", schema, "Line one\nLine two");
+   */
+  multiline(): StringSchema<Src> {
+    return new StringSchema<Src>(
+      this.options,
+      this.opt,
+      this.isRaw,
+      this.customValidateFunctions,
+      this.renderInput,
+      this.isReadonly,
+      this.isHidden,
+      this.description,
+      this.previewInput,
+      true,
+    );
+  }
+
+  /**
+   * How this field is laid out in the editor when it is the item of an array or
+   * record: `{ as: "inline" }` renders the field itself inside each row,
+   * instead of a preview row that navigates to it.
    *
    * Static configuration, not a callback — see `render.ts`. What a CONTAINER
    * shows for its items is a `preview`, which is a different thing entirely.
    */
-  render(input: StringRender): StringSchema<Src> {
+  render(input: FieldRender): StringSchema<Src> {
     return new StringSchema<Src>(
       this.options,
       this.opt,
@@ -350,6 +399,7 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       this.previewInput,
+      this.isMultiline,
     );
   }
 
@@ -369,6 +419,7 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
       this.isHidden,
       this.description,
       select,
+      this.isMultiline,
     );
   }
 

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -57,6 +57,7 @@
   - [keyOf](#keyof)
   - [Route](#route)
   - [Color](#color)
+  - [Code](#code)
   - [Date](#date)
   - [DateTime](#datetime)
 
@@ -353,6 +354,8 @@ To configure your project for monorepos, you can use the `root` parameter descri
 import { s } from "./val.config";
 
 s.string(); // <- Schema<string>
+
+s.string().multiline(); // edited in a growing text box, not a single-line input
 ```
 
 ## Number
@@ -562,6 +565,45 @@ for it to read into the value's content.
 > closure no longer receives `key` — derive the title from `val`. And
 > `.jsonValues()` must come before `.preview(...)`, like `.validate(...)`.
 
+### Multi-line strings and code
+
+A string that holds more than one line says so with `.multiline()`: the editor
+gives it a growing text box instead of a single-line input. Nothing else changes —
+the value is a plain string.
+
+```ts
+const articleSchema = s.object({
+  title: s.string(),
+  // A multi-line box instead of a single-line input
+  summary: s.string().multiline(),
+  // A syntax-highlighted code editor
+  snippet: s.code({ language: "typescript" }),
+});
+```
+
+`s.code()` is its own schema type, edited in a code editor. Its `language`
+option — `typescript`, `javascript`, `json`, `html`, `css`, `markdown`,
+`python`, `sql` and others; see `CodeLanguage` in `@valbuild/core` for the full
+list — decides the syntax highlighting. Leave it out for a plain monospaced
+editor with no highlighting.
+
+The value is a string like any other, with one difference: a code value is
+never stega encoded, so what reaches your app is exactly
+what was written. Invisible characters are an edit tag in prose and corruption
+in source code.
+
+> **Breaking.** `s.string().render({ as: "textarea" })` and
+> `s.string().render({ as: "code", language })` have been removed. Neither was
+> about layout: whether a string may hold line breaks is a fact about the
+> content, and a language is part of what the value is.
+>
+> ```ts
+> s.string().multiline(); // was .render({ as: "textarea" })
+> s.code({ language: "typescript" }); // was .render({ as: "code", language })
+> ```
+>
+> `.render(...)` now takes only `{ as: "inline" }`, on every field alike.
+
 ### Field rendering
 
 A **render** is how ONE field is laid out in the editor when you are LOOKING at
@@ -569,20 +611,6 @@ that field. It is static configuration rather than a function, and it is a
 different thing from a preview: a render is the field's own layout, a preview is
 how the value shows where it is navigable to. A schema can carry both, and a
 second `.render(...)` replaces the first rather than merging with it.
-
-```ts
-const articleSchema = s.object({
-  title: s.string(),
-  // A multi-line box instead of a single-line input
-  summary: s.string().render({ as: "textarea" }),
-  // A syntax-highlighted code editor
-  snippet: s.string().render({ as: "code", language: "typescript" }),
-});
-```
-
-`as: "code"` takes a `language` — `typescript`, `javascript`, `json`, `html`,
-`css`, `markdown`, `python`, `sql` and others; see `CodeLanguage` in
-`@valbuild/core` for the full list.
 
 #### Editing list items in place
 
@@ -1098,6 +1126,49 @@ To hand a color to a stylesheet instead, set it as a CSS custom property:
 ```
 
 **NOTE**: colors are not steganographically tagged, since the value ends up in CSS where the invisible characters would break the declaration. Colors therefore do not participate in click-then-edit visual editing (the same is true of dates) - edit them from the studio instead.
+
+## Code
+
+The `code` schema is a string edited in a code editor. It is a schema type of
+its own rather than a layout on `s.string()`, because the language is part of
+what the value is — and because a code value is never stega encoded, so what
+reaches your app is exactly what was written.
+
+### Code Schema
+
+```ts
+s.code(); // <- Schema<string>, a monospaced editor with no highlighting
+s.code({ language: "typescript" }); // syntax highlighted
+```
+
+### Languages
+
+`language` is one of `typescript`, `javascript`, `typescriptreact`,
+`javascriptreact`, `json`, `java`, `html`, `css`, `xml`, `markdown`, `sql`,
+`python`, `rust`, `php`, `go`, `cpp`, `sass`, `vue` or `angular` — the
+`CodeLanguage` type exported from `@valbuild/core`. Leave it out for a plain
+monospaced editor.
+
+The language decides the highlighting only: the content is never checked against
+it, since a half-written snippet is a normal thing to save an editor in. Use
+`.validate()` if you need more than that.
+
+### Initializing code content
+
+```ts
+import { s, c, type t } from "../val.config";
+
+export const schema = s.object({
+  snippet: s.code({ language: "typescript" }).describe("Example usage"),
+  styles: s.code({ language: "css" }).nullable(),
+});
+
+export type Example = t.inferSchema<typeof schema>;
+export default c.define("/content/example.val.ts", schema, {
+  snippet: "const val = initVal();",
+  styles: null,
+});
+```
 
 ## Date
 

--- a/packages/react/src/stega/stegaEncode.test.ts
+++ b/packages/react/src/stega/stegaEncode.test.ts
@@ -291,6 +291,98 @@ describe("stega transform", () => {
     expect(transformed.fill).toStrictEqual("hsl(0 100% 50%)");
   });
 
+  // Code has the same problem as a color, and worse: the invisible characters
+  // stega appends are a syntax error in most languages, and silent corruption
+  // inside a string literal. Byte-for-byte unchanged is the whole reason
+  // `s.code()` is a schema type rather than a layout on `s.string()`.
+  test("skip stegaEncode on code", () => {
+    for (const [schema, code] of [
+      [s.code(), "no language, still untouched"],
+      [s.code({ language: "typescript" }), "const a = 1;"],
+      [s.code({ language: "json" }), '{ "a": 1 }'],
+      [s.code({ language: "python" }), "def f():\n    return 1\n"],
+    ] as const) {
+      const transformed = stegaEncode(
+        c.define("/test1.val.ts", schema, code),
+        {},
+      );
+      expect(transformed).toStrictEqual(code);
+      expect(vercelStegaSplit(transformed).encoded).toStrictEqual("");
+    }
+  });
+
+  test("skip stegaEncode on code, but not on the strings next to it", () => {
+    const schema = s.object({
+      snippet: s.code({ language: "typescript" }),
+      styles: s.code({ language: "css" }).nullable(),
+      caption: s.string(),
+    });
+    const transformed = stegaEncode(
+      c.define("/test1.val.ts", schema, {
+        snippet: "const a = 1;",
+        styles: ".a { color: red }",
+        caption: "An example",
+      }),
+      {},
+    );
+    expect(transformed.snippet).toStrictEqual("const a = 1;");
+    expect(transformed.styles).toStrictEqual(".a { color: red }");
+    // the sibling string is still encoded: the code is skipped because of its
+    // schema, not because encoding is off for the whole module
+    expect(vercelStegaSplit(transformed.caption).cleaned).toStrictEqual(
+      "An example",
+    );
+    expect(vercelStegaDecode(transformed.caption)).toStrictEqual({
+      data: {
+        valPath: '/test1.val.ts?p="caption"',
+      },
+      origin: "val.build",
+    });
+  });
+
+  test("skip stegaEncode on code nested in records and arrays", () => {
+    const schema = s.record(s.array(s.object({ body: s.code() })));
+    const transformed = stegaEncode(
+      c.define("/test1.val.ts", schema, {
+        examples: [{ body: "const a = 1;" }, { body: "const b = 2;" }],
+      }),
+      {},
+    );
+    expect(transformed.examples[0].body).toStrictEqual("const a = 1;");
+    expect(transformed.examples[1].body).toStrictEqual("const b = 2;");
+  });
+
+  // The page-builder shape the example app uses: a code block as one variant of
+  // an inline union. Recursion into a union member is a separate path from the
+  // record/array one above, and the skip has to survive it too.
+  test("skip stegaEncode on code inside a tagged union", () => {
+    const schema = s.union(
+      "type",
+      s.object({
+        type: s.literal("code"),
+        code: s.code({ language: "typescript" }),
+      }),
+      s.object({ type: s.literal("text"), body: s.string() }),
+    );
+    const transformed = stegaEncode(
+      c.define("/test1.val.ts", schema, {
+        type: "code",
+        code: 'console.log("hi");',
+      }),
+      {},
+    );
+    expect(transformed.code).toStrictEqual('console.log("hi");');
+  });
+
+  test("stega type of code is a plain string, not a ValEncodedString", () => {
+    // An arbitrary string is assignable to the stega type of code. It would not
+    // be if the type claimed the value was encoded, since ValEncodedString is
+    // branded - so this line pins the type to match the runtime skip above.
+    const code: StegaOfSource<SchemaOf<ReturnType<typeof s.code>>> =
+      "const a = 1;" as string;
+    expect(code).toStrictEqual("const a = 1;");
+  });
+
   test("stega type of a color is a plain string, not a ValEncodedString", () => {
     // An arbitrary string is assignable to the stega type of a color. It would
     // not be if the type claimed the value was encoded, since ValEncodedString

--- a/packages/react/src/stega/stegaEncode.ts
+++ b/packages/react/src/stega/stegaEncode.ts
@@ -16,6 +16,7 @@ import {
   SerializedDateSchema,
   SerializedDateTimeSchema,
   SerializedColorSchema,
+  SerializedCodeSchema,
 } from "@valbuild/core";
 import { vercelStegaCombine, vercelStegaSplit } from "@vercel/stega";
 import { FileSource, Source, SourceObject } from "@valbuild/core";
@@ -420,6 +421,12 @@ export function stegaEncode(
     if (recOpts?.schema && isColorSchema(recOpts?.schema)) {
       return sourceOrSelector;
     }
+    // Stega weaves invisible characters into the string. In source code they
+    // are not invisible: they are syntax errors, or silent corruption in a
+    // string literal. So a code value is handed back verbatim.
+    if (recOpts?.schema && isCodeSchema(recOpts?.schema)) {
+      return sourceOrSelector;
+    }
     if (recOpts?.schema && isUnionSchema(recOpts?.schema)) {
       // Handle tagged union
       const taggedSchema = resolveTaggedUnionSchema(
@@ -591,6 +598,12 @@ function isColorSchema(
   schema: SerializedSchema | undefined,
 ): schema is SerializedColorSchema {
   return schema?.type === "color";
+}
+
+function isCodeSchema(
+  schema: SerializedSchema | undefined,
+): schema is SerializedCodeSchema {
+  return schema?.type === "code";
 }
 
 function unknownSchema(schema: unknown) {

--- a/packages/server/src/ValOps.ts
+++ b/packages/server/src/ValOps.ts
@@ -803,8 +803,8 @@ export abstract class ValOps {
    * instances in the browser and would otherwise get no previews at all. See
    * #470.
    *
-   * A string's `render` needs none of this — it is static config that travels
-   * with the serialized schema.
+   * A `render`, and a string's `multiline`, need none of this — they are static
+   * config that travels with the serialized schema.
    */
   async getPreviews(
     schemas: Schemas,

--- a/packages/shared/src/internal/zod/SerializedSchema.ts
+++ b/packages/shared/src/internal/zod/SerializedSchema.ts
@@ -17,6 +17,7 @@ import {
   type SerializedDateSchema as SerializedDateSchemaT,
   type SerializedDateTimeSchema as SerializedDateTimeSchemaT,
   type SerializedColorSchema as SerializedColorSchemaT,
+  type SerializedCodeSchema as SerializedCodeSchemaT,
   type SerializedImageSchema as SerializedImageSchemaT,
   CODE_LANGUAGES,
 } from "@valbuild/core";
@@ -24,23 +25,20 @@ import { SourcePath } from "./SourcePath";
 
 // A render is static config, so unlike a `preview` it travels WHOLE — this
 // is the field the editor reads the layout from. See `core/src/render.ts`.
-// Every field can carry `{ as: "inline" }`; strings have layouts of their own
-// on top. NB: these z.objects STRIP unknown keys, so a render variant that is
-// not declared here is silently dropped in transit — add it here when it is
-// added to `render.ts`.
+// Every field can carry `{ as: "inline" }`, and that is all a render says.
+// NB: these z.objects STRIP unknown keys, so a render variant that is not
+// declared here is silently dropped in transit — add it here when it is added
+// to `render.ts`.
 const InlineRender = z.object({ as: z.literal("inline") });
 const FieldRender = InlineRender.optional();
 
 export const SerializedStringSchema: z.ZodType<SerializedStringSchemaT> =
   z.object({
     type: z.literal("string"),
-    render: z
-      .union([
-        z.object({ as: z.literal("textarea") }),
-        z.object({ as: z.literal("code"), language: z.enum(CODE_LANGUAGES) }),
-        InlineRender,
-      ])
-      .optional(),
+    render: FieldRender,
+    // `.multiline()`. Stripped like any undeclared key if it goes missing here,
+    // which is a single-line input where the author asked for a text box.
+    multiline: z.boolean().optional(),
     preview: z.literal(true).optional(),
     options: z
       .object({
@@ -333,6 +331,22 @@ export const SerializedColorSchema: z.ZodType<SerializedColorSchemaT> =
     description: z.string().optional(),
   });
 
+export const CodeOptions = z.object({
+  language: z.enum(CODE_LANGUAGES).optional(),
+});
+
+export const SerializedCodeSchema: z.ZodType<SerializedCodeSchemaT> = z.object({
+  type: z.literal("code"),
+  render: FieldRender,
+  preview: z.literal(true).optional(),
+  options: CodeOptions.optional(),
+  opt: z.boolean(),
+  customValidate: z.boolean().optional(),
+  readonly: z.boolean().optional(),
+  hidden: z.boolean().optional(),
+  description: z.string().optional(),
+});
+
 export const SerializedRouteSchema: z.ZodType<SerializedRouteSchemaT> =
   z.object({
     type: z.literal("route"),
@@ -377,5 +391,6 @@ export const SerializedSchema: z.ZodType<SerializedSchemaT> = z.union([
   SerializedDateSchema,
   SerializedDateTimeSchema,
   SerializedColorSchema,
+  SerializedCodeSchema,
   SerializedImageSchema,
 ]);

--- a/packages/ui/spa/components/AnyField.tsx
+++ b/packages/ui/spa/components/AnyField.tsx
@@ -12,6 +12,7 @@ import { StringField } from "./fields/StringField";
 import { UnionField } from "./fields/UnionField";
 import { DateField } from "./fields/DateField";
 import { DateTimeField } from "./fields/DateTimeField";
+import { CodeField } from "./fields/CodeField";
 import { ColorField } from "./fields/ColorField";
 import { FieldSchemaError } from "./FieldSchemaError";
 import { FileField } from "./fields/FileField";
@@ -144,6 +145,8 @@ export function AnyField({
     leaf = <DateTimeField key={path} path={path} {...leafProps} />;
   } else if (schema.type === "color") {
     leaf = <ColorField key={path} path={path} {...leafProps} />;
+  } else if (schema.type === "code") {
+    leaf = <CodeField key={path} path={path} {...leafProps} />;
   } else if (schema.type === "file") {
     leaf = <FileField key={path} path={path} {...leafProps} />;
   } else if (schema.type === "literal") {

--- a/packages/ui/spa/components/BlockList.stories.tsx
+++ b/packages/ui/spa/components/BlockList.stories.tsx
@@ -142,7 +142,7 @@ const pagesModule = c.define(
       s
         .object({
           title: s.string(),
-          subtitle: s.string().render({ as: "textarea" }),
+          subtitle: s.string().multiline(),
           sections: s.array(
             s
               .object({
@@ -239,7 +239,7 @@ const authorsModule = c.define(
     s.object({
       name: s.string(),
       birthdate: s.date(),
-      bio: s.string().render({ as: "textarea" }),
+      bio: s.string().multiline(),
     }),
   ),
   {
@@ -298,7 +298,7 @@ const sectionsModule = c.define(
         s
           .object({
             type: s.literal("code"),
-            code: s.string().render({ as: "code", language: "typescript" }),
+            code: s.code({ language: "typescript" }),
           })
           .render({ as: "inline" })
           .preview(({ val }) => ({ title: val.code })),

--- a/packages/ui/spa/components/CodeEditor.tsx
+++ b/packages/ui/spa/components/CodeEditor.tsx
@@ -33,7 +33,8 @@ export function CodeEditor({
   options,
   className,
 }: {
-  language: CodeLanguage;
+  /** Omitted for a plain monospaced editor: `s.code()` with no language. */
+  language?: CodeLanguage;
   placeholder?: string;
   options?: BasicSetupOptions;
   value: string;
@@ -44,6 +45,11 @@ export function CodeEditor({
   className?: string;
 }) {
   const extensions = useMemo(() => {
+    if (language === undefined) {
+      // `s.code()` with no language: a monospaced box, no highlighting. Not an
+      // error — the exhaustive check below is for a language we forgot.
+      return [];
+    }
     if (language === "typescript") {
       return [javascript({ typescript: true })];
     } else if (language === "typescriptreact") {

--- a/packages/ui/spa/components/NodeIcon.tsx
+++ b/packages/ui/spa/components/NodeIcon.tsx
@@ -6,6 +6,7 @@ import {
   Clock,
   Palette,
   Code,
+  FileCode,
   FileIcon,
   FileText,
   Hash,
@@ -61,6 +62,8 @@ export function NodeIcon({
       return <Clock size={size} className={className} />;
     case "color":
       return <Palette size={size} className={className} />;
+    case "code":
+      return <FileCode size={size} className={className} />;
     case "image":
       return <ImageIcon size={size} className={className} />;
     default:

--- a/packages/ui/spa/components/Preview.tsx
+++ b/packages/ui/spa/components/Preview.tsx
@@ -11,6 +11,7 @@ import { KeyOfPreview } from "./fields/KeyOfField";
 import { RoutePreview } from "./fields/RouteField";
 import { DatePreview } from "./fields/DateField";
 import { DateTimePreview } from "./fields/DateTimeField";
+import { CodePreview } from "./fields/CodeField";
 import { ColorPreview } from "./fields/ColorField";
 import { LiteralPreview } from "./fields/LiteralPreview";
 import { RecordPreview } from "./fields/RecordFields";
@@ -65,6 +66,8 @@ export function Preview({
     return <DateTimePreview path={path} />;
   } else if (type === "color") {
     return <ColorPreview path={path} />;
+  } else if (type === "code") {
+    return <CodePreview path={path} />;
   } else if (type === "literal") {
     return <LiteralPreview path={path} />;
   } else if (type === "record") {

--- a/packages/ui/spa/components/Search/stories/mockData.ts
+++ b/packages/ui/spa/components/Search/stories/mockData.ts
@@ -347,9 +347,9 @@ function createMockData() {
         s
           .object({
             name: s.string(),
-            description: s.string().render({ as: "textarea" }),
+            description: s.string().multiline(),
             price: s.number(),
-            code: s.string().render({ as: "code", language: "json" }),
+            code: s.code({ language: "json" }),
           })
           .preview(({ val }) => {
             return {
@@ -416,8 +416,8 @@ function createMockData() {
       s
         .object({
           key: s.string(),
-          value: s.string().render({ as: "code", language: "typescript" }),
-          description: s.string().render({ as: "textarea" }),
+          value: s.code({ language: "typescript" }),
+          description: s.string().multiline(),
         })
         .preview(({ val }) => {
           return {

--- a/packages/ui/spa/components/ValFieldProvider.tsx
+++ b/packages/ui/spa/components/ValFieldProvider.tsx
@@ -1359,6 +1359,7 @@ type ShallowSource = {
   date: string;
   dateTime: string;
   color: string;
+  code: string;
   file: {
     path: string;
     mimeType?: string;
@@ -1466,6 +1467,7 @@ function mapSource<SchemaType extends SerializedSchema["type"]>(
     type === "date" ||
     type === "dateTime" ||
     type === "color" ||
+    type === "code" ||
     type === "string" ||
     type === "literal"
   ) {

--- a/packages/ui/spa/components/ValProvider.tsx
+++ b/packages/ui/spa/components/ValProvider.tsx
@@ -2011,6 +2011,7 @@ export type ShallowSource = EnsureAllTypes<{
   date: string;
   dateTime: string;
   color: string;
+  code: string;
   file: {
     path: string;
     mimeType?: string;
@@ -2733,6 +2734,7 @@ function mapSource<SchemaType extends SerializedSchema["type"]>(
     type === "date" ||
     type === "dateTime" ||
     type === "color" ||
+    type === "code" ||
     type === "string" ||
     type === "literal"
   ) {

--- a/packages/ui/spa/components/fields/CodeField.test.tsx
+++ b/packages/ui/spa/components/fields/CodeField.test.tsx
@@ -1,0 +1,96 @@
+/** @jest-environment jsdom */
+// FIRST, and it must stay first: `CodeField` pulls in the shared bundle, which
+// builds a `TextEncoder` at module scope.
+import "../../stores/react/testPolyfills";
+import { render, screen } from "@testing-library/react";
+import { SourcePath } from "@valbuild/core";
+
+/**
+ * `s.code()` is its own field, and the language comes off the SCHEMA — the same
+ * synchronous read `StringField` does for `multiline`, so there is nothing to
+ * wait for and no frame drawn without highlighting.
+ *
+ * `undefined` is a real state here rather than a missing one: `s.code()` with no
+ * language is a monospaced editor with no highlighting, and the field must pass
+ * that through instead of picking a language of its own.
+ */
+const mockSchema = jest.fn();
+const mockSource = jest.fn();
+const mockAddPatch = jest.fn();
+
+jest.mock("../ValFieldProvider", () => ({
+  __esModule: true,
+  useFieldCreatorId: () => "test",
+  useSchemaAtPath: () => mockSchema(),
+  useShallowSourceAtPath: () => mockSource(),
+  useAddPatch: () => ({ patchPath: [], addPatch: mockAddPatch }),
+  useValField: () => ({
+    schema: mockSchema(),
+    source: mockSource(),
+    hasUnsavedOwnEdit: false,
+    patchPath: [],
+    addPatch: mockAddPatch,
+    addAndUploadPatchWithFileOps: jest.fn(),
+    addModuleFilePatch: jest.fn(),
+  }),
+}));
+
+// `Preview` is the generic field dispatcher, so importing it drags in the whole
+// field tree (and, through `ValProvider`, a worker URL jest cannot parse). This
+// field only uses two leaf states from it.
+jest.mock("../../components/Preview", () => ({
+  __esModule: true,
+  PreviewLoading: () => <div data-testid="preview-loading" />,
+  PreviewNull: () => <div data-testid="preview-null" />,
+}));
+
+// CodeMirror needs a real layout to mount into; what matters here is what the
+// field hands it.
+jest.mock("../CodeEditor", () => ({
+  __esModule: true,
+  CodeEditor: ({ language, value }: { language?: string; value: string }) => (
+    <div data-testid="code-editor" data-language={language ?? "none"}>
+      {value}
+    </div>
+  ),
+}));
+
+import { CodeField } from "./CodeField";
+
+const PATH = '/content/page.val.ts?p="snippet"' as SourcePath;
+
+function mount(options: { language?: string } | undefined, source: string) {
+  mockSchema.mockReturnValue({
+    status: "success",
+    data: { type: "code", opt: false, options },
+  });
+  mockSource.mockReturnValue({ status: "success", data: source });
+}
+
+describe("CodeField", () => {
+  test("the code editor, with the language the schema names", () => {
+    mount({ language: "typescript" }, "const a = 1;");
+    render(<CodeField path={PATH} />);
+    const editor = screen.getByTestId("code-editor");
+    expect(editor.getAttribute("data-language")).toBe("typescript");
+    expect(editor.textContent).toBe("const a = 1;");
+  });
+
+  test("no language: the editor gets none, rather than a guessed one", () => {
+    mount(undefined, "plain text");
+    render(<CodeField path={PATH} />);
+    const editor = screen.getByTestId("code-editor");
+    expect(editor.getAttribute("data-language")).toBe("none");
+    expect(editor.textContent).toBe("plain text");
+  });
+
+  test("a schema of another type is a mismatch, not a blank editor", () => {
+    mockSchema.mockReturnValue({
+      status: "success",
+      data: { type: "string", opt: false, raw: false },
+    });
+    mockSource.mockReturnValue({ status: "success", data: "const a = 1;" });
+    render(<CodeField path={PATH} />);
+    expect(screen.queryByTestId("code-editor")).toBeNull();
+  });
+});

--- a/packages/ui/spa/components/fields/CodeField.test.tsx
+++ b/packages/ui/spa/components/fields/CodeField.test.tsx
@@ -2,8 +2,9 @@
 // FIRST, and it must stay first: `CodeField` pulls in the shared bundle, which
 // builds a `TextEncoder` at module scope.
 import "../../stores/react/testPolyfills";
-import { render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { SourcePath } from "@valbuild/core";
+import { FIELD_WRITE_DEBOUNCE_MS } from "./useDebouncedFieldWrite";
 
 /**
  * `s.code()` is its own field, and the language comes off the SCHEMA — the same
@@ -45,13 +46,26 @@ jest.mock("../../components/Preview", () => ({
 }));
 
 // CodeMirror needs a real layout to mount into; what matters here is what the
-// field hands it.
+// field hands it, and that what it hands back reaches `onChange`. The stub is a
+// textarea rather than a div so a keystroke can be fired at it — the debounce
+// test below is the reason.
 jest.mock("../CodeEditor", () => ({
   __esModule: true,
-  CodeEditor: ({ language, value }: { language?: string; value: string }) => (
-    <div data-testid="code-editor" data-language={language ?? "none"}>
-      {value}
-    </div>
+  CodeEditor: ({
+    language,
+    value,
+    onChange,
+  }: {
+    language?: string;
+    value: string;
+    onChange: (value: string) => void;
+  }) => (
+    <textarea
+      data-testid="code-editor"
+      data-language={language ?? "none"}
+      value={value}
+      onChange={(ev) => onChange(ev.target.value)}
+    />
   ),
 }));
 
@@ -71,17 +85,58 @@ describe("CodeField", () => {
   test("the code editor, with the language the schema names", () => {
     mount({ language: "typescript" }, "const a = 1;");
     render(<CodeField path={PATH} />);
-    const editor = screen.getByTestId("code-editor");
+    const editor = screen.getByTestId<HTMLTextAreaElement>("code-editor");
     expect(editor.getAttribute("data-language")).toBe("typescript");
-    expect(editor.textContent).toBe("const a = 1;");
+    expect(editor.value).toBe("const a = 1;");
   });
 
   test("no language: the editor gets none, rather than a guessed one", () => {
     mount(undefined, "plain text");
     render(<CodeField path={PATH} />);
-    const editor = screen.getByTestId("code-editor");
+    const editor = screen.getByTestId<HTMLTextAreaElement>("code-editor");
     expect(editor.getAttribute("data-language")).toBe("none");
-    expect(editor.textContent).toBe("plain text");
+    expect(editor.value).toBe("plain text");
+  });
+
+  /**
+   * A burst of typing is ONE write, and this field is what collapses it.
+   *
+   * The same seam `StringField.test.tsx` pins, and it has to be pinned here
+   * too: `useDebouncedFieldWrite.test.tsx` proves the hook, but nothing there
+   * can show that THIS field goes through it. A field calling `addPatch`
+   * straight from `onChange` would pass every test in that file and put one
+   * patch per keystroke on the chain — and code is typed in longer bursts than
+   * prose. On a fake clock the margin is exact and there is no flake to have.
+   */
+  test("a burst of keystrokes is one write, carrying the last value", () => {
+    jest.useFakeTimers();
+    try {
+      mount({ language: "typescript" }, "");
+      render(<CodeField path={PATH} />);
+      const editor = screen.getByTestId("code-editor");
+
+      for (const value of ["c", "co", "con", "cons", "const"]) {
+        fireEvent.change(editor, { target: { value } });
+        act(() => {
+          jest.advanceTimersByTime(60);
+        });
+      }
+      // The half that a per-keystroke write would fail.
+      expect(mockAddPatch).not.toHaveBeenCalled();
+
+      act(() => {
+        jest.advanceTimersByTime(FIELD_WRITE_DEBOUNCE_MS);
+      });
+      expect(mockAddPatch).toHaveBeenCalledTimes(1);
+      expect(mockAddPatch.mock.calls[0][0]).toEqual([
+        { op: "replace", path: [], value: "const" },
+      ]);
+      // The patch is tagged as a code write, not a string one: the type decides
+      // which schema the server validates the patch against.
+      expect(mockAddPatch.mock.calls[0][1]).toBe("code");
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   test("a schema of another type is a mismatch, not a blank editor", () => {

--- a/packages/ui/spa/components/fields/CodeField.tsx
+++ b/packages/ui/spa/components/fields/CodeField.tsx
@@ -1,0 +1,136 @@
+import React, { useEffect, useState } from "react";
+import { SourcePath } from "@valbuild/core";
+import { useShallowSourceAtPath, useValField } from "../ValFieldProvider";
+import { FieldLoading } from "../../components/FieldLoading";
+import { FieldNotFound } from "../../components/FieldNotFound";
+import { FieldSchemaError } from "../../components/FieldSchemaError";
+import { FieldSourceError } from "../../components/FieldSourceError";
+import { FieldSchemaMismatchError } from "../../components/FieldSchemaMismatchError";
+import { PreviewLoading, PreviewNull } from "../../components/Preview";
+import { CodeEditor } from "../CodeEditor";
+import { ReadonlyGuard } from "./ReadonlyGuard";
+import { useDebouncedFieldWrite } from "./useDebouncedFieldWrite";
+
+export function CodeField({
+  path,
+  autoFocus,
+  readonly,
+}: {
+  path: SourcePath;
+  autoFocus?: boolean;
+  readonly?: boolean;
+}) {
+  const type = "code";
+  const {
+    source: sourceAtPath,
+    schema: schemaAtPath,
+    patchPath,
+    addPatch,
+  } = useValField(path, type);
+  const [currentValue, setCurrentValue] = useState<string | null>(null);
+  /**
+   * One patch per PAUSE in typing, not per keystroke — the same reason
+   * `StringField` debounces, and more of it: code is typed in bursts, and each
+   * write is a patch in the chain, a source rebuild and a wake for every
+   * listener on the module. See `useDebouncedFieldWrite`.
+   */
+  const write = useDebouncedFieldWrite<string>((value) => {
+    addPatch([{ op: "replace", path: patchPath, value }], type);
+  });
+  const maybeSourceData = "data" in sourceAtPath && sourceAtPath.data;
+  const maybeClientSideOnly =
+    "clientSideOnly" in sourceAtPath && sourceAtPath.clientSideOnly;
+  useEffect(() => {
+    // Not while a keystroke is still unwritten: between a keystroke and its
+    // patch the source still holds the PRE-edit value, so taking it would put
+    // back the character just typed. Same guard as `StringField`.
+    if (write.hasPending()) {
+      return;
+    }
+    if (maybeClientSideOnly === false) {
+      setCurrentValue(
+        typeof maybeSourceData === "string" ? maybeSourceData : null,
+      );
+    }
+    // `write` is deliberately not a dependency: it is stable, and re-running
+    // this when a pending edit changes is exactly what the guard prevents.
+  }, [maybeSourceData, maybeClientSideOnly, write]);
+  if (schemaAtPath.status === "error") {
+    return (
+      <FieldSchemaError path={path} error={schemaAtPath.error} type={type} />
+    );
+  }
+  if (sourceAtPath.status === "error") {
+    return (
+      <FieldSourceError
+        path={path}
+        error={sourceAtPath.error}
+        schema={schemaAtPath}
+      />
+    );
+  }
+  if (
+    sourceAtPath.status == "not-found" ||
+    schemaAtPath.status === "not-found"
+  ) {
+    return <FieldNotFound path={path} type={type} />;
+  }
+  if (schemaAtPath.status === "loading") {
+    return <FieldLoading path={path} type={type} />;
+  }
+  if (!("data" in sourceAtPath) || sourceAtPath.data === undefined) {
+    return <FieldLoading path={path} type={type} />;
+  }
+  if (schemaAtPath.data.type !== type) {
+    return (
+      <FieldSchemaMismatchError
+        path={path}
+        expectedType={type}
+        actualType={schemaAtPath.data.type}
+      />
+    );
+  }
+  // `undefined` is a real state: `s.code()` with no language is a monospaced
+  // box with no highlighting, which `CodeEditor` handles.
+  const language = schemaAtPath.data.options?.language;
+  const content: React.ReactNode = (
+    <div id={path}>
+      <CodeEditor
+        language={language}
+        value={currentValue || ""}
+        autoFocus={autoFocus}
+        onChange={(value) => {
+          setCurrentValue(value);
+          write.push(value);
+        }}
+        onBlur={write.flush}
+      />
+    </div>
+  );
+
+  if (readonly) {
+    return <ReadonlyGuard>{content}</ReadonlyGuard>;
+  }
+  return content;
+}
+
+export function CodePreview({ path }: { path: SourcePath }) {
+  const sourceAtPath = useShallowSourceAtPath(path, "code");
+  if (sourceAtPath.status === "error") {
+    return <FieldSourceError path={path} error={sourceAtPath.error} />;
+  }
+  if (!("data" in sourceAtPath) || sourceAtPath.data === undefined) {
+    return <PreviewLoading path={path} />;
+  }
+  if (sourceAtPath.data === null) {
+    return <PreviewNull path={path} />;
+  }
+  // One line of it, monospaced: a preview row has one line to give, and the
+  // newlines a code value is full of would otherwise collapse into a run of
+  // spaces that reads as a single sentence.
+  return (
+    <div className="font-mono text-xs truncate">
+      {sourceAtPath.data.split("\n", 1)[0]}
+    </div>
+  );
+}

--- a/packages/ui/spa/components/fields/StringField.test.tsx
+++ b/packages/ui/spa/components/fields/StringField.test.tsx
@@ -9,8 +9,8 @@ import { FIELD_WRITE_DEBOUNCE_MS } from "./useDebouncedFieldWrite";
 /**
  * A string field's LAYOUT comes off the serialized schema, synchronously.
  *
- * That is the point of the preview/render split: a `render` is static config, so
- * there is nothing to wait for and no flash of a single-line input before the
+ * That is the point of `.multiline()` being static config on the schema: there
+ * is nothing to wait for and no flash of a single-line input before the
  * textarea. What is pinned here is the consequence that bit.
  *
  * The textarea used to be UNCONTROLLED (`defaultValue`), and it worked only
@@ -63,26 +63,16 @@ jest.mock("../../components/Preview", () => ({
   PreviewNull: () => <div data-testid="preview-null" />,
 }));
 
-jest.mock("../CodeEditor", () => ({
-  __esModule: true,
-  CodeEditor: ({ language, value }: { language: string; value: string }) => (
-    <div data-testid="code-editor" data-language={language}>
-      {value}
-    </div>
-  ),
-}));
-
 import { StringField } from "./StringField";
 
 const PATH = '/content/page.val.ts?p="body"' as SourcePath;
 
-function mount(render: unknown, source: string) {
+function mount(multiline: boolean | undefined, source: string) {
   mockSchema.mockReturnValue({
     status: "success",
-    data: { type: "string", opt: false, raw: false, render },
+    data: { type: "string", opt: false, raw: false, multiline },
   });
   mockSource.mockReturnValue({ status: "success", data: source });
-  return render;
 }
 
 describe("StringField", () => {
@@ -95,8 +85,8 @@ describe("StringField", () => {
     expect(input!.value).toBe("Hello");
   });
 
-  test("render textarea: a textarea, on the first frame, with its value in it", () => {
-    mount({ as: "textarea" }, "Multiline\ntext");
+  test("multiline: a textarea, on the first frame, with its value in it", () => {
+    mount(true, "Multiline\ntext");
     const { container } = render(<StringField path={PATH} />);
     const textarea = container.querySelector("textarea");
     expect(textarea).not.toBeNull();
@@ -105,20 +95,12 @@ describe("StringField", () => {
   });
 
   /** The regression guard — see the note at the top of this file. */
-  test("render textarea: the auto-grow ghost is sized for the value", () => {
-    mount({ as: "textarea" }, "Multiline\ntext");
+  test("multiline: the auto-grow ghost is sized for the value", () => {
+    mount(true, "Multiline\ntext");
     render(<StringField path={PATH} />);
     expect(
       screen.getByTestId("auto-growing-textarea-ghost").textContent,
     ).toContain("Multiline\ntext");
-  });
-
-  test("render code: the code editor, with the language the schema names", () => {
-    mount({ as: "code", language: "typescript" }, "const a = 1;");
-    render(<StringField path={PATH} />);
-    const editor = screen.getByTestId("code-editor");
-    expect(editor.getAttribute("data-language")).toBe("typescript");
-    expect(editor.textContent).toBe("const a = 1;");
   });
 
   /**

--- a/packages/ui/spa/components/fields/StringField.tsx
+++ b/packages/ui/spa/components/fields/StringField.tsx
@@ -10,7 +10,6 @@ import { FieldSchemaMismatchError } from "../../components/FieldSchemaMismatchEr
 import { PreviewLoading, PreviewNull } from "../../components/Preview";
 import { useEffect, useState } from "react";
 import { AutoGrowingTextarea } from "../AutoGrowingTextarea";
-import { CodeEditor } from "../CodeEditor";
 import { ReadonlyGuard } from "./ReadonlyGuard";
 import { useDebouncedFieldWrite } from "./useDebouncedFieldWrite";
 
@@ -105,18 +104,18 @@ export function StringField({
   /**
    * The layout comes off the SCHEMA, synchronously.
    *
-   * A render is static config — no closure, no dependency on source — so it
+   * `multiline` is static config — no closure, no dependency on source — so it
    * travels in the serialized schema and there is nothing to wait for. That is
    * what removes the old effect-driven dance here, which existed only because
    * the layout used to arrive asynchronously from the host and the field would
    * otherwise flip from input to textarea a tick later. (It also, silently, was
    * the only reason the uncontrolled textarea below ever had a value — see
-   * `architecture/quirks.md`.) If a render ever stops being static, this read is
-   * the thing that has to change. See `core/src/render.ts`.
+   * `architecture/quirks.md`.) If it ever stops being static, this read is the
+   * thing that has to change. See `core/src/render.ts`.
    */
-  const render = schemaAtPath.data.render;
+  const multiline = schemaAtPath.data.multiline;
   let content: React.ReactNode;
-  if (render?.as === "textarea") {
+  if (multiline) {
     content = (
       <div id={path}>
         <AutoGrowingTextarea
@@ -131,21 +130,6 @@ export function StringField({
           onChange={(ev) => {
             setCurrentValue(ev.target.value);
             write.push(ev.target.value);
-          }}
-          onBlur={write.flush}
-        />
-      </div>
-    );
-  } else if (render?.as === "code") {
-    content = (
-      <div id={path}>
-        <CodeEditor
-          language={render.language}
-          value={currentValue || ""}
-          autoFocus={autoFocus}
-          onChange={(value) => {
-            setCurrentValue(value);
-            write.push(value);
           }}
           onBlur={write.flush}
         />

--- a/packages/ui/spa/components/fields/emptyOf.ts
+++ b/packages/ui/spa/components/fields/emptyOf.ts
@@ -82,6 +82,8 @@ export function emptyOf(schema: SerializedSchema): Json {
       { r: 128, g: 128, b: 128, a: 1 },
       schema.options?.format ?? DEFAULT_COLOR_FORMAT,
     );
+  } else if (schema.type === "code") {
+    return ""; // An empty editor: no language has a sensible starting snippet
   }
   const _exhaustiveCheck: never = schema;
   throw Error("Unexpected schema type: " + JSON.stringify(_exhaustiveCheck));

--- a/packages/ui/spa/components/getKeysOf.ts
+++ b/packages/ui/spa/components/getKeysOf.ts
@@ -58,6 +58,7 @@ export function getKeysOf(
       schema.type === "date" ||
       schema.type === "dateTime" ||
       schema.type === "color" ||
+      schema.type === "code" ||
       schema.type === "image" ||
       schema.type === "file" ||
       schema.type === "richtext" ||

--- a/packages/ui/spa/components/getReferencedFiles.ts
+++ b/packages/ui/spa/components/getReferencedFiles.ts
@@ -44,6 +44,7 @@ export function getReferencedFiles(
       schema.type === "date" ||
       schema.type === "dateTime" ||
       schema.type === "color" ||
+      schema.type === "code" ||
       schema.type === "keyOf" ||
       schema.type === "image" ||
       schema.type === "file" ||

--- a/packages/ui/spa/components/jsonValuesLoadRequirements.ts
+++ b/packages/ui/spa/components/jsonValuesLoadRequirements.ts
@@ -143,6 +143,7 @@ function containsReferrer(
     case "date":
     case "dateTime":
     case "color":
+    case "code":
     case "richtext":
       return false;
     default: {

--- a/packages/ui/spa/search/searchIndex.ts
+++ b/packages/ui/spa/search/searchIndex.ts
@@ -86,6 +86,7 @@ export function indexModule(
       schema.type === "date" ||
       schema.type === "dateTime" ||
       schema.type === "color" ||
+      schema.type === "code" ||
       schema.type === "keyOf" ||
       schema.type === "route"
     ) {

--- a/packages/ui/spa/stores/SchemaStore.ts
+++ b/packages/ui/spa/stores/SchemaStore.ts
@@ -120,10 +120,10 @@ export class SchemaStore {
  * Any node can carry the marker now that `preview` is declared on the ITEM
  * schema (a container reifies its rows from its item's closure), so the walk
  * checks every node and descends where there is somewhere to descend to. A
- * `render` is deliberately NOT a hit: `s.string().render({as:"textarea"})` is
- * static config that travels WITH the serialized schema and is read where the
- * field is drawn, so a module whose only such declaration is a layout must
- * never be sent to the host. See `core/src/render.ts`.
+ * `render` is deliberately NOT a hit, and neither is `s.string().multiline()`:
+ * both are static config that travels WITH the serialized schema and is read
+ * where the field is drawn, so a module whose only such declaration is a layout
+ * must never be sent to the host. See `core/src/render.ts`.
  *
  * `seen` guards a schema that refers to itself structurally, so this cannot
  * recurse forever — the same guard `collectReferences` and

--- a/packages/ui/spa/stores/activityCost.test.ts
+++ b/packages/ui/spa/stores/activityCost.test.ts
@@ -62,7 +62,7 @@ const stringRendered = () => {
   const { c, s } = initVal();
   return c.define(
     "/stringRendered.val.ts",
-    s.object({ body: s.string().render({ as: "textarea" }) }),
+    s.object({ body: s.string().multiline() }),
     { body: "hello" },
   );
 };

--- a/packages/ui/spa/stores/workerSeam.test.ts
+++ b/packages/ui/spa/stores/workerSeam.test.ts
@@ -41,10 +41,12 @@ const project = () => {
         // non-cloneable, in one module: a regexp (serialized as {source, flags}
         // rather than a RegExp), a keyOf (carries a path), an image (carries a
         // referencedModule), a route, a richtext (carries an options object), a
-        // union (carries an items array), and a `render` (which is the LAYOUT
-        // itself now, not a boolean marker, so it is new data on this seam).
+        // union (carries an items array), a `render` (which is the LAYOUT
+        // itself now, not a boolean marker, so it is new data on this seam) and
+        // a code schema (carries a language in its options).
         slug: s.string().regexp(/^[a-z-]+$/),
-        notes: s.string().render({ as: "code", language: "json" }),
+        notes: s.code({ language: "json" }),
+        summary: s.string().multiline().render({ as: "inline" }),
         owner: s.keyOf(authors),
         hero: s.image(),
         link: s.route(),
@@ -59,6 +61,7 @@ const project = () => {
         title: "Hello",
         slug: "hello",
         notes: "{}",
+        summary: "line one\nline two",
         owner: "ada",
         hero: {
           path: "/public/val/x.png",

--- a/packages/ui/spa/utils/getDependentModuleFiles.ts
+++ b/packages/ui/spa/utils/getDependentModuleFiles.ts
@@ -48,6 +48,7 @@ export function getDependentModuleFiles(
       schemaNode.type === "date" ||
       schemaNode.type === "dateTime" ||
       schemaNode.type === "color" ||
+      schemaNode.type === "code" ||
       schemaNode.type === "file" ||
       schemaNode.type === "image" ||
       schemaNode.type === "number" ||

--- a/packages/ui/spa/utils/schemaTypesOfPath.ts
+++ b/packages/ui/spa/utils/schemaTypesOfPath.ts
@@ -55,6 +55,7 @@ export function schemaTypesOfPath(
       current.type === "date" ||
       current.type === "dateTime" ||
       current.type === "color" ||
+      current.type === "code" ||
       current.type === "file" ||
       current.type === "image" ||
       current.type === "keyOf" ||

--- a/packages/ui/spa/utils/traverseSchemaSource.ts
+++ b/packages/ui/spa/utils/traverseSchemaSource.ts
@@ -111,6 +111,14 @@ export function traverseSchemaSource(
     return;
   }
 
+  // Handle code
+  if (schema.type === "code") {
+    if (typeof source === "string") {
+      callback({ source, schema, path });
+    }
+    return;
+  }
+
   // Handle keyOf
   if (schema.type === "keyOf") {
     if (typeof source === "string" || typeof source === "number") {


### PR DESCRIPTION
## Summary

Introduces `s.code()` as a dedicated schema type for code editing and moves multi-line text editing to `s.string().multiline()`. Removes the string-only render variants (`{ as: "textarea" }` and `{ as: "code", language }`), making `.render()` a universal field layout mechanism that only supports `{ as: "inline" }`.

## Key Changes

- **New `CodeSchema` type** (`packages/core/src/schema/code.ts`):
  - Backed by a plain string, edited in a code editor
  - Supports optional `language` option for syntax highlighting (typescript, javascript, json, html, css, markdown, python, sql, rust, php, go, cpp, sass, vue, angular, java, xml)
  - Code values are never stega-encoded (invisible characters would corrupt source code)
  - Supports all standard schema modifiers: `.nullable()`, `.readonly()`, `.hidden()`, `.describe()`, `.validate()`, `.render()`, `.preview()`

- **`s.string().multiline()` method**:
  - Replaces `s.string().render({ as: "textarea" })`
  - Serializes as `multiline: true` on the schema (static config, not a render)
  - Survives all chaining operations and serialize/deserialize round trips
  - Renders as a growing text box instead of single-line input

- **Render system simplification**:
  - `.render()` now only accepts `{ as: "inline" }` across all field types
  - Removed `StringRender` type; `FieldRender` is now the single render type
  - Updated zod validation in `shared` to reflect the single render variant

- **UI Components**:
  - New `CodeField` component with debounced writes (same pattern as `StringField`)
  - `CodePreview` component for displaying code values
  - `CodeEditor` updated to accept optional `language` parameter
  - Updated `AnyField` dispatcher to route code schemas to `CodeField`

- **Integration updates**:
  - Added code schema to deserializer
  - Updated stega encoding to skip code values
  - Added code type to all schema type checks across the codebase
  - Updated examples and documentation

## Implementation Details

- Code values bypass stega encoding entirely, ensuring source code integrity
- The `language` option is read synchronously from the serialized schema (no async loading)
- `multiline` is a schema property (like `opt`, `readonly`, `hidden`) rather than a render variant, reflecting that it describes the content, not the layout
- Both new features integrate with the existing preview/render split architecture
- Comprehensive test coverage for both new schema types and their interactions with other schema methods

https://claude.ai/code/session_01SGkuskcibySEPE1oeb36Vx