### PR TITLE
Warn when a credential-bearing Val URL is not https

### DIFF
--- a/.changeset/warn-insecure-val-urls.md
+++ b/.changeset/warn-insecure-val-urls.md
@@ -1,0 +1,21 @@
+---
+"@valbuild/server": patch
+---
+
+Warn when `valBuildUrl` or `valContentUrl` is configured over plain http
+
+Both default to https, but each is overridable — `opts.valBuildUrl` /
+`VAL_BUILD_URL` and `opts.valContentUrl` / `VAL_CONTENT_URL` — and neither
+override has ever been scheme-checked. Point one at a plain http host and the
+project's api key goes out in clear text, and whatever comes back is whatever
+the network says it is: for `valBuildUrl` that includes the app token the
+server re-signs into the session cookie.
+
+Val now writes a warning on startup naming the option and the URL. Loopback
+over http is exempt, since that is a val.build running on the developer's own
+machine.
+
+This warns rather than refuses to boot: both overrides are set by the operator
+rather than by an attacker, so it is a misconfiguration to surface, not
+untrusted input to reject, and rejecting would break anyone deliberately
+pointing at an internal http host today.

--- a/packages/server/src/ValRouter.ts
+++ b/packages/server/src/ValRouter.ts
@@ -228,17 +228,44 @@ async function initHandlerOptions(
 }
 
 /**
- * Hosts we send credentials to. `valBuildUrl` carries the project's api key and
- * receives the app token that becomes the session cookie; `valContentUrl`
- * carries the api key or the caller's personal access token.
+ * Hosts we send credentials to, and what each one puts at risk. They differ:
+ * only `valBuildUrl` hands back the app token that becomes the session cookie,
+ * so a single shared sentence would overstate one and understate the other.
  */
 type CredentialBearingUrl = "valBuildUrl" | "valContentUrl";
 const CREDENTIAL_BEARING_URLS: CredentialBearingUrl[] = [
   "valBuildUrl",
   "valContentUrl",
 ];
+const WHAT_IS_AT_RISK: Record<CredentialBearingUrl, string> = {
+  valBuildUrl:
+    "Val's api key is sent to this host, and the token it returns is what this server signs into the session cookie, " +
+    "so both can be read - and the token replaced - by anyone on the network path.",
+  valContentUrl:
+    "Val's api key, or the caller's personal access token, is sent to this host, " +
+    "so it can be read by anyone on the network path.",
+};
 
