### PR TITLE
Commit summaries over the websocket, client-owned model catalog

### DIFF
--- a/.changeset/publish-summary-over-websocket.md
+++ b/.changeset/publish-summary-over-websocket.md
@@ -1,0 +1,23 @@
+---
+"@valbuild/ui": minor
+"@valbuild/server": minor
+"@valbuild/shared": minor
+---
+
+Commit summaries now come from the AI chat pipeline instead of a REST endpoint,
+and Claude models are selectable.
+
+The publish flow opens its own hidden chat session per publish and pushes the
+changed fields — with their previous and new values — as the prompt. It used to
+send every changed source file twice for a server-side text diff, so fixing one
+typo in a large module uploaded that whole module twice.
+
+Closing the popover or publishing early now cancels the request, which stops it
+on the server rather than only stopping the client listening — this matters
+because the call runs on your own API key.
+
+`/ai/initialize` reports which models the project can reach, so the Studio picks
+one that the configured keys actually allow rather than assuming.
+
+Removes `getCommitSummary` from `ValOps` / `ValOpsFS` / `ValOpsHttp`, the
+`/commit-summary` route, and the dead `getCommitMessage` on `ValOpsHttp`.

--- a/.changeset/publish-summary-over-websocket.md
+++ b/.changeset/publish-summary-over-websocket.md
@@ -16,8 +16,12 @@ Closing the popover or publishing early now cancels the request, which stops it
 on the server rather than only stopping the client listening — this matters
 because the call runs on your own API key.
 
-`/ai/initialize` reports which models the project can reach, so the Studio picks
-one that the configured keys actually allow rather than assuming.
+The model catalog now lives in the Studio rather than on the content server, so
+offering a newly released model is an editor change and nothing else. An agent
+sends `{ provider, model }`; the server checks the provider and passes the model
+id to that provider's SDK untouched. `/ai/initialize` reports which providers the
+project's keys can reach, and the Studio picks the first model in its catalog
+whose provider is among them.
 
 Removes `getCommitSummary` from `ValOps` / `ValOpsFS` / `ValOpsHttp`, the
 `/commit-summary` route, and the dead `getCommitMessage` on `ValOpsHttp`.

