### PR TITLE
Verify session JWTs: check exp, compare in constant time, require the secret

### DIFF
--- a/.changeset/jwt-session-verification.md
+++ b/.changeset/jwt-session-verification.md
@@ -1,0 +1,41 @@
+---
+"@valbuild/server": minor
+---
+
+Fix session token verification in `@valbuild/server`
+
+`decodeJwt` had three problems, each of which let a session cookie be accepted
+that should not have been:
+
+- **`exp` was never checked.** The payload was parsed and returned as-is, and
+  the callers' zod schemas only asserted that `exp` was a number. A session
+  cookie was therefore valid forever: the four-day expiry existed only as the
+  `expires` attribute on the cookie, which the browser holding it controls. The
+  Studio's "session invalid or, most likely, expired" message was never once
+  produced by an expiry check.
+- **The signature was compared with `!==`.** String comparison short-circuits on
+  the first differing byte, which leaks how much of a guessed signature was
+  correct.
+- **Verification was skipped entirely when `secretKey` was falsy.** One
+  forgotten argument — or a `VAL_SECRET` that read as `""` — turned the session
+  cookie into an unauthenticated, attacker-writable claim of identity, with no
+  error anywhere to say so.
+
+`decodeJwt` is replaced by two functions that cannot be confused for each other:
+
+- `verifyJwt(token, secretKey)` requires the secret, compares the HMAC with
+  `crypto.timingSafeEqual`, validates the payload shape, and rejects an expired
+  token (with 60s of leeway for clock drift). An empty secret is a failure, not
+  a token that validates against `HMAC("")`.
+- `decodeJwtWithoutVerifying(token)` is the explicitly-unverified path, for the
+  one caller that does not hold the signing key: the app token fetched from
+  val.build over an api-key authenticated request.
+
+Both return a `JwtResult` carrying why a token was rejected, so an expired
+session is now reported as expired rather than as an invalid token. `alg` was
+already pinned to `HS256`, so algorithm confusion was not reachable, and it
+still is not. The token itself is no longer written to the debug log.
+
+**Breaking:** `decodeJwt` is no longer exported. Callers passing a secret should
+use `verifyJwt` and read `.success`/`.data` instead of a nullable payload.
+Existing session cookies keep working until their `exp` passes.

--- a/.changeset/jwt-session-verification.md
+++ b/.changeset/jwt-session-verification.md
@@ -4,8 +4,9 @@
 
 Fix session token verification in `@valbuild/server`
 
-`decodeJwt` had three problems, each of which let a session cookie be accepted
-that should not have been:
+`decodeJwt` had three problems. Two of them let a session cookie be accepted
+that should not have been; the third leaked information about the signature it
+was checking:
 
 - **`exp` was never checked.** The payload was parsed and returned as-is, and
   the callers' zod schemas only asserted that `exp` was a number. A session
@@ -13,9 +14,9 @@ that should not have been:
   `expires` attribute on the cookie, which the browser holding it controls. The
   Studio's "session invalid or, most likely, expired" message was never once
   produced by an expiry check.
-- **The signature was compared with `!==`.** String comparison short-circuits on
-  the first differing byte, which leaks how much of a guessed signature was
-  correct.
+- **The signature was compared with `!==`.** This one did reject every invalid
+  signature - but string comparison short-circuits on the first differing byte,
+  so how long it took leaked how much of a guessed signature was correct.
 - **Verification was skipped entirely when `secretKey` was falsy.** One
   forgotten argument — or a `VAL_SECRET` that read as `""` — turned the session
   cookie into an unauthenticated, attacker-writable claim of identity, with no

--- a/packages/server/src/ValServer.ts
+++ b/packages/server/src/ValServer.ts
@@ -28,7 +28,13 @@ import {
   ValServerError,
   ValServerErrorStatus,
 } from "@valbuild/shared/internal";
-import { decodeJwt, encodeJwt, getExpire } from "./jwt";
+import {
+  decodeJwtWithoutVerifying,
+  encodeJwt,
+  getExpire,
+  verifyJwt,
+  type JwtFailureReason,
+} from "./jwt";
 import { z } from "zod";
 import { ValOpsFS } from "./ValOpsFS";
 import { computePatchesToDrop, DroppedPatch } from "./computePatchesToDrop";