-const LOOPBACK_HOSTNAMES = ["localhost", "127.0.0.1", "::1", "[::1]"];
+// NOTE: `URL.hostname` keeps the brackets on an IPv6 literal, so this is
+// "[::1]" and not "::1" - and `http://[0:0:0:0:0:0:0:1]` normalises to the
+// same short form before it gets here. Dropping the brackets looks like a
+// tidy-up and silently stops matching IPv6 loopback.
+const LOOPBACK_HOSTNAMES = ["localhost", "127.0.0.1", "[::1]"];
+
+/**
+ * The URL as it is safe to print. `http://user:pass@host` is a legal override,
+ * and a warning about credential exposure that puts the password in the log
+ * would be the very thing it is warning about.
+ */
+function forLog(parsed: URL): string {
+  if (!parsed.username && !parsed.password) {
+    return parsed.href;
+  }
+  const redacted = new URL(parsed.href);
+  redacted.username = "";
+  redacted.password = "";
+  return `${redacted.href} (credentials redacted)`;
+}
 
 /**
  * Returns a warning if `url` would send credentials somewhere they can be read
@@ -267,7 +294,9 @@ export function insecureUrlWarning(
   try {
     parsed = new URL(url);
   } catch {
-    return `Val: ${name} is not a valid URL: ${url}`;
+    // NOTE: the URL is not echoed here. It did not parse, so there is nothing
+    // to redact with, and an unparseable string can still hold a password.
+    return `Val: ${name} is not a valid URL.`;
   }
   if (parsed.protocol === "https:") {
     return null;
@@ -280,9 +309,9 @@ export function insecureUrlWarning(
     return null;
   }
   return (
-    `Val: ${name} is set to ${url}, which is not https. ` +
-    `Val's api key is sent to this host, so it - and the session token it returns - can be read ` +
-    `and altered by anyone on the network path. Use https, or a loopback address for local development.`
+    `Val: ${name} is set to ${forLog(parsed)}, which is not https. ` +
+    `${WHAT_IS_AT_RISK[name]} ` +
+    `Use https, or a loopback address for local development.`
   );
 }
 

--- a/packages/server/src/ValRouter.ts
+++ b/packages/server/src/ValRouter.ts
@@ -165,6 +165,7 @@ async function initHandlerOptions(
     opts.valBuildUrl || process.env.VAL_BUILD_URL || "https://admin.val.build";
   const valContentUrl =
     opts.valContentUrl || process.env.VAL_CONTENT_URL || DEFAULT_CONTENT_HOST;
+  warnIfInsecureUrls({ valBuildUrl, valContentUrl });
   if (isProxyMode) {
     if (!maybeApiKey || !maybeValSecret) {
       throw new Error(
@@ -210,10 +211,6 @@ async function initHandlerOptions(
     };
   } else {
     const cwd = process.cwd();
-    const valBuildUrl =
-      opts.valBuildUrl ||
-      process.env.VAL_BUILD_URL ||
-      "https://admin.val.build";
     return {
       mode: "fs",
       cwd,
@@ -227,6 +224,74 @@ async function initHandlerOptions(
       project: maybeValProject,
       config,
     };
+  }
+}
+
+/**
+ * Hosts we send credentials to. `valBuildUrl` carries the project's api key and
+ * receives the app token that becomes the session cookie; `valContentUrl`
+ * carries the api key or the caller's personal access token.
+ */
+type CredentialBearingUrl = "valBuildUrl" | "valContentUrl";
+const CREDENTIAL_BEARING_URLS: CredentialBearingUrl[] = [
+  "valBuildUrl",
+  "valContentUrl",
+];
+
+const LOOPBACK_HOSTNAMES = ["localhost", "127.0.0.1", "::1", "[::1]"];
+
+/**
+ * Returns a warning if `url` would send credentials somewhere they can be read
+ * off the wire, or null if it is fine.
+ *
+ * Both URLs default to https, but each is overridable - `opts.valBuildUrl` /
+ * `VAL_BUILD_URL`, `opts.valContentUrl` / `VAL_CONTENT_URL` - and neither
+ * override has ever been scheme-checked. Point one at a plain http host and the
+ * api key goes out in clear text, and whatever comes back is whatever the
+ * network says: for `valBuildUrl` that includes the app token this server
+ * re-signs into the session cookie.
+ *
+ * Loopback over http is exempt: that is a val.build running on the developer's
+ * own machine, and there is no network to be on the wrong side of.
+ *
+ * This warns rather than throws. Both overrides are set by the operator, not by
+ * an attacker, so this is a misconfiguration to surface - not untrusted input to
+ * reject - and refusing to boot would break anyone deliberately pointing at an
+ * internal http host today.
+ */
+export function insecureUrlWarning(
+  name: CredentialBearingUrl,
+  url: string,
+): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return `Val: ${name} is not a valid URL: ${url}`;
+  }
+  if (parsed.protocol === "https:") {
+    return null;
+  }
+  if (
+    parsed.protocol === "http:" &&
+    (LOOPBACK_HOSTNAMES.includes(parsed.hostname) ||
+      parsed.hostname.endsWith(".localhost"))
+  ) {
+    return null;
+  }
+  return (
+    `Val: ${name} is set to ${url}, which is not https. ` +
+    `Val's api key is sent to this host, so it - and the session token it returns - can be read ` +
+    `and altered by anyone on the network path. Use https, or a loopback address for local development.`
+  );
+}
+
+function warnIfInsecureUrls(urls: Record<CredentialBearingUrl, string>): void {
+  for (const name of CREDENTIAL_BEARING_URLS) {
+    const warning = insecureUrlWarning(name, urls[name]);
+    if (warning) {
+      console.warn(warning);
+    }
   }
 }
 

