### PR TITLE
Generate a changelog for every release

### DIFF
--- a/.agent/rules.md
+++ b/.agent/rules.md
@@ -515,6 +515,32 @@ Releases go out through changesets: land a PR with a changeset on `main`, the
 Release workflow opens a "Version Packages" PR, and merging that publishes to
 npm.
 
+### The changeset summary is the release note
+
+`.changeset/config.json` generates changelogs with
+`@changesets/changelog-github`, so `changeset version` writes each changeset's
+summary into every affected package's `CHANGELOG.md` under the new version,
+prefixed with the PR link, the commit link and the author. `changesets/action`
+then uses that entry as the body of the GitHub Release it creates for the tag,
+and the file ships in the npm tarball.
+
+So the summary in `.changeset/*.md` is what users read on the release — write it
+for them, not for the reviewer of the PR. It is Markdown, and lists, code fences
+and `#123` issue references all survive (the last gets linkified).
+Front-matter-style lines in the summary are consumed rather than printed:
+`pr: 123`, `commit: <sha>` and `author: @who` override what changesets inferred
+from git, which is how a changeset that landed via a squash or a rebase gets the
+right link.
+
+Two things to know before running `changeset version` by hand:
+
+- It needs a `GITHUB_TOKEN` in the environment. Without one the GitHub API call
+  fails with `Bad credentials` and **no files are written** — the generator is
+  fail-closed, so a missing token stops the release rather than publishing a
+  version with empty notes. CI has the token; a laptop usually does not.
+- Normal releases do not need it run by hand at all. The Release workflow runs
+  `pnpm run version-packages` and puts the result in the "Version Packages" PR.
+
 **After a release, ask whether to update the starter template** — and default to
 yes. The template repository ([`valbuild/template-nextjs-starter`](https://github.com/valbuild/template-nextjs-starter))
 pins `@valbuild/*` versions in its `package.json`, so it keeps serving the old

--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -6,3 +6,13 @@ find the full documentation for it [in our repository](https://github.com/change
 
 We have a quick list of common questions to get you started engaging with this project in
 [our documentation](https://github.com/changesets/changesets/blob/main/docs/common-questions.md)
+
+## In this repo
+
+The summary you write in a changeset is the release note. It is rendered into
+each affected package's `CHANGELOG.md` and becomes the body of the GitHub
+Release for the tag, so write it for the people who will read it on the release
+page — Markdown, lists and code fences all survive, and `#123` becomes a link.
+
+`changeset version` is run by the Release workflow, not by hand; it needs a
+`GITHUB_TOKEN` to resolve the PR and author links.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
-  "changelog": false,
+  "$schema": "https://unpkg.com/@changesets/config@4.0.0/schema.json",
+  "changelog": ["@changesets/changelog-github", { "repo": "valbuild/val" }],
   "commit": false,
   "fixed": [],
   "linked": [["@valbuild/*"]],

--- a/.changeset/rich-changelogs.md
+++ b/.changeset/rich-changelogs.md
@@ -1,0 +1,19 @@
+---
+"@valbuild/language-server": patch
+"@valbuild/core": patch
+"@valbuild/next": patch
+"@valbuild/react": patch
+"@valbuild/server": patch
+"@valbuild/shared": patch
+"@valbuild/ui": patch
+---
+
+Every release now ships a changelog. Each package's `CHANGELOG.md` records what
+changed under the version that shipped it — with a link to the pull request, the
+commit and the author — and the same entry becomes the body of the GitHub
+Release for the tag. The file is included in the npm tarball, so it is also
+readable from an installed copy.
+
+Up to now those changelogs were generated empty, and the GitHub Releases with
+them, so there was no record of what any given version contained. Releases from
+this one on have one; earlier versions stay blank.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@babel/preset-env": "^7.28.6",
     "@babel/preset-react": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
+    "@changesets/changelog-github": "^1.0.0",
     "@changesets/cli": "^3.0.1",
     "@eslint/eslintrc": "^3.3.6",
     "@eslint/js": "^10.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,6 +45,7 @@
     "ts-toolbelt": "^9.6.0"
   },
   "files": [
+    "CHANGELOG.md",
     "dist",
     "fp/dist",
     "fp/package.json",

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -47,6 +47,7 @@
     "node": "^20.19.0 || >=22"
   },
   "files": [
+    "CHANGELOG.md",
     "dist",
     "bin.js",
     "README.md"

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -77,6 +77,7 @@
     "next"
   ],
   "files": [
+    "CHANGELOG.md",
     "dist",
     "client",
     "server",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -104,6 +104,7 @@
   },
   "types": "dist/valbuild-react.cjs.d.ts",
   "files": [
+    "CHANGELOG.md",
     "dist",
     "jsx-runtime",
     "jsx-dev-runtime",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -42,6 +42,7 @@
     "node": "^20.19.0 || >=22"
   },
   "files": [
+    "CHANGELOG.md",
     "dist"
   ]
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -38,6 +38,7 @@
     "zod-validation-error": "^5.0.0"
   },
   "files": [
+    "CHANGELOG.md",
     "dist",
     "internal/dist",
     "internal/package.json"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -174,6 +174,7 @@
   },
   "types": "dist/valbuild-ui.cjs.d.ts",
   "files": [
+    "CHANGELOG.md",
     "dist",
     "server"
   ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@babel/preset-typescript':
         specifier: ^7.28.5
         version: 7.28.5(@babel/core@7.29.7)
+      '@changesets/changelog-github':
+        specifier: ^1.0.0
+        version: 1.0.0
       '@changesets/cli':
         specifier: ^3.0.1
         version: 3.0.1
@@ -1740,6 +1743,10 @@ packages:
     resolution: {integrity: sha512-3Dst2Ime2Op5nd4XmWJLPIgp11ZFqJqSkVug9izK6TDcIV4YlhPS4ECbEVR+eGI0bk0r1ItogD4j2Oli87bJrA==}
     engines: {node: ^22.11 || ^24 || >=26}
 
+  '@changesets/changelog-github@1.0.0':
+    resolution: {integrity: sha512-PNCSH5CGJrqOKxRjrMp2NLhceQv2QBs6HkjrLvYQqsEE2/ItN5R8GD/mskZZluoNWYvjPYFsY9T6swXfp5E0UA==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
   '@changesets/cli@3.0.1':
     resolution: {integrity: sha512-3IVpRSgiKDj2aRbBHKtWTXSRH2/iR3bWxau9iQUoEsZjDhRIj9nhl90k7FWMxZAJvLgJBbgMq8+qS0xQsenYsQ==}
     engines: {node: ^22.11 || ^24 || >=26, npm: '>=10.9.0', pnpm: '>=10.0.0', yarn: '>=4.5.2'}
@@ -1759,6 +1766,10 @@ packages:
 
   '@changesets/get-dependents-graph@3.0.0':
     resolution: {integrity: sha512-ji/t5wFA1zREKXRUePE6Qi+Qu2UgxCeSSGQrphezwvQZrp49B7sJ+8+wvM0tA7zPeSxYKCojDy3WWgrl+s+awg==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
+  '@changesets/get-github-info@1.0.0':
+    resolution: {integrity: sha512-nf5zPSqEKW0eXiJ4ltbjyIQ/srUHfxbghkLCjKdOLI3LehKXhiqxXcpja39eGPaj6qqGx2lFCrLJ7VWYUf9H2w==}
     engines: {node: ^22.11 || ^24 || >=26}
 
   '@changesets/git@4.0.0':
@@ -10303,6 +10314,11 @@ snapshots:
     dependencies:
       '@changesets/types': 7.0.0
 
+  '@changesets/changelog-github@1.0.0':
+    dependencies:
+      '@changesets/get-github-info': 1.0.0
+      '@changesets/types': 7.0.0
+
   '@changesets/cli@3.0.1':
     dependencies:
       '@changesets/apply-release-plan': 8.0.0
@@ -10346,6 +10362,10 @@ snapshots:
     dependencies:
       '@changesets/types': 7.0.0
       semver: 7.8.5
+
+  '@changesets/get-github-info@1.0.0':
+    dependencies:
+      dataloader: 2.2.3
 
   '@changesets/git@4.0.0':
     dependencies:
@@ -14594,8 +14614,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.3.3(eslint@10.9.1(jiti@2.7.0))
       eslint: 10.9.1(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.9.1(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.9.1(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.9.1(jiti@2.7.0)))(eslint@10.9.1(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.9.1(jiti@2.7.0)))(eslint@10.9.1(jiti@2.7.0)))(eslint@10.9.1(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.9.1(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@10.9.1(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@10.9.1(jiti@2.7.0))
@@ -14621,7 +14641,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@10.9.1(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.9.1(jiti@2.7.0)))(eslint@10.9.1(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -14632,22 +14652,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.9.1(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.9.1(jiti@2.7.0)))(eslint@10.9.1(jiti@2.7.0)))(eslint@10.9.1(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@10.9.1(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.9.1(jiti@2.7.0)))(eslint@10.9.1(jiti@2.7.0)))(eslint@10.9.1(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3)
       eslint: 10.9.1(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.9.1(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.9.1(jiti@2.7.0)))(eslint@10.9.1(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.9.1(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.9.1(jiti@2.7.0)))(eslint@10.9.1(jiti@2.7.0)))(eslint@10.9.1(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -14658,7 +14678,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 10.9.1(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@10.9.1(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.9.1(jiti@2.7.0)))(eslint@10.9.1(jiti@2.7.0)))(eslint@10.9.1(jiti@2.7.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
The changesets config had `"changelog": false`, so `changeset version` created
each package's `CHANGELOG.md` and then wrote nothing into it — all eleven are
0 bytes on `main`. `changesets/action` reads that same file for the body of the
GitHub Release it creates per tag, so the releases are empty too, and there is
no record anywhere of what shipped in 0.108 through 0.116.

Switch the generator to `@changesets/changelog-github`, which renders each
changeset's summary under the new version with the pull request link, the commit
link and the author, and linkifies `#123` issue references. Verified end to end
against a probe changeset: rich summaries (nested lists, code fences, several
paragraphs) come out intact and `prettier --check` accepts the result, so the
format gate stays green on the "Version Packages" PR without a formatting step.

Worth knowing about the generator: it resolves those links through the GitHub
API and is fail-closed, so `changeset version` needs a `GITHUB_TOKEN` and
writes nothing at all without one. The Release workflow already passes
`secrets.GITHUB_TOKEN` to the step that runs it. That is the one part not
exercisable from here — the sandbox proxy serves no arbitrary GitHub GraphQL —
so it will first run for real on the next release.

Also add `CHANGELOG.md` to the `files` array of the seven packages that pin one,
since npm ships only what `files` lists, and document the mechanism where
someone will meet it: the `Releasing` section of the agent rules and the
`.changeset` README.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D5oUF8gV8bZqRNLFVDKmRd