@@ -195,7 +201,15 @@ export const ValServer = (
       .then(async (res) => {
         if (res.status === 200) {
           const token = await res.text();
-          const verification = ValAppJwtPayload.safeParse(decodeJwt(token));
+          // NOTE: this token is signed by val.build with a key we do not hold,
+          // so we cannot verify it. What makes it trustworthy is where it came
+          // from: an api-key authenticated HTTPS POST to val.build, above. It
+          // is not user input.
+          const decoded = decodeJwtWithoutVerifying(token);
+          if (!decoded.success) {
+            return null;
+          }
+          const verification = ValAppJwtPayload.safeParse(decoded.data);
           if (!verification.success) {
             return null;
           }
@@ -234,8 +248,8 @@ export const ValServer = (
       }
     }
     if (typeof cookie === "string") {
-      const decodedToken = decodeJwt(cookie, options.valSecret);
-      if (!decodedToken) {
+      const verifiedToken = verifyJwt(cookie, options.valSecret);
+      if (!verifiedToken.success) {
         if (serverOps instanceof ValOpsFS) {
           return {
             error: null,
@@ -243,11 +257,12 @@ export const ValServer = (
           };
         }
         return {
-          error:
-            "Could not verify session (invalid token). You will need to login again.",
+          error: sessionErrorMessage(verifiedToken.reason),
         };
       }
-      const verification = IntegratedServerJwtPayload.safeParse(decodedToken);
+      const verification = IntegratedServerJwtPayload.safeParse(
+        verifiedToken.data,
+      );
       if (!verification.success) {
         if (serverOps instanceof ValOpsFS) {
           return {
@@ -256,8 +271,7 @@ export const ValServer = (
           };
         }
         return {
-          error:
-            "Session invalid or, most likely, expired. You will need to login again.",
+          error: "Session invalid. You will need to login again.",
         };
       }
       return {
@@ -3007,6 +3021,23 @@ export type IntegratedServerJwtPayload = z.infer<
   typeof IntegratedServerJwtPayload
 >;
 
+/**
+ * The message we show the user when their session cookie does not verify. The
+ * distinction matters: an expired session is normal and self-explanatory, while
+ * a bad signature means the cookie was tampered with or `VAL_SECRET` changed.
+ */
+function sessionErrorMessage(reason: JwtFailureReason): string {
+  switch (reason) {
+    case "expired":
+      return "Session expired. You will need to login again.";
+    case "malformed":
+    case "invalid-signature":
+      return "Could not verify session (invalid token). You will need to login again.";
+    case "missing-secret":
+      return "Setup is not correct: secret is missing";
+  }
+}
+
 async function withAuth<T>(
   secret: string,
   cookies: ValCookies<VAL_SESSION_COOKIE>,
@@ -3030,23 +3061,24 @@ async function withAuth<T>(
 > {
   const cookie = cookies[VAL_SESSION_COOKIE];
   if (typeof cookie === "string") {
-    const decodedToken = decodeJwt(cookie, secret);
-    if (!decodedToken) {
+    const verifiedToken = verifyJwt(cookie, secret);
+    if (!verifiedToken.success) {
       return {
         status: 401 as const,
         json: {
-          message: "Could not verify session. You will need to login again.",
-          details: "Invalid token",
+          message: sessionErrorMessage(verifiedToken.reason),
+          details: verifiedToken.reason,
         },
       };
     }
-    const verification = IntegratedServerJwtPayload.safeParse(decodedToken);
+    const verification = IntegratedServerJwtPayload.safeParse(
+      verifiedToken.data,
+    );
     if (!verification.success) {
       return {
         status: 401 as const,
         json: {
-          message:
-            "Session invalid or, most likely, expired. You will need to login again.",
+          message: "Session invalid. You will need to login again.",
           details: fromError(verification.error).toString(),
         },
       };

--- a/packages/server/src/ValServer.ts
+++ b/packages/server/src/ValServer.ts
@@ -201,10 +201,15 @@ export const ValServer = (
       .then(async (res) => {
         if (res.status === 200) {
           const token = await res.text();
-          // NOTE: this token is signed by val.build with a key we do not hold,
-          // so we cannot verify it. What makes it trustworthy is where it came
-          // from: an api-key authenticated HTTPS POST to val.build, above. It
-          // is not user input.
+          // NOTE: this token is signed by val.build with a key we do not
+          // hold, so we cannot verify it. What stands in for a signature check
+          // is where it came from: the POST above, authenticated with the
+          // project's api key, to the configured `valBuildUrl`. It is not user
+          // input - but it is only as trustworthy as that host and that
+          // channel, and `valBuildUrl` is overridable (`opts.valBuildUrl`,
+          // `VAL_BUILD_URL`) and not required to be https. Point it at a plain
+          // http host and this payload - which is re-signed into the session
+          // cookie below - is whatever the network says it is.
           const decoded = decodeJwtWithoutVerifying(token);
           if (!decoded.success) {
             return null;

--- a/packages/server/src/jwt.test.ts
+++ b/packages/server/src/jwt.test.ts
@@ -1,0 +1,255 @@
+import crypto from "crypto";
+import {
+  decodeJwtWithoutVerifying,
+  encodeJwt,
+  getExpire,
+  verifyJwt,
+} from "./jwt";
+
+const SECRET = "a-test-secret";
+const OTHER_SECRET = "a-different-test-secret";
+
+function payload(overrides: Record<string, unknown> = {}) {
+  return {
+    sub: "profile-id",
+    exp: getExpire(),
+    org: "an-org",
+    project: "a-project",
+    ...overrides,
+  };
+}
+
+function base64(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString("base64");
+}
+
+/** Build a token with an arbitrary header, signed correctly for that header. */
+function signWith(header: unknown, body: unknown, secret: string): string {
+  const headerBase64 = base64(header);
+  const payloadBase64 = base64(body);
+  const signature = crypto
+    .createHmac("sha256", secret)
+    .update(`${headerBase64}.${payloadBase64}`)
+    .digest("base64");
+  return `${headerBase64}.${payloadBase64}.${signature}`;
+}
+
+describe("verifyJwt", () => {
+  test("round trips a token it signed itself", () => {
+    const body = payload();
+    const res = verifyJwt(encodeJwt(body, SECRET), SECRET);
+    expect(res).toEqual({ success: true, data: body });
+  });
+
+  test("keeps payload fields beyond the base shape", () => {
+    const body = payload({ token: "the-val-build-token" });
+    const res = verifyJwt(encodeJwt(body, SECRET), SECRET);
+    expect(res.success && res.data.token).toBe("the-val-build-token");
+  });
+
+  test("rejects a token signed with a different secret", () => {
+    const token = encodeJwt(payload(), OTHER_SECRET);
+    expect(verifyJwt(token, SECRET)).toMatchObject({
+      success: false,
+      reason: "invalid-signature",
+    });
+  });
+
+  test("rejects a token whose payload was swapped after signing", () => {
+    const [header, , signature] = encodeJwt(
+      payload({ sub: "victim" }),
+      SECRET,
+    ).split(".");
+    const tampered = `${header}.${base64(payload({ sub: "attacker" }))}.${signature}`;
+    expect(verifyJwt(tampered, SECRET)).toMatchObject({
+      success: false,
+      reason: "invalid-signature",
+    });
+  });
+
+  // This is the whole point of the signature: without a secret you must not be
+  // able to mint a session, no matter how well-formed the token looks.
+  test("rejects an unsigned but otherwise perfect token", () => {
+    const [header, body] = encodeJwt(payload(), SECRET).split(".");
+    expect(verifyJwt(`${header}.${body}.`, SECRET)).toMatchObject({
+      success: false,
+      reason: "malformed",
+    });
+    expect(verifyJwt(`${header}.${body}.notasignature`, SECRET)).toMatchObject({
+      success: false,
+      reason: "invalid-signature",
+    });
+  });
+
+  test("refuses to verify without a secret instead of skipping the check", () => {
+    const token = encodeJwt(payload(), SECRET);
+    expect(verifyJwt(token, "")).toMatchObject({
+      success: false,
+      reason: "missing-secret",
+    });
+  });
+
+  test("rejects a token whose signature is the right shape but the wrong bytes", () => {
+    const [header, body] = encodeJwt(payload(), SECRET).split(".");
+    const wrong = crypto.randomBytes(32).toString("base64");
+    expect(verifyJwt(`${header}.${body}.${wrong}`, SECRET)).toMatchObject({
+      success: false,
+      reason: "invalid-signature",
+    });
+  });
+
+  describe("expiry", () => {
+    test("rejects a token that expired", () => {
+      const body = payload({ exp: Math.floor(Date.now() / 1000) - 60 * 60 });
+      expect(verifyJwt(encodeJwt(body, SECRET), SECRET)).toMatchObject({
+        success: false,
+        reason: "expired",
+      });
+    });
+
+    test("rejects a token that expired a moment ago, once the leeway is past", () => {
+      const body = payload({ exp: Math.floor(Date.now() / 1000) - 61 });
+      expect(verifyJwt(encodeJwt(body, SECRET), SECRET)).toMatchObject({
+        success: false,
+        reason: "expired",
+      });
+    });
+
+    test("accepts a token inside the clock skew leeway", () => {
+      const body = payload({ exp: Math.floor(Date.now() / 1000) - 5 });
+      expect(verifyJwt(encodeJwt(body, SECRET), SECRET).success).toBe(true);
+    });
+
+    test("accepts a token that has not expired", () => {
+      const body = payload({ exp: Math.floor(Date.now() / 1000) + 60 });
+      expect(verifyJwt(encodeJwt(body, SECRET), SECRET).success).toBe(true);
+    });
+
+    // The signature is checked before the payload, so a forged token never gets
+    // to claim it is merely expired.
+    test("reports a forged expired token as a bad signature, not as expired", () => {
+      const body = payload({ exp: Math.floor(Date.now() / 1000) - 60 * 60 });
+      expect(verifyJwt(encodeJwt(body, OTHER_SECRET), SECRET)).toMatchObject({
+        success: false,
+        reason: "invalid-signature",
+      });
+    });
+  });
+
+  describe("header", () => {
+    test("rejects alg: none, even with a matching empty signature", () => {
+      const headerBase64 = base64({ alg: "none", typ: "JWT" });
+      const token = `${headerBase64}.${base64(payload())}.${crypto
+        .createHmac("sha256", SECRET)
+        .update(`${headerBase64}.${base64(payload())}`)
+        .digest("base64")}`;
+      expect(verifyJwt(token, SECRET)).toMatchObject({
+        success: false,
+        reason: "malformed",
+      });
+    });
+
+    test.each(["HS512", "RS256", "hs256"])("rejects alg: %s", (alg) => {
+      const token = signWith({ alg, typ: "JWT" }, payload(), SECRET);
+      expect(verifyJwt(token, SECRET)).toMatchObject({
+        success: false,
+        reason: "malformed",
+      });
+    });
+
+    test("rejects a non-JWT typ", () => {
+      const token = signWith({ alg: "HS256", typ: "JWS" }, payload(), SECRET);
+      expect(verifyJwt(token, SECRET)).toMatchObject({
+        success: false,
+        reason: "malformed",
+      });
+    });
+
+    test("rejects a header that is not JSON", () => {
+      const headerBase64 = Buffer.from("not json").toString("base64");
+      const token = `${headerBase64}.${base64(payload())}.sig`;
+      expect(verifyJwt(token, SECRET)).toMatchObject({
+        success: false,
+        reason: "malformed",
+      });
+    });
+  });
+
+  describe("format", () => {
+    test.each([
+      ["empty", ""],
+      ["no dots", "abc"],
+      ["two segments", "abc.def"],
+      ["four segments", "abc.def.ghi.jkl"],
+      ["empty header", ".def.ghi"],
+      ["empty payload", "abc..ghi"],
+    ])("rejects %s", (_name, token) => {
+      expect(verifyJwt(token, SECRET)).toMatchObject({
+        success: false,
+        reason: "malformed",
+      });
+    });
+  });
+
+  describe("payload", () => {
+    test("rejects a payload that is not JSON", () => {
+      const headerBase64 = base64({ alg: "HS256", typ: "JWT" });
+      const payloadBase64 = Buffer.from("not json").toString("base64");
+      const token = `${headerBase64}.${payloadBase64}.${crypto
+        .createHmac("sha256", SECRET)
+        .update(`${headerBase64}.${payloadBase64}`)
+        .digest("base64")}`;
+      expect(verifyJwt(token, SECRET)).toMatchObject({
+        success: false,
+        reason: "malformed",
+      });
+    });
+
+    test.each([
+      ["empty", {}],
+      ["no exp", { sub: "s", org: "o", project: "p" }],
+      [
+        "exp as a string",
+        { sub: "s", exp: "9999999999", org: "o", project: "p" },
+      ],
+      ["no sub", { exp: getExpire(), org: "o", project: "p" }],
+      ["no org", { sub: "s", exp: getExpire(), project: "p" }],
+    ])("rejects a payload with %s", (_name, body) => {
+      expect(verifyJwt(encodeJwt(body, SECRET), SECRET)).toMatchObject({
+        success: false,
+        reason: "malformed",
+      });
+    });
+  });
+});
+
+describe("decodeJwtWithoutVerifying", () => {
+  test("returns the payload of a token it cannot verify", () => {
+    const body = payload();
+    const res = decodeJwtWithoutVerifying(encodeJwt(body, "some-other-key"));
+    expect(res).toEqual({ success: true, data: body });
+  });
+
+  test("still rejects an expired token", () => {
+    const body = payload({ exp: Math.floor(Date.now() / 1000) - 60 * 60 });
+    expect(decodeJwtWithoutVerifying(encodeJwt(body, SECRET))).toMatchObject({
+      success: false,
+      reason: "expired",
+    });
+  });
+
+  test("still rejects a bad header", () => {
+    const token = signWith({ alg: "none", typ: "JWT" }, payload(), SECRET);
+    expect(decodeJwtWithoutVerifying(token)).toMatchObject({
+      success: false,
+      reason: "malformed",
+    });
+  });
+
+  test("still rejects a payload that is not a Val payload", () => {
+    expect(decodeJwtWithoutVerifying(encodeJwt({}, SECRET))).toMatchObject({
+      success: false,
+      reason: "malformed",
+    });
+  });
+});

--- a/packages/server/src/jwt.ts
+++ b/packages/server/src/jwt.ts
@@ -33,8 +33,9 @@ export type JwtFailure = {
 export type JwtResult = { success: true; data: JwtPayload } | JwtFailure;
 
 /**
- * Tokens are rejected `exp` seconds after they were issued, with this much
- * slack to absorb clock drift between whoever signed the token and us.
+ * `exp` is an absolute Unix timestamp: a token is rejected once that moment has
+ * passed, with this much slack to absorb clock drift between whoever signed the
+ * token and us.
  */
 const CLOCK_SKEW_LEEWAY_SECONDS = 60;
 

--- a/packages/server/src/jwt.ts
+++ b/packages/server/src/jwt.ts
@@ -1,68 +1,177 @@
 import crypto from "crypto";
 import { z } from "zod";
 
-export type JwtPayload = {
-  sub: string;
-  exp: number;
-  org: string;
-  project: string;
+const JwtPayloadSchema = z
+  .object({
+    sub: z.string(),
+    exp: z.number(),
+    org: z.string(),
+    project: z.string(),
+  })
+  // NOTE: passthrough, because the session cookie payload carries more than
+  // this (the val.build token, notably). This is the minimum every Val JWT has.
+  .passthrough();
+
+export type JwtPayload = z.infer<typeof JwtPayloadSchema>;
+
+export type JwtFailureReason =
+  /** Not a JWT we issued: wrong number of segments, bad header, or a payload that is not a Val payload. */
+  | "malformed"
+  /** The HMAC did not match: the token was forged or tampered with. */
+  | "invalid-signature"
+  /** The token parsed and verified, but `exp` is in the past. */
+  | "expired"
+  /** Programming error: {@link verifyJwt} was called without a secret. */
+  | "missing-secret";
+
+export type JwtFailure = {
+  success: false;
+  reason: JwtFailureReason;
+  message: string;
 };
 
-export function decodeJwt(
-  token: string,
-  secretKey?: string,
-): JwtPayload | null {
+export type JwtResult = { success: true; data: JwtPayload } | JwtFailure;
+
+/**
+ * Tokens are rejected `exp` seconds after they were issued, with this much
+ * slack to absorb clock drift between whoever signed the token and us.
+ */
+const CLOCK_SKEW_LEEWAY_SECONDS = 60;
+
+function failure(reason: JwtFailureReason, message: string): JwtFailure {
+  // NOTE: deliberately never logs the token itself - it is a credential, and
+  // anything we print here ends up in the host's request logs.
+  console.debug(`Invalid JWT (${reason}): ${message}`);
+  return { success: false, reason, message };
+}
+
+type JwtSegments = {
+  headerBase64: string;
+  payloadBase64: string;
+  signatureBase64: string;
+};
+
+function splitToken(token: string): JwtSegments | null {
   const [headerBase64, payloadBase64, signatureBase64, ...rest] =
     token.split(".");
   if (!headerBase64 || !payloadBase64 || !signatureBase64 || rest.length > 0) {
-    console.debug(
-      "Invalid JWT: format is not exactly {header}.{payload}.{signature}",
-      token,
-    );
     return null;
   }
+  return { headerBase64, payloadBase64, signatureBase64 };
+}
 
+/** Returns the failure if the header is not one of ours, or null if it is fine. */
+function verifyHeader(headerBase64: string): JwtFailure | null {
+  let parsedHeader: unknown;
   try {
-    const parsedHeader = JSON.parse(
+    parsedHeader = JSON.parse(
       Buffer.from(headerBase64, "base64").toString("utf8"),
-    ) as unknown;
-    const headerVerification = JwtHeaderSchema.safeParse(parsedHeader);
-    if (!headerVerification.success) {
-      console.debug("Invalid JWT: invalid header", parsedHeader);
-      return null;
-    }
-    if (headerVerification.data.typ !== jwtHeader.typ) {
-      console.debug("Invalid JWT: invalid header typ", parsedHeader);
-      return null;
-    }
-    if (headerVerification.data.alg !== jwtHeader.alg) {
-      console.debug("Invalid JWT: invalid header alg", parsedHeader);
-      return null;
-    }
-  } catch (err) {
-    console.debug("Invalid JWT: could not parse header", err);
-    return null;
+    );
+  } catch {
+    return failure("malformed", "could not parse header");
+  }
+  const headerVerification = JwtHeaderSchema.safeParse(parsedHeader);
+  if (!headerVerification.success) {
+    // NOTE: JwtHeaderSchema pins alg to HS256, so `alg: "none"` and every other
+    // algorithm-confusion header is rejected here, before we look at the
+    // signature at all.
+    return failure("malformed", "unsupported header");
+  }
+  return null;
+}
+
+function parsePayload(payloadBase64: string): JwtResult {
+  let parsedPayload: unknown;
+  try {
+    parsedPayload = JSON.parse(
+      Buffer.from(payloadBase64, "base64").toString("utf8"),
+    );
+  } catch {
+    return failure("malformed", "could not parse payload");
+  }
+  const payloadVerification = JwtPayloadSchema.safeParse(parsedPayload);
+  if (!payloadVerification.success) {
+    return failure("malformed", "payload is not a Val JWT payload");
+  }
+  const payload = payloadVerification.data;
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (payload.exp + CLOCK_SKEW_LEEWAY_SECONDS <= nowSeconds) {
+    return failure("expired", "token expired");
+  }
+  return { success: true, data: payload };
+}
+
+/**
+ * Verify a JWT that we issued with {@link encodeJwt}, and return its payload.
+ *
+ * Checks, in order: the segment count, the header (`alg` is pinned to HS256, so
+ * algorithm confusion is rejected before the signature is looked at), the HMAC
+ * (compared in constant time), the payload shape, and `exp`.
+ *
+ * There is deliberately no way to make this skip the signature check: the
+ * secret is required, and an empty one is a failure rather than a token that
+ * validates against `HMAC("")`. Use {@link decodeJwtWithoutVerifying} - and read
+ * what it says - when you genuinely do not hold the signing key.
+ */
+export function verifyJwt(token: string, secretKey: string): JwtResult {
+  if (!secretKey) {
+    return failure("missing-secret", "no secret key was provided");
+  }
+  const segments = splitToken(token);
+  if (!segments) {
+    return failure(
+      "malformed",
+      "format is not exactly {header}.{payload}.{signature}",
+    );
+  }
+  const { headerBase64, payloadBase64, signatureBase64 } = segments;
+
+  const headerFailure = verifyHeader(headerBase64);
+  if (headerFailure) {
+    return headerFailure;
   }
 
-  if (secretKey) {
-    const signature = crypto
-      .createHmac("sha256", secretKey)
-      .update(`${headerBase64}.${payloadBase64}`)
-      .digest("base64");
-    if (signature !== signatureBase64) {
-      console.debug("Invalid JWT: invalid signature");
-      return null;
-    }
+  const expectedSignature = crypto
+    .createHmac("sha256", secretKey)
+    .update(`${headerBase64}.${payloadBase64}`)
+    .digest();
+  const actualSignature = Buffer.from(signatureBase64, "base64");
+  // NOTE: the length check is what makes timingSafeEqual usable at all (it
+  // throws on a length mismatch), and the length of an HMAC-SHA256 is public.
+  if (
+    actualSignature.length !== expectedSignature.length ||
+    !crypto.timingSafeEqual(actualSignature, expectedSignature)
+  ) {
+    return failure("invalid-signature", "signature does not match");
   }
-  try {
-    const parsedPayload = JSON.parse(
-      Buffer.from(payloadBase64, "base64").toString("utf8"),
-    ) as JwtPayload;
-    return parsedPayload;
-  } catch (err) {
-    console.debug("Invalid JWT: could not parse payload", err);
-    return null;
+
+  return parsePayload(payloadBase64);
+}
+
+/**
+ * Parse a JWT's payload **without checking its signature**.
+ *
+ * The header, the payload shape and `exp` are still validated, but nothing here
+ * establishes that the token was issued by anyone in particular. Only use this
+ * for a token whose authenticity is already established by the channel it
+ * arrived on - the app token we fetch from val.build over an api-key
+ * authenticated HTTPS request is the one such case. Anything that arrives from
+ * a browser (a cookie, a header, a query parameter) must go through
+ * {@link verifyJwt}.
+ */
+export function decodeJwtWithoutVerifying(token: string): JwtResult {
+  const segments = splitToken(token);
+  if (!segments) {
+    return failure(
+      "malformed",
+      "format is not exactly {header}.{payload}.{signature}",
+    );
   }
+  const headerFailure = verifyHeader(segments.headerBase64);
+  if (headerFailure) {
+    return headerFailure;
+  }
+  return parsePayload(segments.payloadBase64);
 }
 
 export function getExpire(): number {


### PR DESCRIPTION
All three claims check out. `decodeJwt` in `packages/server/src/jwt.ts` accepted session cookies it should have rejected — with the caveat, per Copilot's review, that the timing issue is a leak rather than an acceptance bug.

## What was wrong

**`exp` was never checked.** The payload was parsed and handed straight back:

```ts
const parsedPayload = JSON.parse(
  Buffer.from(payloadBase64, "base64").toString("utf8"),
) as JwtPayload;
return parsedPayload;
```

The callers' zod schemas (`IntegratedServerJwtPayload`, `ValAppJwtPayload`) only assert `exp: z.number()` — nothing ever compares it to the clock. So a session cookie was valid forever. The four-day lifetime from `getExpire()` existed only as the `expires` attribute on the cookie, which is enforced by the browser holding it, i.e. by the party you are trying to authenticate. A cookie captured once keeps working indefinitely, and revocation by expiry does not exist. The `"Session invalid or, most likely, expired"` message in `getAuth` and `withAuth` was never once produced by an expiry check.

**The signature was compared with `!==`.** This one did reject every invalid signature — but string comparison short-circuits on the first differing byte, so how long it took leaked how much of a guessed signature was correct.

**Verification was skipped entirely when `secretKey` was falsy** — `if (secretKey) { ...check... }`, with the parameter declared optional. One forgotten argument, or a `VAL_SECRET` that reads as `""`, turns the session cookie into an unauthenticated, attacker-writable claim of identity, and nothing anywhere says so. Every current call site happens to guard for a missing secret first, so this was a latent footgun rather than a live hole — but it is the kind that gets stepped on by the next caller.

The one thing that was already right: `alg` is pinned to `HS256` via `z.literal`, so `alg: "none"` and algorithm confusion were never reachable. That property is preserved, and the ordering (header → signature → payload) keeps it that way.

## What this changes

`decodeJwt` is replaced by two functions that cannot be mistaken for one another:

- **`verifyJwt(token, secretKey)`** — the secret is required; the HMAC is compared with `crypto.timingSafeEqual` (guarded by a length check, since it throws on mismatched lengths); the payload is validated with a zod schema rather than an unchecked `as JwtPayload`; and `exp` is enforced, with 60s of leeway for clock drift. An empty secret is a `missing-secret` failure, not a token that validates against `HMAC("")`.
- **`decodeJwtWithoutVerifying(token)`** — the explicitly unverified path, for the one caller that genuinely does not hold the signing key: the app token fetched from val.build in `consumeCode`, whose authenticity comes from the api-key authenticated request it arrived on. The header, payload shape and `exp` are still checked; the doc comment says what it does not check and that anything arriving from a browser must not use it.

Both return a `JwtResult` carrying *why* a token was rejected (`malformed` / `invalid-signature` / `expired` / `missing-secret`), so `getAuth` and `withAuth` can now say "Session expired" when that is what happened, instead of guessing in prose.

The token is also no longer written to the debug log on a format error — it is a credential, and that line put it in the host's request logs.

## Tests

`jwt.ts` had no test file. It has one now, 34 cases, with the three holes covered directly:

- expired tokens rejected; a token inside the leeway accepted; a *forged* expired token reported as `invalid-signature`, not `expired` (the signature is checked first, so a forgery never gets to claim it is merely stale)
- wrong secret, swapped payload, right-length-wrong-bytes signature, and an unsigned token all rejected
- `verifyJwt(token, "")` returns `missing-secret` rather than accepting the token
- `alg: none`, `HS512`, `RS256`, lowercase `hs256`, wrong `typ`, non-JSON header/payload, every malformed segment count, and payloads missing `exp`/`sub`/`org` or carrying `exp` as a string

Each of the first three groups fails against the old implementation.

## Review follow-up

Copilot raised three points; all three were about text that said something untrue, and all three are fixed in 71d452c. The third also carries a code suggestion that is **not** taken here: `valBuildUrl` is overridable via `opts.valBuildUrl` / `VAL_BUILD_URL` with no scheme check, so an `http:` override would expose the api key and the app token. That is pre-existing, operator-controlled rather than attacker-reachable, and shared by every `valBuildUrl` use (`/authorize`, `/auth/session`) — so it belongs in its own change to the login flow, not bolted onto `consumeCode`. Discussion on [that thread](https://github.com/valbuild/val/pull/564#discussion_r3897864269).

## Compatibility

`decodeJwt` was exported from `@valbuild/server`'s index, so removing it is breaking — hence a `minor` changeset (0.x). Existing session cookies keep working until their `exp` passes; nobody is logged out by this. The wire format is unchanged.

## Checks

`pnpm lint`, `prettier --check .`, `pnpm run -r typecheck`, `pnpm test` (229 suites / 2870 tests), `pnpm run build`, and `cd examples/next && pnpm run build` all pass. Also ran the CLI's `validate` against `examples/next` per the repo instructions for `packages/server` changes — 19 modules load, only the known pre-existing content errors.