### PR TITLE
Publish summary that never waits on AI, and a stop button for chat

### DIFF
--- a/.changeset/publish-summary-and-chat-cancel.md
+++ b/.changeset/publish-summary-and-chat-cancel.md
@@ -1,0 +1,22 @@
+---
+"@valbuild/ui": minor
+"@valbuild/shared": minor
+---
+
+Publishing no longer waits on the AI, and chat turns can be stopped.
+
+The publish summary box opens filled with a summary built locally from the
+changed modules and is editable from the first frame. It used to disable its
+textarea and blank the text while the AI wrote, so a typo fix meant waiting on
+a model before you could type. The AI is now an offer beside the heading: it
+fills a box you have not touched, or is offered as "Use AI summary" if you have
+started writing. Pressing Publish while it is still writing publishes after a
+short grace period, and pressing Publish again skips the wait.
+
+The chat's send button becomes a stop button while the assistant is streaming.
+Stopping aborts the request on the server rather than only stopping the client
+listening, which matters when the call runs on your own API key.
+
+Also fixes AI error messages being dropped in the Studio: the error code list
+was strict and had fallen behind the content server, so newer codes failed to
+parse and the turn appeared to hang instead of reporting why it stopped.

--- a/packages/ui/spa/components/AIChat.stories.tsx
+++ b/packages/ui/spa/components/AIChat.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   AIChat,
   AIChatHandle,