--- a/packages/server/src/insecureUrlWarning.test.ts
+++ b/packages/server/src/insecureUrlWarning.test.ts
@@ -1,0 +1,62 @@
+import { insecureUrlWarning } from "./ValRouter";
+
+describe("insecureUrlWarning", () => {
+  test.each([
+    "https://admin.val.build",
+    "https://admin.val.build/",
+    "https://val.internal.example.com:8443",
+  ])("accepts https: %s", (url) => {
+    expect(insecureUrlWarning("valBuildUrl", url)).toBeNull();
+  });
+
+  // A val.build running on the developer's own machine: there is no network
+  // path to be on the wrong side of.
+  test.each([
+    "http://localhost:3000",
+    "http://127.0.0.1:4000",
+    "http://[::1]:4000",
+    "http://val.localhost:3000",
+  ])("accepts loopback over http: %s", (url) => {
+    expect(insecureUrlWarning("valBuildUrl", url)).toBeNull();
+  });
+
+  test.each([
+    "http://admin.val.build",
+    "http://val.internal.example.com",
+    "http://10.0.0.5:8080",
+    // Not loopback: the label only *contains* localhost.
+    "http://notlocalhost.example.com",
+    "http://localhost.evil.com",
+  ])("warns on non-loopback http: %s", (url) => {
+    const warning = insecureUrlWarning("valBuildUrl", url);
+    expect(warning).toContain("not https");
+    expect(warning).toContain(url);
+  });
+
+  test("warns for valContentUrl too, naming that option", () => {
+    const warning = insecureUrlWarning(
+      "valContentUrl",
+      "http://content.example.com",
+    );
+    expect(warning).toContain("valContentUrl");
+  });
+
+  test("warns on a URL that does not parse", () => {
+    expect(insecureUrlWarning("valBuildUrl", "not a url")).toContain(
+      "not a valid URL",
+    );
+  });
+
+  test.each(["ftp://admin.val.build", "ws://admin.val.build"])(
+    "warns on a non-http(s) scheme: %s",
+    (url) => {
+      expect(insecureUrlWarning("valBuildUrl", url)).toContain("not https");
+    },
+  );
+
+  test("the default is not warned about", () => {
+    expect(
+      insecureUrlWarning("valBuildUrl", "https://admin.val.build"),
+    ).toBeNull();
+  });
+});

--- a/packages/server/src/insecureUrlWarning.test.ts
+++ b/packages/server/src/insecureUrlWarning.test.ts
@@ -9,15 +9,23 @@ describe("insecureUrlWarning", () => {
     expect(insecureUrlWarning("valBuildUrl", url)).toBeNull();
   });
 
