### PR TITLE
Only warn about image metadata when something is actually wrong

### DIFF
--- a/.changeset/quiet-image-metadata-warnings.md
+++ b/.changeset/quiet-image-metadata-warnings.md
@@ -1,0 +1,45 @@
+---
+"@valbuild/language-server": patch
+"@valbuild/core": patch
+---
+
+Images no longer show a validation warning in the editor when nothing is wrong
+with them.
+
+Every `s.image()` carrying width, height or a mime type used to be marked in VS
+Code with "Found image metadata, but it could not be validated", whether or not
+the metadata was correct — so the warning sat on every image in the project and
+never went away, not even after applying its own quick fix.
+
+That message was never a finding. `@valbuild/core` cannot read files, so it
+cannot answer whether stored dimensions match the image, and it hands the
+question on as an `image:check-metadata` fix instead. `val validate` has always
+resolved that by reading the file and comparing; the language server now does
+the same, and reports only what actually disagrees:
+
+```
+Image width is incorrect! Found: 800. Expected: 944
+```
+
+An image whose metadata is right gets nothing. A missing `width`, `height` or
+`mimeType` is reported, as is a stale one, with the quick fix still offered. A
+file that is not on disk is still reported as a missing file rather than as a
+metadata problem.
+
+The four messages involved say what they mean now, in the editor and in
+`val validate` alike:
+
+- "Image metadata has not been checked against the file." (was "Found image
+  metadata, but it could not be validated. An image must have a width (positive
+  number), a height (positive number) and a mime type." — which described a
+  check that never ran)
+- "Image metadata is missing: width, height and mimeType." (was "Could not
+  validate Image metadata.")
+- "File mimeType has not been checked against the file." (was "Found mimeType,
+  but it could not be validated.")
+- "File metadata is missing: mimeType." (was "Missing File mimeType.")
+
+Also fixes an `s.file()` whose `mimeType` is missing: it reported "Mime type and
+file extension not matching. Mime type is 'undefined'" with no fix attached, so
+no quick fix was offered and the `file:add-metadata` case was unreachable. It
+now reports the missing mime type and offers to add it.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -106,6 +106,7 @@ import {
   getMimeType,
   mimeTypeToFileExt,
   filenameToMimeType,
+  mimeTypeMatchesAccept,
   EXT_TO_MIME_TYPES,
   MIME_TYPES_TO_EXT,
 } from "./mimeType";
@@ -264,6 +265,7 @@ const Internal = {
   getMimeType,
   mimeTypeToFileExt,
   filenameToMimeType,
+  mimeTypeMatchesAccept,
   EXT_TO_MIME_TYPES,
   MIME_TYPES_TO_EXT,
   ModuleFilePathSep,

--- a/packages/core/src/mimeType/convertMimeType.test.ts
+++ b/packages/core/src/mimeType/convertMimeType.test.ts
@@ -1,0 +1,39 @@
+import { mimeTypeMatchesAccept } from "./convertMimeType";
+
+/**
+ * The `accept` matcher, which used to be written out three times -- in
+ * `ImageSchema`, `FileSchema` and the media branch of `RecordSchema`. The
+ * copies had drifted: the record one special-cased `image/*` to compare against
+ * `"image/"`, while the other two compared against `"image"` and so matched
+ * anything merely starting with those letters.
+ */
+describe("mimeTypeMatchesAccept", () => {
+  test("matches an exact type", () => {
+    expect(mimeTypeMatchesAccept("image/png", "image/png")).toBe(true);
+    expect(mimeTypeMatchesAccept("image/jpeg", "image/png")).toBe(false);
+  });
+
+  test("matches any of a comma-separated list, spaces and all", () => {
+    expect(mimeTypeMatchesAccept("image/webp", "image/png, image/webp")).toBe(
+      true,
+    );
+    expect(mimeTypeMatchesAccept("image/gif", "image/png, image/webp")).toBe(
+      false,
+    );
+  });
+
+  test("the catch-all accepts anything", () => {
+    expect(mimeTypeMatchesAccept("application/pdf", "*/*")).toBe(true);
+  });
+
+  test("a type wildcard matches that type only", () => {
+    expect(mimeTypeMatchesAccept("image/png", "image/*")).toBe(true);
+    expect(mimeTypeMatchesAccept("application/pdf", "image/*")).toBe(false);
+  });
+
+  test("a type wildcard does not match a type that merely starts the same", () => {
+    // The bug the record copy was written to dodge: dropping the slash as well
+    // as the star makes "image/*" match "imagex/png".
+    expect(mimeTypeMatchesAccept("imagex/png", "image/*")).toBe(false);
+  });
+});

--- a/packages/core/src/mimeType/convertMimeType.ts
+++ b/packages/core/src/mimeType/convertMimeType.ts
@@ -51,7 +51,11 @@ export function mimeTypeMatchesAccept(
         return true;
       }
       if (acceptedType.endsWith("/*")) {
-        return mimeType.startsWith(acceptedType.slice(0, -2));
+        // Keep the slash: dropping it too (`slice(0, -2)`, which is what the
+        // image and file copies did) makes "image/*" match "imagex/png". The
+        // record copy special-cased "image/*" to avoid exactly that, so this is
+        // the strict behaviour of the three, not a fourth.
+        return mimeType.startsWith(acceptedType.slice(0, -1));
       }
       return acceptedType === mimeType;
     });

--- a/packages/core/src/mimeType/convertMimeType.ts
+++ b/packages/core/src/mimeType/convertMimeType.ts
@@ -25,3 +25,34 @@ export function filenameToMimeType(filename: string) {
     return recognizedExt;
   }
 }
+
+/**
+ * Whether `mimeType` satisfies an `accept` string.
+ *
+ * `accept` is the HTML file-input syntax: a comma-separated list of exact mime
+ * types (`image/png`), type wildcards (`image` followed by `/` and a star) or
+ * the catch-all star-slash-star.
+ *
+ * This lived in three places - `ImageSchema`, `FileSchema` and the media
+ * branch of `RecordSchema` - which is how the third copy grew a redundant
+ * `image` wildcard case that the general wildcard branch already covered.
+ * Anything that has to decide whether an `accept` is satisfied, validation and
+ * editor tooling alike, should call this.
+ */
+export function mimeTypeMatchesAccept(
+  mimeType: string,
+  accept: string,
+): boolean {
+  return accept
+    .split(",")
+    .map((acceptedType) => acceptedType.trim())
+    .some((acceptedType) => {
+      if (acceptedType === "*/*") {
+        return true;
+      }
+      if (acceptedType.endsWith("/*")) {
+        return mimeType.startsWith(acceptedType.slice(0, -2));
+      }
+      return acceptedType === mimeType;
+    });
+}

--- a/packages/core/src/schema/file.ts
+++ b/packages/core/src/schema/file.ts
@@ -21,6 +21,7 @@ import { ItemPreviewInput, PreviewItem, ReifiedPreview } from "../preview";
 import { FieldRender } from "../render";
 import { FilesEntryMetadata } from "./files";
 import { getSource } from "../module";