@@ -169,6 +169,61 @@ function AutoStartStreamingDemo() {
           id: "auto-stream-user-1",
           role: "user",
           content: "Explain the authors schema",
+          status: "complete",
+        },
+      ]}
+    />
+  );
+}
+
+/**
+ * Streaming with a stop control. The send button becomes a stop button for as
+ * long as the assistant is talking — the two are never both available, and one
+ * of them is always the thing you want.
+ */
+export const StreamingCancellable: Story = {
+  render: () => <CancellableStreamingDemo />,
+};
+
+function CancellableStreamingDemo() {
+  const chatRef = useRef<AIChatHandle>(null);
+  const [stopped, setStopped] = useState(false);
+
+  useEffect(() => {
+    if (!chatRef.current) return;
+    const assistantId = "cancellable-1";
+    chatRef.current.startAssistantMessage(assistantId);
+    let idx = 0;
+    const interval = setInterval(() => {
+      if (!chatRef.current || stopped) return;
+      const chunk = STREAMING_TEXT.slice(idx, idx + 3);
+      if (chunk) {
+        chatRef.current.appendAssistantChunk(assistantId, chunk);
+        idx += 3;
+      } else {
+        chatRef.current.completeAssistantMessage(assistantId);
+        clearInterval(interval);
+      }
+    }, 60);
+    return () => clearInterval(interval);
+  }, [stopped]);
+
+  return (
+    <AIChat
+      ref={chatRef}
+      isConnected={true}
+      authError={false}
+      mode="http"
+      onCancel={() => {
+        setStopped(true);
+        // What arriving `ai_cancelled` does: settle, keeping the partial text.
+        chatRef.current?.completeAssistantMessage("cancellable-1");
+      }}
+      initialMessages={[
+        {
+          id: "cancellable-user-1",
+          role: "user",
+          content: "Rewrite every page in a friendlier tone",
           status: "complete",
         },
       ]}

--- a/packages/ui/spa/components/AIChat.stories.tsx
+++ b/packages/ui/spa/components/AIChat.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import {
   AIChat,
   AIChatHandle,
@@ -187,7 +187,10 @@ export const StreamingCancellable: Story = {
 
 function CancellableStreamingDemo() {
   const chatRef = useRef<AIChatHandle>(null);
-  const [stopped, setStopped] = useState(false);
+  // A ref, not state: making this a dependency re-ran the effect on stop, which
+  // started a second assistant message and left an empty bubble streaming
+  // forever — the opposite of what the story is meant to show.
+  const stoppedRef = useRef(false);
 
   useEffect(() => {
     if (!chatRef.current) return;
@@ -195,7 +198,7 @@ function CancellableStreamingDemo() {
     chatRef.current.startAssistantMessage(assistantId);
     let idx = 0;
     const interval = setInterval(() => {
-      if (!chatRef.current || stopped) return;
+      if (!chatRef.current || stoppedRef.current) return;
       const chunk = STREAMING_TEXT.slice(idx, idx + 3);
       if (chunk) {
         chatRef.current.appendAssistantChunk(assistantId, chunk);
@@ -206,7 +209,7 @@ function CancellableStreamingDemo() {
       }
     }, 60);
     return () => clearInterval(interval);
-  }, [stopped]);
+  }, []);
 
   return (
     <AIChat
@@ -215,8 +218,9 @@ function CancellableStreamingDemo() {
       authError={false}
       mode="http"
       onCancel={() => {
-        setStopped(true);
-        // What arriving `ai_cancelled` does: settle, keeping the partial text.
+        stoppedRef.current = true;
+        // What arriving `ai_cancelled` does: settle as complete, keeping the
+        // partial text — a stop is not a failure.
         chatRef.current?.completeAssistantMessage("cancellable-1");
       }}
       initialMessages={[

--- a/packages/ui/spa/components/AIChat.tsx
+++ b/packages/ui/spa/components/AIChat.tsx
@@ -14,6 +14,7 @@ import { Button } from "./designSystem/button";
 import { cn } from "./designSystem/cn";
 import {
   Send,
+  Square,
   RotateCcw,
   Sparkles,
   Loader2,
@@ -170,6 +171,12 @@ export type AIChatHandle = {
 };
 
 export type AIChatProps = {
+  /**
+   * Stop the running turn. When given, the send button becomes a stop button
+   * while the assistant is streaming — the same control, because the two are
+   * never both available and one of them is always the thing you want.
+   */
+  onCancel?: () => void;
   /** Called when the user submits a message (via input or suggestion chip). Returns true if sent successfully. */
   onSendMessage?: (
     content: string | ChatDocument,
@@ -523,6 +530,7 @@ function getImageUrls(content: AIMessageContent): string[] {
 
 export const AIChat = forwardRef<AIChatHandle, AIChatProps>(function AIChat(
   {
+    onCancel,
     onSendMessage,
     onUploadFile,
     onNewSession,
@@ -1311,23 +1319,36 @@ export const AIChat = forwardRef<AIChatHandle, AIChatProps>(function AIChat(
                     <Paperclip className="h-4 w-4" />
                   </Button>
                 )}
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  disabled={
-                    !isConnected ||
-                    isStreaming ||
-                    isUploading ||
-                    hasPendingInlineImage ||
-                    authError ||
-                    isEditorEmpty
-                  }
-                  onClick={() => handleSend()}
-                  aria-label="Send message"
-                  className="ml-auto"
-                >
-                  <Send className="h-4 w-4" />
-                </Button>
+                {isStreaming && onCancel ? (
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    onClick={onCancel}
+                    aria-label="Stop generating"
+                    title="Stop generating"
+                    className="ml-auto"
+                  >
+                    <Square className="h-3.5 w-3.5 fill-current" />
+                  </Button>
+                ) : (
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    disabled={
+                      !isConnected ||
+                      isStreaming ||
+                      isUploading ||
+                      hasPendingInlineImage ||
+                      authError ||
+                      isEditorEmpty
+                    }
+                    onClick={() => handleSend()}
+                    aria-label="Send message"
+                    className="ml-auto"
+                  >
+                    <Send className="h-4 w-4" />
+                  </Button>
+                )}
               </div>
             </div>
           </>

--- a/packages/ui/spa/components/AIChatSurface.tsx
+++ b/packages/ui/spa/components/AIChatSurface.tsx
@@ -62,6 +62,7 @@ export function AIChatSurface({ className }: { className?: string }) {
     isLoadingSession,
     answerToolQuestions,
     cancelToolQuestion,
+    cancel,
   } = useAI(chatRef, {
     initialSessionId: initialSessionIdRef.current,
     onSessionBorn: (id) => {
@@ -110,6 +111,7 @@ export function AIChatSurface({ className }: { className?: string }) {
       className={className}
       chatEditorRef={chatEditorRef}
       onSendMessage={sendMessage}
+      onCancel={cancel}
       onUploadFile={uploadAiImage}
       onNewSession={newSession}
       isConnected={isConnected}

--- a/packages/ui/spa/components/PublishButton.tsx
+++ b/packages/ui/spa/components/PublishButton.tsx
@@ -79,15 +79,8 @@ export function PublishButton({
   compact?: boolean;
 }) {
   const [summaryOpen, setSummaryOpen] = useState(false);
-  const {
-    publish,
-    publishDisabled,
-    isPublishing,
-    summary,
-    generateSummary,
-    setSummary,
-    canGenerate,
-  } = usePublishSummary();
+  const { publish, publishDisabled, isPublishing, summary } =
+    usePublishSummary();
   const allValidationErrors = useAllValidationErrors();
   const validationErrorPaths = Object.keys(allValidationErrors ?? {});
   const { patchErrors } = useAllPatchErrors();
@@ -229,23 +222,9 @@ export function PublishButton({
       className={buttonClassName}
       aria-label={compact ? state.description : undefined}
       onClick={() => {
+        // Generation starts when the popover mounts, which is this same press —
+        // it lives with the summary it fills in, not with the button.
         setSummaryOpen(true);
-        // Always generate a new summary when opening
-        if (canGenerate) {
-          const timeoutPromise = new Promise<{ type: "timeout" }>((resolve) =>
-            setTimeout(() => resolve({ type: "timeout" }), 20000),
-          );
-
-          Promise.race([generateSummary(), timeoutPromise]).then((result) => {
-            if (result.type === "timeout") {
-              console.warn("Val: Summary generation timed out after 20s");
-            } else if (result.type === "ai") {
-              setSummary({ type: "ai", text: result.text.trim() });
-            } else if (result.type === "error") {
-              console.warn("Val: Summary generation failed:", result.message);
-            }
-          });
-        }
       }}
     >
       {face}

--- a/packages/ui/spa/components/PublishSummary.tsx
+++ b/packages/ui/spa/components/PublishSummary.tsx
@@ -1,8 +1,30 @@
-import { usePublishSummary } from "./ValProvider";
-import { Button } from "./designSystem/button";
-import { Upload } from "lucide-react";
-import { cn } from "./designSystem/cn";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { usePatchSets, usePublishSummary } from "./ValProvider";
+import {
+  PublishSummaryView,
+  usePublishGrace,
+  type AiSummaryState,
+} from "./PublishSummaryView";
+import {
+  buildDefaultCommitSummary,
+  shouldAutoApplyAiSummary,
+} from "./publish/defaultCommitSummary";
 
+/**
+ * How long publishing waits for an AI summary that is still being written.
+ *
+ * Publishing was already asked for, so this is a courtesy, not a gate: it ends
+ * either way, and pressing Publish again ends it immediately.
+ */
+const PUBLISH_GRACE_SECONDS = 10;
+
+/**
+ * The publish summary popover.
+ *
+ * Mounting this IS "publish was hit" — the popover only renders when opened —
+ * so this is where the AI request starts, and where the box is seeded with a
+ * summary that needed no network call.
+ */
 export function PublishSummary({
   onPublish,
   onClose,
@@ -10,89 +32,155 @@ export function PublishSummary({
   onPublish?: () => void;
   onClose: () => void;
 }) {
-  const { summary, setSummary, publishDisabled } = usePublishSummary();
+  const {
+    summary,
+    setSummary,
+    publishDisabled,
+    isPublishing,
+    generateSummary,
+    canGenerate,
+  } = usePublishSummary();
+  const patchSets = usePatchSets();
+  const grace = usePublishGrace(PUBLISH_GRACE_SECONDS);
 
-  const className = "w-full p-2 border rounded bg-bg-secondary";
-  const text = "text" in summary ? summary.text : "";
+  const defaultSummary = useMemo(() => {
+    const paths =
+      patchSets.status === "success"
+        ? patchSets.data.map((patchSet) => patchSet.moduleFilePath)
+        : [];
+    return buildDefaultCommitSummary(paths);
+  }, [patchSets]);
+
+  const [ai, setAi] = useState<AiSummaryState>({
+    status: canGenerate ? "idle" : "off",
+  });
+  // Latches on the first keystroke and never clears, so deleting back to the
+  // default text does not re-arm the AI's takeover.
+  const [hasEdited, setHasEdited] = useState(false);
+
+  const value = "text" in summary ? summary.text : "";
+
+  // Fill the box before anything else happens. An empty publish box is the one
+  // state this flow must never be in, because it disables Publish.
+  //
+  // Ref-guarded rather than keyed off `value`: seeding must happen once, and
+  // re-running as the box changes would put the default back the moment the
+  // user cleared it to write their own.
+  const seededRef = useRef(false);
+  useEffect(() => {
+    if (seededRef.current) {
+      return;
+    }
+    seededRef.current = true;
+    if (value.trim() === "") {
+      setSummary({ type: "manual", text: defaultSummary });
+    }
+  }, [defaultSummary, value, setSummary]);
+
+  // Start the AI when the popover opens, and never block on it.
+  const startedRef = useRef(false);
+  useEffect(() => {
+    if (startedRef.current || !canGenerate) {
+      return;
+    }
+    startedRef.current = true;
+    let cancelled = false;
+    setAi({ status: "loading" });
+    generateSummary().then((result) => {
+      if (cancelled) {
+        return;
+      }
+      if (result.type === "ai") {
+        const text = result.text.trim();
+        setAi({ status: "ready", text, sessionId: null });
+      } else {
+        setAi({ status: "failed", message: result.message });
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [canGenerate, generateSummary]);
+
+  // Applying the AI summary is a separate effect from receiving it so the
+  // decision reads off the box as it is now, not as it was when the request was
+  // made. It happens at most once — one arrival, one chance to take over, and
+  // after that the suggestion is offered rather than applied.
+  const appliedRef = useRef(false);
+  useEffect(() => {
+    if (appliedRef.current || ai.status !== "ready") {
+      return;
+    }
+    appliedRef.current = true;
+    if (
+      shouldAutoApplyAiSummary({
+        hasEdited,
+        currentValue: value,
+        defaultSummary,
+      })
+    ) {
+      setSummary({ type: "ai", text: ai.text });
+    }
+  }, [ai, hasEdited, value, defaultSummary, setSummary]);
+
+  // The countdown exists to give the summary a chance to arrive. Once it has —
+  // or has failed — there is nothing left to wait for, so go.
+  const { isWaiting, skip } = grace;
+  useEffect(() => {
+    if (!isWaiting) {
+      return;
+    }
+    if (ai.status === "ready" || ai.status === "failed") {
+      skip();
+    }
+  }, [ai.status, isWaiting, skip]);
+
+  const publishNow = () => {
+    onPublish?.();
+  };
 
   return (
-    <div className="flex flex-col gap-4">
-      <span className="font-semibold">Summary</span>
-      <div className="grid text-xs font-light">
-        {/* https://css-tricks.com/the-cleanest-trick-for-autogrowing-textareas */}
-        <div
-          aria-hidden
-          className={cn(className, "invisible whitespace-pre-wrap")}
-          style={{
-            gridArea: "1 / 1 / 2 / 2",
-          }}
-        >
-          {/* Note the weird space! Needed to prevent jumpy behavior */}
-          {(summary.isGenerating ? "" : text) + " "}
-        </div>
-        <textarea
-          disabled={!!summary.isGenerating}
-          className={cn(
-            className,
-            "resize-none overflow-clip disabled:opacity-50",
-          )}
-          value={summary.isGenerating ? "" : text}
-          style={{
-            gridArea: "1 / 1 / 2 / 2",
-          }}
-          placeholder={
-            summary.isGenerating
-              ? "Generating summary..."
-              : "Write a summary of your changes"
-          }
-          onChange={(e) => {
-            setSummary({
-              type: "manual",
-              text: e.currentTarget.value,
-            });
-          }}
-        />
-      </div>
-      <div className="flex items-center justify-end gap-2">
-        {summary.isGenerating && (
-          <Button
-            variant="outline"
-            onClick={() => {
-              setSummary({ type: "manual", text: "" });
-            }}
-          >
-            Cancel
-          </Button>
-        )}
-        <Button
-          variant="outline"
-          onClick={() => {
-            // Reset to "not-asked" if text is empty so it will regenerate on next open
-            if (text.trim() === "") {
-              setSummary({ type: "not-asked" });
-            }
-            onClose();
-          }}
-        >
-          Close
-        </Button>
-        {onPublish && (
-          <Button
-            disabled={publishDisabled || text.trim() === ""}
-            onClick={() => {
-              if (summary.type === "not-asked") {
-                return;
-              }
-              onPublish();
-            }}
-            variant="default"
-            className="flex items-center gap-2"
-          >
-            <span>{publishDisabled ? "Pushing..." : "Publish"}</span>
-            <Upload size={16} />
-          </Button>
-        )}
-      </div>
-    </div>
+    <PublishSummaryView
+      value={value}
+      onChange={(next) => {
+        setHasEdited(true);
+        setSummary({ type: "manual", text: next });
+      }}
+      ai={ai}
+      onUseAiSummary={() => {
+        if (ai.status === "ready") {
+          setSummary({ type: "ai", text: ai.text });
+        }
+      }}
+      onPublish={() => {
+        // A second press during the countdown skips the rest of it.
+        if (grace.isWaiting) {
+          grace.skip();
+          return;
+        }
+        // Only worth waiting for if it could still change the text: someone who
+        // wrote their own summary is not waiting on a suggestion they will not
+        // get.
+        const couldStillHelp =
+          ai.status === "loading" &&
+          shouldAutoApplyAiSummary({
+            hasEdited,
+            currentValue: value,
+            defaultSummary,
+          });
+        if (couldStillHelp) {
+          grace.start(publishNow);
+          return;
+        }
+        publishNow();
+      }}
+      onClose={() => {
+        grace.cancel();
+        onClose();
+      }}
+      publishDisabled={publishDisabled}
+      isPublishing={isPublishing}
+      waitingForAiSeconds={grace.remaining}
+    />
   );
 }

--- a/packages/ui/spa/components/PublishSummaryView.stories.tsx
+++ b/packages/ui/spa/components/PublishSummaryView.stories.tsx
@@ -1,9 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { fn } from "storybook/test";
 import { PublishSummaryView } from "./PublishSummaryView";
 import type { AiSummaryState } from "./PublishSummaryView";
-import { buildDefaultCommitSummary } from "./publish/defaultCommitSummary";
+import {
+  buildDefaultCommitSummary,
+  shouldAutoApplyAiSummary,
+} from "./publish/defaultCommitSummary";
 
 const DEFAULT_SUMMARY = buildDefaultCommitSummary([
   "/content/home.val.ts",
@@ -25,7 +28,6 @@ const meta: Meta<typeof PublishSummaryView> = {
     onUseAiSummary: fn(),
     onPublish: fn(),
     onClose: fn(),
-    onPublishNow: fn(),
     publishDisabled: false,
     isPublishing: false,
     waitingForAiSeconds: null,
@@ -118,7 +120,8 @@ export const AiFailed: Story = {
 
 /**
  * Publish was pressed while the AI was still writing. Publishing is already
- * happening — this is the 10 second grace period, with a way to skip it.
+ * happening — this is the 10 second grace period. Pressing Publish again
+ * skips the rest of it, so there is no separate escape control.
  */
 export const WaitingForAiOnPublish: Story = {
   args: {
@@ -141,12 +144,15 @@ export const Publishing: Story = {
 
 /**
  * The whole flow, driven for real: the summary is there immediately, the AI
- * lands after three seconds, and typing at any point keeps your text.
+ * lands after three seconds, and typing at any point cancels the takeover so
+ * your text survives — the same `shouldAutoApplyAiSummary` rule the app uses.
  */
 export const InteractiveFlow: Story = {
   render: function InteractiveFlowStory() {
     const [value, setValue] = useState(DEFAULT_SUMMARY);
     const [isEdited, setIsEdited] = useState(false);
+    // Read inside the timeout, which closes over the state at scheduling time.
+    const hasEditedRef = useRef(false);
     const [ai, setAi] = useState<AiSummaryState>({ status: "idle" });
 
     return (
@@ -162,9 +168,15 @@ export const InteractiveFlow: Story = {
                 text: AI_SUMMARY,
                 sessionId: "session-1",
               });
-              // Only take over the box when the user has not written anything
+              // Typing cancels the takeover: same rule the app runs on.
               setValue((current) =>
-                current === DEFAULT_SUMMARY ? AI_SUMMARY : current,
+                shouldAutoApplyAiSummary({
+                  hasEdited: hasEditedRef.current,
+                  currentValue: current,
+                  defaultSummary: DEFAULT_SUMMARY,
+                })
+                  ? AI_SUMMARY
+                  : current,
               );
             }, 3000);
           }}
@@ -176,12 +188,15 @@ export const InteractiveFlow: Story = {
           onChange={(next) => {
             setValue(next);
             setIsEdited(true);
+            hasEditedRef.current = true;
           }}
           ai={ai}
           isEdited={isEdited}
           onUseAiSummary={() => {
             if (ai.status === "ready") {
               setValue(ai.text);
+              // Taking the suggestion is not "unedited": a later arrival must
+              // still not overwrite it.
               setIsEdited(false);
             }
           }}
@@ -192,7 +207,6 @@ export const InteractiveFlow: Story = {
           publishDisabled={false}
           isPublishing={false}
           waitingForAiSeconds={null}
-          onPublishNow={fn()}
         />
       </div>
     );

--- a/packages/ui/spa/components/PublishSummaryView.stories.tsx
+++ b/packages/ui/spa/components/PublishSummaryView.stories.tsx
@@ -31,7 +31,6 @@ const meta: Meta<typeof PublishSummaryView> = {
     publishDisabled: false,
     isPublishing: false,
     waitingForAiSeconds: null,
-    isEdited: false,
   },
   decorators: [
     (Story) => (
@@ -75,7 +74,6 @@ export const AiWriting: Story = {
 export const AiWritingWhileUserTypes: Story = {
   args: {
     value: "Fix typo in hero",
-    isEdited: true,
     ai: { status: "loading" },
   },
 };
@@ -99,7 +97,6 @@ export const AiSummaryApplied: Story = {
 export const AiSummaryOffered: Story = {
   args: {
     value: "Fix typo in hero",
-    isEdited: true,
     ai: { status: "ready", text: AI_SUMMARY, sessionId: "session-1" },
     onOpenAiSession: fn(),
   },
@@ -150,8 +147,8 @@ export const Publishing: Story = {
 export const InteractiveFlow: Story = {
   render: function InteractiveFlowStory() {
     const [value, setValue] = useState(DEFAULT_SUMMARY);
-    const [isEdited, setIsEdited] = useState(false);
-    // Read inside the timeout, which closes over the state at scheduling time.
+    // A ref, not state: the timeout below closes over its scheduling-time
+    // value, and nothing renders off it.
     const hasEditedRef = useRef(false);
     const [ai, setAi] = useState<AiSummaryState>({ status: "idle" });
 
@@ -187,17 +184,12 @@ export const InteractiveFlow: Story = {
           value={value}
           onChange={(next) => {
             setValue(next);
-            setIsEdited(true);
             hasEditedRef.current = true;
           }}
           ai={ai}
-          isEdited={isEdited}
           onUseAiSummary={() => {
             if (ai.status === "ready") {
               setValue(ai.text);
-              // Taking the suggestion is not "unedited": a later arrival must
-              // still not overwrite it.
-              setIsEdited(false);
             }
           }}
           onOpenAiSession={ai.status === "ready" ? fn() : undefined}

--- a/packages/ui/spa/components/PublishSummaryView.stories.tsx
+++ b/packages/ui/spa/components/PublishSummaryView.stories.tsx
@@ -1,0 +1,200 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { fn } from "storybook/test";
+import { PublishSummaryView } from "./PublishSummaryView";
+import type { AiSummaryState } from "./PublishSummaryView";
+import { buildDefaultCommitSummary } from "./publish/defaultCommitSummary";
+
+const DEFAULT_SUMMARY = buildDefaultCommitSummary([
+  "/content/home.val.ts",
+  "/content/blogs/page.val.ts",
+]);
+
+const AI_SUMMARY =
+  "Rewrite the hero heading and add a third blog post\n\n" +
+  "The landing page hero now leads with the product name instead of the tagline. " +
+  "A new post about migrating content was added to the blog listing.";
+
+const meta: Meta<typeof PublishSummaryView> = {
+  title: "Components/PublishSummaryView",
+  component: PublishSummaryView,
+  parameters: { layout: "padded" },
+  tags: ["autodocs"],
+  args: {
+    onChange: fn(),
+    onUseAiSummary: fn(),
+    onPublish: fn(),
+    onClose: fn(),
+    onPublishNow: fn(),
+    publishDisabled: false,
+    isPublishing: false,
+    waitingForAiSeconds: null,
+    isEdited: false,
+  },
+  decorators: [
+    (Story) => (
+      // The publish popover this lives in
+      <div className="mx-auto w-[420px] rounded-md border border-border-primary bg-bg-primary p-4 shadow-lg">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof PublishSummaryView>;
+
+/**
+ * No AI configured at all. This is the baseline the whole flow is measured
+ * against: a summary is already written, the box is editable, publish is live.
+ */
+export const NoAiConfigured: Story = {
+  args: {
+    value: DEFAULT_SUMMARY,
+    ai: { status: "off" },
+    onSetUpAi: fn(),
+  },
+};
+
+/**
+ * The typo fix. AI is writing in the background, and none of it is in the way:
+ * the generic summary is already there and Publish is enabled.
+ */
+export const AiWriting: Story = {
+  args: {
+    value: DEFAULT_SUMMARY,
+    ai: { status: "loading" },
+  },
+};
+
+/**
+ * The user started typing while the AI was still working. Their words win.
+ */
+export const AiWritingWhileUserTypes: Story = {
+  args: {
+    value: "Fix typo in hero",
+    isEdited: true,
+    ai: { status: "loading" },
+  },
+};
+
+/**
+ * The AI finished and its summary was taken (the user had not typed), so there
+ * is nothing to offer — only the way back into the chat that wrote it.
+ */
+export const AiSummaryApplied: Story = {
+  args: {
+    value: AI_SUMMARY,
+    ai: { status: "ready", text: AI_SUMMARY, sessionId: "session-1" },
+    onOpenAiSession: fn(),
+  },
+};
+
+/**
+ * The AI finished but the user had already written their own summary, so the
+ * suggestion is offered rather than applied.
+ */
+export const AiSummaryOffered: Story = {
+  args: {
+    value: "Fix typo in hero",
+    isEdited: true,
+    ai: { status: "ready", text: AI_SUMMARY, sessionId: "session-1" },
+    onOpenAiSession: fn(),
+  },
+};
+
+/** The AI failed. The summary is untouched and publishing is unaffected. */
+export const AiFailed: Story = {
+  args: {
+    value: DEFAULT_SUMMARY,
+    ai: {
+      status: "failed",
+      message: "The Anthropic key was rejected.",
+      canSetUp: true,
+    },
+    onSetUpAi: fn(),
+  },
+};
+
+/**
+ * Publish was pressed while the AI was still writing. Publishing is already
+ * happening — this is the 10 second grace period, with a way to skip it.
+ */
+export const WaitingForAiOnPublish: Story = {
+  args: {
+    value: DEFAULT_SUMMARY,
+    ai: { status: "loading" },
+    waitingForAiSeconds: 7,
+  },
+};
+
+/** Mid-publish. */
+export const Publishing: Story = {
+  args: {
+    value: AI_SUMMARY,
+    ai: { status: "ready", text: AI_SUMMARY, sessionId: "session-1" },
+    isPublishing: true,
+    publishDisabled: true,
+    onOpenAiSession: fn(),
+  },
+};
+
+/**
+ * The whole flow, driven for real: the summary is there immediately, the AI
+ * lands after three seconds, and typing at any point keeps your text.
+ */
+export const InteractiveFlow: Story = {
+  render: function InteractiveFlowStory() {
+    const [value, setValue] = useState(DEFAULT_SUMMARY);
+    const [isEdited, setIsEdited] = useState(false);
+    const [ai, setAi] = useState<AiSummaryState>({ status: "idle" });
+
+    return (
+      <div className="flex flex-col gap-3">
+        <button
+          type="button"
+          className="self-start text-xs underline cursor-pointer"
+          onClick={() => {
+            setAi({ status: "loading" });
+            setTimeout(() => {
+              setAi({
+                status: "ready",
+                text: AI_SUMMARY,
+                sessionId: "session-1",
+              });
+              // Only take over the box when the user has not written anything
+              setValue((current) =>
+                current === DEFAULT_SUMMARY ? AI_SUMMARY : current,
+              );
+            }, 3000);
+          }}
+        >
+          Simulate hitting Publish (AI starts, lands after 3s)
+        </button>
+        <PublishSummaryView
+          value={value}
+          onChange={(next) => {
+            setValue(next);
+            setIsEdited(true);
+          }}
+          ai={ai}
+          isEdited={isEdited}
+          onUseAiSummary={() => {
+            if (ai.status === "ready") {
+              setValue(ai.text);
+              setIsEdited(false);
+            }
+          }}
+          onOpenAiSession={ai.status === "ready" ? fn() : undefined}
+          onSetUpAi={fn()}
+          onPublish={fn()}
+          onClose={fn()}
+          publishDisabled={false}
+          isPublishing={false}
+          waitingForAiSeconds={null}
+          onPublishNow={fn()}
+        />
+      </div>
+    );
+  },
+};

--- a/packages/ui/spa/components/PublishSummaryView.tsx
+++ b/packages/ui/spa/components/PublishSummaryView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   AlertTriangle,
   Loader2,
@@ -33,8 +33,6 @@ export type PublishSummaryViewProps = {
   value: string;
   onChange: (value: string) => void;
   ai: AiSummaryState;
-  /** True once the user has typed: their words are never overwritten. */
-  isEdited: boolean;
   /** Replace the box with the AI's suggestion. */
   onUseAiSummary: () => void;
   /**
@@ -70,7 +68,6 @@ export function PublishSummaryView({
   value,
   onChange,
   ai,
-  isEdited,
   onUseAiSummary,
   onOpenAiSession,
   onSetUpAi,
@@ -89,7 +86,11 @@ export function PublishSummaryView({
         <span className="font-semibold">Summary</span>
         <AiSummaryButton
           ai={ai}
-          isEdited={isEdited}
+          // Offered whenever it is not already what is in the box. Gating this
+          // on "has the user typed" left a gap: a box restored from a previous
+          // session is not the default either, and the suggestion was then
+          // neither applied nor offered.
+          canApply={ai.status === "ready" && ai.text.trim() !== value.trim()}
           onUseAiSummary={onUseAiSummary}
           onOpenAiSession={onOpenAiSession}
           onSetUpAi={onSetUpAi}
@@ -152,13 +153,13 @@ export function PublishSummaryView({
  */
 function AiSummaryButton({
   ai,
-  isEdited,
+  canApply,
   onUseAiSummary,
   onOpenAiSession,
   onSetUpAi,
 }: {
   ai: AiSummaryState;
-  isEdited: boolean;
+  canApply: boolean;
   onUseAiSummary: () => void;
   onOpenAiSession?: () => void;
   onSetUpAi?: () => void;
@@ -232,7 +233,7 @@ function AiSummaryButton({
   // ready
   return (
     <span className="flex items-center gap-2">
-      {isEdited && (
+      {canApply && (
         <AiTooltip
           container={portalContainer}
           text="Replace what you have written with the AI's summary."
@@ -286,36 +287,62 @@ function AiTooltip({
 }
 
 /**
- * Counts a publish grace period down to zero and then lets publishing proceed.
+ * Counts a publish grace period down and then lets publishing proceed.
  *
  * Exported for the container to drive the `waitingForAiSeconds` prop; the view
  * itself stays a pure function of its props so stories can pin any frame of it.
+ *
+ * Pressing Publish committed to publishing, so the pending publish outlives
+ * this component: closing the popover mid-countdown fires it rather than
+ * dropping it on the floor.
  */
 export function usePublishGrace(totalSeconds: number) {
   const [remaining, setRemaining] = useState<number | null>(null);
   const onElapsed = useRef<(() => void) | null>(null);
+
+  const fire = useCallback(() => {
+    const pending = onElapsed.current;
+    onElapsed.current = null;
+    setRemaining(null);
+    pending?.();
+  }, []);
 
   useEffect(() => {
     if (remaining === null) {
       return;
     }
     if (remaining <= 0) {
-      const fire = onElapsed.current;
-      onElapsed.current = null;
-      setRemaining(null);
-      fire?.();
+      fire();
       return;
     }
     const timer = setTimeout(() => setRemaining((r) => (r ?? 1) - 1), 1000);
     return () => clearTimeout(timer);
-  }, [remaining]);
+  }, [remaining, fire]);
+
+  // Escape, or a click outside, unmounts the popover mid-countdown. The user
+  // already asked to publish, so honour it instead of silently losing it.
+  useEffect(
+    () => () => {
+      const pending = onElapsed.current;
+      onElapsed.current = null;
+      pending?.();
+    },
+    [],
+  );
 
   return {
     remaining,
+    isWaiting: remaining !== null,
+    /** Ignored while a countdown is already running: a second press skips it. */
     start: (whenElapsed: () => void) => {
+      if (onElapsed.current !== null) {
+        return;
+      }
       onElapsed.current = whenElapsed;
       setRemaining(totalSeconds);
     },
+    /** Publish now, without waiting for the rest of the countdown. */
+    skip: fire,
     cancel: () => {
       onElapsed.current = null;
       setRemaining(null);

--- a/packages/ui/spa/components/PublishSummaryView.tsx
+++ b/packages/ui/spa/components/PublishSummaryView.tsx
@@ -1,0 +1,334 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  AlertTriangle,
+  Loader2,
+  MessageSquare,
+  Sparkles,
+  Upload,
+} from "lucide-react";
+import { Button } from "./designSystem/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "./designSystem/tooltip";
+import { cn } from "./designSystem/cn";
+import { useValPortal } from "./ValPortalProvider";
+
+/**
+ * What the AI is doing about this summary, if anything.
+ *
+ * `off` is a first-class state, not an error: without a key configured there
+ * is no AI, and the publish flow is expected to work exactly as well.
+ */
+export type AiSummaryState =
+  | { status: "off" }
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "ready"; text: string; sessionId: string | null }
+  | { status: "failed"; message: string; canSetUp?: boolean };
+
+export type PublishSummaryViewProps = {
+  /** The text that will be committed. Always editable, never blocked. */
+  value: string;
+  onChange: (value: string) => void;
+  ai: AiSummaryState;
+  /** True once the user has typed: their words are never overwritten. */
+  isEdited: boolean;
+  /** Replace the box with the AI's suggestion. */
+  onUseAiSummary: () => void;
+  /**
+   * Open the chat session that wrote the summary, so the user can ask what
+   * changed. Absent when there is no session to open.
+   */
+  onOpenAiSession?: () => void;
+  /** Where to send someone who has no AI configured. */
+  onSetUpAi?: () => void;
+  onPublish: () => void;
+  onClose: () => void;
+  publishDisabled: boolean;
+  isPublishing: boolean;
+  /**
+   * Publish was pressed while the AI was still writing. Publishing is already
+   * committed to happening — this is the short grace period before it goes
+   * ahead with whatever is in the box.
+   */
+  waitingForAiSeconds: number | null;
+  onPublishNow: () => void;
+};
+
+/**
+ * The publish summary box.
+ *
+ * The rule the whole component is built around: **the user is never blocked**.
+ * The box arrives filled with a summary that needed no network call, the
+ * textarea is editable from the first frame, and everything the AI does is an
+ * offer on the side rather than a gate in front. Someone fixing a typo should
+ * be able to open this and publish without noticing an AI exists.
+ */
+export function PublishSummaryView({
+  value,
+  onChange,
+  ai,
+  isEdited,
+  onUseAiSummary,
+  onOpenAiSession,
+  onSetUpAi,
+  onPublish,
+  onClose,
+  publishDisabled,
+  isPublishing,
+  waitingForAiSeconds,
+  onPublishNow,
+}: PublishSummaryViewProps) {
+  const className = "w-full p-2 border rounded bg-bg-secondary";
+  const isWaiting = waitingForAiSeconds !== null;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-semibold">Summary</span>
+        <AiSummaryButton
+          ai={ai}
+          isEdited={isEdited}
+          onUseAiSummary={onUseAiSummary}
+          onOpenAiSession={onOpenAiSession}
+          onSetUpAi={onSetUpAi}
+        />
+      </div>
+      <div className="grid text-xs font-light">
+        {/* https://css-tricks.com/the-cleanest-trick-for-autogrowing-textareas */}
+        <div
+          aria-hidden
+          className={cn(className, "invisible whitespace-pre-wrap")}
+          style={{ gridArea: "1 / 1 / 2 / 2" }}
+        >
+          {/* Note the weird space! Needed to prevent jumpy behavior */}
+          {value + " "}
+        </div>
+        <textarea
+          // Never disabled, not even while the AI is writing or during the
+          // grace period: waiting for a model is exactly what this flow is
+          // designed not to make anyone do.
+          className={cn(className, "resize-none overflow-clip")}
+          value={value}
+          style={{ gridArea: "1 / 1 / 2 / 2" }}
+          placeholder="Write a summary of your changes"
+          onChange={(e) => onChange(e.currentTarget.value)}
+        />
+      </div>
+      {isWaiting && (
+        <div className="flex items-center justify-between gap-2 text-xs text-fg-secondary">
+          <span className="flex items-center gap-2">
+            <Loader2 size={12} className="animate-spin" />
+            <span>
+              Waiting for the AI summary — publishing in {waitingForAiSeconds}s
+              either way
+            </span>
+          </span>
+          <button
+            type="button"
+            className="underline cursor-pointer"
+            onClick={onPublishNow}
+          >
+            Publish now
+          </button>
+        </div>
+      )}
+      <div className="flex items-center justify-end gap-2">
+        <Button variant="outline" onClick={onClose}>
+          Close
+        </Button>
+        <Button
+          disabled={publishDisabled || value.trim() === ""}
+          onClick={onPublish}
+          variant="default"
+          className="flex items-center gap-2"
+        >
+          <span>{isPublishing ? "Pushing..." : "Publish"}</span>
+          <Upload size={16} />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The small AI affordance beside the heading.
+ *
+ * Deliberately small and off to the side: it reports what the AI is up to and
+ * offers its result, and at no point does it stand between the user and the
+ * publish button.
+ */
+function AiSummaryButton({
+  ai,
+  isEdited,
+  onUseAiSummary,
+  onOpenAiSession,
+  onSetUpAi,
+}: {
+  ai: AiSummaryState;
+  isEdited: boolean;
+  onUseAiSummary: () => void;
+  onOpenAiSession?: () => void;
+  onSetUpAi?: () => void;
+}) {
+  const portalContainer = useValPortal();
+
+  if (ai.status === "off") {
+    if (!onSetUpAi) {
+      return null;
+    }
+    return (
+      <AiTooltip
+        container={portalContainer}
+        text="Val can write these for you once an AI key is set up. Publishing works the same either way."
+      >
+        <button
+          type="button"
+          onClick={onSetUpAi}
+          className="flex items-center gap-1 text-xs text-fg-secondary underline cursor-pointer"
+        >
+          <Sparkles size={12} />
+          <span>Set up AI</span>
+        </button>
+      </AiTooltip>
+    );
+  }
+
+  if (ai.status === "idle") {
+    return null;
+  }
+
+  if (ai.status === "loading") {
+    return (
+      <AiTooltip
+        container={portalContainer}
+        text="Writing a summary with AI. You do not have to wait — edit the text or publish whenever you like."
+      >
+        <span className="flex items-center gap-1 text-xs text-fg-secondary">
+          <Loader2 size={12} className="animate-spin" />
+          <span>AI is writing…</span>
+        </span>
+      </AiTooltip>
+    );
+  }
+
+  if (ai.status === "failed") {
+    return (
+      <AiTooltip
+        container={portalContainer}
+        text={`${ai.message} Your summary is unaffected — publish when ready.`}
+      >
+        {ai.canSetUp && onSetUpAi ? (
+          <button
+            type="button"
+            onClick={onSetUpAi}
+            className="flex items-center gap-1 text-xs text-fg-secondary underline cursor-pointer"
+          >
+            <AlertTriangle size={12} />
+            <span>AI unavailable</span>
+          </button>
+        ) : (
+          <span className="flex items-center gap-1 text-xs text-fg-secondary">
+            <AlertTriangle size={12} />
+            <span>AI unavailable</span>
+          </span>
+        )}
+      </AiTooltip>
+    );
+  }
+
+  // ready
+  return (
+    <span className="flex items-center gap-2">
+      {isEdited && (
+        <AiTooltip
+          container={portalContainer}
+          text="Replace what you have written with the AI's summary."
+        >
+          <button
+            type="button"
+            onClick={onUseAiSummary}
+            className="flex items-center gap-1 text-xs text-fg-secondary underline cursor-pointer"
+          >
+            <Sparkles size={12} />
+            <span>Use AI summary</span>
+          </button>
+        </AiTooltip>
+      )}
+      {onOpenAiSession && (
+        <AiTooltip
+          container={portalContainer}
+          text="Open the chat where this summary was written, to ask what changed."
+        >
+          <button
+            type="button"
+            onClick={onOpenAiSession}
+            className="flex items-center gap-1 text-xs text-fg-secondary underline cursor-pointer"
+          >
+            <MessageSquare size={12} />
+            <span>Ask what changed</span>
+          </button>
+        </AiTooltip>
+      )}
+    </span>
+  );
+}
+
+function AiTooltip({
+  text,
+  container,
+  children,
+}: {
+  text: string;
+  container: HTMLElement | null;
+  children: React.ReactElement;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent container={container} className="max-w-[260px] text-xs">
+        {text}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+/**
+ * Counts a publish grace period down to zero and then lets publishing proceed.
+ *
+ * Exported for the container to drive the `waitingForAiSeconds` prop; the view
+ * itself stays a pure function of its props so stories can pin any frame of it.
+ */
+export function usePublishGrace(totalSeconds: number) {
+  const [remaining, setRemaining] = useState<number | null>(null);
+  const onElapsed = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    if (remaining === null) {
+      return;
+    }
+    if (remaining <= 0) {
+      const fire = onElapsed.current;
+      onElapsed.current = null;
+      setRemaining(null);
+      fire?.();
+      return;
+    }
+    const timer = setTimeout(() => setRemaining((r) => (r ?? 1) - 1), 1000);
+    return () => clearTimeout(timer);
+  }, [remaining]);
+
+  return {
+    remaining,
+    start: (whenElapsed: () => void) => {
+      onElapsed.current = whenElapsed;
+      setRemaining(totalSeconds);
+    },
+    cancel: () => {
+      onElapsed.current = null;
+      setRemaining(null);
+    },
+  };
+}

--- a/packages/ui/spa/components/PublishSummaryView.tsx
+++ b/packages/ui/spa/components/PublishSummaryView.tsx
@@ -51,10 +51,10 @@ export type PublishSummaryViewProps = {
   /**
    * Publish was pressed while the AI was still writing. Publishing is already
    * committed to happening — this is the short grace period before it goes
-   * ahead with whatever is in the box.
+   * ahead with whatever is in the box. Pressing Publish again during it skips
+   * the wait, so there is no separate escape control.
    */
   waitingForAiSeconds: number | null;
-  onPublishNow: () => void;
 };
 
 /**
@@ -79,7 +79,6 @@ export function PublishSummaryView({
   publishDisabled,
   isPublishing,
   waitingForAiSeconds,
-  onPublishNow,
 }: PublishSummaryViewProps) {
   const className = "w-full p-2 border rounded bg-bg-secondary";
   const isWaiting = waitingForAiSeconds !== null;
@@ -118,21 +117,12 @@ export function PublishSummaryView({
         />
       </div>
       {isWaiting && (
-        <div className="flex items-center justify-between gap-2 text-xs text-fg-secondary">
-          <span className="flex items-center gap-2">
-            <Loader2 size={12} className="animate-spin" />
-            <span>
-              Waiting for the AI summary — publishing in {waitingForAiSeconds}s
-              either way
-            </span>
+        <div className="flex items-start gap-2 text-xs text-fg-secondary">
+          <Loader2 size={12} className="animate-spin mt-0.5 shrink-0" />
+          <span>
+            Waiting for the AI summary — publishing in {waitingForAiSeconds}s
+            either way. Press Publish again to go now.
           </span>
-          <button
-            type="button"
-            className="underline cursor-pointer"
-            onClick={onPublishNow}
-          >
-            Publish now
-          </button>
         </div>
       )}
       <div className="flex items-center justify-end gap-2">

--- a/packages/ui/spa/components/PublishSummaryView.tsx
+++ b/packages/ui/spa/components/PublishSummaryView.tsx
@@ -120,8 +120,8 @@ export function PublishSummaryView({
         <div className="flex items-start gap-2 text-xs text-fg-secondary">
           <Loader2 size={12} className="animate-spin mt-0.5 shrink-0" />
           <span>
-            Waiting for the AI summary — publishing in {waitingForAiSeconds}s
-            either way. Press Publish again to go now.
+            Waiting for the AI summary. Publishing in {waitingForAiSeconds}s
+            either way — press Publish again to skip the wait.
           </span>
         </div>
       )}
@@ -172,7 +172,7 @@ function AiSummaryButton({
     return (
       <AiTooltip
         container={portalContainer}
-        text="Val can write these for you once an AI key is set up. Publishing works the same either way."
+        text="Val can write your summary for you once an AI key is set up. Publishing works the same either way."
       >
         <button
           type="button"
@@ -250,7 +250,7 @@ function AiSummaryButton({
       {onOpenAiSession && (
         <AiTooltip
           container={portalContainer}
-          text="Open the chat where this summary was written, to ask what changed."
+          text="Open the chat that wrote this summary to ask what changed."
         >
           <button
             type="button"

--- a/packages/ui/spa/components/publish/defaultCommitSummary.test.ts
+++ b/packages/ui/spa/components/publish/defaultCommitSummary.test.ts
@@ -1,6 +1,7 @@
 import {
   buildDefaultCommitSummary,
   moduleDisplayName,
+  shouldAutoApplyAiSummary,
 } from "./defaultCommitSummary";
 
 describe("moduleDisplayName", () => {
@@ -58,5 +59,70 @@ describe("buildDefaultCommitSummary", () => {
     const summary = buildDefaultCommitSummary(paths);
     expect(summary).toContain("Update content in 9 places");
     expect(summary).toContain("and 3 more");
+  });
+});
+
+describe("shouldAutoApplyAiSummary", () => {
+  const defaultSummary = "Update Home";
+
+  test("takes over a box the user has not touched", () => {
+    expect(
+      shouldAutoApplyAiSummary({
+        hasEdited: false,
+        currentValue: defaultSummary,
+        defaultSummary,
+      }),
+    ).toBe(true);
+  });
+
+  test("leaves the box alone once the user has started writing", () => {
+    expect(
+      shouldAutoApplyAiSummary({
+        hasEdited: true,
+        currentValue: "Fix typo in hero",
+        defaultSummary,
+      }),
+    ).toBe(false);
+  });
+
+  test("stays cancelled after the user deletes back to the default", () => {
+    // hasEdited latches, so retyping the default does not re-arm the takeover
+    expect(
+      shouldAutoApplyAiSummary({
+        hasEdited: true,
+        currentValue: defaultSummary,
+        defaultSummary,
+      }),
+    ).toBe(false);
+  });
+
+  test("stays cancelled when the box is empty because they cleared it", () => {
+    expect(
+      shouldAutoApplyAiSummary({
+        hasEdited: true,
+        currentValue: "",
+        defaultSummary,
+      }),
+    ).toBe(false);
+  });
+
+  test("does not take over a box that differs from the default anyway", () => {
+    expect(
+      shouldAutoApplyAiSummary({
+        hasEdited: false,
+        currentValue: "Something a previous session left here",
+        defaultSummary,
+      }),
+    ).toBe(false);
+  });
+
+  test("ignores whitespace the textarea may have left behind", () => {
+    expect(
+      shouldAutoApplyAiSummary({
+        hasEdited: false,
+        currentValue: `  ${defaultSummary}\n`,
+        defaultSummary,
+      }),
+    ).toBe(true);
   });
 });

--- a/packages/ui/spa/components/publish/defaultCommitSummary.test.ts
+++ b/packages/ui/spa/components/publish/defaultCommitSummary.test.ts
@@ -17,6 +17,13 @@ describe("moduleDisplayName", () => {
     );
   });
 
+  test("strips .val.json too, so JSON entry modules do not leak an extension", () => {
+    expect(moduleDisplayName("/content/students.val.json")).toBe("Students");
+    expect(moduleDisplayName("/content/students/page.val.json")).toBe(
+      "Students",
+    );
+  });
+
   test("falls back to the path when there is no name to show", () => {
     expect(moduleDisplayName("/")).toBe("/");
   });

--- a/packages/ui/spa/components/publish/defaultCommitSummary.test.ts
+++ b/packages/ui/spa/components/publish/defaultCommitSummary.test.ts
@@ -1,0 +1,62 @@
+import {
+  buildDefaultCommitSummary,
+  moduleDisplayName,
+} from "./defaultCommitSummary";
+
+describe("moduleDisplayName", () => {
+  test("names a router file for its route, not for the file", () => {
+    expect(moduleDisplayName("/content/blogs/page.val.ts")).toBe("Blogs");
+    expect(moduleDisplayName("/content/index.val.ts")).toBe("Content");
+  });
+
+  test("uses the file name when it is not a router", () => {
+    expect(moduleDisplayName("/content/home.val.ts")).toBe("Home");
+    expect(moduleDisplayName("/content/site-settings.val.ts")).toBe(
+      "Site settings",
+    );
+  });
+
+  test("falls back to the path when there is no name to show", () => {
+    expect(moduleDisplayName("/")).toBe("/");
+  });
+});
+
+describe("buildDefaultCommitSummary", () => {
+  test("is never empty, so publishing always has something to commit", () => {
+    expect(buildDefaultCommitSummary([])).toBe("Update content");
+  });
+
+  test("names the one thing that changed", () => {
+    expect(buildDefaultCommitSummary(["/content/home.val.ts"])).toBe(
+      "Update Home",
+    );
+  });
+
+  test("counts and lists when several changed", () => {
+    expect(
+      buildDefaultCommitSummary([
+        "/content/home.val.ts",
+        "/content/about.val.ts",
+      ]),
+    ).toBe("Update content in 2 places\n\nChanged: About, Home");
+  });
+
+  test("collapses duplicates from several patches to one module", () => {
+    expect(
+      buildDefaultCommitSummary([
+        "/content/home.val.ts",
+        "/content/home.val.ts",
+      ]),
+    ).toBe("Update Home");
+  });
+
+  test("truncates a long list rather than listing everything", () => {
+    const paths = Array.from(
+      { length: 9 },
+      (_, i) => `/content/page-${i}.val.ts`,
+    );
+    const summary = buildDefaultCommitSummary(paths);
+    expect(summary).toContain("Update content in 9 places");
+    expect(summary).toContain("and 3 more");
+  });
+});

--- a/packages/ui/spa/components/publish/defaultCommitSummary.test.ts
+++ b/packages/ui/spa/components/publish/defaultCommitSummary.test.ts
@@ -33,13 +33,36 @@ describe("buildDefaultCommitSummary", () => {
     );
   });
 
-  test("counts and lists when several changed", () => {
+  test("names a couple of things rather than counting them", () => {
     expect(
       buildDefaultCommitSummary([
         "/content/home.val.ts",
         "/content/about.val.ts",
       ]),
-    ).toBe("Update content in 2 places\n\nChanged: About, Home");
+    ).toBe("Update About and Home");
+  });
+
+  test("names up to three, with no Oxford comma", () => {
+    expect(
+      buildDefaultCommitSummary([
+        "/content/home.val.ts",
+        "/content/about.val.ts",
+        "/content/blogs/page.val.ts",
+      ]),
+    ).toBe("Update About, Blogs and Home");
+  });
+
+  test("switches to a count once naming them stops reading as a title", () => {
+    expect(
+      buildDefaultCommitSummary([
+        "/content/home.val.ts",
+        "/content/about.val.ts",
+        "/content/blogs/page.val.ts",
+        "/content/contact.val.ts",
+      ]),
+    ).toBe(
+      "Update content in 4 places\n\nChanged: About, Blogs, Contact, Home",
+    );
   });
 
   test("collapses duplicates from several patches to one module", () => {

--- a/packages/ui/spa/components/publish/defaultCommitSummary.ts
+++ b/packages/ui/spa/components/publish/defaultCommitSummary.ts
@@ -24,7 +24,9 @@ const MAX_LISTED = 6;
 export function moduleDisplayName(moduleFilePath: string): string {
   const segments = moduleFilePath.split("/").filter(Boolean);
   const fileName = segments[segments.length - 1] ?? moduleFilePath;
-  const base = fileName.replace(/\.val\.(ts|js|tsx|jsx)$/, "");
+  // `.val.json` too: JSON entry modules are real module paths, and leaving the
+  // extension on leaked "Student.val.json" into publish summaries.
+  const base = fileName.replace(/\.val\.(ts|tsx|js|jsx|json)$/, "");
   // A router file is named for its route, which is the folder above it.
   const name =
     base === "page" || base === "index"

--- a/packages/ui/spa/components/publish/defaultCommitSummary.ts
+++ b/packages/ui/spa/components/publish/defaultCommitSummary.ts
@@ -1,0 +1,54 @@
+import type { ModuleFilePath } from "@valbuild/core";
+
+/**
+ * The commit summary you get without asking anyone.
+ *
+ * Publishing must never wait on a model. The box is filled with this the
+ * moment the publish popover opens, it is editable straight away, and it is
+ * what gets committed unless the user edits it or takes an AI suggestion. It
+ * is also the whole story when no AI is configured.
+ */
+
+/** How many names to list before falling back to "and N more". */
+const MAX_LISTED = 6;
+
+/**
+ * A name a non-technical reader recognises, from a module file path.
+ *
+ * `/content/blogs/page.val.ts` is the router for the `blogs` route, so it is
+ * "blogs", not "page" - the same rule the AI prompt has always been given.
+ */
+export function moduleDisplayName(moduleFilePath: string): string {
+  const segments = moduleFilePath.split("/").filter(Boolean);
+  const fileName = segments[segments.length - 1] ?? moduleFilePath;
+  const base = fileName.replace(/\.val\.(ts|js|tsx|jsx)$/, "");
+  // A router file is named for its route, which is the folder above it.
+  const name =
+    base === "page" || base === "index"
+      ? (segments[segments.length - 2] ?? base)
+      : base;
+  const spaced = name.replace(/[-_]+/g, " ").trim();
+  if (!spaced) {
+    return moduleFilePath;
+  }
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+export function buildDefaultCommitSummary(
+  moduleFilePaths: readonly ModuleFilePath[] | readonly string[],
+): string {
+  const names = Array.from(
+    new Set(moduleFilePaths.map((path) => moduleDisplayName(path))),
+  ).sort((a, b) => a.localeCompare(b));
+
+  if (names.length === 0) {
+    return "Update content";
+  }
+  if (names.length === 1) {
+    return `Update ${names[0]}`;
+  }
+  const listed = names.slice(0, MAX_LISTED).join(", ");
+  const remaining = names.length - MAX_LISTED;
+  const changed = remaining > 0 ? `${listed} and ${remaining} more` : listed;
+  return `Update content in ${names.length} places\n\nChanged: ${changed}`;
+}

--- a/packages/ui/spa/components/publish/defaultCommitSummary.ts
+++ b/packages/ui/spa/components/publish/defaultCommitSummary.ts
@@ -9,6 +9,9 @@ import type { ModuleFilePath } from "@valbuild/core";
  * is also the whole story when no AI is configured.
  */
 
+/** How many names fit in a title before a count reads better. */
+const MAX_NAMED = 3;
+
 /** How many names to list before falling back to "and N more". */
 const MAX_LISTED = 6;
 
@@ -44,13 +47,24 @@ export function buildDefaultCommitSummary(
   if (names.length === 0) {
     return "Update content";
   }
-  if (names.length === 1) {
-    return `Update ${names[0]}`;
+  // A few names read better than a count — "Update Home and Blogs" says more
+  // than "Update content in 2 places" in fewer words, and is what someone
+  // scanning a commit list actually wants.
+  if (names.length <= MAX_NAMED) {
+    return `Update ${joinNames(names)}`;
   }
   const listed = names.slice(0, MAX_LISTED).join(", ");
   const remaining = names.length - MAX_LISTED;
   const changed = remaining > 0 ? `${listed} and ${remaining} more` : listed;
   return `Update content in ${names.length} places\n\nChanged: ${changed}`;
+}
+
+/** "A", "A and B", "A, B and C" — no Oxford comma, matching the UI's copy. */
+function joinNames(names: string[]): string {
+  if (names.length === 1) {
+    return names[0];
+  }
+  return `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
 }
 
 /**

--- a/packages/ui/spa/components/publish/defaultCommitSummary.ts
+++ b/packages/ui/spa/components/publish/defaultCommitSummary.ts
@@ -52,3 +52,27 @@ export function buildDefaultCommitSummary(
   const changed = remaining > 0 ? `${listed} and ${remaining} more` : listed;
   return `Update content in ${names.length} places\n\nChanged: ${changed}`;
 }
+
+/**
+ * Whether an AI summary that just arrived may take over the box.
+ *
+ * Once the user has started writing, it may not — not on this arrival and not
+ * on any later one, because `hasEdited` latches. The AI's version is then
+ * offered as a suggestion instead of applied, so nobody watches their own
+ * sentence get replaced mid-word.
+ *
+ * The value check is a second lock on the same door: even with the flag
+ * somehow clear, a box that no longer holds the untouched default is treated
+ * as the user's and left alone.
+ */
+export function shouldAutoApplyAiSummary(args: {
+  /** Latches true on the first keystroke and never clears. */
+  hasEdited: boolean;
+  currentValue: string;
+  defaultSummary: string;
+}): boolean {
+  if (args.hasEdited) {
+    return false;
+  }
+  return args.currentValue.trim() === args.defaultSummary.trim();
+}

--- a/packages/ui/spa/hooks/useAI.ts
+++ b/packages/ui/spa/hooks/useAI.ts
@@ -871,7 +871,9 @@ export function useAI(
         }
         chatRef.current.completeAssistantMessage(message.id);
         activeIdRef.current = null;
-        inFlightPromptIdRef.current = null;
+        if (inFlightPromptIdRef.current === message.id) {
+          inFlightPromptIdRef.current = null;
+        }
         setIsStreaming(false);
       } else if (message.type === "ai_tool_call") {
         // ask_user_question renders a question card instead of the plain tool
@@ -2105,14 +2107,20 @@ export function useAI(
           message.code,
         );
         activeIdRef.current = null;
-        inFlightPromptIdRef.current = null;
+        if (inFlightPromptIdRef.current === message.id) {
+          inFlightPromptIdRef.current = null;
+        }
         setIsStreaming(false);
       } else if (message.type === "ai_cancelled") {
         // The user asked for this, so it settles rather than fails: whatever
         // arrived before the stop stays in the transcript, and a stop before
         // any text says so instead of leaving an empty bubble behind.
         if (!chatRef.current) return;
-        if (activeIdRef.current !== message.id) {
+        // Text already on screen counts, even if the server sent no partial:
+        // keying only off `partialResponse` turned a streamed answer into a red
+        // error, which is the opposite of settling it.
+        const wasStreaming = activeIdRef.current === message.id;
+        if (!wasStreaming) {
           chatRef.current.startAssistantMessage(message.id);
           if (message.partialResponse) {
             chatRef.current.appendAssistantChunk(
@@ -2121,18 +2129,34 @@ export function useAI(
             );
           }
         }
-        if (message.partialResponse) {
-          chatRef.current.completeAssistantMessage(message.id);
-        } else {
-          chatRef.current.errorAssistantMessage(
-            message.id,
-            "Stopped.",
-            "cancelled",
-          );
+        // Settled as complete, never as an error: the user asked for this, and
+        // an error status paints the turn red and offers a Retry for something
+        // that did not fail. With nothing to keep, "Stopped." is the body.
+        if (!wasStreaming && !message.partialResponse) {
+          chatRef.current.appendAssistantChunk(message.id, "Stopped.");
         }
-        activeIdRef.current = null;
-        inFlightPromptIdRef.current = null;
-        setIsStreaming(false);
+        chatRef.current.completeAssistantMessage(message.id);
+        // A question card left pending keeps the turn open: it stays
+        // clickable, and it disables the chat's own turn timeout, so a stop
+        // would wedge the composer with no way out but a reload. The server has
+        // already abandoned these waits, so there is nothing to answer — just
+        // stop tracking them.
+        for (const [toolCallId, questionMessageId] of Array.from(
+          pendingQuestionsRef.current.entries(),
+        )) {
+          if (questionMessageId === message.id) {
+            pendingQuestionsRef.current.delete(toolCallId);
+          }
+        }
+        if (activeIdRef.current === message.id) {
+          activeIdRef.current = null;
+        }
+        // A late settle for an abandoned turn must not clear the tracking of a
+        // newer one, or its streamed text is orphaned and Stop goes inert.
+        if (inFlightPromptIdRef.current === message.id) {
+          inFlightPromptIdRef.current = null;
+          setIsStreaming(false);
+        }
       } else if (message.type === "ai_agent_handoff") {
         // TODO: show this in the UI in some way to indicate that the AI has handed off to a human agent:
         console.log(
@@ -2417,12 +2441,26 @@ Do not describe what you will do unless you do it for clarification — just do 
    */
   const cancel = useCallback((): boolean => {
     const id = inFlightPromptIdRef.current;
+    // Nothing is running as far as we know, but the composer is showing a stop
+    // button, so something is out of step. Settle locally rather than leaving
+    // the user pressing a button that does nothing.
     if (id === null) {
+      const streamingId = activeIdRef.current;
+      if (streamingId !== null) {
+        chatRef.current?.completeAssistantMessage(streamingId);
+        activeIdRef.current = null;
+      }
+      setIsStreaming(false);
       return false;
     }
     const sent = sendWsMessage({ type: "ai_cancel", id });
     if (!sent) {
-      chatRef.current?.errorAssistantMessage(id, "Stopped.", "cancelled");
+      // Same reasoning as the `ai_cancelled` branch: settle it, do not fail it.
+      if (activeIdRef.current !== id) {
+        chatRef.current?.startAssistantMessage(id);
+        chatRef.current?.appendAssistantChunk(id, "Stopped.");
+      }
+      chatRef.current?.completeAssistantMessage(id);
       inFlightPromptIdRef.current = null;
       activeIdRef.current = null;
       setIsStreaming(false);

--- a/packages/ui/spa/hooks/useAI.ts
+++ b/packages/ui/spa/hooks/useAI.ts
@@ -844,6 +844,10 @@ export function useAI(
   // Track active streaming ID — startAssistantMessage always appends a new
   // message (NOT idempotent), so we must only call it once per message ID.
   const activeIdRef = useRef<string | null>(null);
+  // The prompt currently running on the server, so it can be cancelled. Set on
+  // a successful send and cleared by whichever of response/error/cancelled
+  // settles it.
+  const inFlightPromptIdRef = useRef<string | null>(null);
   // Pending ask_user_question tool calls, as toolCallId -> the id of the
   // assistant message that opened the card. Needed to reject them on session
   // change, and to fail that specific turn if the result cannot be delivered.
@@ -867,6 +871,7 @@ export function useAI(
         }
         chatRef.current.completeAssistantMessage(message.id);
         activeIdRef.current = null;
+        inFlightPromptIdRef.current = null;
         setIsStreaming(false);
       } else if (message.type === "ai_tool_call") {
         // ask_user_question renders a question card instead of the plain tool
@@ -2100,6 +2105,33 @@ export function useAI(
           message.code,
         );
         activeIdRef.current = null;
+        inFlightPromptIdRef.current = null;
+        setIsStreaming(false);
+      } else if (message.type === "ai_cancelled") {
+        // The user asked for this, so it settles rather than fails: whatever
+        // arrived before the stop stays in the transcript, and a stop before
+        // any text says so instead of leaving an empty bubble behind.
+        if (!chatRef.current) return;
+        if (activeIdRef.current !== message.id) {
+          chatRef.current.startAssistantMessage(message.id);
+          if (message.partialResponse) {
+            chatRef.current.appendAssistantChunk(
+              message.id,
+              message.partialResponse,
+            );
+          }
+        }
+        if (message.partialResponse) {
+          chatRef.current.completeAssistantMessage(message.id);
+        } else {
+          chatRef.current.errorAssistantMessage(
+            message.id,
+            "Stopped.",
+            "cancelled",
+          );
+        }
+        activeIdRef.current = null;
+        inFlightPromptIdRef.current = null;
         setIsStreaming(false);
       } else if (message.type === "ai_agent_handoff") {
         // TODO: show this in the UI in some way to indicate that the AI has handed off to a human agent:
@@ -2343,6 +2375,9 @@ Do not describe what you will do unless you do it for clarification — just do 
         ],
       };
       const sent = sendWsMessage(message);
+      if (sent) {
+        inFlightPromptIdRef.current = message.id;
+      }
       // Notify the session was "born" only after a successful send so a failed
       // first send doesn't leak an empty session id into the URL.
       if (sent && wasUnborn) {
@@ -2371,6 +2406,29 @@ Do not describe what you will do unless you do it for clarification — just do 
     },
     [chatRef],
   );
+
+  /**
+   * Stop the prompt that is running.
+   *
+   * The server settles this with `ai_cancelled`, which is what clears the UI —
+   * doing it optimistically here would race a response already on its way.
+   * Only when there is no socket to ask do we stop locally, so a dropped
+   * connection cannot leave the chat wedged mid-turn with no way out.
+   */
+  const cancel = useCallback((): boolean => {
+    const id = inFlightPromptIdRef.current;
+    if (id === null) {
+      return false;
+    }
+    const sent = sendWsMessage({ type: "ai_cancel", id });
+    if (!sent) {
+      chatRef.current?.errorAssistantMessage(id, "Stopped.", "cancelled");
+      inFlightPromptIdRef.current = null;
+      activeIdRef.current = null;
+      setIsStreaming(false);
+    }
+    return true;
+  }, [sendWsMessage, chatRef]);
 
   const answerToolQuestions = useCallback(
     (toolCallId: string, answers: AskUserQuestionAnswer[]) => {
@@ -2504,6 +2562,8 @@ Do not describe what you will do unless you do it for clarification — just do 
     sendMessage,
     uploadAiImage,
     isStreaming,
+    /** Stop the running prompt. False when there is nothing running. */
+    cancel,
     isLoadingSession,
     isConnected: isWsConnected,
     authError: aiAuthError,

--- a/packages/ui/spa/hooks/useAIWebSocket.ts
+++ b/packages/ui/spa/hooks/useAIWebSocket.ts
@@ -49,9 +49,7 @@ export const AIErrorCode = z.enum([
   "authentication_required",
   "session_not_found",
   "internal_error",
-  // The content server grew these with BYOK. The enum is strict, so a code
-  // missing here fails the whole discriminated union and the error is dropped
-  // rather than shown — keep it in step with AIErrorCode on the server.
+  // The content server grew these with BYOK.
   "byok_invalid_key",
   "provider_not_configured",
   "model_refusal",
@@ -69,7 +67,16 @@ export type AIErrorAction = z.infer<typeof AIErrorAction>;
 export const AIErrorMessage = z.object({
   type: z.literal("ai_error"),
   id: z.string(),
-  code: AIErrorCode,
+  /**
+   * Unknown codes fall back rather than failing the parse.
+   *
+   * This enum is strict and sits inside a discriminated union, so a code the
+   * server has but this client does not used to drop the entire message: the
+   * user saw the turn hang instead of the reason it stopped, and the only
+   * trace was a console log. The server is free to add codes without waiting
+   * for a Studio release; the message still arrives, with its text intact.
+   */
+  code: AIErrorCode.catch("internal_error"),
   message: z.string(),
   resetDate: z.string().optional(),
   action: AIErrorAction.optional(),

--- a/packages/ui/spa/hooks/useAIWebSocket.ts
+++ b/packages/ui/spa/hooks/useAIWebSocket.ts
@@ -49,14 +49,30 @@ export const AIErrorCode = z.enum([
   "authentication_required",
   "session_not_found",
   "internal_error",
+  // The content server grew these with BYOK. The enum is strict, so a code
+  // missing here fails the whole discriminated union and the error is dropped
+  // rather than shown — keep it in step with AIErrorCode on the server.
+  "byok_invalid_key",
+  "provider_not_configured",
+  "model_refusal",
 ]);
 export type AIErrorCode = z.infer<typeof AIErrorCode>;
+
+/** Something the client can offer after an error, e.g. a link to set up a key. */
+export const AIErrorAction = z.object({
+  type: z.literal("setup_byok"),
+  label: z.string(),
+  url: z.string(),
+});
+export type AIErrorAction = z.infer<typeof AIErrorAction>;
 
 export const AIErrorMessage = z.object({
   type: z.literal("ai_error"),
   id: z.string(),
   code: AIErrorCode,
   message: z.string(),
+  resetDate: z.string().optional(),
+  action: AIErrorAction.optional(),
 });
 export type AIErrorMessage = z.infer<typeof AIErrorMessage>;
 
@@ -81,6 +97,18 @@ export const AIStreamingMessage = z.object({
 });
 export type AIStreamingMessage = z.infer<typeof AIStreamingMessage>;
 
+/**
+ * A prompt the user stopped. Not an error: the client should settle rather than
+ * report a failure, keeping whatever text arrived first.
+ */
+export const AICancelledMessage = z.object({
+  type: z.literal("ai_cancelled"),
+  id: z.string(),
+  sessionId: z.string().optional(),
+  partialResponse: z.string().optional(),
+});
+export type AICancelledMessage = z.infer<typeof AICancelledMessage>;
+
 export const AIAgentHandoffMessage = z.object({
   type: z.literal("ai_agent_handoff"),
   id: z.string(),
@@ -96,6 +124,7 @@ export const AIServerMessage = z.discriminatedUnion("type", [
   AIStreamingMessage,
   AIToolCallMessage,
   AIErrorMessage,
+  AICancelledMessage,
   AIAgentHandoffMessage,
 ]);
 
@@ -164,7 +193,17 @@ export type AIGetSessionsWithMessagesMessage = z.infer<
   typeof AIGetSessionsWithMessagesMessage
 >;
 
-export type AIClientMessage = AIPromptMessage | AIToolResultMessage;
+/** Stop an in-flight prompt. `id` is the id of the `ai_prompt` to stop. */
+export const AICancelMessage = z.object({
+  type: z.literal("ai_cancel"),
+  id: z.string(),
+});
+export type AICancelMessage = z.infer<typeof AICancelMessage>;
+
+export type AIClientMessage =
+  | AIPromptMessage
+  | AIToolResultMessage
+  | AICancelMessage;
 
 export type AIMessageHandler = (message: AIServerMessage) => void;
 


### PR DESCRIPTION
The Studio half of the BYOK work in valbuild/home#40. Two independent changes.

## The publish summary no longer waits on a model

`PublishSummary` set `disabled={!!summary.isGenerating}` on its textarea *and* blanked the value to show "Generating summary…". A typo fix meant watching a spinner before you could type a word — which is both the most common case and the worst one to block.

The box now opens filled with a summary built locally from the changed modules — no network call, editable from the first frame, and the whole story when no AI is configured. `buildDefaultCommitSummary` names what changed ("Update Blogs and Home"), switching to a count past three; router files are named for their route, not the file, the same rule the AI prompt has always been given.

The AI became an offer beside the heading rather than a gate in front: a small indicator with a tooltip while it writes, and when it lands it either fills a box the user has not touched or is offered as "Use AI summary" if they have.

**Typing cancels the takeover, permanently.** `shouldAutoApplyAiSummary` is a function rather than an inline comparison because the obvious version has a hole: `hasEdited` latches on the first keystroke, so deleting back to the default text does not re-arm the AI's takeover. It also checks the box still holds the untouched default, so a box that is the user's is left alone even if the flag were somehow wrong.

Publishing is never blocked. Press Publish while the AI is still writing and it publishes with a 10 second grace period, counted down in the open; pressing Publish again skips the rest of it.

`PublishSummaryView` is a pure function of its props, so every state is a story under `Components/PublishSummaryView`, including an interactive one that plays the whole flow with a delayed AI response.

## A stop button for chat

The send button becomes a stop button for as long as the assistant is streaming. They are never both available and one of them is always the thing you want, so it is the same control rather than a second one.

`cancel` sends `ai_cancel` for the running prompt and then waits: the server settles it with `ai_cancelled`, and clearing the UI optimistically would race a response already in flight. Only when there is no socket to ask does it stop locally, so a dropped connection cannot leave the chat wedged mid-turn. A cancelled turn keeps whatever text arrived; a stop before any text says "Stopped." rather than leaving an empty bubble.

## Bug found on the way

The client's `AIErrorCode` had fallen behind the content server's. It is a strict zod enum inside a discriminated union, so `byok_invalid_key`, `provider_not_configured` and `model_refusal` all failed to parse — the whole message was dropped and the user saw the turn **hang** rather than the reason it stopped. Every BYOK error the server can send was invisible in the UI. The error message also carries `action` now, which is what will render the "set up your own API key" link.

## Ordering

`ai_cancel` needs a content server that understands it (valbuild/home#40). Against an older server the message fails validation and the stop button appears to do nothing — the turn keeps streaming. **home#40 should be deployed before this is released**, or the stop button should be gated on a server capability.

## Not in this PR

`PublishSummaryView` is not yet wired into `PublishSummary` — that swap comes with replacing the `/commit-summary` REST call with a websocket session, which needs the `hidden` session work in home#40. The view and its default summary are complete and tested; the container still calls the old endpoint.

## Verification

Full suite green: 2914 tests, 232 suites. `tsc --noEmit` clean across the workspace, eslint and prettier clean. 33 tests on the new summary logic. Storybook screens reviewed for every state.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNUsgdTXVi4CdybXaKpvGy)_