-  // A val.build running on the developer's own machine: there is no network
-  // path to be on the wrong side of.
+  // NOTE: `URL.hostname` keeps the brackets on an IPv6 literal, so the
+  // allowlist entry is "[::1]", not "::1". The bracketed cases below are what
+  // stops someone "tidying" the brackets away and silently losing IPv6
+  // loopback - the warning would then fire on a developer's own machine.
   test.each([
     "http://localhost:3000",
     "http://127.0.0.1:4000",
     "http://[::1]:4000",
+    "http://[::1]",
+    "http://[0:0:0:0:0:0:0:1]:4000",
     "http://val.localhost:3000",
   ])("accepts loopback over http: %s", (url) => {
     expect(insecureUrlWarning("valBuildUrl", url)).toBeNull();
+  });
+
+  test("an IPv6 loopback literal keeps its brackets in URL.hostname", () => {
+    expect(new URL("http://[::1]:4000").hostname).toBe("[::1]");
   });
 
   test.each([
@@ -33,20 +41,6 @@ describe("insecureUrlWarning", () => {
     expect(warning).toContain(url);
   });
 
-  test("warns for valContentUrl too, naming that option", () => {
-    const warning = insecureUrlWarning(
-      "valContentUrl",
-      "http://content.example.com",
-    );
-    expect(warning).toContain("valContentUrl");
-  });
-
-  test("warns on a URL that does not parse", () => {
-    expect(insecureUrlWarning("valBuildUrl", "not a url")).toContain(
-      "not a valid URL",
-    );
-  });
-
   test.each(["ftp://admin.val.build", "ws://admin.val.build"])(
     "warns on a non-http(s) scheme: %s",
     (url) => {
@@ -54,9 +48,69 @@ describe("insecureUrlWarning", () => {
     },
   );
 
+  test("warns on a URL that does not parse", () => {
+    expect(insecureUrlWarning("valBuildUrl", "not a url")).toContain(
+      "not a valid URL",
+    );
+  });
+
   test("the default is not warned about", () => {
     expect(
       insecureUrlWarning("valBuildUrl", "https://admin.val.build"),
     ).toBeNull();
+  });
+
+  describe("wording is specific to the URL", () => {
+    test("valBuildUrl names the session cookie it hands back", () => {
+      const warning = insecureUrlWarning(
+        "valBuildUrl",
+        "http://admin.example.com",
+      );
+      expect(warning).toContain("valBuildUrl");
+      expect(warning).toContain("session cookie");
+    });
+
+    // There is no session token on this one, so claiming there is would be the
+    // message overstating what is at risk.
+    test("valContentUrl names the PAT, and does not claim a session token", () => {
+      const warning = insecureUrlWarning(
+        "valContentUrl",
+        "http://content.example.com",
+      );
+      expect(warning).toContain("valContentUrl");
+      expect(warning).toContain("personal access token");
+      expect(warning).not.toContain("session cookie");
+    });
+  });
+
+  // A warning about credentials on the wire must not put a credential into the
+  // log while making its point.
+  describe("does not leak credentials into the log", () => {
+    test("redacts basic-auth userinfo", () => {
+      const warning = insecureUrlWarning(
+        "valBuildUrl",
+        "http://someone:hunter2@admin.example.com:8080/x",
+      );
+      expect(warning).not.toContain("hunter2");
+      expect(warning).not.toContain("someone");
+      expect(warning).toContain("credentials redacted");
+      // Still names the host, which is the actionable part.
+      expect(warning).toContain("admin.example.com:8080");
+    });
+
+    test("does not echo a URL that failed to parse", () => {
+      const warning = insecureUrlWarning(
+        "valBuildUrl",
+        "http://user:hunter2@:::",
+      );
+      expect(warning).toContain("not a valid URL");
+      expect(warning).not.toContain("hunter2");
+    });
+
+    test("a clean URL is still shown in full", () => {
+      expect(
+        insecureUrlWarning("valBuildUrl", "http://admin.example.com"),
+      ).toContain("http://admin.example.com");
+    });
   });
 });


### PR DESCRIPTION
Follow-up to [#564](https://github.com/valbuild/val/pull/564), where Copilot pointed out that my note in `consumeCode` claimed the app token arrives over "an api-key authenticated HTTPS POST" when nothing guarantees the HTTPS half. That PR corrected the comment; this one surfaces the underlying condition.

## The problem

`valBuildUrl` and `valContentUrl` both default to https, but each is overridable — `opts.valBuildUrl` / `VAL_BUILD_URL`, `opts.valContentUrl` / `VAL_CONTENT_URL` — and neither override has ever been scheme-checked:

```ts
const valBuildUrl =
  opts.valBuildUrl || process.env.VAL_BUILD_URL || "https://admin.val.build";
```

Point either at a plain http host and the project's api key goes out in clear text. For `valBuildUrl` it is worse than eavesdropping: the response is the app token, and `consumeCode` re-signs that payload into the session cookie, so anyone on the path can choose who the Studio thinks you are.

## What this does

Both URLs are checked once, where they are resolved, and a non-https one is named in a startup warning. The two carry different wording, because only `valBuildUrl` hands back a session token:

```
Val: valBuildUrl is set to http://admin.example.com/, which is not https. Val's api key is
sent to this host, and the token it returns is what this server signs into the session
cookie, so both can be read - and the token replaced - by anyone on the network path.
Use https, or a loopback address for local development.

Val: valContentUrl is set to http://content.example.com/, which is not https. Val's api key,
or the caller's personal access token, is sent to this host, so it can be read by anyone on
the network path. Use https, or a loopback address for local development.
```

Loopback over http is exempt — that is a val.build running on the developer's own machine, with no network path to be on the wrong side of. `localhost`, `127.0.0.1`, `[::1]` and `*.localhost` pass; `localhost.evil.com` does not, since it only *contains* the string.

**Credentials never reach the log.** `http://user:pass@host` is a legal override, and a warning about credential exposure that prints the password would be the very thing it warns about. Userinfo is stripped before printing, and the message says so — the host survives, since that is the actionable part:

```
http://someone:hunter2@admin.example.com:8080/x
  -> Val: valBuildUrl is set to http://admin.example.com:8080/x (credentials redacted), …
```

The unparseable branch does not echo the string at all: it did not parse, so there is nothing to redact with, but it can still hold a password.

**It warns rather than refusing to boot.** Both overrides are set by the operator, not by an attacker, so this is a misconfiguration to surface rather than untrusted input to reject — and throwing would break anyone deliberately pointing at an internal http host today. That was the explicit call from the maintainer on [the review thread](https://github.com/valbuild/val/pull/564#discussion_r3897864269).

## Also

The `fs` branch re-resolved `valBuildUrl` with the identical expression that had already run a few lines above it. Removed — it was dead, and leaving it would make the single warning look mode-specific when it is not.

## On the IPv6 entry

Copilot's review asked for `"[::1]"` to be dropped from `LOOPBACK_HOSTNAMES` as dead code, on the basis that `URL.hostname` normalises IPv6 literals without brackets. It is the other way round:

```
$ node -e 'console.log(new URL("http://[::1]:4000").hostname)'
[::1]
```

`"[::1]"` was the entry doing the work; taking it out would have stopped IPv6 loopback matching and started warning developers about their own machines. `"::1"` was the dead one, and is gone. The list now carries a note recording which way round it is, and a test asserts the bracketed form directly so the next tidy-up fails loudly. `http://[0:0:0:0:0:0:0:1]` normalises to the same short form before it reaches the check, and is covered.

## Tests

24 cases: https, loopback over http (including both IPv6 spellings), non-loopback http with the two near-miss hostnames, non-http schemes, an unparseable URL, that the two messages differ and that `valContentUrl` does not claim a session token, and that basic-auth userinfo is absent from the output while the host is not.

Also smoke-tested through the real `createValServer` path rather than only the helper, since the value of this change is entirely that it is reached:

```
defaults                    -> (no warning)
loopback + ipv6 loopback    -> (no warning)
valBuildUrl over http       -> Val: valBuildUrl … signs into the session cookie …
valContentUrl over http     -> Val: valContentUrl … personal access token …
basic-auth in the url       -> Val: valBuildUrl … (credentials redacted) …
```

`insecureUrlWarning` is exported from `ValRouter.ts` for the test only; `index.ts` does not re-export it, so this adds nothing to the package's public API.

## Checks

`pnpm lint`, `prettier --check .`, `pnpm run -r typecheck`, `pnpm test` (236 suites / 2962 tests), `pnpm run build`, `cd examples/next && pnpm run build`, and `val validate` against `examples/next` (19 modules load; only the known pre-existing content errors) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AR5QXnLrknUZheYuAziuG