+import { mimeTypeMatchesAccept } from "../mimeType";
 
 export type FileOptions = {
   accept?: string;
@@ -223,20 +224,7 @@ export class FileSchema<Src extends FileSource | null> extends Schema<Src> {
     }
 
     if (accept && mimeType && mimeType.includes("/")) {
-      const acceptedTypes = accept.split(",").map((type) => type.trim());
-
-      const isValidMimeType = acceptedTypes.some((acceptedType) => {
-        if (acceptedType === "*/*") {
-          return true;
-        }
-        if (acceptedType.endsWith("/*")) {
-          const baseType = acceptedType.slice(0, -2);
-          return mimeType.startsWith(baseType);
-        }
-        return acceptedType === mimeType;
-      });
-
-      if (!isValidMimeType) {
+      if (!mimeTypeMatchesAccept(mimeType, accept)) {
         return {
           [path]: [
             ...customValidationErrors,
@@ -262,7 +250,13 @@ export class FileSchema<Src extends FileSource | null> extends Schema<Src> {
       } as ValidationErrors;
     }
 
-    if (fileMimeType !== mimeType) {
+    // Guarded on `mimeType` being set, as `ImageSchema` guards the same check.
+    // Without it, an absent mimeType reported "Mime type and file extension not
+    // matching. Mime type is 'undefined'" -- with no fix attached, so no quick
+    // fix was offered -- and the `file:add-metadata` branch below could never be
+    // reached for any file whose extension is recognized, which is all of them
+    // that get this far.
+    if (mimeType && fileMimeType !== mimeType) {
       return {
         [path]: [
           ...customValidationErrors,
@@ -282,7 +276,7 @@ export class FileSchema<Src extends FileSource | null> extends Schema<Src> {
         [path]: [
           ...customValidationErrors,
           {
-            message: `Found mimeType, but it could not be validated.`,
+            message: `File mimeType has not been checked against the file.`,
             value: src,
             fixes: ["file:check-metadata"],
           },
@@ -294,7 +288,7 @@ export class FileSchema<Src extends FileSource | null> extends Schema<Src> {
       [path]: [
         ...customValidationErrors,
         {
-          message: `Missing File mimeType.`,
+          message: `File metadata is missing: mimeType.`,
           value: src,
           fixes: ["file:add-metadata"],
         },

--- a/packages/core/src/schema/image.ts
+++ b/packages/core/src/schema/image.ts
@@ -19,6 +19,7 @@ import { ItemPreviewInput, PreviewItem, ReifiedPreview } from "../preview";
 import { FieldRender } from "../render";
 import { ImagesEntryMetadata } from "./images";
 import { getSource } from "../module";
+import { mimeTypeMatchesAccept } from "../mimeType";
 
 /**
  * How an uploaded image is re-encoded in the browser, before it is uploaded.
@@ -295,20 +296,7 @@ export class ImageSchema<Src extends ImageSource | null> extends Schema<Src> {
     }
 
     if (accept && mimeType && mimeType.includes("/")) {
-      const acceptedTypes = accept.split(",").map((type) => type.trim());
-
-      const isValidMimeType = acceptedTypes.some((acceptedType) => {
-        if (acceptedType === "*/*") {
-          return true;
-        }
-        if (acceptedType.endsWith("/*")) {
-          const baseType = acceptedType.slice(0, -2);
-          return mimeType.startsWith(baseType);
-        }
-        return acceptedType === mimeType;
-      });
-
-      if (!isValidMimeType) {
+      if (!mimeTypeMatchesAccept(mimeType, accept)) {
         return {
           [path]: [
             ...customValidationErrors,
@@ -361,7 +349,7 @@ export class ImageSchema<Src extends ImageSource | null> extends Schema<Src> {
         [path]: [
           ...customValidationErrors,
           {
-            message: `Found image metadata, but it could not be validated. An image must have a width (positive number), a height (positive number) and a mime type.`,
+            message: `Image metadata has not been checked against the file.`,
             value: src,
             fixes: ["image:check-metadata"],
           },
@@ -373,7 +361,7 @@ export class ImageSchema<Src extends ImageSource | null> extends Schema<Src> {
       [path]: [
         ...customValidationErrors,
         {
-          message: `Could not validate Image metadata.`,
+          message: `Image metadata is missing: width, height and mimeType.`,
           value: src,
           fixes: ["image:add-metadata"],
         },

--- a/packages/core/src/schema/record.ts
+++ b/packages/core/src/schema/record.ts
@@ -27,6 +27,7 @@ import {
   ValidationErrors,
 } from "./validation/ValidationError";
 import { splitRemoteRef } from "../remote/splitRemoteRef";
+import { mimeTypeMatchesAccept } from "../mimeType";
 import type { ImageEncodeOption } from "./image";
 
 type MediaOptions = {
@@ -510,23 +511,7 @@ export class RecordSchema<
       return `Invalid mime type format. Got: '${mimeType}'`;
     }
 
-    const acceptedTypes = accept.split(",").map((type) => type.trim());
-
-    const isValidMimeType = acceptedTypes.some((acceptedType) => {
-      if (acceptedType === "*/*") {
-        return true;
-      }
-      if (acceptedType === "image/*") {
-        return mimeType.startsWith("image/");
-      }
-      if (acceptedType.endsWith("/*")) {
-        const baseType = acceptedType.slice(0, -2);
-        return mimeType.startsWith(baseType);
-      }
-      return acceptedType === mimeType;
-    });
-
-    if (!isValidMimeType) {
+    if (!mimeTypeMatchesAccept(mimeType, accept)) {
       return `Mime type mismatch. Found '${mimeType}' but schema accepts '${accept}'`;
     }
 

--- a/packages/language-server/src/codeActions.test.ts
+++ b/packages/language-server/src/codeActions.test.ts
@@ -154,7 +154,11 @@ describe("code actions over LSP", () => {
     expect(fixable.length).toBeGreaterThan(0);
 
     const actions = await session.requestCodeActions(FIXTURE_URI, fixable);
-    expect(actions.length).toBeGreaterThan(0);
+    // Exactly one. Both the width and the height are wrong, so this is reported
+    // as two diagnostics -- but one patch corrects both, so offering the same
+    // "Val: update image metadata" twice would be noise.
+    expect(fixable.length).toBe(2);
+    expect(actions).toHaveLength(1);
 
     const action = actions[0];
     expect(action.kind).toBe("quickfix");

--- a/packages/language-server/src/codeActions.test.ts
+++ b/packages/language-server/src/codeActions.test.ts
@@ -174,14 +174,12 @@ describe("code actions over LSP", () => {
     expect(applied).toContain(`path: "${FIXTURE_IMAGE_REF}"`);
   });
 
-  test("applying the fix writes the image's real dimensions and adds no new errors", async () => {
-    // NOTE: deliberately not asserting the diagnostic disappears. For a direct
-    // `s.image()`, core reports "Found metadata, but it could not be validated"
-    // both before AND after the fix, even though the resulting metadata has
-    // width/height/mimeType all present and correct (944/944/image/png). So this
-    // error class is not cleared by image:check-metadata -- worth chasing down in
-    // Val separately. What must hold is that the fix writes the real dimensions
-    // and does not make things worse.
+  test("applying the fix clears the diagnostic and adds no new errors", async () => {
+    // This used to be the other way round: core reports `image:check-metadata`
+    // for a direct `s.image()` whether or not the metadata is right, so the
+    // warning survived its own fix and sat on every image in the project. The
+    // server now adjudicates that placeholder against the file, so a correct
+    // image has nothing to report.
     session.openDocument(FIXTURE_URI, FIXTURE_TEXT);
 
     const published = await session.nextDiagnostics(FIXTURE_URI, (d) =>
@@ -203,9 +201,15 @@ describe("code actions over LSP", () => {
     expect(applied).toMatch(/height:\s*944/);
     expect(applied).toMatch(/mimeType:\s*"image\/png"/);
 
-    // Re-validate the fixed buffer: no new problems introduced.
+    // Re-validate the fixed buffer: the metadata now agrees with the file, so
+    // the warning is gone rather than merely no worse.
     session.changeDocument(FIXTURE_URI, 2, applied);
     const after = await session.nextDiagnostics(FIXTURE_URI);
+    expect(
+      after.diagnostics.filter((d) =>
+        d.data?.fixes?.some((f) => f.endsWith("check-metadata")),
+      ),
+    ).toEqual([]);
     expect(after.diagnostics.length).toBeLessThanOrEqual(
       published.diagnostics.length,
     );
@@ -327,9 +331,11 @@ describe("code actions over LSP", () => {
     const stillFixable = afterClose.diagnostics.filter((d) =>
       d.data?.fixes?.some((f) => f.endsWith("check-metadata")),
     );
-    // The diagnostic itself survives — core reports check-metadata for a direct
-    // `s.image()` whether or not the metadata is right — but there is nothing
-    // left to change, so no action is offered.
+    // On disk the entry already says 944x944, so once the overlay is gone there
+    // is nothing left to report: the placeholder core still emits is
+    // adjudicated against the file and dropped. (It used to survive, and only
+    // the absence of an offered action showed the invalidation had worked.)
+    expect(stillFixable).toEqual([]);
     const actions = await session.requestCodeActions(
       ENTRY_MODULE_URI,
       stillFixable,

--- a/packages/language-server/src/codeActions.ts
+++ b/packages/language-server/src/codeActions.ts
@@ -130,6 +130,17 @@ export async function createValCodeActions({
   remoteHost?: string;
 }): Promise<CodeAction[]> {
   const actions: CodeAction[] = [];
+  /**
+   * Fixes already offered, as `<fix target>|<fix>`.
+   *
+   * One problem can be reported as several diagnostics that share a fix: a
+   * stale image reports its width and its height separately, and a gallery
+   * check reports one finding per entry. The fix is the same patch each time --
+   * `createFixPatch` corrects every field, and the gallery branch walks every
+   * entry -- so without this the editor offers the identical "Val: update image
+   * metadata" twice, and recomputes it (re-reading the image) to do so.
+   */
+  const offered = new Set<string>();
 
   for (const diagnostic of diagnostics) {
     const data = diagnostic.data as ValDiagnosticData | undefined;
@@ -167,6 +178,10 @@ export async function createValCodeActions({
       if (!isLocalFix(fix)) {
         continue;
       }
+      const fixTarget = data.fixSourcePath ?? data.sourcePath;
+      if (offered.has(`${fixTarget}|${fix}`)) {
+        continue;
+      }
       const fixEdit = await computeFixEdit({
         document,
         // A gallery check is reported on the entry but fixed against the record
@@ -188,6 +203,7 @@ export async function createValCodeActions({
       if (!fixEdit) {
         continue;
       }
+      offered.add(`${fixTarget}|${fix}`);
       actions.push(
         CodeAction.create(
           FIX_TITLES[fix] ?? `Val: ${fix}`,

--- a/packages/language-server/src/diagnostics.test.ts
+++ b/packages/language-server/src/diagnostics.test.ts
@@ -40,6 +40,21 @@ describe("diagnostics over LSP", () => {
     expect(published.diagnostics).toEqual([]);
   });
 
+  test("publishes nothing for an image whose metadata matches its file", async () => {
+    // The reported bug: core reports `image:check-metadata` on every image that
+    // carries metadata -- it cannot read bytes, so it defers rather than
+    // finding anything -- and the server used to publish that verbatim, putting
+    // a permanent warning on every image in the project. `jsonEntryMedia` holds
+    // a correct 944x944 image, and is the awkward `.jsonValues()` shape whose
+    // value lives in a separate *.val.json.
+    const file = path.join(EXAMPLE_APP, "content", "jsonEntryMedia.val.ts");
+    const uri = `file://${file}`;
+    session.openDocument(uri, fs.readFileSync(file, "utf8"));
+
+    const published = await session.nextDiagnostics(uri);
+    expect(published.diagnostics).toEqual([]);
+  });
+
   test("reports a fixable validation error as a warning", async () => {
     // Known bad image metadata in the example app. Val's own CLI prints fixable
     // errors with a warning glyph, so an editor shows them as warnings.

--- a/packages/language-server/src/diagnostics.ts
+++ b/packages/language-server/src/diagnostics.ts
@@ -19,6 +19,11 @@ import {
   type Range,
 } from "vscode-languageserver";
 import { createModulePathMap, getModulePathRange } from "./modulePathMap";
+import {
+  isDeferredMediaMetadataCheckAt,
+  mediaMetadataCheckKey,
+  type MediaMetadataVerdict,
+} from "./mediaMetadataChecks";
 import type { ValModuleContent } from "./ValProject";
 
 /** Marks diagnostics as ours, so a client can filter on it. */
@@ -164,6 +169,7 @@ export function createValDiagnostics({
   valRoot,
   snapshot,
   galleryChecks,
+  mediaMetadataChecks,
 }: {
   moduleFilePath: ModuleFilePath;
   content: ValModuleContent;
@@ -192,6 +198,15 @@ export function createValDiagnostics({
    * the caller that can adjudicate them is the one that has a `Service`.
    */
   galleryChecks?: ReadonlyMap<string, GalleryCheckVerdict>;
+  /**
+   * Verdicts for the media metadata placeholders core emits unconditionally,
+   * from {@link resolveMediaMetadataChecks}. Without it the placeholders are
+   * dropped, for the same reason the gallery ones are: core reports
+   * `image:check-metadata` on every `s.image()` that carries metadata whether
+   * or not anything is wrong, so publishing them raw puts a permanent warning
+   * on every image in the project.
+   */
+  mediaMetadataChecks?: ReadonlyMap<string, MediaMetadataVerdict>;
 }): Diagnostic[] {
   if (content.errors === false) {
     return [];
@@ -268,6 +283,29 @@ export function createValDiagnostics({
             { code: "val/file-not-found", sourcePath, filePath: missing },
           ),
         );
+        continue;
+      }
+
+      // An unconditional media metadata placeholder: core reports
+      // `image:check-metadata` on every `s.image()` carrying metadata, whether
+      // or not it disagrees with the file. Show only what the adjudication
+      // actually found, and nothing when it found nothing. Deliberately after
+      // the missing-file branch above, so a deleted file is still reported as
+      // `val/file-not-found` rather than as a metadata mismatch.
+      if (isDeferredMediaMetadataCheckAt({ sourcePath, error, content })) {
+        const verdict = mediaMetadataChecks?.get(
+          mediaMetadataCheckKey(sourcePath, error),
+        );
+        for (const finding of verdict ?? []) {
+          diagnostics.push(
+            build(rangeOf(sourcePath, modulePathMap), finding.message, {
+              code: "val/validation",
+              sourcePath,
+              ...(finding.fixes ? { fixes: finding.fixes } : {}),
+              ...(finding.value !== undefined ? { value: finding.value } : {}),
+            }),
+          );
+        }
         continue;
       }
 

--- a/packages/language-server/src/mediaMetadataChecks.test.ts
+++ b/packages/language-server/src/mediaMetadataChecks.test.ts
@@ -14,7 +14,6 @@ import type {
 } from "@valbuild/core";
 import { createValDiagnostics } from "./diagnostics";
 import {
-  clearImageDimensionsCache,
   isDeferredMediaMetadataCheck,
   mediaMetadataCheckKey,
   resolveMediaMetadataChecks,
@@ -346,7 +345,6 @@ describe("resolveMediaMetadataChecks", () => {
   };
 
   beforeEach(() => {
-    clearImageDimensionsCache();
     valRoot = fs.mkdtempSync(path.join(os.tmpdir(), "val-media-checks-"));
     fs.mkdirSync(path.join(valRoot, "public", "val"), { recursive: true });
     fs.writeFileSync(path.join(valRoot, IMAGE_REF), PNG_1X1);
@@ -400,11 +398,10 @@ describe("resolveMediaMetadataChecks", () => {
     );
   });
 
-  test("bytes that cannot be measured are reported as unreadable", async () => {
-    // `extractImageMetadata` answers 0x0 for anything `image-size` cannot
-    // parse, and `createFixPatch` only guards against `undefined` -- so without
-    // this guard a truncated file reports "Expected: 0", and applying the fix
-    // would write those zeroes into the module.
+  test("bytes that cannot be measured keep the placeholder", async () => {
+    // `image-size` throws on bytes it cannot parse, so `createFixPatch` throws
+    // too. There is nothing to say about the metadata, and inventing a second
+    // opinion here would only disagree with what `val validate` reports.
     fs.writeFileSync(path.join(valRoot, IMAGE_REF), Buffer.from("not a png"));
     const verdict = await resolve({
       path: IMAGE_REF,
@@ -412,21 +409,32 @@ describe("resolveMediaMetadataChecks", () => {
       height: 944,
       mimeType: "image/png",
     });
-    expect(verdict).toEqual([
-      {
-        message:
-          "Could not read the image dimensions of '/public/val/logo.png'. " +
-          "The file may be corrupt or truncated.",
-        value: {
-          path: IMAGE_REF,
-          width: 944,
-          height: 944,
-          mimeType: "image/png",
-        },
-      },
-    ]);
-    // No fix: the only one available would write the 0x0 it just failed to read.
-    expect(verdict?.[0].fixes).toBeUndefined();
+    expect(verdict).toHaveLength(1);
+    expect(verdict?.[0].message).toBe(
+      "Image metadata has not been checked against the file.",
+    );
+  });
+
+  test("an SVG with no intrinsic size keeps the placeholder", async () => {
+    // `image-size` throws "Invalid SVG" for an SVG with no width, height or
+    // viewBox -- which is a legitimate SVG, not a broken file. It must not be
+    // reported as corrupt, and it must keep its fix.
+    const svgRef = "/public/val/icon.svg";
+    fs.writeFileSync(
+      path.join(valRoot, svgRef),
+      '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/></svg>',
+    );
+    const verdict = await resolve({
+      path: svgRef,
+      width: 10,
+      height: 10,
+      mimeType: "image/svg+xml",
+    });
+    expect(verdict).toHaveLength(1);
+    expect(verdict?.[0].message).toBe(
+      "Image metadata has not been checked against the file.",
+    );
+    expect(verdict?.[0].fixes).toEqual(["image:check-metadata"]);
   });
 
   test("a file that is not on disk keeps the placeholder", async () => {
@@ -470,13 +478,9 @@ describe("resolveMediaMetadataChecks", () => {
     expect(verdicts.size).toBe(0);
   });
 
-  test("a second look at an unchanged file reuses the measured dimensions", async () => {
-    // The cache is keyed on mtime+size, so a debounced re-validation of a module
-    // full of images does not re-read every one of them.
+  test("a file deleted between passes stops being accepted", async () => {
     expect(await resolve(CORRECT)).toEqual([]);
     fs.rmSync(path.join(valRoot, IMAGE_REF));
-    // Still measurable from the cache -- but the on-disk check ahead of it now
-    // fails, which is what keeps a deleted file from being silently accepted.
     expect(await resolve(CORRECT)).toHaveLength(1);
   });
 });

--- a/packages/language-server/src/mediaMetadataChecks.test.ts
+++ b/packages/language-server/src/mediaMetadataChecks.test.ts
@@ -1,0 +1,578 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { initVal } from "@valbuild/core";
+import type {
+  FileSchema,
+  FileSource,
+  ImageSchema,
+  ImageSource,
+  ModuleFilePath,
+  SourcePath,
+  ValidationError,
+  ValidationErrors,
+} from "@valbuild/core";
+import { createValDiagnostics } from "./diagnostics";
+import {
+  clearImageDimensionsCache,
+  isDeferredMediaMetadataCheck,
+  mediaMetadataCheckKey,
+  resolveMediaMetadataChecks,
+  type MediaMetadataVerdict,
+} from "./mediaMetadataChecks";
+import type { ValModuleContent } from "./ValProject";
+
+const { s } = initVal();
+
+const MODULE_FILE_PATH = "/content/media.val.ts" as ModuleFilePath;
+const SOURCE_PATH = MODULE_FILE_PATH as unknown as SourcePath;
+
+/**
+ * A 1x1 PNG. Small enough to inline, and `image-size` reads it, which is all
+ * the adjudication needs from real bytes.
+ */
+const PNG_1X1 = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8AAAAMBAQBBLXAyAAAAAElFTkSuQmCC",
+  "base64",
+);
+
+type CoreVerdict = {
+  errors: ValidationError[];
+  schema: unknown;
+  source: unknown;
+};
+
+/**
+ * Run real core validation over a media value and hand back both the errors and
+ * the serialized schema.
+ *
+ * The point of going through core rather than writing `ValidationError`
+ * literals: these tests exist to check that
+ * {@link isDeferredMediaMetadataCheck} agrees with
+ * `ImageSchema.executeValidate` about which of its five `image:check-metadata`
+ * errors is the unconditional placeholder. A literal would only check the
+ * classifier against itself, and would keep passing after core changed.
+ *
+ * `executeValidate` and `executeSerialize` are reached by bracket access, as
+ * they are from `@valbuild/server` (`ValOps`, `ValServer`).
+ */
+function validateImage(
+  schema: ImageSchema<ImageSource>,
+  source: ImageSource,
+): CoreVerdict {
+  const validation: ValidationErrors = schema["executeValidate"](
+    SOURCE_PATH,
+    source,
+  );
+  return {
+    errors: validation === false ? [] : (validation[SOURCE_PATH] ?? []),
+    schema: schema["executeSerialize"](),
+    source,
+  };
+}
+
+function validateFile(
+  schema: FileSchema<FileSource>,
+  source: FileSource,
+): CoreVerdict {
+  const validation: ValidationErrors = schema["executeValidate"](
+    SOURCE_PATH,
+    source,
+  );
+  return {
+    errors: validation === false ? [] : (validation[SOURCE_PATH] ?? []),
+    schema: schema["executeSerialize"](),
+    source,
+  };
+}
+
+/** The single error core reported, failing loudly if it reported none or many. */
+function onlyError(errors: ValidationError[]): ValidationError {
+  expect(errors).toHaveLength(1);
+  return errors[0];
+}
+
+describe("isDeferredMediaMetadataCheck: the five image errors core conflates", () => {
+  /**
+   * Core attaches `image:check-metadata` to five different errors. Four are
+   * real findings about the mime type and must keep being shown; the fifth is a
+   * placeholder that only means "nobody has read the file yet". Each case below
+   * is driven through core, so the assertion is about core's actual output.
+   */
+
+  test("1. invalid mime type format is a real finding", () => {
+    const { errors, schema } = validateImage(s.image({ accept: "image/png" }), {
+      path: "/public/val/logo.png",
+      width: 1,
+      height: 1,
+      mimeType: "png",
+    });
+    const error = onlyError(errors);
+    expect(error.fixes).toContain("image:check-metadata");
+    expect(isDeferredMediaMetadataCheck({ error, schema })).toBe(false);
+  });
+
+  test("2. a mime type the schema does not accept is a real finding", () => {
+    const { errors, schema } = validateImage(
+      s.image({ accept: "image/webp" }),
+      {
+        path: "/public/val/logo.png",
+        width: 1,
+        height: 1,
+        mimeType: "image/png",
+      },
+    );
+    const error = onlyError(errors);
+    expect(error.fixes).toContain("image:check-metadata");
+    expect(isDeferredMediaMetadataCheck({ error, schema })).toBe(false);
+  });
+
+  test("3. an extension with no known mime type is a real finding", () => {
+    const { errors, schema } = validateImage(s.image(), {
+      path: "/public/val/logo.unknownext",
+      width: 1,
+      height: 1,
+      mimeType: "image/png",
+    });
+    const error = onlyError(errors);
+    expect(error.fixes).toContain("image:check-metadata");
+    expect(isDeferredMediaMetadataCheck({ error, schema })).toBe(false);
+  });
+
+  test("4. a mime type disagreeing with the extension is a real finding", () => {
+    const { errors, schema } = validateImage(s.image(), {
+      path: "/public/val/logo.png",
+      width: 1,
+      height: 1,
+      mimeType: "image/jpeg",
+    });
+    const error = onlyError(errors);
+    expect(error.fixes).toContain("image:check-metadata");
+    expect(isDeferredMediaMetadataCheck({ error, schema })).toBe(false);
+  });
+
+  test("5. the fall-through IS the deferral", () => {
+    const { errors, schema } = validateImage(s.image(), {
+      path: "/public/val/logo.png",
+      width: 1,
+      height: 1,
+      mimeType: "image/png",
+    });
+    const error = onlyError(errors);
+    expect(error.fixes).toEqual(["image:check-metadata"]);
+    expect(isDeferredMediaMetadataCheck({ error, schema })).toBe(true);
+  });
+
+  test("the deferral is what a wholly correct image gets, which is the bug", () => {
+    // The reported symptom: a correct `s.image()` is still an error, on every
+    // image in the project. Nothing about the value is wrong, so nothing but
+    // reading the file can settle it.
+    const { errors } = validateImage(s.image({ accept: "image/png" }), {
+      path: "/public/val/logo.png",
+      width: 944,
+      height: 944,
+      mimeType: "image/png",
+      alt: "A logo",
+    });
+    expect(onlyError(errors).fixes).toEqual(["image:check-metadata"]);
+  });
+
+  test("a partially filled image is still the deferral, not a separate error", () => {
+    // Core does not distinguish "mimeType missing" from "metadata unverified":
+    // any one of the three being present takes the same branch. So this must be
+    // adjudicated, and the adjudication is what notices the missing field.
+    const { errors, schema } = validateImage(s.image(), {
+      path: "/public/val/logo.png",
+      width: 1,
+      height: 1,
+    });
+    const error = onlyError(errors);
+    expect(error.fixes).toEqual(["image:check-metadata"]);
+    expect(isDeferredMediaMetadataCheck({ error, schema })).toBe(true);
+  });
+
+  test("wholly absent metadata is add-metadata, and is never deferred", () => {
+    // Nothing is stored, so there is nothing to verify: the error stands on its
+    // own and must keep being shown.
+    const { errors, schema } = validateImage(s.image(), {
+      path: "/public/val/logo.png",
+    });
+    const error = onlyError(errors);
+    expect(error.fixes).toEqual(["image:add-metadata"]);
+    expect(error.message).toBe(
+      "Image metadata is missing: width, height and mimeType.",
+    );
+    expect(isDeferredMediaMetadataCheck({ error, schema })).toBe(false);
+  });
+});
+
+describe("isDeferredMediaMetadataCheck: files", () => {
+  /**
+   * `FileSchema` tags only its fall-through, so `file:check-metadata` is
+   * unambiguous and needs no re-derivation. These tests exist to notice if that
+   * ever stops being true -- the classifier trusts it.
+   */
+
+  test("the fall-through IS the deferral", () => {
+    const { errors, schema } = validateFile(s.file(), {
+      path: "/public/val/doc.pdf",
+      mimeType: "application/pdf",
+    });
+    const error = onlyError(errors);
+    expect(error.fixes).toEqual(["file:check-metadata"]);
+    expect(isDeferredMediaMetadataCheck({ error, schema })).toBe(true);
+  });
+
+  test("the four mime findings still carry no fixes at all", () => {
+    const cases = [
+      // accept set, mimeType has no "/"
+      [s.file({ accept: "application/pdf" }), { mimeType: "pdf" }],
+      // accept set and not satisfied
+      [s.file({ accept: "image/png" }), { mimeType: "application/pdf" }],
+      // extension with no known mime type
+      [s.file(), { mimeType: "application/pdf", ext: ".unknownext" }],
+      // mimeType disagreeing with the extension
+      [s.file(), { mimeType: "image/png" }],
+    ] as const;
+    for (const [schema, spec] of cases) {
+      const { errors } = validateFile(schema, {
+        path: `/public/val/doc${"ext" in spec ? spec.ext : ".pdf"}`,
+        mimeType: spec.mimeType,
+      });
+      expect(onlyError(errors).fixes).toBeUndefined();
+    }
+  });
+
+  test("a missing mimeType is add-metadata, and is never deferred", () => {
+    const { errors, schema } = validateFile(s.file(), {
+      path: "/public/val/doc.pdf",
+    });
+    const error = onlyError(errors);
+    expect(error.fixes).toEqual(["file:add-metadata"]);
+    expect(error.message).toBe("File metadata is missing: mimeType.");
+    expect(isDeferredMediaMetadataCheck({ error, schema })).toBe(false);
+  });
+});
+
+describe("isDeferredMediaMetadataCheck: nothing to go on", () => {
+  const deferral: ValidationError = {
+    message: "Image metadata has not been checked against the file.",
+    value: { path: "/public/val/logo.png" },
+    fixes: ["image:check-metadata"],
+  };
+
+  test("an unrelated fix is not a metadata check", () => {
+    expect(
+      isDeferredMediaMetadataCheck({
+        error: { ...deferral, fixes: ["image:check-remote"] },
+        schema: { type: "image" },
+      }),
+    ).toBe(false);
+  });
+
+  test("an error with no fixes is not a metadata check", () => {
+    expect(
+      isDeferredMediaMetadataCheck({
+        error: { message: "something else" },
+        schema: { type: "image" },
+      }),
+    ).toBe(false);
+  });
+
+  test("an error with no media value keeps the error rather than assuming it is fine", () => {
+    expect(
+      isDeferredMediaMetadataCheck({
+        error: { ...deferral, value: undefined },
+        schema: { type: "image" },
+      }),
+    ).toBe(false);
+  });
+
+  test("an unresolvable schema still classifies from the value", () => {
+    // Only `accept` lives on the schema, and a schema that failed to serialize
+    // simply means there is no `accept` to check -- the filename and mimeType
+    // conditions are still decidable, so this must not become noise.
+    expect(
+      isDeferredMediaMetadataCheck({
+        error: {
+          ...deferral,
+          value: { path: "/public/val/logo.png", mimeType: "image/png" },
+        },
+        schema: undefined,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("resolveMediaMetadataChecks", () => {
+  let valRoot: string;
+
+  const IMAGE_REF = "/public/val/logo.png";
+
+  /**
+   * `ValModuleContent` is what `Service.get` answers with. Only `source` and
+   * `schema` are read from it here -- by `Internal.resolvePath` for the
+   * classifier, and by `createFixPatch` for the comparison.
+   */
+  const contentFor = (source: unknown): ValModuleContent =>
+    ({
+      source,
+      schema: s.image()["executeSerialize"](),
+      errors: false,
+      path: SOURCE_PATH,
+    }) as ValModuleContent;
+
+  const deferralFor = (value: unknown): ValidationError => ({
+    message: "Image metadata has not been checked against the file.",
+    value,
+    fixes: ["image:check-metadata"],
+  });
+
+  const resolve = async (value: unknown) => {
+    const error = deferralFor(value);
+    const verdicts = await resolveMediaMetadataChecks({
+      validation: { [SOURCE_PATH]: [error] },
+      content: contentFor(value),
+      valRoot,
+    });
+    return verdicts.get(mediaMetadataCheckKey(SOURCE_PATH, error));
+  };
+
+  const CORRECT = {
+    path: IMAGE_REF,
+    width: 1,
+    height: 1,
+    mimeType: "image/png",
+  };
+
+  beforeEach(() => {
+    clearImageDimensionsCache();
+    valRoot = fs.mkdtempSync(path.join(os.tmpdir(), "val-media-checks-"));
+    fs.mkdirSync(path.join(valRoot, "public", "val"), { recursive: true });
+    fs.writeFileSync(path.join(valRoot, IMAGE_REF), PNG_1X1);
+  });
+
+  afterEach(() => {
+    fs.rmSync(valRoot, { recursive: true, force: true });
+  });
+
+  test("metadata that agrees with the file publishes nothing", async () => {
+    // The whole point: this is the case that was warning on every image.
+    expect(await resolve(CORRECT)).toEqual([]);
+  });
+
+  test("stale dimensions are reported, one finding per wrong field", async () => {
+    const verdict = await resolve({
+      path: IMAGE_REF,
+      width: 800,
+      height: 600,
+      mimeType: "image/png",
+    });
+    expect(verdict).toHaveLength(2);
+    // The CLI's own wording, because this is the CLI's own comparison.
+    expect(verdict?.[0].message).toBe(
+      "Image width is incorrect! Found: 800. Expected: 1",
+    );
+    expect(verdict?.[1].message).toBe(
+      "Image height is incorrect! Found: 600. Expected: 1",
+    );
+  });
+
+  test("a finding keeps the fix, so the quick fix and Warning severity survive", async () => {
+    const verdict = await resolve({
+      path: IMAGE_REF,
+      width: 800,
+      height: 600,
+      mimeType: "image/png",
+    });
+    for (const finding of verdict ?? []) {
+      expect(finding.fixes).toEqual(["image:check-metadata"]);
+    }
+  });
+
+  test("a missing mimeType is reported as the mismatch it is", async () => {
+    // This is the case the request was about: only what is actually absent or
+    // wrong gets reported.
+    const verdict = await resolve({ path: IMAGE_REF, width: 1, height: 1 });
+    expect(verdict).toHaveLength(1);
+    expect(verdict?.[0].message).toBe(
+      "Image mimeType is incorrect! Found: <empty>. Expected: image/png",
+    );
+  });
+
+  test("bytes that cannot be measured are reported as unreadable", async () => {
+    // `extractImageMetadata` answers 0x0 for anything `image-size` cannot
+    // parse, and `createFixPatch` only guards against `undefined` -- so without
+    // this guard a truncated file reports "Expected: 0", and applying the fix
+    // would write those zeroes into the module.
+    fs.writeFileSync(path.join(valRoot, IMAGE_REF), Buffer.from("not a png"));
+    const verdict = await resolve({
+      path: IMAGE_REF,
+      width: 944,
+      height: 944,
+      mimeType: "image/png",
+    });
+    expect(verdict).toEqual([
+      {
+        message:
+          "Could not read the image dimensions of '/public/val/logo.png'. " +
+          "The file may be corrupt or truncated.",
+        value: {
+          path: IMAGE_REF,
+          width: 944,
+          height: 944,
+          mimeType: "image/png",
+        },
+      },
+    ]);
+    // No fix: the only one available would write the 0x0 it just failed to read.
+    expect(verdict?.[0].fixes).toBeUndefined();
+  });
+
+  test("a file that is not on disk keeps the placeholder", async () => {
+    // `createValDiagnostics` reports this as `val/file-not-found` instead, so
+    // this verdict must not have the last word on it.
+    fs.rmSync(path.join(valRoot, IMAGE_REF));
+    const verdict = await resolve(CORRECT);
+    expect(verdict).toHaveLength(1);
+    expect(verdict?.[0].message).toBe(
+      "Image metadata has not been checked against the file.",
+    );
+  });
+
+  test("a remote ref keeps the placeholder rather than being read from disk", async () => {
+    const verdict = await resolve({
+      path: "https://remote.val.build/file/p/abc/b/main/v/1/h/deadbeef/f/logo.png",
+      width: 1,
+      height: 1,
+      mimeType: "image/png",
+    });
+    expect(verdict).toHaveLength(1);
+  });
+
+  test("a value that is not an object is not a deferral at all", async () => {
+    // Nothing to re-derive core's conditions from, so the classifier declines
+    // it and the error is published verbatim -- no verdict is even asked for.
+    expect(await resolve("not an object")).toBeUndefined();
+  });
+
+  test("errors that are not deferrals get no verdict at all", async () => {
+    const error: ValidationError = {
+      message: "Image metadata is missing: width, height and mimeType.",
+      value: { path: IMAGE_REF },
+      fixes: ["image:add-metadata"],
+    };
+    const verdicts = await resolveMediaMetadataChecks({
+      validation: { [SOURCE_PATH]: [error] },
+      content: contentFor(error.value),
+      valRoot,
+    });
+    expect(verdicts.size).toBe(0);
+  });
+
+  test("a second look at an unchanged file reuses the measured dimensions", async () => {
+    // The cache is keyed on mtime+size, so a debounced re-validation of a module
+    // full of images does not re-read every one of them.
+    expect(await resolve(CORRECT)).toEqual([]);
+    fs.rmSync(path.join(valRoot, IMAGE_REF));
+    // Still measurable from the cache -- but the on-disk check ahead of it now
+    // fails, which is what keeps a deleted file from being silently accepted.
+    expect(await resolve(CORRECT)).toHaveLength(1);
+  });
+});
+
+describe("createValDiagnostics: publishing a verdict", () => {
+  const IMAGE_REF = "/public/val/logo.png";
+  const VALUE = {
+    path: IMAGE_REF,
+    width: 800,
+    height: 600,
+    mimeType: "image/png",
+  };
+  const deferral: ValidationError = {
+    message: "Image metadata has not been checked against the file.",
+    value: VALUE,
+    fixes: ["image:check-metadata"],
+  };
+
+  /** A module whose only error is the deferral, with no `valRoot` given. */
+  const contentWith = (error: ValidationError): ValModuleContent =>
+    ({
+      source: VALUE,
+      schema: s.image()["executeSerialize"](),
+      errors: { validation: { [SOURCE_PATH]: [error] } },
+      path: SOURCE_PATH,
+    }) as unknown as ValModuleContent;
+
+  const diagnose = (error: ValidationError, verdict?: MediaMetadataVerdict) =>
+    createValDiagnostics({
+      moduleFilePath: MODULE_FILE_PATH,
+      content: contentWith(error),
+      text: "export default c.define('/content/media.val.ts', s.image(), {})",
+      ...(verdict
+        ? {
+            mediaMetadataChecks: new Map([
+              [mediaMetadataCheckKey(SOURCE_PATH, error), verdict],
+            ]),
+          }
+        : {}),
+    });
+
+  test("an empty verdict publishes nothing", () => {
+    // The reported bug: a correct image had a permanent warning on it.
+    expect(diagnose(deferral, [])).toEqual([]);
+  });
+
+  test("a finding publishes a Warning that still carries its fix", () => {
+    const diagnostics = diagnose(deferral, [
+      {
+        message: "Image width is incorrect! Found: 800. Expected: 944",
+        fixes: ["image:check-metadata"],
+        value: VALUE,
+      },
+    ]);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toBe(
+      "Image width is incorrect! Found: 800. Expected: 944",
+    );
+    expect(diagnostics[0].severity).toBe(2); // Warning
+    expect(diagnostics[0].code).toBe("val/validation");
+    // The quick fix is built from `data.fixes`, so it has to survive.
+    expect(diagnostics[0].data).toMatchObject({
+      fixes: ["image:check-metadata"],
+    });
+  });
+
+  test("one placeholder can publish several findings", () => {
+    expect(
+      diagnose(deferral, [
+        { message: "Image width is incorrect! Found: 800. Expected: 944" },
+        { message: "Image height is incorrect! Found: 600. Expected: 944" },
+      ]),
+    ).toHaveLength(2);
+  });
+
+  test("no verdict at all drops the placeholder", () => {
+    // Same precedent as the gallery placeholders: a caller that cannot
+    // adjudicate must not publish an unconditional warning, because a warning
+    // that is always there is one nobody reads -- which is this whole bug.
+    expect(diagnose(deferral)).toEqual([]);
+  });
+
+  test("an error that is not a deferral is published without any verdict", () => {
+    const real: ValidationError = {
+      message: "Mime type mismatch. Found 'image/png' but schema accepts 'x'",
+      value: VALUE,
+      fixes: ["image:check-metadata"],
+    };
+    // A mimeType that disagrees with the extension: one of the four real
+    // findings core tags with the same fix, so it must be published verbatim
+    // rather than adjudicated away.
+    const diagnostics = diagnose(
+      { ...real, value: { ...VALUE, mimeType: "image/jpeg" } },
+      undefined,
+    );
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toBe(real.message);
+  });
+});

--- a/packages/language-server/src/mediaMetadataChecks.ts
+++ b/packages/language-server/src/mediaMetadataChecks.ts
@@ -1,0 +1,465 @@
+/**
+ * Adjudicating the media metadata placeholders core emits unconditionally.
+ *
+ * `ImageSchema.validate` cannot read bytes, so it never answers "does the
+ * stored width/height/mimeType match the file". It defers instead: any
+ * `s.image()` carrying metadata gets an `image:check-metadata` error whether
+ * or not anything is wrong (`packages/core/src/schema/image.ts`), and
+ * `s.file()` does the same with `file:check-metadata`.
+ *
+ * `val validate` resolves those by running the fix handler and then
+ * `createFixPatch` in report mode, which compares each field against the file
+ * and returns one error per field that disagrees. The Studio cannot do that at
+ * all -- a browser has no filesystem -- so it drops them wholesale
+ * (`partitionValidationErrors` in `@valbuild/shared`).
+ *
+ * An editor is in the CLI's position, not the browser's, and publishing the
+ * placeholders raw put a permanent warning on every image in the project. So
+ * they are adjudicated here, by the same comparison `val validate` makes, and
+ * only a real disagreement is shown.
+ */
+
+import fs from "fs";
+import path from "path";
+import {
+  Internal,
+  type SourcePath,
+  type ValidationError,
+  type ValidationFix,
+  DEFAULT_VAL_REMOTE_HOST,
+} from "@valbuild/core";
+import { createFixPatch, extractImageMetadata } from "@valbuild/server";
+import type { ValModuleContent } from "./ValProject";
+
+/**
+ * The fixes that carry an unconditional metadata placeholder.
+ *
+ * `*:add-metadata` is deliberately absent: it is emitted only when every
+ * metadata field is missing, which needs no adjudication -- there is nothing
+ * stored to compare, and the error stands on its own.
+ */
+const METADATA_CHECK_FIXES: readonly string[] = [
+  "image:check-metadata",
+  "file:check-metadata",
+];
+
+/** One field of a media value that disagrees with the file behind it. */
+export type MediaMetadataFinding = {
+  message: string;
+  /** The placeholder's own fixes, so the quick fix and severity survive. */
+  fixes?: ValidationFix[];
+  /** The placeholder's `value`, which `createFixPatch` reads. */
+  value?: unknown;
+};
+
+/**
+ * The verdict on one placeholder. Empty means the metadata agrees with the
+ * file and nothing should be published.
+ */
+export type MediaMetadataVerdict = MediaMetadataFinding[];
+
+/**
+ * Whether this error is the unconditional deferral rather than a real finding.
+ *
+ * This is the whole difficulty of the change. `image:check-metadata` is
+ * attached to FIVE different image errors, and only the last is a placeholder:
+ *
+ *  1. `Invalid mime type format`            -- `accept` set, mimeType has no `/`
+ *  2. `Mime type mismatch`                  -- `accept` set and not satisfied
+ *  3. `Could not determine mime type from file extension`
+ *  4. `Mime type and file extension not matching`
+ *  5. the fall-through deferral
+ *
+ * The first four are real: they are about the mime type disagreeing with the
+ * schema or with the filename, neither of which reading the file can settle.
+ * Adjudicating one of them would find the stored metadata matches the bytes and
+ * drop a genuine error -- so they have to be told apart before any file is read.
+ *
+ * There is no flag on `ValidationError` saying which is which, so the four
+ * conditions are re-derived here from the same inputs core used. They are
+ * transcribed from `ImageSchema.executeValidate`, in its order, and
+ * `mediaMetadataChecks.test.ts` drives real core through all five cases to
+ * check that this agrees with it. If core grows a sixth condition, that test is
+ * what catches it.
+ *
+ * `FileSchema` needs none of this: its four equivalent errors carry no `fixes`
+ * at all, so `file:check-metadata` is unambiguous. The test pins that too.
+ */
+export function isDeferredMediaMetadataCheck({
+  error,
+  schema,
+}: {
+  /**
+   * The error to classify. Its `value` is the media value core validated, and
+   * so is what core's conditions are re-derived from -- the same value
+   * `createFixPatch` compares against the file, so the classification and the
+   * comparison cannot disagree about which image they are talking about.
+   */
+  error: ValidationError;
+  /** The resolved serialized schema, which is where `accept` lives. */
+  schema: unknown;
+}): boolean {
+  const fixes = error.fixes ?? [];
+  if (!fixes.some((fix) => METADATA_CHECK_FIXES.includes(fix))) {
+    return false;
+  }
+  if (fixes.includes("file:check-metadata")) {
+    return true;
+  }
+  const value = mediaValueOf(error.value);
+  if (typeof value?.path !== "string") {
+    // Nothing to re-derive the conditions from. Keep the error: claiming an
+    // image is fine on no evidence is the worse failure.
+    return false;
+  }
+  const accept = acceptOf(schema);
+  // Core reads `src.mimeType ?? ""`, and every condition below is guarded on
+  // it being non-empty, so an absent mimeType passes all four.
+  const mimeType = typeof value.mimeType === "string" ? value.mimeType : "";
+
+  if (accept && mimeType && !mimeType.includes("/")) {
+    return false;
+  }
+  if (
+    accept &&
+    mimeType &&
+    mimeType.includes("/") &&
+    !Internal.mimeTypeMatchesAccept(mimeType, accept)
+  ) {
+    return false;
+  }
+  const fileMimeType = Internal.filenameToMimeType(value.path);
+  if (!fileMimeType) {
+    return false;
+  }
+  if (mimeType && fileMimeType !== mimeType) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * {@link isDeferredMediaMetadataCheck} for an error in a module, resolving the
+ * schema it needs.
+ *
+ * Both the adjudicator and `createValDiagnostics` have to make the same call,
+ * on the same inputs -- one to decide what to adjudicate, the other to decide
+ * what to publish -- so it lives here rather than being written out twice.
+ */
+export function isDeferredMediaMetadataCheckAt({
+  sourcePath,
+  error,
+  content,
+}: {
+  sourcePath: string;
+  error: ValidationError;
+  content: ValModuleContent;
+}): boolean {
+  return isDeferredMediaMetadataCheck({
+    error,
+    schema: resolveSchemaAt(sourcePath, content),
+  });
+}
+
+/**
+ * Adjudicate every deferred metadata placeholder in `validation`.
+ *
+ * Async, and therefore separate from `createValDiagnostics`, which stays
+ * synchronous so it can be tested without a project -- the same split
+ * `resolveGalleryChecks` uses. The caller runs this first and passes the
+ * result in.
+ */
+export async function resolveMediaMetadataChecks({
+  validation,
+  content,
+  valRoot,
+  remoteHost = process.env.VAL_REMOTE_HOST || DEFAULT_VAL_REMOTE_HOST,
+}: {
+  validation: Record<SourcePath, ValidationError[]>;
+  content: ValModuleContent;
+  valRoot: string;
+  remoteHost?: string;
+}): Promise<Map<string, MediaMetadataVerdict>> {
+  const verdicts = new Map<string, MediaMetadataVerdict>();
+  for (const [sourcePath, errors] of Object.entries(validation) as [
+    SourcePath,
+    ValidationError[],
+  ][]) {
+    for (const error of errors) {
+      if (!isDeferredMediaMetadataCheckAt({ sourcePath, error, content })) {
+        continue;
+      }
+      const key = mediaMetadataCheckKey(sourcePath, error);
+      try {
+        verdicts.set(
+          key,
+          await adjudicate({ sourcePath, error, content, valRoot, remoteHost }),
+        );
+      } catch {
+        // This runs inside `validate`, which publishes NOTHING if it throws --
+        // one bad image would silently clear every Val diagnostic in the file.
+        // Keep the placeholder rather than claiming the metadata is fine.
+        verdicts.set(key, keep(error));
+      }
+    }
+  }
+  return verdicts;
+}
+
+/**
+ * Key for one placeholder. A value can in principle carry more than one, so
+ * the fix names are part of the key -- as they are for the gallery checks.
+ */
+export function mediaMetadataCheckKey(
+  sourcePath: string,
+  error: ValidationError,
+): string {
+  return `${sourcePath}|${(error.fixes ?? []).join(",")}`;
+}
+
+/** Keeping the placeholder: what to publish when we learned nothing. */
+function keep(error: ValidationError): MediaMetadataVerdict {
+  return [
+    {
+      message: error.message,
+      ...(error.fixes ? { fixes: error.fixes } : {}),
+      ...(error.value !== undefined ? { value: error.value } : {}),
+    },
+  ];
+}
+
+/**
+ * What `createFixPatch` says about one placeholder, in report mode.
+ *
+ * `val validate` runs the fix handler first and then `createFixPatch`, but for
+ * these four fixes the handler is `handleFileMetadata`, whose whole job is the
+ * precondition "the ref resolves and the file is on disk". That precondition is
+ * checked directly here instead, for two reasons:
+ *
+ *  - `createValDiagnostics` already reports a missing file as
+ *    `val/file-not-found`, which is a better diagnostic than a metadata
+ *    mismatch and is produced before this verdict is consulted.
+ *  - `handleFileMetadata` resolves the source path through the module, and that
+ *    throws outright for a `.jsonValues()` entry ("Cannot resolve path into a
+ *    jsonValues entry until its content is loaded") -- so routing through it
+ *    would leave every entry-backed image stuck on the placeholder.
+ *
+ * The comparison itself is still `createFixPatch`, unchanged, which is the
+ * parity that matters: the editor's wording is the CLI's wording because it is
+ * the CLI's code.
+ */
+async function adjudicate({
+  sourcePath,
+  error,
+  content,
+  valRoot,
+  remoteHost,
+}: {
+  sourcePath: SourcePath;
+  error: ValidationError;
+  content: ValModuleContent;
+  valRoot: string;
+  remoteHost: string;
+}): Promise<MediaMetadataVerdict> {
+  const ref = mediaValueOf(error.value)?.path;
+  if (typeof ref !== "string") {
+    return keep(error);
+  }
+  // A remote ref is a URL and is not expected on disk. Core does not emit these
+  // fixes for one, but a stale ref should not be reported as a local mismatch.
+  if (Internal.remote.splitRemoteRef(ref).status === "success") {
+    return keep(error);
+  }
+  if (!fs.existsSync(path.join(valRoot, ref))) {
+    // Reported as `val/file-not-found` instead; keeping the placeholder here
+    // means this verdict never has the last word on a file that is not there.
+    return keep(error);
+  }
+  if (!(await imageBytesAreReadable({ error, valRoot }))) {
+    // No fix offered: the only fix available writes what was read from the
+    // bytes, and what was read is 0x0. The file is the problem.
+    return [
+      {
+        message:
+          `Could not read the image dimensions of '${ref}'. ` +
+          `The file may be corrupt or truncated.`,
+        ...(error.value !== undefined ? { value: error.value } : {}),
+      },
+    ];
+  }
+  let fixed;
+  try {
+    fixed = await createFixPatch(
+      { projectRoot: valRoot, remoteHost },
+      // `false`: this is a question, not a fix. Asking for the patch would have
+      // createFixPatch read and rewrite files behind the editor's back.
+      false,
+      sourcePath,
+      error,
+      {},
+      content.source,
+      content.schema,
+    );
+  } catch {
+    return keep(error);
+  }
+  return (fixed?.remainingErrors ?? []).map((remaining) => ({
+    message: remaining.message,
+    // `createFixPatch` clears `fixes` on the per-field errors it reports, but
+    // the fix is still available and still the remedy -- it is what the
+    // placeholder was asking for. Carrying the placeholder's own fixes is what
+    // keeps the "update image metadata" quick fix offered, and the diagnostic
+    // a Warning rather than an Error.
+    ...(error.fixes ? { fixes: error.fixes } : {}),
+    ...(error.value !== undefined ? { value: error.value } : {}),
+  }));
+}
+
+/**
+ * Whether an image's dimensions can actually be read from its bytes.
+ *
+ * `extractImageMetadata` reports `width: 0, height: 0` for bytes `image-size`
+ * cannot parse, and `createFixPatch` only guards against `undefined` -- so a
+ * corrupt or truncated file would otherwise be reported as "Expected: 0", and
+ * "fixing" it would write those zeroes into the module. Keep the placeholder
+ * instead: something is wrong, and it is not the stored metadata.
+ *
+ * Only images have dimensions; a file's metadata is its mime type, which is
+ * derived from the name and always readable.
+ */
+async function imageBytesAreReadable({
+  error,
+  valRoot,
+}: {
+  error: ValidationError;
+  valRoot: string;
+}): Promise<boolean> {
+  if (!(error.fixes ?? []).includes("image:check-metadata")) {
+    return true;
+  }
+  const value = mediaValueOf(error.value);
+  if (typeof value?.path !== "string") {
+    return true;
+  }
+  const dimensions = await readImageDimensions(path.join(valRoot, value.path));
+  return (
+    dimensions !== undefined && dimensions.width > 0 && dimensions.height > 0
+  );
+}
+
+/**
+ * Image dimensions, cached on the file's identity.
+ *
+ * Validation is debounced per keystroke and a module can hold many images, so
+ * without this every edit re-reads every one of them. `mtimeMs` and `size`
+ * together change whenever the bytes do, which is all this has to notice.
+ *
+ * Read with `@valbuild/server`'s extractor -- the same one `createFixPatch`
+ * and the gallery fixes use -- so this cannot disagree with the comparison it
+ * is guarding.
+ */
+const dimensionsCache = new Map<
+  string,
+  { mtimeMs: number; size: number; width: number; height: number }
+>();
+
+async function readImageDimensions(
+  filePath: string,
+): Promise<{ width: number; height: number } | undefined> {
+  let stats;
+  try {
+    stats = fs.statSync(filePath);
+  } catch {
+    return undefined;
+  }
+  const cached = dimensionsCache.get(filePath);
+  if (
+    cached &&
+    cached.mtimeMs === stats.mtimeMs &&
+    cached.size === stats.size
+  ) {
+    return { width: cached.width, height: cached.height };
+  }
+  let metadata;
+  try {
+    metadata = await extractImageMetadata(filePath, fs.readFileSync(filePath));
+  } catch {
+    return undefined;
+  }
+  // `ImageMetadata` types both as optional, and `extractImageMetadata` already
+  // substitutes 0 for bytes it could not parse. Treat absent the same way: the
+  // caller reads 0 as "not readable".
+  const width = metadata.width ?? 0;
+  const height = metadata.height ?? 0;
+  dimensionsCache.set(filePath, {
+    mtimeMs: stats.mtimeMs,
+    size: stats.size,
+    width,
+    height,
+  });
+  return { width, height };
+}
+
+/** Drop cached dimensions. For tests. */
+export function clearImageDimensionsCache(): void {
+  dimensionsCache.clear();
+}
+
+/**
+ * The `accept` a media schema declares, if any.
+ *
+ * Read from the serialized schema (`SerializedImageSchema.options`) rather
+ * than from a schema instance: this runs against what `Service.get` returns.
+ */
+function acceptOf(schema: unknown): string | undefined {
+  if (typeof schema !== "object" || schema === null || !("options" in schema)) {
+    return undefined;
+  }
+  const { options } = schema;
+  if (
+    typeof options !== "object" ||
+    options === null ||
+    !("accept" in options)
+  ) {
+    return undefined;
+  }
+  const { accept } = options;
+  return typeof accept === "string" ? accept : undefined;
+}
+
+/** A media value, read as a plain record. */
+function mediaValueOf(
+  value: unknown,
+): { path?: unknown; mimeType?: unknown } | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  return value;
+}
+
+/**
+ * The serialized schema at a source path.
+ *
+ * Only the schema is taken from resolution -- `accept` is not on the value, and
+ * the value itself comes from the error. Same call `missingFileRef` in
+ * `diagnostics.ts` makes, and it can fail the same ways (a schema that failed
+ * to serialize, a path that no longer resolves), so failure is not an error
+ * here, just an absence.
+ */
+function resolveSchemaAt(
+  sourcePath: string,
+  content: ValModuleContent,
+): unknown {
+  if (!content.source || !content.schema) {
+    return undefined;
+  }
+  try {
+    const [, modulePath] = Internal.splitModuleFilePathAndModulePath(
+      sourcePath as never,
+    );
+    return Internal.resolvePath(modulePath, content.source, content.schema)
+      .schema;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/language-server/src/mediaMetadataChecks.ts
+++ b/packages/language-server/src/mediaMetadataChecks.ts
@@ -28,7 +28,7 @@ import {
   type ValidationFix,
   DEFAULT_VAL_REMOTE_HOST,
 } from "@valbuild/core";
-import { createFixPatch, extractImageMetadata } from "@valbuild/server";
+import { createFixPatch } from "@valbuild/server";
 import type { ValModuleContent } from "./ValProject";
 
 /**
@@ -246,7 +246,11 @@ function keep(error: ValidationError): MediaMetadataVerdict {
  *
  * The comparison itself is still `createFixPatch`, unchanged, which is the
  * parity that matters: the editor's wording is the CLI's wording because it is
- * the CLI's code.
+ * the CLI's code -- including for bytes it cannot measure, where it reports
+ * what `val validate` reports rather than a second opinion of our own.
+ *
+ * `createFixPatch` reads and decodes the image itself, so this is one file read
+ * per media field per validation pass, and nothing here should add another.
  */
 async function adjudicate({
   sourcePath,
@@ -275,18 +279,6 @@ async function adjudicate({
     // means this verdict never has the last word on a file that is not there.
     return keep(error);
   }
-  if (!(await imageBytesAreReadable({ error, valRoot }))) {
-    // No fix offered: the only fix available writes what was read from the
-    // bytes, and what was read is 0x0. The file is the problem.
-    return [
-      {
-        message:
-          `Could not read the image dimensions of '${ref}'. ` +
-          `The file may be corrupt or truncated.`,
-        ...(error.value !== undefined ? { value: error.value } : {}),
-      },
-    ];
-  }
   let fixed;
   try {
     fixed = await createFixPatch(
@@ -313,96 +305,6 @@ async function adjudicate({
     ...(error.fixes ? { fixes: error.fixes } : {}),
     ...(error.value !== undefined ? { value: error.value } : {}),
   }));
-}
-
-/**
- * Whether an image's dimensions can actually be read from its bytes.
- *
- * `extractImageMetadata` reports `width: 0, height: 0` for bytes `image-size`
- * cannot parse, and `createFixPatch` only guards against `undefined` -- so a
- * corrupt or truncated file would otherwise be reported as "Expected: 0", and
- * "fixing" it would write those zeroes into the module. Keep the placeholder
- * instead: something is wrong, and it is not the stored metadata.
- *
- * Only images have dimensions; a file's metadata is its mime type, which is
- * derived from the name and always readable.
- */
-async function imageBytesAreReadable({
-  error,
-  valRoot,
-}: {
-  error: ValidationError;
-  valRoot: string;
-}): Promise<boolean> {
-  if (!(error.fixes ?? []).includes("image:check-metadata")) {
-    return true;
-  }
-  const value = mediaValueOf(error.value);
-  if (typeof value?.path !== "string") {
-    return true;
-  }
-  const dimensions = await readImageDimensions(path.join(valRoot, value.path));
-  return (
-    dimensions !== undefined && dimensions.width > 0 && dimensions.height > 0
-  );
-}
-
-/**
- * Image dimensions, cached on the file's identity.
- *
- * Validation is debounced per keystroke and a module can hold many images, so
- * without this every edit re-reads every one of them. `mtimeMs` and `size`
- * together change whenever the bytes do, which is all this has to notice.
- *
- * Read with `@valbuild/server`'s extractor -- the same one `createFixPatch`
- * and the gallery fixes use -- so this cannot disagree with the comparison it
- * is guarding.
- */
-const dimensionsCache = new Map<
-  string,
-  { mtimeMs: number; size: number; width: number; height: number }
->();
-
-async function readImageDimensions(
-  filePath: string,
-): Promise<{ width: number; height: number } | undefined> {
-  let stats;
-  try {
-    stats = fs.statSync(filePath);
-  } catch {
-    return undefined;
-  }
-  const cached = dimensionsCache.get(filePath);
-  if (
-    cached &&
-    cached.mtimeMs === stats.mtimeMs &&
-    cached.size === stats.size
-  ) {
-    return { width: cached.width, height: cached.height };
-  }
-  let metadata;
-  try {
-    metadata = await extractImageMetadata(filePath, fs.readFileSync(filePath));
-  } catch {
-    return undefined;
-  }
-  // `ImageMetadata` types both as optional, and `extractImageMetadata` already
-  // substitutes 0 for bytes it could not parse. Treat absent the same way: the
-  // caller reads 0 as "not readable".
-  const width = metadata.width ?? 0;
-  const height = metadata.height ?? 0;
-  dimensionsCache.set(filePath, {
-    mtimeMs: stats.mtimeMs,
-    size: stats.size,
-    width,
-    height,
-  });
-  return { width, height };
-}
-
-/** Drop cached dimensions. For tests. */
-export function clearImageDimensionsCache(): void {
-  dimensionsCache.clear();
 }
 
 /**

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -40,6 +40,7 @@ import {
   resolveGalleryChecks,
   type ValDiagnosticData,
 } from "./diagnostics";
+import { resolveMediaMetadataChecks } from "./mediaMetadataChecks";
 import {
   createValCodeActions,
   createMissingModuleCodeAction,
@@ -355,6 +356,17 @@ export function createValLanguageServer(connection: Connection): {
                 }),
             })
           : undefined;
+      // Core also defers "does this image's stored metadata match its file",
+      // reporting it on every `s.image()` that carries any metadata. Same
+      // treatment: adjudicate with the fix machinery before showing anything.
+      const mediaMetadataChecks =
+        result.content.errors !== false && result.content.errors.validation
+          ? await resolveMediaMetadataChecks({
+              validation: result.content.errors.validation,
+              content: result.content,
+              valRoot: activeProject.valRoot,
+            })
+          : undefined;
       const diagnostics = createValDiagnostics({
         moduleFilePath,
         content: result.content,
@@ -364,6 +376,7 @@ export function createValLanguageServer(connection: Connection): {
           ? { snapshot: snapshotResult.snapshot }
           : {}),
         ...(galleryChecks ? { galleryChecks } : {}),
+        ...(mediaMetadataChecks ? { mediaMetadataChecks } : {}),
       });
       const unregistered = findMissingModuleDiagnostic(
         project.valRoot,


### PR DESCRIPTION
Every `s.image()` carrying width, height or a mime type was marked in VS Code with

> Found image metadata, but it could not be validated. An image must have a width (positive number), a height (positive number) and a mime type. `val(val/validation)`

whether or not the metadata was correct — so the warning sat on every image in the project and survived its own quick fix.

## Why it happened

That message was never a finding. `ImageSchema.executeValidate` cannot read bytes, so it cannot answer whether the stored dimensions match the file; it defers, handing the question on as an `image:check-metadata` fix. The comment above it says so.

Every other consumer already adjudicates that before showing it:

- `val validate` runs the comparison and reports only what disagrees.
- The Studio drops these wholesale (`partitionValidationErrors`) — a browser has no filesystem.

The language server was the one consumer publishing them raw. It *can* read the bytes, so it now adjudicates rather than hides: `createFixPatch` in report mode — the CLI's own comparison, so the editor's wording is the CLI's wording — and nothing is published when the metadata is right.

## The hard part

`image:check-metadata` is attached to **five** different errors, and only the last is the deferral:

| `schema/image.ts` | Condition | Real finding? |
| --- | --- | --- |
| 284-295 | `accept` set, mimeType has no `/` | yes |
| 297-323 | `accept` set and not satisfied | yes |
| 326-337 | extension has no known mime type | yes |
| 339-350 | mimeType disagrees with the extension | yes |
| 355-370 | fall-through: any of the three present | **no — the deferral** |

Adjudicating one of the first four would find the metadata matches the bytes and silently drop a genuine error. There is no flag on `ValidationError` saying which is which, so `isDeferredMediaMetadataCheck` re-derives those four conditions, and the test drives **real core** through all five cases so a sixth condition cannot slip past unnoticed. `FileSchema` needs none of this — its four equivalents carry no `fixes` at all — and the test pins that too.

The adjudication deliberately skips `handleFileMetadata`: its only job is a file-exists precondition, already reported as the better `val/file-not-found`, and it throws outright for a `.jsonValues()` entry (`Cannot resolve path into a jsonValues entry until its content is loaded`), which would have left every entry-backed image stuck on the warning.

Bytes that cannot be measured — `image-size` throws for those — keep the placeholder rather than getting a second opinion invented here, so the editor says what `val validate` says in that case too.

## Scope

The suppression is language-server-only. Core still emits the placeholder unconditionally, so **the CLI still validates images exactly as before** — verified against `examples/next` by breaking an image to 800×600:

```
content/jsonEntryMedia.val.ts  ✘ 2 errors
│  ✘  Image width is incorrect! Found: 800. Expected: 944
│  ✘  Image height is incorrect! Found: 600. Expected: 944
```

and `--fix` wrote 944×944 back. The editor reports that same case with those same messages now; the difference is only that a *correct* image is silent.

Three core changes do reach the CLI and Studio:

1. **The four media metadata messages are reworded.** Two described a check that never ran; two did not say what was missing.
2. **`FileSchema`'s extension-vs-mimeType check is guarded on `mimeType` being set**, as `ImageSchema` already is. Without it an `s.file()` with no mimeType reported `Mime type ... is 'undefined'` with no fix attached, and the `file:add-metadata` branch was unreachable dead code — including the message this PR reworded. Note this means `val validate --fix` will now add a missing mime type where it previously only errored.
3. **`mimeTypeMatchesAccept` extracted**, having been written out three times in core. The copies had drifted: `ImageSchema`/`FileSchema` compared `image/*` against `"image"` (so `imagex/png` matched), while `RecordSchema` special-cased it to compare against `"image/"`. The shared helper keeps the slash, which is the strict behaviour, for all three callers.

## Review fixes (032e1c8)

Four findings, all verified before acting:

- One quick fix per problem. A stale image reports width and height as two diagnostics sharing one fix, so the editor offered the identical "Val: update image metadata" twice — and recomputed it, re-reading the image, to do so. Gallery checks had the same shape.
- Dropped a pre-read probe that cost a second full read and decode of every image per validation pass, and whose dimensions cache could only ever save one of those two reads.
- That probe also turned an SVG with no intrinsic size — `image-size` throws `Invalid SVG`, and such an SVG is perfectly legitimate — into a hard error claiming the file was corrupt, with no quick fix.
- The wildcard strictness above.

Copilot's other finding, that `path.join(valRoot, ref)` discards `valRoot` for an absolute ref, is [not correct](https://github.com/valbuild/val/pull/581#issuecomment-5516399817) — that is `path.resolve` — and the code is unchanged there.

## Verification

Full CI set locally: lint, format, `pnpm run -r typecheck`, 3068 tests, root build, and the `examples/next` build. `val validate` run through both `tsx src/cli.ts` and the packaged `bin.js`.

Two tests pin the bug at the level it was reported: a module with a correct image publishes zero diagnostics over LSP, and applying the metadata quick fix now clears the warning instead of leaving it behind — replacing a standing `NOTE` in `codeActions.test.ts` that documented exactly this bug as unexplained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBM6U6tLRxKmYLi7pV6vza