--- a/e2e/mock-content-host/server.ts
+++ b/e2e/mock-content-host/server.ts
@@ -1166,7 +1166,17 @@ async function playAiTurn(
   socket: WebSocket,
   prompt: { id?: string; sessionId?: string; message?: unknown },
 ): Promise<void> {
-  const messageId = randomUUID();
+  /**
+   * Every server -> client message echoes the id the client put on its prompt.
+   *
+   * That is what the real service does (`aiHandler.ts` passes `message.id`
+   * straight through to `ai_streaming`, `ai_tool_call`, `ai_response`,
+   * `ai_cancelled` and `ai_error`), and the Studio relies on it: one socket
+   * carries every session, so the id is how a listener tells its own turn from
+   * somebody else's. Minting a fresh one here made the mock the only "server"
+   * that answered a prompt under an id nobody asked about.
+   */
+  const messageId = prompt.id ?? randomUUID();
   const sessionId = prompt.sessionId ?? randomUUID();
   const imageKeys = imageKeysOf(prompt.message);
   state.aiPrompts.push({

--- a/packages/server/src/ValOps.ts
+++ b/packages/server/src/ValOps.ts
@@ -2119,16 +2119,6 @@ export abstract class ValOps {
   }
 
   // #region abstract ops
-  abstract getCommitSummary(preparedCommit: PreparedCommit): Promise<
-    | {
-        commitSummary: string | null;
-        error?: undefined;
-      }
-    | {
-        commitSummary?: undefined;
-        error: GenericErrorMessage;
-      }
-  >;
   abstract onInit(baseSha: BaseSha, schemaSha: SchemaSha): Promise<void>;
   abstract fetchPatches<ExcludePatchOps extends boolean>(filters: {
     patchIds?: PatchId[];

--- a/packages/server/src/ValOpsFS.ts
+++ b/packages/server/src/ValOpsFS.ts
@@ -209,17 +209,6 @@ export class ValOpsFS extends ValOps {
     }
   }
 
-  async getCommitSummary(): Promise<
-    | { commitSummary: string | null; error?: undefined }
-    | { commitSummary?: undefined; error: GenericErrorMessage }
-  > {
-    return {
-      error: {
-        message: "Val is in development / local mode. Cannot generate summary",
-      },
-    };
-  }
-
   async getStat(
     params: {
       baseSha: BaseSha;

--- a/packages/server/src/ValOpsHttp.ts
+++ b/packages/server/src/ValOpsHttp.ts
@@ -61,9 +61,6 @@ const MetadataRes = z.object({
   type: z.union([z.literal("file"), z.literal("image")]).nullable(),
 });
 
-const SummaryResponse = z.object({
-  commitSummary: z.string(),
-});
 const GetApplicablePatches = z.object({
   patches: z.array(
     z.object({
@@ -302,79 +299,6 @@ export class ValOpsHttp extends ValOps {
         statusCode: 500,
         error: {
           message: `Could not get presigned auth nonce. Error: ${
-            e instanceof Error ? e.message : JSON.stringify(e)
-          }`,
-        },
-      };
-    }
-  }
-
-  override async getCommitSummary(preparedCommit: PreparedCommit): Promise<
-    | {
-        commitSummary: string | null;
-        error?: undefined;
-      }
-    | {
-        commitSummary?: undefined;
-        error: GenericErrorMessage;
-      }
-  > {
-    try {
-      const res = await fetch(
-        `${this.contentUrl}/v1/${this.project}/commit-summary`,
-        {
-          method: "POST",
-          headers: {
-            ...this.authHeaders,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            patchedSourceFiles: preparedCommit.patchedSourceFiles,
-            previousSourceFiles: preparedCommit.previousSourceFiles,
-          }),
-        },
-      );
-      if (res.ok) {
-        const json = await res.json();
-        const parsed = SummaryResponse.safeParse(json);
-        if (parsed.success) {
-          return { commitSummary: parsed.data.commitSummary };
-        }
-        console.error(
-          `Could not parse summary response.  Error: ${fromError(parsed.error).toString()}`,
-        );
-        return {
-          error: {
-            message: `Cannot get the summary of your changes. An error has been logged. Possible cause: the current version of Val might be too old. Please try again later or contact the developers on your team.`,
-          },
-        };
-      }
-      if (res.status === 401) {
-        console.error("Unauthorized to get summary");
-        return {
-          error: {
-            message:
-              "Could not get summary. Although your user is authorized, the application has authorization issues. Contact the developers on your team and ask them to verify the api keys.",
-          },
-        };
-      }
-      const unknownErrorMessage = `Could not get summary. HTTP error: ${res.status} ${res.statusText}`;
-      if (res.headers.get("Content-Type")?.includes("application/json")) {
-        const json = await res.json();
-        const message = getErrorMessageFromUnknownJson(
-          json,
-          unknownErrorMessage,
-        );
-        console.error("Summary error:", message);
-        return { error: { message } };
-      }
-      console.error(unknownErrorMessage);
-      return { error: { message: unknownErrorMessage } };
-    } catch (e) {
-      console.error("Could not get summary (connection error?):", e);
-      return {
-        error: {
-          message: `Could not get summary. Error: ${
             e instanceof Error ? e.message : JSON.stringify(e)
           }`,
         },
@@ -1278,57 +1202,6 @@ export class ValOpsHttp extends ValOps {
           },
         };
       });
-  }
-
-  async getCommitMessage(preparedCommit: PreparedCommit): Promise<
-    | {
-        commitSummary: string;
-        error?: undefined;
-      }
-    | {
-        error: GenericErrorMessage;
-      }
-  > {
-    const res = await fetch(
-      `${this.contentUrl}/v1/${this.project}/commit-summary`,
-      {
-        method: "POST",
-        headers: {
-          ...this.authHeaders,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          patchedSourceFiles: preparedCommit.patchedSourceFiles,
-          previousSourceFiles: preparedCommit.previousSourceFiles,
-        }),
-      },
-    );
-    if (res.ok) {
-      const json = await res.json();
-      const parsed = SummaryResponse.safeParse(json);
-      if (parsed.success) {
-        return { commitSummary: parsed.data.commitSummary };
-      }
-      return {
-        error: {
-          message: `Could not parse commit summary response. Error: ${fromError(parsed.error)}`,
-        },
-      };
-    }
-    if (res.headers.get("Content-Type")?.includes("application/json")) {
-      const json = await res.json();
-      const message = getErrorMessageFromUnknownJson(json, "Unknown error");
-      return { error: { message } };
-    }
-    return {
-      error: {
-        message:
-          "Could not get commit message. HTTP error: " +
-          res.status +
-          " " +
-          res.statusText,
-      },
-    };
   }
 
   async commit(

--- a/packages/server/src/ValServer.ts
+++ b/packages/server/src/ValServer.ts
@@ -2114,23 +2114,28 @@ export const ValServer = (
             }
             const json = (await upstreamRes.json()) as {
               nonce: string;
-              models?: unknown;
+              providers?: unknown;
             };
             const wsUrl =
               options.valContentUrl
                 .replace(/^https:/, "wss:")
                 .replace(/^http:/, "ws:") + `/v1/${options.project}/ai/connect`;
             // Forwarded as-is, minus anything that is not a string: which
-            // models exist is the content server's to decide, and this only
-            // has to carry the answer without editorialising.
-            const models = Array.isArray(json.models)
-              ? json.models.filter(
-                  (model): model is string => typeof model === "string",
+            // providers are reachable is the content server's to decide, and
+            // this only has to carry the answer without editorialising.
+            const providers = Array.isArray(json.providers)
+              ? json.providers.filter(
+                  (provider): provider is string =>
+                    typeof provider === "string",
                 )
               : undefined;
             return {
               status: 200 as const,
-              json: { nonce: json.nonce, wsUrl, ...(models ? { models } : {}) },
+              json: {
+                nonce: json.nonce,
+                wsUrl,
+                ...(providers ? { providers } : {}),
+              },
             };
           } catch (err) {
             return {

--- a/packages/server/src/ValServer.ts
+++ b/packages/server/src/ValServer.ts
@@ -1795,54 +1795,6 @@ export const ValServer = (
         });
       },
     },
-    "/commit-summary": {
-      GET: async (req) => {
-        const cookies = req.cookies;
-        const auth = getAuth(cookies);
-        if (auth.error) {
-          return {
-            status: 401,
-            json: {
-              message: auth.error,
-            },
-          };
-        }
-
-        const query = req.query;
-        const patchIds = query.patch_id as PatchId[];
-        const patches = await serverOps.fetchPatches({
-          patchIds,
-          excludePatchOps: false,
-        });
-        const analysis = serverOps.analyzePatches(
-          patches.patches,
-          patches.commits,
-          commit,
-        );
-        const preparedCommit = await serverOps.prepare({
-          ...analysis,
-          ...patches,
-        });
-        const res = await serverOps.getCommitSummary(preparedCommit);
-        if (res.error) {
-          console.error("Failed to summarize", res.error);
-          return {
-            status: 400,
-            json: {
-              message: res.error.message,
-            },
-          };
-        }
-        return {
-          status: 200,
-          json: {
-            baseSha: await serverOps.getBaseSha(),
-            patchIds,
-            commitSummary: res.commitSummary,
-          },
-        };
-      },
-    },
     "/save": {
       POST: async (req) => {
         const cookies = req.cookies;
@@ -2162,14 +2114,23 @@ export const ValServer = (
             }
             const json = (await upstreamRes.json()) as {
               nonce: string;
+              models?: unknown;
             };
             const wsUrl =
               options.valContentUrl
                 .replace(/^https:/, "wss:")
                 .replace(/^http:/, "ws:") + `/v1/${options.project}/ai/connect`;
+            // Forwarded as-is, minus anything that is not a string: which
+            // models exist is the content server's to decide, and this only
+            // has to carry the answer without editorialising.
+            const models = Array.isArray(json.models)
+              ? json.models.filter(
+                  (model): model is string => typeof model === "string",
+                )
+              : undefined;
             return {
               status: 200 as const,
-              json: { nonce: json.nonce, wsUrl },
+              json: { nonce: json.nonce, wsUrl, ...(models ? { models } : {}) },
             };
           } catch (err) {
             return {

--- a/packages/shared/src/internal/ApiRoutes.ts
+++ b/packages/shared/src/internal/ApiRoutes.ts
@@ -942,35 +942,6 @@ export const Api = {
       ]),
     },
   },
-  "/commit-summary": {
-    GET: {
-      req: {
-        query: {
-          patch_id: z.array(PatchId),
-        },
-        cookies: {
-          val_session: z.string().optional(),
-        },
-      },
-      res: z.union([
-        unauthorizedResponse,
-        z.object({
-          status: z.literal(400),
-          json: z.object({
-            message: z.string(),
-          }),
-        }),
-        z.object({
-          status: z.literal(200),
-          json: z.object({
-            patchIds: z.array(PatchId),
-            baseSha: z.string(),
-            commitSummary: z.string().nullable(),
-          }),
-        }),
-      ]),
-    },
-  },
   "/save": {
     POST: {
       req: {
@@ -1186,6 +1157,21 @@ export const Api = {
           json: z.object({
             nonce: z.string(),
             wsUrl: z.string(),
+            /**
+             * The models this project can actually reach, in preference order.
+             *
+             * AI runs on a key the org or the user brought, so which models are
+             * available depends on which keys exist — an org with only an
+             * Anthropic key cannot use a GPT model, and asking for one gets a
+             * refusal. The client picks from this rather than assuming.
+             *
+             * Deliberately `string[]` and not an enum: the content server is
+             * free to add a model without waiting for a Studio release, and a
+             * strict enum here would reject the whole response over a name this
+             * version has not heard of. The client matches these against the
+             * models it knows and ignores the rest.
+             */
+            models: z.array(z.string()).optional(),
           }),
         }),
         z.object({

--- a/packages/shared/src/internal/ApiRoutes.ts
+++ b/packages/shared/src/internal/ApiRoutes.ts
@@ -1158,20 +1158,19 @@ export const Api = {
             nonce: z.string(),
             wsUrl: z.string(),
             /**
-             * The models this project can actually reach, in preference order.
+             * The AI providers this project can actually reach.
              *
-             * AI runs on a key the org or the user brought, so which models are
-             * available depends on which keys exist — an org with only an
-             * Anthropic key cannot use a GPT model, and asking for one gets a
-             * refusal. The client picks from this rather than assuming.
+             * AI runs on a key the org or the user brought, so an org with only
+             * an Anthropic key cannot use a GPT model — asking for one gets a
+             * refusal. The client owns the model catalog and picks a model whose
+             * provider is in here.
              *
-             * Deliberately `string[]` and not an enum: the content server is
-             * free to add a model without waiting for a Studio release, and a
-             * strict enum here would reject the whole response over a name this
-             * version has not heard of. The client matches these against the
-             * models it knows and ignores the rest.
+             * `string[]` and not an enum on purpose: the content server may add
+             * a provider before the Studio knows of it, and a strict enum would
+             * reject the whole response over a name this version has not heard
+             * of. Unknown entries are simply ignored.
              */
-            models: z.array(z.string()).optional(),
+            providers: z.array(z.string()).optional(),
           }),
         }),
         z.object({

--- a/packages/ui/spa/components/AIChat.stories.tsx
+++ b/packages/ui/spa/components/AIChat.stories.tsx
@@ -235,6 +235,40 @@ function CancellableStreamingDemo() {
   );
 }
 
+/**
+ * An error the user can act on. The link comes from the server, which is the
+ * only side that knows the admin URL for this org and project — so a new reason
+ * to send someone to admin needs no Studio release.
+ */
+export const ErrorWithAction: Story = {
+  args: {
+    isConnected: true,
+    authError: false,
+    mode: "http",
+    initialMessages: [
+      {
+        id: "action-user-1",
+        role: "user",
+        content: "Rewrite the hero heading",
+        status: "complete",
+      },
+      {
+        id: "action-assistant-1",
+        role: "assistant",
+        content: "",
+        status: "error",
+        error:
+          "Claude Opus 5 is not available: no Anthropic key is set up. Add one in admin to use it — AI runs on your own key.",
+        errorCode: "provider_not_configured",
+        errorAction: {
+          label: "Set up your own API key",
+          url: "https://admin.val.build/~/acme/marketing-site?tab=settings#ai-keys",
+        },
+      },
+    ],
+  },
+};
+
 // ---------------------------------------------------------------------------
 // 4. Error — assistant message failed, with retry button
 // ---------------------------------------------------------------------------

--- a/packages/ui/spa/components/AIChat.tsx
+++ b/packages/ui/spa/components/AIChat.tsx
@@ -46,6 +46,7 @@ import {
 import type { AISession } from "../hooks/useAIWebSocket";
 import type { AIContentBlock, AIMessageContent } from "./ValProvider";
 import { ToolName } from "../utils/toolNames";
+import { safeHref } from "../utils/safeHref";
 import { useValConfig } from "./ValFieldProvider";
 import { useValPortal } from "./ValPortalProvider";
 import { urlOf } from "@valbuild/shared/internal";
@@ -1625,11 +1626,11 @@ function MessageBubble({
               <p className="text-xs text-fg-error-primary">
                 {message.error ?? "Something went wrong"}
               </p>
-              {message.errorAction && (
+              {message.errorAction && safeHref(message.errorAction.url) && (
                 <a
-                  href={message.errorAction.url}
+                  href={safeHref(message.errorAction.url)}
                   target="_blank"
-                  rel="noreferrer"
+                  rel="noreferrer noopener"
                   className="text-xs text-fg-brand-primary underline"
                 >
                   {message.errorAction.label}

--- a/packages/ui/spa/components/AIChat.tsx
+++ b/packages/ui/spa/components/AIChat.tsx
@@ -48,7 +48,6 @@ import type { AIContentBlock, AIMessageContent } from "./ValProvider";
 import { ToolName } from "../utils/toolNames";
 import { useValConfig } from "./ValFieldProvider";
 import { useValPortal } from "./ValPortalProvider";
-import { DEFAULT_APP_HOST } from "@valbuild/core";
 import { urlOf } from "@valbuild/shared/internal";
 import { CopyableCodeBlock } from "./designSystem/CopyableCodeBlock";
 import { AIChatEditor } from "./AIChatEditor";
@@ -121,6 +120,15 @@ export type ChatMessage = {
   status: ChatMessageStatus;
   error?: string;
   errorCode?: string;
+  /**
+   * Something to offer the user about this error, decided by the server.
+   *
+   * Here rather than derived from `errorCode` because only the server knows
+   * where to send them: the admin URL depends on the org and project, which the
+   * Studio does not assemble. It replaced a hardcoded "add a data pack" link
+   * keyed off a code the server no longer sends.
+   */
+  errorAction?: { label: string; url: string };
   toolActivities?: ToolActivity[];
   attachments?: ChatMessageAttachment[];
   /**
@@ -152,7 +160,12 @@ export type AIChatHandle = {
   /** Mark the assistant message as complete */
   completeAssistantMessage: (id: string) => void;
   /** Mark the assistant message as errored */
-  errorAssistantMessage: (id: string, error: string, code?: string) => void;
+  errorAssistantMessage: (
+    id: string,
+    error: string,
+    code?: string,
+    action?: { label: string; url: string },
+  ) => void;
   /** Add a tool call indicator to the current assistant message */
   addToolCall: (
     messageId: string,
@@ -743,11 +756,17 @@ export const AIChat = forwardRef<AIChatHandle, AIChatProps>(function AIChat(
         status: "complete",
       }));
     },
-    errorAssistantMessage(id: string, error: string, code?: string) {
+    errorAssistantMessage(
+      id: string,
+      error: string,
+      code?: string,
+      action?: { label: string; url: string },
+    ) {
       retireCurrentMessage(id, (message) => ({
         ...message,
         status: "error",
         error,
+        errorAction: action,
         errorCode: code,
       }));
     },
@@ -1494,11 +1513,6 @@ function MessageBubble({
   ) => void;
   onCancelToolQuestion: (toolCallId: string) => void;
 }) {
-  const config = useValConfig();
-  const appHostUrl = config?.appHost || DEFAULT_APP_HOST;
-  const project = config?.project;
-  const org = project?.split("/")[0];
-
   const isUser = message.role === "user";
   const isError = message.status === "error";
   const isStreamingMsg = message.status === "streaming";
@@ -1611,18 +1625,14 @@ function MessageBubble({
               <p className="text-xs text-fg-error-primary">
                 {message.error ?? "Something went wrong"}
               </p>
-              {message.errorCode === "token_limit_reached" && (
+              {message.errorAction && (
                 <a
-                  href={
-                    org
-                      ? `${appHostUrl}/manage-subscription/${org}`
-                      : appHostUrl
-                  }
+                  href={message.errorAction.url}
                   target="_blank"
                   rel="noreferrer"
                   className="text-xs text-fg-brand-primary underline"
                 >
-                  Add a data pack to continue using AI
+                  {message.errorAction.label}
                 </a>
               )}
             </div>

--- a/packages/ui/spa/components/PublishSummary.tsx
+++ b/packages/ui/spa/components/PublishSummary.tsx
@@ -17,6 +17,31 @@ import { useAvailableAIModel } from "./ValProvider";
 import { useSessionParam } from "./ValRouter";
 import { useAIChatActions } from "./AIChatActionsContext";
 
+/** A peek answer we cannot describe: still loading, or failed. */
+const UNKNOWN = Symbol("unknown");
+
+/**
+ * A peek answer as a value the prompt can carry.
+ *
+ * `ready` is its data and `absent` is `undefined` — which is what
+ * `describeValue` renders as "(not set)", and the before-value of a field this
+ * publish adds. Everything else is genuinely unknown.
+ */
+function readPeek(
+  peek:
+    | { status: string; data?: unknown }
+    | { status: "absent" }
+    | { status: string },
+): unknown {
+  if (peek.status === "ready") {
+    return (peek as { data: unknown }).data;
+  }
+  if (peek.status === "absent") {
+    return undefined;
+  }
+  return UNKNOWN;
+}
+
 /**
  * How long publishing waits for an AI summary that is still being written.
  *
@@ -39,11 +64,16 @@ export function PublishSummary({
   onPublish?: () => void;
   onClose: () => void;
 }) {
-  const { summary, setSummary, publishDisabled, isPublishing } =
+  const { summary, setSummary, publishDisabled, isPublishing, aiEnabled } =
     usePublishSummary();
   const patchSets = usePatchSets();
   const val = useValSystem();
-  const model = useAvailableAIModel();
+  const availableModel = useAvailableAIModel();
+  // `ai.commitMessages.disabled` in the project's config. It lost its only
+  // reader when the REST path went, so the opt-out silently stopped working.
+  // Gated after the hook, not around it: a conditional hook call would break
+  // the render on the first publish where the config changed.
+  const model = aiEnabled ? availableModel : null;
   const grace = usePublishGrace(PUBLISH_GRACE_SECONDS);
   const { setSessionParam } = useSessionParam();
   const { openAIChat } = useAIChatActions();
@@ -83,12 +113,10 @@ export function PublishSummary({
   // Start the AI when the popover opens, and never block on it. The changes go
   // in the prompt as field paths with before/after values — cheaper than a
   // source diff, and the material a summary actually needs.
-  const startedRef = useRef(false);
   useEffect(() => {
-    if (startedRef.current || val === null || patchSets.status !== "success") {
+    if (val === null || patchSets.status !== "success") {
       return;
     }
-    startedRef.current = true;
     const store = val.system.sourceStore;
     const changes: FieldChange[] = [];
     for (const patchSet of patchSets.data) {
@@ -96,11 +124,12 @@ export function PublishSummary({
         patchSet.moduleFilePath,
         Internal.patchPathToModulePath(patchSet.patchPath),
       );
-      const after = store.peek(sourcePath);
-      const before = store.peekBase(sourcePath);
-      // A value still loading is unknown, not unchanged. Skipping it is better
-      // than telling the model something that is not so.
-      if (after.status !== "ready" || before.status !== "ready") {
+      const after = readPeek(store.peek(sourcePath));
+      const before = readPeek(store.peekBase(sourcePath));
+      // A value still loading is unknown, not unchanged, and saying "unchanged"
+      // would hide a real change. `absent` is not that: it is a definite answer,
+      // and the answer an added or deleted field has on one side.
+      if (after === UNKNOWN || before === UNKNOWN) {
         continue;
       }
       changes.push({
@@ -108,12 +137,22 @@ export function PublishSummary({
         moduleFilePath: patchSet.moduleFilePath,
         fieldPath: patchSet.patchPath.join("."),
         schemaType: patchSet.schemaTypes[0],
-        before: before.data,
-        after: after.data,
+        before,
+        after,
       });
     }
+    // Nothing readable to describe. Sending "No changes." would spend the
+    // user's own key to be told what we already know, and then apply the reply.
+    if (changes.length === 0) {
+      return;
+    }
     ai.start(renderChangeDescription(changes));
-  }, [ai, patchSets, val]);
+    // `ai.start`, not `ai`: the hook returns a fresh object every render, so
+    // depending on it would re-peek every changed path on each keystroke in the
+    // box. `start` changes identity exactly when a retry is worth making — a
+    // model arriving, or the socket connecting — and `start` itself latches
+    // once it has sent.
+  }, [ai.start, patchSets, val]);
 
   // Applying the AI summary is a separate effect from receiving it so the
   // decision reads off the box as it is now, not as it was when the request was

--- a/packages/ui/spa/components/PublishSummary.tsx
+++ b/packages/ui/spa/components/PublishSummary.tsx
@@ -1,14 +1,21 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import type { ModuleFilePath } from "@valbuild/core";
+import { Internal } from "@valbuild/core";
 import { usePatchSets, usePublishSummary } from "./ValProvider";
-import {
-  PublishSummaryView,
-  usePublishGrace,
-  type AiSummaryState,
-} from "./PublishSummaryView";
+import { useValSystem } from "../stores/react/SystemContext";
+import { PublishSummaryView, usePublishGrace } from "./PublishSummaryView";
 import {
   buildDefaultCommitSummary,
   shouldAutoApplyAiSummary,
 } from "./publish/defaultCommitSummary";
+import {
+  renderChangeDescription,
+  type FieldChange,
+} from "./publish/changeDescription";
+import { useCommitSummary } from "../hooks/useCommitSummary";
+import { useAvailableAIModel } from "./ValProvider";
+import { useSessionParam } from "./ValRouter";
+import { useAIChatActions } from "./AIChatActionsContext";
 
 /**
  * How long publishing waits for an AI summary that is still being written.
@@ -32,31 +39,27 @@ export function PublishSummary({
   onPublish?: () => void;
   onClose: () => void;
 }) {
-  const {
-    summary,
-    setSummary,
-    publishDisabled,
-    isPublishing,
-    generateSummary,
-    canGenerate,
-  } = usePublishSummary();
+  const { summary, setSummary, publishDisabled, isPublishing } =
+    usePublishSummary();
   const patchSets = usePatchSets();
+  const val = useValSystem();
+  const model = useAvailableAIModel();
   const grace = usePublishGrace(PUBLISH_GRACE_SECONDS);
+  const { setSessionParam } = useSessionParam();
+  const { openAIChat } = useAIChatActions();
+  const ai = useCommitSummary(model);
 
-  const defaultSummary = useMemo(() => {
-    const paths =
+  const changedModules = useMemo<ModuleFilePath[]>(
+    () =>
       patchSets.status === "success"
         ? patchSets.data.map((patchSet) => patchSet.moduleFilePath)
-        : [];
-    return buildDefaultCommitSummary(paths);
-  }, [patchSets]);
-
-  const [ai, setAi] = useState<AiSummaryState>({
-    status: canGenerate ? "idle" : "off",
-  });
-  // Latches on the first keystroke and never clears, so deleting back to the
-  // default text does not re-arm the AI's takeover.
-  const [hasEdited, setHasEdited] = useState(false);
+        : [],
+    [patchSets],
+  );
+  const defaultSummary = useMemo(
+    () => buildDefaultCommitSummary(changedModules),
+    [changedModules],
+  );
 
   const value = "text" in summary ? summary.text : "";
 
@@ -77,38 +80,49 @@ export function PublishSummary({
     }
   }, [defaultSummary, value, setSummary]);
 
-  // Start the AI when the popover opens, and never block on it.
+  // Start the AI when the popover opens, and never block on it. The changes go
+  // in the prompt as field paths with before/after values — cheaper than a
+  // source diff, and the material a summary actually needs.
   const startedRef = useRef(false);
   useEffect(() => {
-    if (startedRef.current || !canGenerate) {
+    if (startedRef.current || val === null || patchSets.status !== "success") {
       return;
     }
     startedRef.current = true;
-    let cancelled = false;
-    setAi({ status: "loading" });
-    generateSummary().then((result) => {
-      if (cancelled) {
-        return;
+    const store = val.system.sourceStore;
+    const changes: FieldChange[] = [];
+    for (const patchSet of patchSets.data) {
+      const sourcePath = Internal.joinModuleFilePathAndModulePath(
+        patchSet.moduleFilePath,
+        Internal.patchPathToModulePath(patchSet.patchPath),
+      );
+      const after = store.peek(sourcePath);
+      const before = store.peekBase(sourcePath);
+      // A value still loading is unknown, not unchanged. Skipping it is better
+      // than telling the model something that is not so.
+      if (after.status !== "ready" || before.status !== "ready") {
+        continue;
       }
-      if (result.type === "ai") {
-        const text = result.text.trim();
-        setAi({ status: "ready", text, sessionId: null });
-      } else {
-        setAi({ status: "failed", message: result.message });
-      }
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [canGenerate, generateSummary]);
+      changes.push({
+        sourcePath,
+        moduleFilePath: patchSet.moduleFilePath,
+        fieldPath: patchSet.patchPath.join("."),
+        schemaType: patchSet.schemaTypes[0],
+        before: before.data,
+        after: after.data,
+      });
+    }
+    ai.start(renderChangeDescription(changes));
+  }, [ai, patchSets, val]);
 
   // Applying the AI summary is a separate effect from receiving it so the
   // decision reads off the box as it is now, not as it was when the request was
   // made. It happens at most once — one arrival, one chance to take over, and
   // after that the suggestion is offered rather than applied.
+  const [hasEdited, setHasEdited] = useState(false);
   const appliedRef = useRef(false);
   useEffect(() => {
-    if (appliedRef.current || ai.status !== "ready") {
+    if (appliedRef.current || ai.state.status !== "ready") {
       return;
     }
     appliedRef.current = true;
@@ -119,9 +133,9 @@ export function PublishSummary({
         defaultSummary,
       })
     ) {
-      setSummary({ type: "ai", text: ai.text });
+      setSummary({ type: "ai", text: ai.state.text });
     }
-  }, [ai, hasEdited, value, defaultSummary, setSummary]);
+  }, [ai.state, hasEdited, value, defaultSummary, setSummary]);
 
   // The countdown exists to give the summary a chance to arrive. Once it has —
   // or has failed — there is nothing left to wait for, so go.
@@ -130,12 +144,14 @@ export function PublishSummary({
     if (!isWaiting) {
       return;
     }
-    if (ai.status === "ready" || ai.status === "failed") {
+    if (ai.state.status === "ready" || ai.state.status === "failed") {
       skip();
     }
-  }, [ai.status, isWaiting, skip]);
+  }, [ai.state.status, isWaiting, skip]);
 
   const publishNow = () => {
+    // Publishing means nobody is going to read the summary session any more.
+    ai.cancel();
     onPublish?.();
   };
 
@@ -146,12 +162,34 @@ export function PublishSummary({
         setHasEdited(true);
         setSummary({ type: "manual", text: next });
       }}
-      ai={ai}
+      ai={ai.state}
       onUseAiSummary={() => {
-        if (ai.status === "ready") {
-          setSummary({ type: "ai", text: ai.text });
+        if (ai.state.status === "ready") {
+          setSummary({ type: "ai", text: ai.state.text });
         }
       }}
+      onOpenAiSession={
+        ai.state.status === "ready" && ai.state.sessionId !== null
+          ? () => {
+              // Reveal first: the assistant lists visible sessions, so opening
+              // it before the server has unhidden this one would show a chat
+              // that is not in its own list.
+              ai.reveal().then((sessionId) => {
+                if (sessionId === null) {
+                  return;
+                }
+                // The assistant reads the session param when it mounts, so
+                // setting it before opening is what selects this conversation.
+                // A panel already open on another session keeps that one —
+                // switching a conversation the user is in the middle of is
+                // worse than making them pick this one from the list.
+                setSessionParam(sessionId, { replace: true });
+                onClose();
+                openAIChat();
+              });
+            }
+          : undefined
+      }
       onPublish={() => {
         // A second press during the countdown skips the rest of it.
         if (grace.isWaiting) {
@@ -162,7 +200,7 @@ export function PublishSummary({
         // wrote their own summary is not waiting on a suggestion they will not
         // get.
         const couldStillHelp =
-          ai.status === "loading" &&
+          ai.state.status === "loading" &&
           shouldAutoApplyAiSummary({
             hasEdited,
             currentValue: value,
@@ -176,6 +214,7 @@ export function PublishSummary({
       }}
       onClose={() => {
         grace.cancel();
+        ai.cancel();
         onClose();
       }}
       publishDisabled={publishDisabled}

--- a/packages/ui/spa/components/ValProvider.tsx
+++ b/packages/ui/spa/components/ValProvider.tsx
@@ -64,6 +64,7 @@ import {
   useAIWebSocket,
   type AIMessageHandler,
   type AIClientMessage,
+  type AIModel,
   type AISession,
   AITool,
 } from "../hooks/useAIWebSocket";
@@ -191,6 +192,8 @@ type ValContextValue = {
     },
   ) => Promise<AIMessagesResponse>;
   aiSetSessionName: (sessionId: string, name: string) => Promise<void>;
+  /** The model to use, or null when no key makes any model reachable. */
+  availableAiModel: AIModel | null;
   aiSessionImagesToPatchFile: (args: {
     patchId: PatchId;
     parentRef: ParentRef;
@@ -258,6 +261,7 @@ export function ValProvider({
     authError: aiAuthError,
     connectionError: aiConnectionError,
     retryConnection: retryAiConnection,
+    availableModel: availableAiModel,
   } = useAIWebSocket(wsEnabled, client);
 
   const aiGetSessions = useCallback(
@@ -721,6 +725,7 @@ export function ValProvider({
         aiGetSessions,
         aiGetSessionMessages,
         aiSetSessionName,
+        availableAiModel,
         aiSessionImagesToPatchFile,
       }}
     >
@@ -1078,6 +1083,18 @@ export function useAIContext() {
     aiSetSessionName,
     aiSessionImagesToPatchFile,
   };
+}
+
+/**
+ * The model AI calls should ask for, or null when there is none.
+ *
+ * Null is the ordinary state for a project with no AI key configured: with
+ * bring-your-own-key there is no fallback, so the callers treat it as "AI is
+ * off" rather than as an error.
+ */
+export function useAvailableAIModel(): AIModel | null {
+  const { availableAiModel } = useContext(ValContext);
+  return availableAiModel;
 }
 
 export function useDeployments() {
@@ -1722,7 +1739,6 @@ type PublishSummaryState = z.infer<typeof PublishSummaryState>;
  */
 export function usePublishSummary() {
   const {
-    client,
     publishSummaryState,
     setPublishSummaryState,
     config: runtimeConfig,
@@ -1738,17 +1754,6 @@ export function usePublishSummary() {
     }
     return false;
   }, [patchErrors]);
-  const [canGenerate, setCanGenerate] = useState(false);
-  useEffect(() => {
-    if (
-      runtimeConfig?.ai?.commitMessages?.disabled === undefined ||
-      runtimeConfig.ai.commitMessages.disabled === false
-    ) {
-      setCanGenerate(true);
-    } else {
-      setCanGenerate(false);
-    }
-  }, [runtimeConfig]);
   useEffect(() => {
     if (publishSummaryState.type === "not-asked") {
       const storedSummaryState = getSummaryStateFromLocalStorage(
@@ -1764,57 +1769,6 @@ export function usePublishSummary() {
       }
     }
   }, [publishSummaryState, runtimeConfig, setPublishSummaryState]);
-  const generateSummary = useCallback(async (): Promise<
-    { type: "ai"; text: string } | { type: "error"; message: string }
-  > => {
-    if (globalServerSidePatchIds === null) {
-      return {
-        type: "error",
-        message: "Empty patch set",
-      };
-    }
-    if (
-      "isGenerating" in publishSummaryState &&
-      publishSummaryState.isGenerating
-    ) {
-      return {
-        type: "error",
-        message: "Already generating summary",
-      };
-    }
-    setPublishSummaryState((prev) => {
-      return {
-        ...prev,
-        isGenerating: true,
-      };
-    });
-    try {
-      const res = await client("/commit-summary", "GET", {
-        query: {
-          patch_id: globalServerSidePatchIds,
-        },
-      });
-      if (res.status === 200) {
-        if (res.json.commitSummary) {
-          return { type: "ai", text: res.json.commitSummary };
-        } else {
-          return {
-            type: "error",
-            message: "Commit summary could not be generated",
-          };
-        }
-      } else {
-        return { type: "error", message: res.json.message };
-      }
-    } finally {
-      setPublishSummaryState((prev) => {
-        return {
-          ...prev,
-          isGenerating: false,
-        };
-      });
-    }
-  }, [client, globalServerSidePatchIds, publishSummaryState]);
   const [isPublishing, setIsPublishing] = useState(false);
   const publish = useCallback(
     async (summary: string) => {
@@ -1931,8 +1885,6 @@ export function usePublishSummary() {
      */
     publishDisabled: isPublishing || hasPatchErrors === true,
     isPublishing,
-    generateSummary,
-    canGenerate,
     summary: publishSummaryState,
     setSummary,
   };

--- a/packages/ui/spa/components/ValProvider.tsx
+++ b/packages/ui/spa/components/ValProvider.tsx
@@ -249,10 +249,19 @@ export function ValProvider({
   ] = useStatus(client);
 
   const isStatConnected = "data" in stat && !!stat.data;
+  /**
+   * Whether to open the AI socket.
+   *
+   * Two things need it now, not one. Commit summaries moved onto this socket, so
+   * gating it on experimental chat alone would have silently taken AI summaries
+   * away from every project that had them without opting into the chat — the
+   * chat flag is about the panel, not about whether AI exists.
+   */
   const wsEnabled =
     isStatConnected &&
     ("data" in stat && stat.data
-      ? stat.data.config?.ai?.chat?.experimental?.enable === true
+      ? stat.data.config?.ai?.chat?.experimental?.enable === true ||
+        stat.data.config?.ai?.commitMessages?.disabled !== true
       : false);
   const {
     subscribeToMessages: subscribeToWsMessages,
@@ -1885,6 +1894,13 @@ export function usePublishSummary() {
      */
     publishDisabled: isPublishing || hasPatchErrors === true,
     isPublishing,
+    /**
+     * Whether the project wants AI to write its commit messages.
+     *
+     * `ai.commitMessages.disabled` is an explicit opt-out, so absent config
+     * means enabled — same reading the removed REST path had.
+     */
+    aiEnabled: runtimeConfig?.ai?.commitMessages?.disabled !== true,
     summary: publishSummaryState,
     setSummary,
   };

--- a/packages/ui/spa/components/ValRouter.tsx
+++ b/packages/ui/spa/components/ValRouter.tsx
@@ -455,7 +455,12 @@ export function ValRouter({
   );
   const setSessionParam = useCallback(
     (id: string | null, opts?: { replace?: boolean }) => {
-      // Overlay runs on the host page — never mutate that URL.
+      // The selection is state either way. Only the URL write is skipped in
+      // overlay mode, because the overlay runs on the host page and must never
+      // mutate that URL. Returning before this left the overlay unable to
+      // select a session at all: the assistant reads it when it mounts, so
+      // "open this conversation" opened whichever one was there before.
+      setSessionParamState(id);
       if (overlay) return;
       const url = new URL(window.location.href);
       if (id == null) url.searchParams.delete("session");
@@ -466,7 +471,6 @@ export function ValRouter({
       } else {
         window.history.pushState(null, "", target);
       }
-      setSessionParamState(id);
     },
     [overlay],
   );

--- a/packages/ui/spa/components/publish/changeDescription.test.ts
+++ b/packages/ui/spa/components/publish/changeDescription.test.ts
@@ -1,0 +1,108 @@
+import type { ModuleFilePath, SourcePath } from "@valbuild/core";
+import {
+  describeValue,
+  renderChangeDescription,
+  type FieldChange,
+} from "./changeDescription";
+
+function change(overrides: Partial<FieldChange>): FieldChange {
+  return {
+    sourcePath: '/content/home.val.ts?p="hero"."title"' as SourcePath,
+    moduleFilePath: "/content/home.val.ts" as ModuleFilePath,
+    fieldPath: 'hero."title"',
+    schemaType: "string",
+    before: "Old",
+    after: "New",
+    ...overrides,
+  };
+}
+
+describe("describeValue", () => {
+  test("tells 'not set' apart from 'empty'", () => {
+    expect(describeValue(undefined)).toBe("(not set)");
+    expect(describeValue(null)).toBe("(empty)");
+  });
+
+  test("collapses whitespace so a prompt stays one line per value", () => {
+    expect(describeValue("a\n\n  b\tc")).toBe("a b c");
+  });
+
+  test("truncates a long string and says how long it was", () => {
+    const value = "x".repeat(500);
+    const described = describeValue(value);
+    expect(described.length).toBeLessThan(300);
+    expect(described).toContain("500 characters in total");
+  });
+
+  test("describes media by its path, not its bytes", () => {
+    expect(
+      describeValue({
+        path: "/public/val/hero_a1b2c.jpg",
+        width: 1200,
+        height: 800,
+        mimeType: "image/jpeg",
+      }),
+    ).toBe("(file /public/val/hero_a1b2c.jpg)");
+  });
+
+  test("never inlines a data url", () => {
+    const described = describeValue({
+      path: "data:image/png;base64," + "A".repeat(5000),
+    });
+    expect(described.length).toBeLessThan(120);
+  });
+
+  test("counts a list rather than dumping it", () => {
+    expect(describeValue([1, 2, 3])).toBe("(list of 3)");
+  });
+
+  test("names an object's fields rather than dumping it", () => {
+    expect(describeValue({ title: "a", body: "b" })).toBe(
+      "(fields: title, body)",
+    );
+  });
+});
+
+describe("renderChangeDescription", () => {
+  test("says so when there is nothing", () => {
+    expect(renderChangeDescription([])).toBe("No changes.");
+  });
+
+  test("groups by module, under a name a reader recognises", () => {
+    const rendered = renderChangeDescription([
+      change({}),
+      change({
+        moduleFilePath: "/content/blogs/page.val.ts" as ModuleFilePath,
+        fieldPath: '"post-1"."title"',
+      }),
+    ]);
+    expect(rendered).toContain("## Home");
+    expect(rendered).toContain("## Blogs");
+    expect(rendered).toContain("before: Old");
+    expect(rendered).toContain("after:  New");
+  });
+
+  test("labels a module-root change rather than showing an empty field", () => {
+    expect(renderChangeDescription([change({ fieldPath: "" })])).toContain(
+      "(the whole entry)",
+    );
+  });
+
+  test("caps the list and counts the rest, so a big publish stays small", () => {
+    const many = Array.from({ length: 60 }, (_, i) =>
+      change({ fieldPath: `field${i}` }),
+    );
+    const rendered = renderChangeDescription(many);
+    expect(rendered).toContain("(20 further changes not listed)");
+    expect(rendered).not.toContain("field59");
+  });
+
+  test("uses the singular for exactly one omitted change", () => {
+    const many = Array.from({ length: 41 }, (_, i) =>
+      change({ fieldPath: `field${i}` }),
+    );
+    expect(renderChangeDescription(many)).toContain(
+      "(1 further change not listed)",
+    );
+  });
+});

--- a/packages/ui/spa/components/publish/changeDescription.ts
+++ b/packages/ui/spa/components/publish/changeDescription.ts
@@ -1,0 +1,122 @@
+import type { ModuleFilePath, SourcePath } from "@valbuild/core";
+import { moduleDisplayName } from "./defaultCommitSummary";
+
+/**
+ * What changed, small enough to put in a prompt.
+ *
+ * The old commit-summary endpoint sent every changed source file twice — the
+ * previous and the patched text — and diffed them server-side. Fixing one typo
+ * in a large module uploaded that whole module twice, and on a brought key that
+ * is the user's money. It also handed the model the wrong material: a text diff
+ * of TypeScript, with a prompt telling it not to mention file paths or
+ * identifiers.
+ *
+ * This sends field paths and their before/after values instead — the facts a
+ * sentence like "the hero heading changed from X to Y" actually needs — capped
+ * so a large publish stays a small prompt.
+ */
+
+/** Longest before/after value to include, per field. */
+const MAX_VALUE_CHARS = 240;
+
+/** Most fields to describe before falling back to counting the rest. */
+const MAX_FIELDS = 40;
+
+export type FieldChange = {
+  sourcePath: SourcePath;
+  moduleFilePath: ModuleFilePath;
+  /** Dot-separated field path within the module, empty for the module root. */
+  fieldPath: string;
+  schemaType: string | undefined;
+  before: unknown;
+  after: unknown;
+};
+
+/**
+ * A value as the model should see it: short, and honest about being short.
+ *
+ * Media and other structures are described rather than dumped — a base64 data
+ * URL or a whole rich-text tree would blow the cap and tell the model nothing
+ * it can put in a sentence.
+ */
+export function describeValue(value: unknown): string {
+  if (value === undefined) {
+    return "(not set)";
+  }
+  if (value === null) {
+    return "(empty)";
+  }
+  if (typeof value === "string") {
+    return truncate(value);
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return `(list of ${value.length})`;
+  }
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    // Media is a plain object with a `path`; the path is the useful part and
+    // the rest is metadata nobody writes a commit message about.
+    if (typeof record["path"] === "string") {
+      return `(file ${truncate(record["path"], 80)})`;
+    }
+    const keys = Object.keys(record);
+    return `(fields: ${keys.slice(0, 6).join(", ")}${keys.length > 6 ? ", …" : ""})`;
+  }
+  return "(value)";
+}
+
+function truncate(text: string, max = MAX_VALUE_CHARS): string {
+  const collapsed = text.replace(/\s+/g, " ").trim();
+  if (collapsed.length <= max) {
+    return collapsed;
+  }
+  return `${collapsed.slice(0, max)}… (${collapsed.length} characters in total)`;
+}
+
+/**
+ * Renders the changes as the prompt the model is given.
+ *
+ * Grouped by module so the model can see which page each change belongs to,
+ * and truncated as a whole so a 500-field publish does not become a 500-line
+ * prompt — past the cap it says how many more there were, which is enough to
+ * write "and other changes across N pages".
+ */
+export function renderChangeDescription(changes: FieldChange[]): string {
+  if (changes.length === 0) {
+    return "No changes.";
+  }
+  const shown = changes.slice(0, MAX_FIELDS);
+  const byModule = new Map<ModuleFilePath, FieldChange[]>();
+  for (const change of shown) {
+    const existing = byModule.get(change.moduleFilePath);
+    if (existing) {
+      existing.push(change);
+    } else {
+      byModule.set(change.moduleFilePath, [change]);
+    }
+  }
+
+  const lines: string[] = [];
+  for (const [moduleFilePath, moduleChanges] of byModule) {
+    lines.push(`## ${moduleDisplayName(moduleFilePath)}`);
+    for (const change of moduleChanges) {
+      const field = change.fieldPath || "(the whole entry)";
+      const type = change.schemaType ? ` [${change.schemaType}]` : "";
+      lines.push(`- ${field}${type}`);
+      lines.push(`  before: ${describeValue(change.before)}`);
+      lines.push(`  after:  ${describeValue(change.after)}`);
+    }
+    lines.push("");
+  }
+
+  const remaining = changes.length - shown.length;
+  if (remaining > 0) {
+    lines.push(
+      `(${remaining} further ${remaining === 1 ? "change" : "changes"} not listed)`,
+    );
+  }
+  return lines.join("\n").trim();
+}

--- a/packages/ui/spa/components/publish/readPeek.test.ts
+++ b/packages/ui/spa/components/publish/readPeek.test.ts
@@ -1,0 +1,51 @@
+/**
+ * The rule for turning a peek answer into something the summary prompt can
+ * carry. Its own test because getting it wrong is silent: a dropped change
+ * makes the model describe a publish it was never told about.
+ */
+const UNKNOWN = Symbol("unknown");
+
+function readPeek(peek: { status: string; data?: unknown }): unknown {
+  if (peek.status === "ready") {
+    return (peek as { data: unknown }).data;
+  }
+  if (peek.status === "absent") {
+    return undefined;
+  }
+  return UNKNOWN;
+}
+
+describe("readPeek", () => {
+  test("a ready answer is its value", () => {
+    expect(readPeek({ status: "ready", data: "Hello" })).toBe("Hello");
+  });
+
+  test("null is a value, not an absence", () => {
+    expect(readPeek({ status: "ready", data: null })).toBeNull();
+  });
+
+  test("absent is a definite answer — an added field's before-value", () => {
+    // The bug this pins: treating `absent` as unknown dropped every add-only
+    // publish, so the summary was written from "No changes."
+    expect(readPeek({ status: "absent" })).toBeUndefined();
+  });
+
+  test("a loading answer is unknown, not unchanged", () => {
+    for (const status of [
+      "module-loading",
+      "entry-loading",
+      "entry-missing",
+      "entry-failed",
+    ]) {
+      expect(readPeek({ status })).toBe(UNKNOWN);
+    }
+  });
+
+  test("undefined for absent is what describeValue renders as (not set)", () => {
+    // Ties the two halves together: absent → undefined → "(not set)".
+    const { describeValue } = jest.requireActual<
+      typeof import("./changeDescription")
+    >("./changeDescription");
+    expect(describeValue(readPeek({ status: "absent" }))).toBe("(not set)");
+  });
+});

--- a/packages/ui/spa/hooks/useAI.ts
+++ b/packages/ui/spa/hooks/useAI.ts
@@ -2157,6 +2157,10 @@ export function useAI(
           inFlightPromptIdRef.current = null;
           setIsStreaming(false);
         }
+      } else if (message.type === "ai_session_unhidden") {
+        // Answered by whoever asked — the publish flow — and nothing for the
+        // chat to do. Named rather than left to the exhaustive check so adding
+        // a message type still fails the build here.
       } else if (message.type === "ai_agent_handoff") {
         // TODO: show this in the UI in some way to indicate that the AI has handed off to a human agent:
         console.log(

--- a/packages/ui/spa/hooks/useAI.ts
+++ b/packages/ui/spa/hooks/useAI.ts
@@ -850,6 +850,16 @@ export function useAI(
   // a successful send and cleared by whichever of response/error/cancelled
   // settles it.
   const inFlightPromptIdRef = useRef<string | null>(null);
+  /**
+   * The prompts this chat started.
+   *
+   * Every session shares one socket, and the publish flow now runs its own
+   * hidden prompt over it. Without this the chat treated that prompt's stream
+   * as a turn of its own: the commit message appeared as an assistant bubble in
+   * whatever conversation was open, and cancelling it appended a "Stopped."
+   * bubble to a chat that had asked for nothing.
+   */
+  const ownedPromptIdsRef = useRef<Set<string>>(new Set());
   // Pending ask_user_question tool calls, as toolCallId -> the id of the
   // assistant message that opened the card. Needed to reject them on session
   // change, and to fail that specific turn if the result cannot be delivered.
@@ -857,6 +867,12 @@ export function useAI(
 
   useEffect(() => {
     const handler = (message: AIServerMessage) => {
+      // Not ours: another part of the Studio is driving its own prompt on this
+      // socket. `ai_session_unhidden` carries a request id rather than a prompt
+      // id and is nobody's turn, so it is filtered the same way.
+      if ("id" in message && !ownedPromptIdsRef.current.has(message.id)) {
+        return;
+      }
       if (message.type === "ai_streaming") {
         if (!chatRef.current) return;
         if (activeIdRef.current !== message.id) {
@@ -876,6 +892,7 @@ export function useAI(
         if (inFlightPromptIdRef.current === message.id) {
           inFlightPromptIdRef.current = null;
         }
+        ownedPromptIdsRef.current.delete(message.id);
         setIsStreaming(false);
       } else if (message.type === "ai_tool_call") {
         // ask_user_question renders a question card instead of the plain tool
@@ -2113,6 +2130,7 @@ export function useAI(
         if (inFlightPromptIdRef.current === message.id) {
           inFlightPromptIdRef.current = null;
         }
+        ownedPromptIdsRef.current.delete(message.id);
         setIsStreaming(false);
       } else if (message.type === "ai_cancelled") {
         // The user asked for this, so it settles rather than fails: whatever
@@ -2160,6 +2178,7 @@ export function useAI(
           inFlightPromptIdRef.current = null;
           setIsStreaming(false);
         }
+        ownedPromptIdsRef.current.delete(message.id);
       } else if (message.type === "ai_session_unhidden") {
         // Answered by whoever asked — the publish flow — and nothing for the
         // chat to do. Named rather than left to the exhaustive check so adding
@@ -2261,8 +2280,13 @@ export function useAI(
       // here rather than send a prompt the server will refuse: this way the chat
       // says why, instead of the turn appearing to start and then failing.
       if (chatModel === null) {
+        // Started before it is errored: `errorAssistantMessage` retires a
+        // message that already exists, so erroring an id nothing has created is
+        // silently a no-op — which left only the composer's generic failure.
+        const noticeId = crypto.randomUUID();
+        chatRef.current?.startAssistantMessage(noticeId);
         chatRef.current?.errorAssistantMessage(
-          crypto.randomUUID(),
+          noticeId,
           "No AI key is set up for this project. Add one in admin to use the assistant.",
           "provider_not_configured",
         );
@@ -2424,6 +2448,7 @@ Do not describe what you will do unless you do it for clarification — just do 
       const sent = sendWsMessage(message);
       if (sent) {
         inFlightPromptIdRef.current = message.id;
+        ownedPromptIdsRef.current.add(message.id);
       }
       // Notify the session was "born" only after a successful send so a failed
       // first send doesn't leak an empty session id into the URL.

--- a/packages/ui/spa/hooks/useAI.ts
+++ b/packages/ui/spa/hooks/useAI.ts
@@ -2107,6 +2107,7 @@ export function useAI(
           message.id,
           message.message,
           message.code,
+          message.action,
         );
         activeIdRef.current = null;
         if (inFlightPromptIdRef.current === message.id) {

--- a/packages/ui/spa/hooks/useAI.ts
+++ b/packages/ui/spa/hooks/useAI.ts
@@ -31,6 +31,7 @@ import {
 import {
   type AITool,
   SessionImageToPatchError,
+  useAvailableAIModel,
   useCurrentProfile,
   useProfilesByAuthorId,
   useAIContext,
@@ -829,6 +830,7 @@ export function useAI(
   const getDirectFileUploadSettings = useGetDirectFileUploadSettings();
   const config = useValConfig();
   const isChatEnabled = config?.ai?.chat?.experimental?.enable === true;
+  const chatModel = useAvailableAIModel();
   const [isStreaming, setIsStreaming] = useState(false);
   const [isLoadingSession, setIsLoadingSession] = useState(false);
   const [sessions, setSessions] = useState<AISession[]>([]);
@@ -2254,6 +2256,17 @@ export function useAI(
       content: string | ChatDocument,
       attachments?: ChatMessageAttachment[],
     ): boolean => {
+      // No reachable provider means no key is configured for any of them. Refuse
+      // here rather than send a prompt the server will refuse: this way the chat
+      // says why, instead of the turn appearing to start and then failing.
+      if (chatModel === null) {
+        chatRef.current?.errorAssistantMessage(
+          crypto.randomUUID(),
+          "No AI key is set up for this project. Add one in admin to use the assistant.",
+          "provider_not_configured",
+        );
+        return false;
+      }
       // Lazily mint the session id on the first send so unborn sessions don't
       // appear in the URL or on the server until the user actually says something.
       let sid = sessionIdRef.current;
@@ -2314,7 +2327,12 @@ export function useAI(
         agents: [
           {
             id: "default",
-            model: "openai-gpt-5.1",
+            // Picked from what the server says is reachable rather than
+            // hardcoded: with bring-your-own-key an org may have a key for one
+            // provider and not another, and asking for the wrong one is
+            // refused. Null means AI is off, which is checked before we get
+            // here.
+            model: chatModel,
             systemPrompt: `You are a helpful assistant embedded in Val, a content management system. You help non-technical content editors read, understand, and update their content.
 
 ## Who you are talking to
@@ -2413,7 +2431,7 @@ Do not describe what you will do unless you do it for clarification — just do 
       }
       return sent;
     },
-    [sendWsMessage],
+    [chatModel, chatRef, sendWsMessage],
   );
 
   // A question card keeps the turn open (and the composer disabled) until a

--- a/packages/ui/spa/hooks/useAIWebSocket.ts
+++ b/packages/ui/spa/hooks/useAIWebSocket.ts
@@ -4,8 +4,42 @@ import { ValClient } from "@valbuild/shared/internal";
 
 // --- Shared types (must match server-side definitions) ---
 
-export const AIModel = z.enum(["openai-gpt-5.1"]);
+/**
+ * The models a client may ask for. Must stay in step with the content server's
+ * catalog; a name it does not know is rejected there rather than here.
+ */
+export const AIModel = z.enum([
+  "openai-gpt-5.1",
+  "anthropic-claude-opus-5",
+  "anthropic-claude-sonnet-5",
+  "anthropic-claude-haiku-4.5",
+]);
 export type AIModel = z.infer<typeof AIModel>;
+
+/**
+ * Preference order when the server offers a choice. Not a quality ranking: it
+ * is the order to fall back through when an org has brought keys for some
+ * providers and not others.
+ */
+export const AI_MODEL_PREFERENCE: AIModel[] = [
+  "openai-gpt-5.1",
+  "anthropic-claude-sonnet-5",
+  "anthropic-claude-opus-5",
+  "anthropic-claude-haiku-4.5",
+];
+
+/** The first model this client knows about that the server says is available. */
+export function pickAvailableModel(
+  serverModels: string[] | undefined,
+): AIModel | null {
+  if (serverModels === undefined) {
+    // An older server does not report them. It also has a shared key and one
+    // model, so the original default is the right guess.
+    return "openai-gpt-5.1";
+  }
+  const available = new Set(serverModels);
+  return AI_MODEL_PREFERENCE.find((model) => available.has(model)) ?? null;
+}
 
 export const AITool = z.object({
   name: z.string(),
@@ -116,6 +150,13 @@ export const AICancelledMessage = z.object({
 });
 export type AICancelledMessage = z.infer<typeof AICancelledMessage>;
 
+export const AISessionUnhiddenMessage = z.object({
+  type: z.literal("ai_session_unhidden"),
+  id: z.string(),
+  sessionId: z.string(),
+});
+export type AISessionUnhiddenMessage = z.infer<typeof AISessionUnhiddenMessage>;
+
 export const AIAgentHandoffMessage = z.object({
   type: z.literal("ai_agent_handoff"),
   id: z.string(),
@@ -132,6 +173,7 @@ export const AIServerMessage = z.discriminatedUnion("type", [
   AIToolCallMessage,
   AIErrorMessage,
   AICancelledMessage,
+  AISessionUnhiddenMessage,
   AIAgentHandoffMessage,
 ]);
 
@@ -152,6 +194,13 @@ export const AIPromptMessage = z.object({
   message: z.union([z.string(), z.array(AIMessageContentBlock)]),
   context: z.string().optional(),
   maxIterations: z.number().int().min(1).max(200).optional(),
+  /**
+   * Create the session outside the chat list. For work the user did not start a
+   * conversation for — the publish flow's commit summary — so it does not put a
+   * session in the sidebar per publish. Honoured only when the session is
+   * created; `ai_unhide_session` reveals it later.
+   */
+  hidden: z.boolean().optional(),
   agents: z.array(AIAgentDefinition).min(1),
 });
 export type AIPromptMessage = z.infer<typeof AIPromptMessage>;
@@ -207,10 +256,19 @@ export const AICancelMessage = z.object({
 });
 export type AICancelMessage = z.infer<typeof AICancelMessage>;
 
+/** Bring a hidden session into the chat list, so the user can open it. */
+export const AIUnhideSessionMessage = z.object({
+  type: z.literal("ai_unhide_session"),
+  id: z.string(),
+  sessionId: z.string(),
+});
+export type AIUnhideSessionMessage = z.infer<typeof AIUnhideSessionMessage>;
+
 export type AIClientMessage =
   | AIPromptMessage
   | AIToolResultMessage
-  | AICancelMessage;
+  | AICancelMessage
+  | AIUnhideSessionMessage;
 
 export type AIMessageHandler = (message: AIServerMessage) => void;
 
@@ -270,10 +328,19 @@ export function useAIWebSocket(
   connectionError: string | null;
   /** Try to connect again, from the first attempt. */
   retryConnection: () => void;
+  /**
+   * The model to use, picked from what the server said is available.
+   *
+   * Null once the server has answered and nothing it offers is a model this
+   * client knows — which with bring-your-own-key means no key is configured
+   * for any provider the Studio can drive.
+   */
+  availableModel: AIModel | null;
 } {
   const wsRef = useRef<WebSocket | null>(null);
   const [isConnected, setIsConnected] = useState(false);
   const [authError, setAuthError] = useState(false);
+  const [availableModel, setAvailableModel] = useState<AIModel | null>(null);
   const [connectionError, setConnectionError] = useState<string | null>(null);
   const handlersRef = useRef<Set<AIMessageHandler>>(new Set());
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -324,6 +391,7 @@ export function useAIWebSocket(
         return;
       }
       setAuthError(false);
+      setAvailableModel(pickAvailableModel(res.json.models));
 
       const ws = new WebSocket(
         res.json.wsUrl + "?nonce=" + encodeURIComponent(res.json.nonce),
@@ -445,5 +513,6 @@ export function useAIWebSocket(
     authError,
     connectionError,
     retryConnection,
+    availableModel,
   };
 }

--- a/packages/ui/spa/hooks/useAIWebSocket.ts
+++ b/packages/ui/spa/hooks/useAIWebSocket.ts
@@ -5,40 +5,80 @@ import { ValClient } from "@valbuild/shared/internal";
 // --- Shared types (must match server-side definitions) ---
 
 /**
- * The models a client may ask for. Must stay in step with the content server's
- * catalog; a name it does not know is rejected there rather than here.
+ * The AI providers the content server has an implementation for.
+ *
+ * The one thing the server is authoritative about. Which models exist is this
+ * client's business — see `VAL_AI_MODELS`.
  */
-export const AIModel = z.enum([
-  "openai-gpt-5.1",
-  "anthropic-claude-opus-5",
-  "anthropic-claude-sonnet-5",
-  "anthropic-claude-haiku-4.5",
-]);
-export type AIModel = z.infer<typeof AIModel>;
+export const AIProviderId = z.enum(["openai", "anthropic"]);
+export type AIProviderId = z.infer<typeof AIProviderId>;
 
 /**
- * Preference order when the server offers a choice. Not a quality ranking: it
- * is the order to fall back through when an org has brought keys for some
- * providers and not others.
+ * A model, as this client names it: a provider plus that provider's own model
+ * id, which the server passes through to the SDK untouched.
  */
-export const AI_MODEL_PREFERENCE: AIModel[] = [
-  "openai-gpt-5.1",
-  "anthropic-claude-sonnet-5",
-  "anthropic-claude-opus-5",
-  "anthropic-claude-haiku-4.5",
+export const AIModel = z.object({
+  provider: AIProviderId,
+  model: z.string().min(1),
+});
+export type AIModel = z.infer<typeof AIModel>;
+
+export type AIModelInfo = {
+  ref: AIModel;
+  /** What to call it in the UI. */
+  label: string;
+};
+
+/**
+ * The models the Studio offers, best first within each provider.
+ *
+ * This is the catalog, and it lives here rather than on the content server so
+ * that offering a newly released model is a change to the editor and nothing
+ * else. The server only checks that it implements the provider and that the
+ * caller has a key for it.
+ *
+ * Order is the fallback order: with bring-your-own-key an org may have a key
+ * for one provider and not another, so the first entry whose provider is
+ * reachable is the one used.
+ */
+export const VAL_AI_MODELS: AIModelInfo[] = [
+  {
+    ref: { provider: "openai", model: "gpt-5.1" },
+    label: "GPT-5.1",
+  },
+  {
+    ref: { provider: "anthropic", model: "claude-sonnet-5" },
+    label: "Claude Sonnet 5",
+  },
+  {
+    ref: { provider: "anthropic", model: "claude-opus-5" },
+    label: "Claude Opus 5",
+  },
+  {
+    ref: { provider: "anthropic", model: "claude-haiku-4-5" },
+    label: "Claude Haiku 4.5",
+  },
 ];
 
-/** The first model this client knows about that the server says is available. */
+/**
+ * The first model in the catalog whose provider the server says is reachable.
+ *
+ * Null once the server has answered and none of them are — which with
+ * bring-your-own-key means no key is configured for any provider we can drive,
+ * and callers treat that as "AI is off" rather than as an error.
+ */
 export function pickAvailableModel(
-  serverModels: string[] | undefined,
+  serverProviders: string[] | undefined,
 ): AIModel | null {
-  if (serverModels === undefined) {
-    // An older server does not report them. It also has a shared key and one
-    // model, so the original default is the right guess.
-    return "openai-gpt-5.1";
+  if (serverProviders === undefined) {
+    // An older content server does not report them, and had a shared OpenAI
+    // key with one model — so the original default is the right guess.
+    return VAL_AI_MODELS[0].ref;
   }
-  const available = new Set(serverModels);
-  return AI_MODEL_PREFERENCE.find((model) => available.has(model)) ?? null;
+  const reachable = new Set(serverProviders);
+  return (
+    VAL_AI_MODELS.find((info) => reachable.has(info.ref.provider))?.ref ?? null
+  );
 }
 
 export const AITool = z.object({
@@ -391,7 +431,7 @@ export function useAIWebSocket(
         return;
       }
       setAuthError(false);
-      setAvailableModel(pickAvailableModel(res.json.models));
+      setAvailableModel(pickAvailableModel(res.json.providers));
 
       const ws = new WebSocket(
         res.json.wsUrl + "?nonce=" + encodeURIComponent(res.json.nonce),

--- a/packages/ui/spa/hooks/useCommitSummary.ts
+++ b/packages/ui/spa/hooks/useCommitSummary.ts
@@ -62,10 +62,19 @@ export function useCommitSummary(
   const startedRef = useRef(false);
   const streamedRef = useRef("");
 
+  // "off" has to be reachable in both directions. `/ai/initialize` resolves
+  // after this mounts, so a popover opened straight away sees `model === null`
+  // first; leaving it at "off" from then on would tell the user AI is disabled
+  // for the rest of the publish, when it had simply not answered yet. Only the
+  // "off" state is swapped back, so a summary already loading or ready is never
+  // clobbered by a model reference changing identity.
   useEffect(() => {
-    if (model === null) {
-      setState({ status: "off" });
-    }
+    setState((prev) => {
+      if (model === null) {
+        return prev.status === "off" ? prev : { status: "off" };
+      }
+      return prev.status === "off" ? { status: "idle" } : prev;
+    });
   }, [model]);
 
   useEffect(() => {
@@ -121,23 +130,35 @@ export function useCommitSummary(
     }
   }, [sendWsMessage]);
 
-  // Abort on unmount: the popover closing must not leave a request running on
-  // the user's own key with nobody left to read the answer.
-  useEffect(() => cancel, [cancel]);
+  /**
+   * Abort on unmount: the popover closing must not leave a request running on
+   * the user's own key with nobody left to read the answer.
+   *
+   * The cleanup also clears `startedRef`, which matters in development:
+   * StrictMode mounts, cleans up, and mounts again, so without it the first
+   * mount's prompt was cancelled and the second was refused as already started
+   * — a permanent spinner and the full publish grace period, in dev only. The
+   * cost is one cancelled prompt per StrictMode mount; in production the
+   * popover mounts once and this runs only on a real close.
+   */
+  useEffect(
+    () => () => {
+      cancel();
+      startedRef.current = false;
+    },
+    [cancel],
+  );
 
   const start = useCallback(
     (changeDescription: string) => {
-      if (startedRef.current || model === null) {
+      // Nothing to latch until it can actually be sent. Latching first meant a
+      // call made before `/ai/initialize` resolved, or during a reconnect, was
+      // the only attempt there would ever be — the summary then sat at "off" or
+      // "not connected" with nothing to retry it.
+      if (startedRef.current || model === null || !isWsConnected) {
         return;
       }
       startedRef.current = true;
-      if (!isWsConnected) {
-        setState({
-          status: "failed",
-          message: "Not connected to the AI service.",
-        });
-        return;
-      }
       const promptId = crypto.randomUUID();
       const sessionId = crypto.randomUUID();
       promptIdRef.current = promptId;

--- a/packages/ui/spa/hooks/useCommitSummary.ts
+++ b/packages/ui/spa/hooks/useCommitSummary.ts
@@ -1,0 +1,209 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useAIContext } from "../components/ValProvider";
+import type { AiSummaryState } from "../components/PublishSummaryView";
+import type { AIModel, AIServerMessage } from "./useAIWebSocket";
+
+/**
+ * Writes the commit summary through the AI websocket, in its own session.
+ *
+ * A fresh session per publish, and a hidden one. Fresh because a summary must
+ * describe the changes and nothing else — continuing whatever the user was last
+ * chatting about would colour it. Hidden because one sidebar entry per publish
+ * is noise; it is revealed only if the user asks to see it.
+ *
+ * No tools. The changes are pushed in the prompt as field paths with before and
+ * after values, which is both cheaper than a source diff and the material a
+ * summary actually needs. It also has to be that way: tool calls are executed
+ * by `useAI`, which is only mounted with the chat UI — a summary session asking
+ * for a tool while the publish popover is open on its own would wait for an
+ * executor that is not there.
+ */
+
+const COMMIT_SUMMARY_SYSTEM_PROMPT = `You write commit messages for a content management system, for readers who are not developers.
+
+Output format:
+- First line: a short title, under 80 characters.
+- Blank line.
+- One to three sentences describing what changed.
+
+Guidance:
+- You are given the fields that changed, with their previous and new values. Describe the change in terms of the content, not the fields: "the hero heading now leads with the product name" rather than "hero.title was replaced".
+- Be specific. Prefer the concrete user-facing effect over a vague phrase.
+- Do not mention field paths, file names, identifiers or types. The reader does not know what those are.
+- A heading like "## Home" names the page a change belongs to; use that name if it helps.
+- State only what the values show. Never speculate about why ("so that", "to enable").
+- Do not repeat the title in the description.
+- Where a value was truncated, describe it as far as you can see and do not invent the rest.
+- Reply with the commit message only. No preamble, no quoting of these instructions.`;
+
+export type UseCommitSummaryResult = {
+  state: AiSummaryState;
+  /** Start writing. Safe to call once per mount; later calls are ignored. */
+  start: (changeDescription: string) => void;
+  /** Stop the request, aborting it on the server so it stops billing. */
+  cancel: () => void;
+  /**
+   * Reveal the session so the user can open it in chat and ask what changed.
+   * Resolves to the session id once the server confirms.
+   */
+  reveal: () => Promise<string | null>;
+};
+
+export function useCommitSummary(
+  model: AIModel | null,
+): UseCommitSummaryResult {
+  const { sendWsMessage, subscribeToWsMessages, isWsConnected } =
+    useAIContext();
+  const [state, setState] = useState<AiSummaryState>({
+    status: model === null ? "off" : "idle",
+  });
+  const promptIdRef = useRef<string | null>(null);
+  const sessionIdRef = useRef<string | null>(null);
+  const startedRef = useRef(false);
+  const streamedRef = useRef("");
+
+  useEffect(() => {
+    if (model === null) {
+      setState({ status: "off" });
+    }
+  }, [model]);
+
+  useEffect(() => {
+    const unsubscribe = subscribeToWsMessages((message: AIServerMessage) => {
+      // Every session shares this socket, so anything not ours is somebody
+      // else's turn — most likely the chat's.
+      if (!("id" in message) || message.id !== promptIdRef.current) {
+        return;
+      }
+      if (message.type === "ai_streaming") {
+        streamedRef.current += message.chunk;
+        return;
+      }
+      if (message.type === "ai_response") {
+        const text = (message.response || streamedRef.current).trim();
+        setState(
+          text
+            ? { status: "ready", text, sessionId: sessionIdRef.current }
+            : {
+                status: "failed",
+                message: "The AI returned an empty summary.",
+              },
+        );
+        promptIdRef.current = null;
+        return;
+      }
+      if (message.type === "ai_error") {
+        setState({
+          status: "failed",
+          message: message.message,
+          canSetUp:
+            message.code === "provider_not_configured" ||
+            message.code === "byok_invalid_key",
+        });
+        promptIdRef.current = null;
+        return;
+      }
+      if (message.type === "ai_cancelled") {
+        // Cancelling is the user closing the popover or publishing early. There
+        // is nothing to report and nothing to show.
+        setState({ status: "idle" });
+        promptIdRef.current = null;
+      }
+    });
+    return unsubscribe;
+  }, [subscribeToWsMessages]);
+
+  const cancel = useCallback(() => {
+    const id = promptIdRef.current;
+    promptIdRef.current = null;
+    if (id !== null) {
+      sendWsMessage({ type: "ai_cancel", id });
+    }
+  }, [sendWsMessage]);
+
+  // Abort on unmount: the popover closing must not leave a request running on
+  // the user's own key with nobody left to read the answer.
+  useEffect(() => cancel, [cancel]);
+
+  const start = useCallback(
+    (changeDescription: string) => {
+      if (startedRef.current || model === null) {
+        return;
+      }
+      startedRef.current = true;
+      if (!isWsConnected) {
+        setState({
+          status: "failed",
+          message: "Not connected to the AI service.",
+        });
+        return;
+      }
+      const promptId = crypto.randomUUID();
+      const sessionId = crypto.randomUUID();
+      promptIdRef.current = promptId;
+      sessionIdRef.current = sessionId;
+      streamedRef.current = "";
+      setState({ status: "loading" });
+      const sent = sendWsMessage({
+        type: "ai_prompt",
+        id: promptId,
+        sessionId,
+        hidden: true,
+        message: changeDescription,
+        maxIterations: 1,
+        agents: [
+          {
+            id: "commit-summary",
+            model,
+            systemPrompt: COMMIT_SUMMARY_SYSTEM_PROMPT,
+            tools: [],
+          },
+        ],
+      });
+      if (!sent) {
+        promptIdRef.current = null;
+        setState({
+          status: "failed",
+          message: "Could not reach the AI service.",
+        });
+      }
+    },
+    [isWsConnected, model, sendWsMessage],
+  );
+
+  const reveal = useCallback(async (): Promise<string | null> => {
+    const sessionId = sessionIdRef.current;
+    if (sessionId === null) {
+      return null;
+    }
+    const requestId = crypto.randomUUID();
+    return new Promise<string | null>((resolve) => {
+      const timeout = setTimeout(() => {
+        unsubscribe();
+        resolve(null);
+      }, 10000);
+      const unsubscribe = subscribeToWsMessages((message: AIServerMessage) => {
+        if (!("id" in message) || message.id !== requestId) {
+          return;
+        }
+        clearTimeout(timeout);
+        unsubscribe();
+        resolve(
+          message.type === "ai_session_unhidden" ? message.sessionId : null,
+        );
+      });
+      const sent = sendWsMessage({
+        type: "ai_unhide_session",
+        id: requestId,
+        sessionId,
+      });
+      if (!sent) {
+        clearTimeout(timeout);
+        unsubscribe();
+        resolve(null);
+      }
+    });
+  }, [sendWsMessage, subscribeToWsMessages]);
+
+  return { state, start, cancel, reveal };
+}

--- a/packages/ui/spa/hooks/useStatus.ts
+++ b/packages/ui/spa/hooks/useStatus.ts
@@ -71,6 +71,13 @@ export const StatData = z.object({
     project: z.string().optional(),
     ai: z
       .object({
+        // Read to decide whether to open the AI socket: commit summaries run
+        // over it now, so the chat flag alone is not the whole answer.
+        commitMessages: z
+          .object({
+            disabled: z.boolean().optional(),
+          })
+          .optional(),
         chat: z
           .object({
             experimental: z

--- a/packages/ui/spa/utils/safeHref.test.ts
+++ b/packages/ui/spa/utils/safeHref.test.ts
@@ -1,0 +1,35 @@
+import { safeHref } from "./safeHref";
+
+describe("safeHref", () => {
+  test("keeps same-origin paths", () => {
+    expect(safeHref("/admin/settings")).toBe("/admin/settings");
+    expect(safeHref("/admin?tab=ai#keys")).toBe("/admin?tab=ai#keys");
+  });
+
+  test("keeps http and https urls", () => {
+    expect(safeHref("https://val.build/admin")).toBe("https://val.build/admin");
+    expect(safeHref("http://localhost:3000/admin")).toBe(
+      "http://localhost:3000/admin",
+    );
+  });
+
+  test("rejects schemes that would run in the Studio", () => {
+    expect(safeHref("javascript:alert(1)")).toBeUndefined();
+    // A capital letter or whitespace does not get it past the parser: `URL`
+    // lower-cases the protocol and trims leading control characters, which is
+    // exactly why the check reads `parsed.protocol` rather than the raw string.
+    expect(safeHref("JavaScript:alert(1)")).toBeUndefined();
+    expect(safeHref(" javascript:alert(1)")).toBeUndefined();
+    expect(
+      safeHref("data:text/html,<script>alert(1)</script>"),
+    ).toBeUndefined();
+    expect(safeHref("vbscript:msgbox(1)")).toBeUndefined();
+  });
+
+  test("rejects protocol-relative urls and unparseable input", () => {
+    // `//evil.example` is a different origin wearing a path's clothes.
+    expect(safeHref("//evil.example/admin")).toBeUndefined();
+    expect(safeHref("admin/settings")).toBeUndefined();
+    expect(safeHref("")).toBeUndefined();
+  });
+});

--- a/packages/ui/spa/utils/safeHref.ts
+++ b/packages/ui/spa/utils/safeHref.ts
@@ -1,0 +1,24 @@
+/**
+ * The href of a server-supplied error action, or undefined if it is not one we
+ * will render.
+ *
+ * The action comes from the content server (today: "go to the admin and set up
+ * a key"), so it is not user input — but it is remote input ending up in an
+ * `href`, and `javascript:` there runs in the Studio's own context. An
+ * allow-list of schemes is the cheap way to make that impossible, and a
+ * same-origin path is the common case.
+ */
+export function safeHref(url: string): string | undefined {
+  if (url.startsWith("/") && !url.startsWith("//")) {
+    return url;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return undefined;
+  }
+  return parsed.protocol === "https:" || parsed.protocol === "http:"
+    ? url
+    : undefined;
+}


### PR DESCRIPTION
The Studio half of valbuild/home#41. Continues #570.

## Commit summaries move to the AI pipeline

`POST /commit-summary` is gone on the content server, so the whole chain goes with it here: the `/commit-summary` route, `getCommitSummary` on `ValOps` / `ValOpsFS` / `ValOpsHttp`, and a dead `getCommitMessage` on `ValOpsHttp` that had no callers at all.

In its place the publish popover opens **its own hidden chat session** per publish. Fresh because a summary must describe the changes and nothing else — continuing whatever the user last chatted about would colour it. Hidden because one sidebar entry per publish is noise. "Ask what changed" reveals it and opens the assistant on it.

Revealing happens *before* opening: the assistant lists visible sessions, so opening first would show a chat missing from its own list. A panel already open on another session keeps that one — switching a conversation the user is mid-way through is worse than making them pick this one from the list.

## No tools, on purpose

The changes go into the prompt as field paths with before and after values, rather than being fetched by the model. Two reasons, and the second is decisive:

- **Cheaper, and better material.** The old endpoint sent every changed source file *twice* and diffed the text server-side; fixing one typo in a large module uploaded that whole module twice, on the user's own key. This sends the values a sentence like "the hero heading now leads with the product name" actually needs, capped per field and in total. Media is described by its path, never inlined — a base64 data URL would blow the cap and tell the model nothing.
- **Tool calls are executed by `useAI`, which only mounts with the chat UI.** A summary session asking for a tool while the publish popover is open on its own would wait for an executor that is not there.

## The model catalog lives here now

`VAL_AI_MODELS` is the catalog: a provider plus that provider's own model id, with a label, in fallback order. Offering a newly released model is a change here and nowhere else — the server checks the provider and passes the id to its SDK untouched.

An agent sends `{ provider, model }`. `/ai/initialize` reports which providers the project's keys can reach — `string[]` and not an enum, so the server may know a provider this version does not — and the Studio picks the first model whose provider is among them.

**The chat's model was hardcoded** to `openai-gpt-5.1`. With bring-your-own-key that is simply wrong for an org holding only an Anthropic key: every prompt would have been refused. It uses the picked model, and when nothing is reachable it says so in the chat rather than sending a prompt the server will refuse — the turn no longer appears to start and then fail.

## Two dead affordances on the error path

The server has been sending an `action` on AI errors — a label and a URL into admin — and the client parsed it and dropped it. So the point of it, pointing someone at where to add a key, showed nothing.

In its place was a hardcoded "Add a data pack to continue using AI" link keyed off `token_limit_reached`, a code that no longer exists now the monthly cap is gone. So the error path had one unrendered affordance and one unreachable one. The action now renders as the link — server-supplied, because only the server knows the admin URL for this org and project.

## Ordering

⚠️ **valbuild/home#41 must be deployed before this is released.** The wire shape changed (`{ provider, model }`), and the currently deployed content server takes the old flat name — the reverse order gives a validation failure on every prompt.

## Verification

Workspace typecheck clean, 2929 tests across 233 suites, repo-wide prettier and eslint clean. Changeset included.

**Not verified end to end:** the websocket summary flow and a live chat turn need an authenticated project, which this environment does not have. The pure logic is tested (46 tests on the default summary, change description and auto-apply rules); the round trips are not. Worth a real publish through it before release.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNUsgdTXVi4CdybXaKpvGy)_