### PR TITLE
Retry the Val UI dev server fetch instead of failing the run

### DIFF
--- a/packages/ui/src/devServerFetch.test.ts
+++ b/packages/ui/src/devServerFetch.test.ts
@@ -1,0 +1,125 @@
+import {
+  DEV_SERVER_ATTEMPTS,
+  DEV_SERVER_RETRY_DELAY_MS,
+  devServerFetch,
+} from "./devServerFetch";
+
+/**
+ * The clock is faked by injection rather than by `jest.useFakeTimers()`: the
+ * waits are the thing being asserted, and a test that has to advance timers to
+ * let the code proceed cannot also cheaply assert what the waits were.
+ */
+function recordingSleep() {
+  const waited: number[] = [];
+  return {
+    waited,
+    sleep: (ms: number) => {
+      waited.push(ms);
+      return Promise.resolve();
+    },
+  };
+}
+
+const HEADERS = { Accept: "text/javascript" };
+const URL = "http://localhost:5173/api/val/static/spa/main.jsx";
+
+function response(status: number): Response {
+  // Only `status` is read by these tests; the body is irrelevant.
+  return new Response(null, { status });
+}
+
+describe("devServerFetch", () => {
+  let consoleError: jest.SpyInstance;
+
+  beforeEach(() => {
+    // The failure path logs by design; keep it out of the test output.
+    consoleError = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  test("returns the first response and does not retry", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(response(200));
+    const { sleep, waited } = recordingSleep();
+
+    const res = await devServerFetch(URL, HEADERS, { fetchImpl, sleep });
+
+    expect(res.status).toBe(200);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl).toHaveBeenCalledWith(URL, { headers: HEADERS });
+    expect(waited).toEqual([]);
+  });
+
+  test("retries a thrown connection error and returns the response that follows", async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockRejectedValueOnce(
+        Object.assign(new TypeError("fetch failed"), { code: "ETIMEDOUT" }),
+      )
+      .mockResolvedValue(response(200));
+    const { sleep, waited } = recordingSleep();
+
+    const res = await devServerFetch(URL, HEADERS, { fetchImpl, sleep });
+
+    expect(res.status).toBe(200);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(waited).toEqual([DEV_SERVER_RETRY_DELAY_MS]);
+    // The recovered case is not a problem anybody needs to read about.
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The property the e2e flake actually needed. A single dropped connection
+   * used to take out whichever spec was mid-`openStudio`.
+   */
+  test("survives every attempt but the last", async () => {
+    const fetchImpl = jest.fn();
+    for (let i = 0; i < DEV_SERVER_ATTEMPTS - 1; i++) {
+      fetchImpl.mockRejectedValueOnce(new TypeError("fetch failed"));
+    }
+    fetchImpl.mockResolvedValue(response(200));
+    const { sleep, waited } = recordingSleep();
+
+    const res = await devServerFetch(URL, HEADERS, { fetchImpl, sleep });
+
+    expect(res.status).toBe(200);
+    expect(fetchImpl).toHaveBeenCalledTimes(DEV_SERVER_ATTEMPTS);
+    // Backoff grows with the attempt number rather than staying flat.
+    expect(waited).toEqual([250, 500, 750]);
+  });
+
+  test("gives up after the last attempt, throwing the underlying error", async () => {
+    const err = Object.assign(new TypeError("fetch failed"), {
+      code: "ETIMEDOUT",
+    });
+    const fetchImpl = jest.fn().mockRejectedValue(err);
+    const { sleep } = recordingSleep();
+
+    await expect(
+      devServerFetch(URL, HEADERS, { fetchImpl, sleep }),
+    ).rejects.toBe(err);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(DEV_SERVER_ATTEMPTS);
+    // Naming the URL is the point: the old message did not.
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(consoleError.mock.calls[0][0]).toContain(URL);
+  });
+
+  /**
+   * A bad status is an answer, and repeating the request would turn a build
+   * error into a slow build error.
+   */
+  test("does not retry a response, however bad its status", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(response(500));
+    const { sleep, waited } = recordingSleep();
+
+    const res = await devServerFetch(URL, HEADERS, { fetchImpl, sleep });
+
+    expect(res.status).toBe(500);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(waited).toEqual([]);
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/devServerFetch.ts
+++ b/packages/ui/src/devServerFetch.ts
@@ -1,0 +1,82 @@
+/**
+ * Fetch from the Val UI dev server, tolerating a connection that drops.
+ *
+ * Only `server.ts` uses this, and `server.ts` is the local-development shim —
+ * a built package serves the SPA from an embedded record in `vite-server.ts`
+ * and never makes this request. So this is a dev-and-CI concern only.
+ *
+ * ## Why a retry is worth having at all
+ *
+ * The request this wraps is what puts the Studio's JavaScript on the page. When
+ * it fails, `next dev` answers `/api/val/static/...` with nothing usable, the
+ * SPA never boots, and every test in flight fails on whatever it was waiting
+ * for — which is never the request. One `ETIMEDOUT` on a loaded CI runner cost
+ * two separate e2e specs on two consecutive days, each time presenting as
+ * "the store system never took the project in" from `openStudio`, and each time
+ * pointing at the spec that happened to be running rather than at the fetch.
+ *
+ * ## Only a thrown error is retried
+ *
+ * A response is a response, however bad its status. A 500 from Vite means the
+ * module graph does not build, and repeating the request would turn a clear
+ * failure into a slow one — so anything that comes back is returned as-is, and
+ * only a `fetch` that *throws* (`ECONNREFUSED` while the dev server is still
+ * binding its port, `ETIMEDOUT` when the connection is dropped) is tried again.
+ *
+ * ## And no timeout of our own
+ *
+ * Tempting, and left out on purpose. A cold Vite transform of the SPA's module
+ * graph legitimately takes many seconds on a loaded machine, so any deadline
+ * short enough to be useful would also abort requests that were about to
+ * succeed — and then repeat the transform, making the problem worse. The
+ * failure this exists for arrives as a thrown error already.
+ */
+
+/** Attempts in total, not retries after the first. */
+export const DEV_SERVER_ATTEMPTS = 4;
+
+/**
+ * Multiplied by the attempt number, so the waits are 250ms, 500ms, 750ms:
+ * 1.5s of slack in the worst case, against `openStudio`'s 60s.
+ */
+export const DEV_SERVER_RETRY_DELAY_MS = 250;
+
+type FetchLike = (
+  url: string,
+  init: { headers: Record<string, string> },
+) => Promise<Response>;
+
+export type DevServerFetchDeps = {
+  /** Injected so the retry can be tested without a socket. */
+  fetchImpl?: FetchLike;
+  sleep?: (ms: number) => Promise<void>;
+};
+
+export async function devServerFetch(
+  url: string,
+  headers: Record<string, string>,
+  deps: DevServerFetchDeps = {},
+): Promise<Response> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const sleep =
+    deps.sleep ?? ((ms: number) => new Promise((res) => setTimeout(res, ms)));
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= DEV_SERVER_ATTEMPTS; attempt++) {
+    try {
+      return await fetchImpl(url, { headers });
+    } catch (err) {
+      lastError = err;
+      if (attempt < DEV_SERVER_ATTEMPTS) {
+        await sleep(DEV_SERVER_RETRY_DELAY_MS * attempt);
+      }
+    }
+  }
+  // Named, because the previous version of this message said only "could not
+  // fetch from dev server" and left it to the reader to work out which URL and
+  // whether it had been tried more than once.
+  console.error(
+    `Could not fetch ${url} from the Val UI dev server after ${DEV_SERVER_ATTEMPTS} attempts. Make sure you are running \`pnpm dev\` in the packages/ui directory.`,
+  );
+  throw lastError;
+}

--- a/packages/ui/src/server.ts
+++ b/packages/ui/src/server.ts
@@ -11,6 +11,7 @@ import { ValUIRequestHandler } from "@valbuild/shared/internal";
 import { getServerMimeType } from "../spa/serverMimeType";
 import { VAL_APP_PATH, VAL_CSS_PATH } from "./constants";
 import { VERSION } from ".";
+import { devServerFetch } from "./devServerFetch";
 
 export function createUIRequestHandler(): ValUIRequestHandler {
   return async (path) => {
@@ -22,18 +23,13 @@ export function createUIRequestHandler(): ValUIRequestHandler {
       devPath = "/spa/index.css";
     }
     // TODO: believe we can clean up and remove: api/val/static
-    const res = await fetch(`http://localhost:5173/api/val/static${devPath}`, {
-      headers: acceptType
-        ? {
-            Accept: acceptType,
-          }
-        : {},
-    }).catch((err) => {
-      console.error(
-        "Could not fetch from dev server. Make sure you are running npm run dev in the package/ui directory.",
-      );
-      throw err;
-    });
+    // Retried rather than fetched once: a dropped connection here serves the
+    // Studio without its JavaScript, and the failure then surfaces wherever the
+    // page is being waited on instead of here. See `devServerFetch`.
+    const res = await devServerFetch(
+      `http://localhost:5173/api/val/static${devPath}`,
+      acceptType ? { Accept: acceptType } : {},
+    );
     const headersObj: Record<string, string> = {};
     res.headers.forEach((value, key) => {
       headersObj[key] = value;


### PR DESCRIPTION
`packages/ui/src/server.ts` proxies `/api/val/static/*` to the UI package's Vite dev server with a bare `fetch` — no retry, and the only handling was a console message and a rethrow. One dropped connection therefore serves the Studio **without its JavaScript**, the SPA never boots, and the failure surfaces wherever the page was being waited on rather than at the fetch that caused it.

## The evidence

Two e2e specs died on two consecutive days:

| when | spec | how it presented |
| --- | --- | --- |
| Aug 31 | `canvas.spec.ts:474` | `openStudio` — "the store system never took the project in", 60s |
| Sep 1 | `media.spec.ts:309` | `openStudio` — identical |

Both jobs carried four occurrences of:

```
Could not fetch from dev server. Make sure you are running npm run dev in the package/ui directory.
⨯ [TypeError: fetch failed] { [cause]: AggregateError: code: 'ETIMEDOUT' }
```

Which spec dies is only a question of which one was mid-`openStudio` when the connection dropped — which is why it read as a canvas bug and then as a media bug, and why the diagnosis kept landing on the wrong file.

Two explanations that fit the symptom but not the evidence, ruled out:

- **Not a cold compile.** `warmup.setup.ts` *succeeded* in that run — routes in 6.3s, both workers in 22.9s. The failure came later.
- **Not the class #566 quarantined.** Those were tests that sleep and then measure. This is a dependency that did not answer, not a timing margin.

## What changed

`devServerFetch` — four attempts, backing off 250/500/750ms, so 1.5s of slack against `openStudio`'s 60s.

**Only a thrown error is retried.** A response is an answer however bad its status: a 500 from Vite means the module graph does not build, and repeating the request would turn a clear failure into a slow one. So anything that comes back is returned as-is, and only `ECONNREFUSED`/`ETIMEDOUT`-style throws are tried again. The failure message now names the URL and the attempt count, which the old one did not.

**No client-side timeout, deliberately.** Tempting, and wrong here: a cold Vite transform of the SPA's module graph legitimately takes many seconds on a loaded machine, so any deadline short enough to help would also abort requests that were about to succeed — and then repeat the transform, making it worse. The failure this exists for already arrives as a throw.

## Scope

**Dev-only.** A built package serves the SPA from the embedded record in `vite-server.ts` and never makes this request, and the build replaces this entrypoint (`fix-server-hack.js`). Nothing consumers install changes, so there is **no changeset**.

## Verification

Five tests over an injected `fetch` and clock — the clock is injected rather than faked with `jest.useFakeTimers()` because the waits are the thing being asserted, and a test that must advance timers to let the code proceed cannot also cheaply assert what the waits were:

- a successful fetch passes straight through and does not sleep;
- one failure then success returns the response and logs nothing;
- every attempt but the last fails and it still succeeds, with backoff `[250, 500, 750]`;
- all attempts fail → the underlying error is rethrown and the message names the URL;
- a 500 is returned as-is and never retried.

Full local CI green: recursive typecheck, `lint`, `prettier --check`, **236 suites / 2943 tests**, and the `examples/next` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WM94UH5zxHP3yFoKdyvXaL

---
_Generated by [Claude Code](https://claude.ai/code/session_01WM94UH5zxHP3yFoKdyvXaL)_