### PR TITLE
Verify OAuth access tokens on the MCP endpoint

### DIFF
--- a/.changeset/mcp-oauth-resource-server.md
+++ b/.changeset/mcp-oauth-resource-server.md
@@ -1,0 +1,50 @@
+---
+"@valbuild/server": minor
+"@valbuild/next": minor
+---
+
+Accept OAuth access tokens on the MCP endpoint, so editors can authorize as themselves
+
+`initValMcp` takes an optional `oauth` config. Give it the authorization server's
+URL and this endpoint's own URL, and every MCP call must then present an access
+token that Val's authorization server issued:
+
+```ts
+const { valMcpAuthorize, valMcpTools, valMcpMetadata } = initValMcp(
+  valModules,
+  config,
+  {
+    oauth: {
+      issuer: "https://admin.val.build",
+      resource: "https://your-app.com/api/mcp",
+    },
+  },
+);
+```
+
+The token is verified in your app — signature against the issuer's published
+keys, plus issuer, audience and expiry — so the caller's identity is checked
+rather than claimed. **Patches created over MCP now carry that profile as their
+author**, which is what makes an edit made from a phone show up in the review
+screen as somebody's rather than nobody's. Scopes are enforced too: a token
+without `val:write` cannot reach a tool that writes.
+
+Mount the discovery document so clients can find where to authorize:
+
+```ts
+// app/.well-known/oauth-protected-resource/route.ts
+import { valMcpMetadata } from "../../../val/mcp";
+export const { GET, OPTIONS } = valMcpMetadata!;
+```
+
+`valMcpMetadata` is `null` when no `oauth` config is given.
+
+**Nothing changes if you leave `oauth` out.** Local development still works with
+no authorization server, and an app already using a personal access token keeps
+working as before.
+
+One breaking change if you built your own host on `createValTools`:
+`ValToolContext.auth` is now a tagged union, so `{ pat }` becomes
+`{ type: "pat", pat }`. The new variant is
+`{ type: "verified-profile", profileId, scopes }`, for a host that verified a
+token itself.

--- a/examples/next/app/.well-known/oauth-protected-resource/route.ts
+++ b/examples/next/app/.well-known/oauth-protected-resource/route.ts
@@ -1,0 +1,31 @@
+import { valMcpMetadata } from "../../../val/mcp";
+
+/**
+ * RFC 9728 Protected Resource Metadata: how an MCP client discovers where to
+ * authorize for this app's `/api/mcp`.
+ *
+ * Served by the resource — this app — and it names the authorization server.
+ * The *authorization server's* own metadata (RFC 8414) is not served here on
+ * purpose: that document describes the issuer's endpoints and lives at the
+ * issuer, and an app serving a copy would be asserting someone else's
+ * configuration and would be wrong the moment it changed.
+ *
+ * `404` when Val has no `oauth` config, rather than an empty document. A
+ * document that named no authorization server would send clients into a
+ * discovery loop; a 404 tells them plainly that this deployment does not do
+ * OAuth.
+ */
+
+export async function GET(request: Request): Promise<Response> {
+  if (!valMcpMetadata) {
+    return new Response("Not found", { status: 404 });
+  }
+  return valMcpMetadata.GET(request);
+}
+
+export async function OPTIONS(request: Request): Promise<Response> {
+  if (!valMcpMetadata) {
+    return new Response(null, { status: 404 });
+  }
+  return valMcpMetadata.OPTIONS(request);
+}

--- a/examples/next/val/mcp.ts
+++ b/examples/next/val/mcp.ts
@@ -13,12 +13,33 @@ import prettier from "prettier";
  * written to disk in local dev should come out formatted the way the repo
  * formats everything else, whichever path wrote it.
  */
-const { valMcpAuthorize, valMcpTools } = initValMcp(valModules, config, {
-  formatter: (code, filePath) => {
-    return prettier.format(code, {
-      filepath: filePath,
-    });
+const { valMcpAuthorize, valMcpTools, valMcpMetadata } = initValMcp(
+  valModules,
+  config,
+  {
+    formatter: (code, filePath) => {
+      return prettier.format(code, {
+        filepath: filePath,
+      });
+    },
+    /**
+     * Where to authorize, when this app is configured for it.
+     *
+     * Read from the environment rather than hardcoded, and absent by default,
+     * because the two are genuinely different deployments: local development
+     * has no authorization server to talk to and wants the endpoint to work
+     * without one, while a deployed app must not serve MCP to whoever asks.
+     * Set both and every call needs a verified access token.
+     */
+    ...(process.env.VAL_OAUTH_ISSUER && process.env.VAL_MCP_RESOURCE
+      ? {
+          oauth: {
+            issuer: process.env.VAL_OAUTH_ISSUER,
+            resource: process.env.VAL_MCP_RESOURCE,
+          },
+        }
+      : {}),
   },
-});
+);
 
-export { valMcpAuthorize, valMcpTools };
+export { valMcpAuthorize, valMcpTools, valMcpMetadata };

--- a/packages/next/src/server/initValMcp.test.ts
+++ b/packages/next/src/server/initValMcp.test.ts
@@ -1,8 +1,10 @@
 /**
  * @jest-environment node
  */
+import { generateKeyPairSync, sign as cryptoSign } from "node:crypto";
 import { initVal } from "@valbuild/core";
 import { initValMcp } from "./initValMcp";
+import { clearValAccessTokenCache } from "./valAccessToken";
 
 /**
  * What the MCP endpoint refuses, and why each refusal is not optional.
@@ -266,6 +268,7 @@ describe("credentials", () => {
     // Verbatim: this app is not the authority on what the token may do, so it
     // must not normalise, truncate or interpret it on the way to the backend.
     expect(res.status === "ok" && res.ctx.auth).toEqual({
+      type: "pat",
       pat: "pat-from-the-caller",
     });
   });
@@ -294,7 +297,10 @@ describe("credentials", () => {
       ),
     );
 
-    expect(res.status === "ok" && res.ctx.auth).toEqual({ pat: "pat" });
+    expect(res.status === "ok" && res.ctx.auth).toEqual({
+      type: "pat",
+      pat: "pat",
+    });
   });
 
   test("a non-bearer Authorization header is not treated as a credential", async () => {
@@ -327,5 +333,191 @@ describe("a call with no HTTP request", () => {
       return;
     }
     expect(res.response.status).toBe(401);
+  });
+});
+
+/** An oauth-configured registry, plus what it takes to satisfy it. */
+function oauthHarness(): {
+  issuer: string;
+  resource: string;
+  fetchImpl: typeof fetch;
+  signToken: (claims?: Record<string, unknown>) => string;
+} {
+  const issuer = "https://admin.val.build";
+  const resource = "http://localhost:3000/api/mcp";
+  const { privateKey, publicKey } = generateKeyPairSync("ec", {
+    namedCurve: "P-256",
+  });
+  const jwk = publicKey.export({ format: "jwk" });
+  const fetchImpl: typeof fetch = async () =>
+    new Response(
+      JSON.stringify({
+        keys: [{ ...jwk, kid: "k1", alg: "ES256", use: "sig" }],
+      }),
+      { status: 200 },
+    );
+  const b64 = (value: string): string =>
+    Buffer.from(value).toString("base64url");
+  return {
+    issuer,
+    resource,
+    fetchImpl,
+    signToken(claims = {}) {
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      const input = `${b64(
+        JSON.stringify({ alg: "ES256", typ: "JWT", kid: "k1" }),
+      )}.${b64(
+        JSON.stringify({
+          iss: issuer,
+          aud: resource,
+          sub: "profile-123",
+          exp: nowSeconds + 600,
+          scope: "val:read val:write",
+          ...claims,
+        }),
+      )}`;
+      const signature = cryptoSign("sha256", Buffer.from(input, "ascii"), {
+        key: privateKey,
+        dsaEncoding: "ieee-p1363",
+      });
+      return `${input}.${signature.toString("base64url")}`;
+    },
+  };
+}
+
+describe("oauth mode", () => {
+  beforeEach(() => {
+    // The key-set cache is keyed by the issuer's JWKS URL and outlives a
+    // request by design — one issuer really does have one key set. These cases
+    // all use the same issuer with different keys, so without this a later
+    // token is checked against an earlier test's keys.
+    clearValAccessTokenCache();
+  });
+
+  test("no config means nothing changes, and no metadata is published", async () => {
+    // A project that has not been told where to authorize must not publish a
+    // document claiming it knows — and must keep working, because local
+    // development has no authorization server to point at.
+    expect(mcp().valMcpMetadata).toBeNull();
+  });
+
+  test("a request with no token is refused with a challenge that says where to authorize", async () => {
+    const harness = oauthHarness();
+    const res = await withEnv(httpModeEnv(), () =>
+      initValMcp({ config, modules: [] }, config, {
+        oauth: harness,
+      }).valMcpAuthorize(request({})),
+    );
+
+    expect(res.status).toBe("refused");
+    if (res.status !== "refused") {
+      return;
+    }
+    expect(res.response.status).toBe(401);
+    const challenge = res.response.headers.get("www-authenticate");
+    // Without `resource_metadata` the client knows it needs a token and has no
+    // way to find out from where: a dead end rather than a login.
+    expect(challenge).toContain("resource_metadata=");
+    expect(challenge).toContain("oauth-protected-resource");
+    expect(challenge).toContain('error="invalid_request"');
+  });
+
+  test("a verified token becomes a verified profile, not a relayed credential", async () => {
+    const harness = oauthHarness();
+    const res = await withEnv(httpModeEnv(), () =>
+      initValMcp({ config, modules: [] }, config, {
+        oauth: harness,
+      }).valMcpAuthorize(
+        request({ authorization: `Bearer ${harness.signToken()}` }),
+      ),
+    );
+
+    expect(res.status).toBe("ok");
+    // The token itself is deliberately absent from the context: it was checked
+    // here, so what travels onward is the identity it proved rather than the
+    // credential.
+    expect(res.status === "ok" && res.ctx.auth).toEqual({
+      type: "verified-profile",
+      profileId: "profile-123",
+      scopes: ["val:read", "val:write"],
+    });
+  });
+
+  test("a forged token is refused with invalid_token", async () => {
+    const harness = oauthHarness();
+    const other = oauthHarness();
+    const res = await withEnv(httpModeEnv(), () =>
+      initValMcp({ config, modules: [] }, config, {
+        oauth: harness,
+      }).valMcpAuthorize(
+        request({ authorization: `Bearer ${other.signToken()}` }),
+      ),
+    );
+
+    expect(res.status).toBe("refused");
+    if (res.status !== "refused") {
+      return;
+    }
+    expect(res.response.status).toBe(401);
+    expect(res.response.headers.get("www-authenticate")).toContain(
+      'error="invalid_token"',
+    );
+  });
+
+  test("a token with no read scope is 403, not 401", async () => {
+    const harness = oauthHarness();
+    const res = await withEnv(httpModeEnv(), () =>
+      initValMcp({ config, modules: [] }, config, {
+        oauth: harness,
+      }).valMcpAuthorize(
+        request({
+          authorization: `Bearer ${harness.signToken({ scope: "" })}`,
+        }),
+      ),
+    );
+
+    expect(res.status).toBe("refused");
+    if (res.status !== "refused") {
+      return;
+    }
+    // 401 invites the client to authorize again; 403 tells it the grant is the
+    // problem. Sending the wrong one puts a client in a loop.
+    expect(res.response.status).toBe(403);
+    expect(res.response.headers.get("www-authenticate")).toContain(
+      'error="insufficient_scope"',
+    );
+  });
+
+  test("configuring oauth publishes the metadata document", async () => {
+    const harness = oauthHarness();
+    const metadata = initValMcp({ config, modules: [] }, config, {
+      oauth: harness,
+    }).valMcpMetadata;
+
+    expect(metadata).not.toBeNull();
+    const body: unknown = await metadata?.GET(request({})).json();
+    expect(body).toMatchObject({
+      resource: harness.resource,
+      authorization_servers: [harness.issuer],
+    });
+  });
+
+  test("a cross-origin request is still refused before the token is looked at", async () => {
+    const harness = oauthHarness();
+    const res = await withEnv(httpModeEnv(), () =>
+      initValMcp({ config, modules: [] }, config, {
+        oauth: harness,
+      }).valMcpAuthorize(
+        request({
+          origin: "https://evil.example.com",
+          authorization: `Bearer ${harness.signToken()}`,
+        }),
+      ),
+    );
+
+    // Order matters: a valid token does not buy a browser page the right to
+    // drive this endpoint, so the origin check stays in front of verification.
+    expect(res.status).toBe("refused");
+    expect(res.status === "refused" && res.response.status).toBe(403);
   });
 });

--- a/packages/next/src/server/initValMcp.ts
+++ b/packages/next/src/server/initValMcp.ts
@@ -1,11 +1,23 @@
 import { Internal, ValConfig, ValModules } from "@valbuild/core";
 import {
+  VAL_SCOPE_READ,
+  VAL_SCOPE_WRITE,
   createValTools,
   initHandlerOptions,
   type ValToolContext,
   type ValTools,
 } from "@valbuild/server";
 import { VERSION } from "../version";
+import {
+  readBearerToken,
+  verifyValAccessToken,
+  type ValOAuthConfig,
+} from "./valAccessToken";
+import {
+  createValMcpMetadata,
+  wwwAuthenticate,
+  type ValMcpMetadataHandlers,
+} from "./valMcpMetadata";
 
 /**
  * Val's tools over MCP, and the two checks that have to happen before a request
@@ -42,6 +54,14 @@ export type ValMcp = {
    * with an MCP server can happen once rather than per request.
    */
   valMcpTools: () => Promise<ValTools>;
+  /**
+   * The RFC 9728 protected-resource document, for mounting at
+   * `/.well-known/oauth-protected-resource`.
+   *
+   * `null` when no `oauth` config was given: a project that has not been told
+   * where to authorize must not publish a document claiming it knows.
+   */
+  valMcpMetadata: ValMcpMetadataHandlers | null;
 };
 
 export function initValMcp(
@@ -49,6 +69,17 @@ export function initValMcp(
   config: ValConfig,
   opts?: {
     formatter?: (code: string, filePath: string) => string | Promise<string>;
+    /**
+     * Where to authorize, and what audience to expect.
+     *
+     * Omit it and nothing changes: the endpoint behaves exactly as it did
+     * before OAuth existed, which keeps local development a one-liner and keeps
+     * an app that has not been reconfigured working. Provide it and every call
+     * needs a verified access token — including in fs mode, where a token is
+     * refused rather than ignored, because a host that thinks it is
+     * authenticating should never silently get unauthenticated local access.
+     */
+    oauth?: ValOAuthConfig;
   },
 ): ValMcp {
   const route = "/api/val"; // TODO: get from config, as initValServer does
@@ -84,7 +115,12 @@ export function initValMcp(
     // handled per request
   });
 
+  const oauth = opts?.oauth;
+  const scopesSupported = [VAL_SCOPE_READ, VAL_SCOPE_WRITE];
+
   return {
+    valMcpMetadata: oauth ? createValMcpMetadata(oauth, scopesSupported) : null,
+
     async valMcpTools() {
       return (await setupPromise).tools;
     },
@@ -122,19 +158,56 @@ export function initValMcp(
         return { status: "refused", response: refusal };
       }
 
+      // Not the MCP session id, in either branch below. Val's patch `sessionId`
+      // names a Val AI session, and putting an unrelated id in it would claim a
+      // relationship that does not exist.
+      const sessionId = null;
+
+      if (oauth) {
+        const verified = await verifyValAccessToken(request, oauth);
+        if (verified.status === "refused") {
+          // 401 for a missing or bad token, 403 once the token is good but does
+          // not carry the scope: RFC 6750 section 3.1, and the distinction is
+          // what tells a client whether to authorize again or to give up.
+          const status = verified.error === "insufficient_scope" ? 403 : 401;
+          return {
+            status: "refused",
+            response: new Response(
+              JSON.stringify({
+                error: verified.error,
+                error_description: verified.description,
+              }),
+              {
+                status,
+                headers: {
+                  "Content-Type": "application/json",
+                  "WWW-Authenticate": wwwAuthenticate(oauth, scopesSupported, {
+                    error: verified.error,
+                    description: verified.description,
+                  }),
+                },
+              },
+            ),
+          };
+        }
+        return {
+          status: "ok",
+          tools: setup.tools,
+          ctx: { auth: verified.auth, sessionId },
+        };
+      }
+
       const pat = readBearerToken(request);
       return {
         status: "ok",
         tools: setup.tools,
         ctx: {
-          // Passed through unverified, deliberately: this app is not the
-          // authority on what a token may do, and the registry sends it to the
+          // Passed through unverified, deliberately: without an `oauth` config
+          // this app has no key to check anything against, so it is not the
+          // authority on what the token may do and the registry sends it to the
           // backend that is. See `docs/plans/mcp.md` D.2.
-          auth: pat === null ? null : { pat },
-          // Not the MCP session id. Val's patch `sessionId` names a Val AI
-          // session, and putting an unrelated id in it would claim a
-          // relationship that does not exist.
-          sessionId: null,
+          auth: pat === null ? null : { type: "pat", pat },
+          sessionId,
         },
       };
     },
@@ -254,16 +327,6 @@ function hostnameOf(host: string): string {
   }
   const colon = host.indexOf(":");
   return colon === -1 ? host : host.slice(0, colon);
-}
-
-function readBearerToken(request: Request): string | null {
-  const header = request.headers.get("authorization");
-  if (!header) {
-    return null;
-  }
-  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
-  const token = match?.[1]?.trim();
-  return token ? token : null;
 }
 
 function jsonResponse(status: number, body: unknown): Response {

--- a/packages/next/src/server/valAccessToken.test.ts
+++ b/packages/next/src/server/valAccessToken.test.ts
@@ -1,0 +1,465 @@
+import {
+  createPrivateKey,
+  generateKeyPairSync,
+  sign as cryptoSign,
+} from "node:crypto";
+import {
+  clearValAccessTokenCache,
+  verifyValAccessToken,
+  type ValOAuthConfig,
+} from "./valAccessToken";
+
+/**
+ * Access-token verification, exercised against real ES256 keypairs and a real
+ * JWKS document. Only the network is faked.
+ *
+ * That is deliberate rather than thorough-for-its-own-sake: every interesting
+ * case here is one where a *wrong* verifier says yes — a token signed by a key
+ * the issuer does not publish, a token minted for another deployment, an
+ * expired one, one that nominated its own algorithm. A stubbed verifier cannot
+ * fail those the way the real one can, so the keys and signatures are genuine
+ * and the assertions are about refusals.
+ */
+
+const ISSUER = "https://admin.val.build";
+const RESOURCE = "https://acme.example.com/api/mcp";
+
+type Keys = { privateKeyPem: string; publicJwk: Record<string, unknown> };
+
+function makeKeys(kid: string = "test-key"): Keys {
+  const { privateKey, publicKey } = generateKeyPairSync("ec", {
+    namedCurve: "P-256",
+  });
+  const jwk = publicKey.export({ format: "jwk" });
+  return {
+    privateKeyPem: privateKey
+      .export({ format: "pem", type: "pkcs8" })
+      .toString(),
+    publicJwk: { ...jwk, kid, alg: "ES256", use: "sig" },
+  };
+}
+
+function base64url(input: string | Buffer): string {
+  return Buffer.from(input).toString("base64url");
+}
+
+function signToken(
+  keys: Keys,
+  claims: Record<string, unknown> = {},
+  header: Record<string, unknown> = {},
+): string {
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const fullHeader = { alg: "ES256", typ: "JWT", kid: "test-key", ...header };
+  const fullClaims = {
+    iss: ISSUER,
+    aud: RESOURCE,
+    sub: "profile-123",
+    iat: nowSeconds,
+    exp: nowSeconds + 15 * 60,
+    ...claims,
+  };
+  const signingInput = `${base64url(JSON.stringify(fullHeader))}.${base64url(
+    JSON.stringify(fullClaims),
+  )}`;
+  const signature = cryptoSign("sha256", Buffer.from(signingInput, "ascii"), {
+    key: createPrivateKey(keys.privateKeyPem),
+    dsaEncoding: "ieee-p1363",
+  });
+  return `${signingInput}.${signature.toString("base64url")}`;
+}
+
+/** A `fetch` that serves one JWKS and counts how often it was asked. */
+function serveJwks(keys: Record<string, unknown>[]): {
+  fetchImpl: typeof fetch;
+  calls: () => number;
+} {
+  let calls = 0;
+  const fetchImpl: typeof fetch = async (input) => {
+    calls++;
+    const url = typeof input === "string" ? input : String(input);
+    if (!url.endsWith("/.well-known/jwks.json")) {
+      return new Response("not found", { status: 404 });
+    }
+    return new Response(JSON.stringify({ keys }), { status: 200 });
+  };
+  return { fetchImpl, calls: () => calls };
+}
+
+function oauth(fetchImpl: typeof fetch): ValOAuthConfig {
+  return { issuer: ISSUER, resource: RESOURCE, fetchImpl };
+}
+
+function request(token?: string): Request {
+  return new Request(RESOURCE, {
+    headers: token === undefined ? {} : { authorization: `Bearer ${token}` },
+  });
+}
+
+beforeEach(() => {
+  // The key-set cache is per issuer and outlives a request by design, so it has
+  // to be cleared between tests: otherwise a later test verifies against an
+  // earlier test's keys and passes for the wrong reason.
+  clearValAccessTokenCache();
+});
+
+describe("verifyValAccessToken", () => {
+  test("accepts a well-formed token and reports the verified profile", async () => {
+    const keys = makeKeys();
+    const jwks = serveJwks([keys.publicJwk]);
+    const token = signToken(keys, { scope: "val:read val:write" });
+
+    const res = await verifyValAccessToken(
+      request(token),
+      oauth(jwks.fetchImpl),
+    );
+
+    expect(res).toEqual({
+      status: "ok",
+      auth: {
+        type: "verified-profile",
+        profileId: "profile-123",
+        scopes: ["val:read", "val:write"],
+      },
+    });
+  });
+
+  test("distinguishes no token from a bad one", async () => {
+    const keys = makeKeys();
+    const jwks = serveJwks([keys.publicJwk]);
+
+    const missing = await verifyValAccessToken(
+      request(),
+      oauth(jwks.fetchImpl),
+    );
+    // `invalid_request`, not `invalid_token`: a client that has not authorized
+    // yet must be invited to, and RFC 6750 gives the two different codes.
+    expect(missing).toMatchObject({
+      status: "refused",
+      error: "invalid_request",
+    });
+
+    const garbage = await verifyValAccessToken(
+      request("not-a-jwt"),
+      oauth(jwks.fetchImpl),
+    );
+    expect(garbage).toMatchObject({
+      status: "refused",
+      error: "invalid_token",
+    });
+  });
+
+  test("refuses a token signed by a key the issuer does not publish", async () => {
+    const ours = makeKeys();
+    const theirs = makeKeys();
+    // The issuer publishes our key; the token is signed with another. This is
+    // the forged-token case, and the one a careless verifier waves through.
+    const jwks = serveJwks([ours.publicJwk]);
+    const token = signToken(theirs, { scope: "val:read" });
+
+    const res = await verifyValAccessToken(
+      request(token),
+      oauth(jwks.fetchImpl),
+    );
+
+    expect(res).toMatchObject({ status: "refused", error: "invalid_token" });
+  });
+
+  test("refuses a token whose payload was changed after signing", async () => {
+    const keys = makeKeys();
+    const jwks = serveJwks([keys.publicJwk]);
+    const token = signToken(keys, { scope: "val:read" });
+    const [header, , signature] = token.split(".");
+    const tampered = `${header}.${base64url(
+      JSON.stringify({
+        iss: ISSUER,
+        aud: RESOURCE,
+        sub: "somebody-else",
+        exp: Math.floor(Date.now() / 1000) + 600,
+        scope: "val:read val:write",
+      }),
+    )}.${signature}`;
+
+    const res = await verifyValAccessToken(
+      request(tampered),
+      oauth(jwks.fetchImpl),
+    );
+
+    // The point of verifying before reading: a swapped `sub` would otherwise
+    // attribute someone else's edits, and a swapped `scope` would grant writes.
+    expect(res).toMatchObject({ status: "refused", error: "invalid_token" });
+  });
+
+  test("refuses a token minted for another deployment", async () => {
+    const keys = makeKeys();
+    const jwks = serveJwks([keys.publicJwk]);
+    const token = signToken(keys, {
+      scope: "val:read",
+      aud: "https://other.example.com/api/mcp",
+    });
+
+    const res = await verifyValAccessToken(
+      request(token),
+      oauth(jwks.fetchImpl),
+    );
+
+    // Audience binding: without it, one Val site's token works against every
+    // other site its owner can reach.
+    expect(res).toMatchObject({ status: "refused", error: "invalid_token" });
+    if (res.status === "refused") {
+      expect(res.description).toContain("aud");
+    }
+  });
+
+  test("accepts an audience array that includes this resource", async () => {
+    const keys = makeKeys();
+    const jwks = serveJwks([keys.publicJwk]);
+    const token = signToken(keys, {
+      scope: "val:read",
+      aud: ["https://other.example.com/api/mcp", RESOURCE],
+    });
+
+    const res = await verifyValAccessToken(
+      request(token),
+      oauth(jwks.fetchImpl),
+    );
+
+    // RFC 7519 allows an array, and a token may legitimately be addressed to
+    // more than one resource.
+    expect(res.status).toBe("ok");
+  });
+
+  test("refuses a token from another issuer", async () => {
+    const keys = makeKeys();
+    const jwks = serveJwks([keys.publicJwk]);
+    const token = signToken(keys, {
+      scope: "val:read",
+      iss: "https://evil.example.com",
+    });
+
+    const res = await verifyValAccessToken(
+      request(token),
+      oauth(jwks.fetchImpl),
+    );
+
+    expect(res).toMatchObject({ status: "refused", error: "invalid_token" });
+  });
+
+  test("refuses an expired token, and says it can be refreshed", async () => {
+    const keys = makeKeys();
+    const jwks = serveJwks([keys.publicJwk]);
+    // Well beyond the default 60s tolerance, so this tests expiry and not skew.
+    const token = signToken(keys, {
+      scope: "val:read",
+      exp: Math.floor(Date.now() / 1000) - 300,
+    });
+
+    const res = await verifyValAccessToken(
+      request(token),
+      oauth(jwks.fetchImpl),
+    );
+
+    expect(res).toMatchObject({ status: "refused", error: "invalid_token" });
+    if (res.status === "refused") {
+      // The client's move is to refresh, so the message must distinguish this
+      // from a token that will never work.
+      expect(res.description).toMatch(/expired/i);
+    }
+  });
+
+  test("refuses a token with no expiry at all", async () => {
+    const keys = makeKeys();
+    const jwks = serveJwks([keys.publicJwk]);
+    const token = signToken(keys, { scope: "val:read", exp: undefined });
+
+    const res = await verifyValAccessToken(
+      request(token),
+      oauth(jwks.fetchImpl),
+    );
+
+    // A bearer token with no expiry is a permanent grant. This is the exact
+    // defect `decodeJwt` shipped with, so it gets its own test.
+    expect(res).toMatchObject({ status: "refused", error: "invalid_token" });
+  });
+
+  test("tolerates small clock skew rather than failing a fresh token", async () => {
+    const keys = makeKeys();
+    const jwks = serveJwks([keys.publicJwk]);
+    const token = signToken(keys, {
+      scope: "val:read",
+      exp: Math.floor(Date.now() / 1000) - 10,
+    });
+
+    const res = await verifyValAccessToken(
+      request(token),
+      oauth(jwks.fetchImpl),
+    );
+
+    // Ten seconds past expiry is inside the default tolerance. Nobody can tell
+    // "your clock is off by a second" from "login is broken".
+    expect(res.status).toBe("ok");
+  });
+
+  test("refuses a token that nominated its own algorithm", async () => {
+    const keys = makeKeys();
+    const jwks = serveJwks([keys.publicJwk]);
+    // `alg: none` with an empty signature is the textbook forgery, and the one
+    // a verifier that trusts the header accepts.
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const unsigned = `${base64url(
+      JSON.stringify({ alg: "none", typ: "JWT" }),
+    )}.${base64url(
+      JSON.stringify({
+        iss: ISSUER,
+        aud: RESOURCE,
+        sub: "profile-123",
+        exp: nowSeconds + 600,
+        scope: "val:read val:write",
+      }),
+    )}.`;
+
+    const res = await verifyValAccessToken(
+      request(unsigned),
+      oauth(jwks.fetchImpl),
+    );
+
+    expect(res).toMatchObject({ status: "refused", error: "invalid_token" });
+    if (res.status === "refused") {
+      expect(res.description).toMatch(/ES256/);
+    }
+  });
+
+  test("refuses an HS256 token signed with the published public key", async () => {
+    const keys = makeKeys();
+    const jwks = serveJwks([keys.publicJwk]);
+    // Algorithm confusion, concretely: the attacker knows the public key
+    // because it is published, and asks the server to treat it as an HMAC
+    // secret. Pinning `alg` is what refuses this before any key is looked at.
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const signingInput = `${base64url(
+      JSON.stringify({ alg: "HS256", typ: "JWT", kid: "test-key" }),
+    )}.${base64url(
+      JSON.stringify({
+        iss: ISSUER,
+        aud: RESOURCE,
+        sub: "attacker",
+        exp: nowSeconds + 600,
+        scope: "val:read val:write",
+      }),
+    )}`;
+    const { createHmac } = await import("node:crypto");
+    const forged = `${signingInput}.${createHmac(
+      "sha256",
+      JSON.stringify(keys.publicJwk),
+    )
+      .update(signingInput)
+      .digest("base64url")}`;
+
+    const res = await verifyValAccessToken(
+      request(forged),
+      oauth(jwks.fetchImpl),
+    );
+
+    expect(res).toMatchObject({ status: "refused", error: "invalid_token" });
+  });
+
+  test("refuses a token with no val:read scope", async () => {
+    const keys = makeKeys();
+    const jwks = serveJwks([keys.publicJwk]);
+    const token = signToken(keys, { scope: "val:write" });
+
+    const res = await verifyValAccessToken(
+      request(token),
+      oauth(jwks.fetchImpl),
+    );
+
+    // `insufficient_scope` is a 403 rather than an invitation to authorize
+    // again, so the distinction from `invalid_token` is load bearing.
+    expect(res).toMatchObject({
+      status: "refused",
+      error: "insufficient_scope",
+    });
+  });
+
+  test("treats a missing or wrongly-shaped scope claim as no scopes", async () => {
+    const keys = makeKeys();
+    const jwks = serveJwks([keys.publicJwk]);
+
+    for (const scope of [undefined, ["val:read"], 42, null]) {
+      const res = await verifyValAccessToken(
+        request(signToken(keys, { scope })),
+        oauth(jwks.fetchImpl),
+      );
+      // Read generously and an array someone sent would authorize a write.
+      expect(res).toMatchObject({
+        status: "refused",
+        error: "insufficient_scope",
+      });
+      clearValAccessTokenCache();
+    }
+  });
+
+  test("refuses when the key set cannot be fetched, and says it may be temporary", async () => {
+    const keys = makeKeys();
+    const failing: typeof fetch = async () =>
+      new Response("boom", { status: 500 });
+    const token = signToken(keys, { scope: "val:read" });
+
+    const res = await verifyValAccessToken(request(token), oauth(failing));
+
+    expect(res).toMatchObject({ status: "refused", error: "invalid_token" });
+    if (res.status === "refused") {
+      // Retrying is the right client behaviour here; re-authorizing is not.
+      expect(res.description).toMatch(/temporary/i);
+    }
+  });
+
+  test("verifies against a rotated key set holding both keys", async () => {
+    const oldKeys = makeKeys("old-key");
+    const newKeys = makeKeys("test-key");
+    // Mid-rotation: the issuer publishes both, and tokens signed with either
+    // must keep working or every editor is logged out at the moment of a
+    // rotation.
+    const jwks = serveJwks([oldKeys.publicJwk, newKeys.publicJwk]);
+
+    const res = await verifyValAccessToken(
+      request(signToken(newKeys, { scope: "val:read" })),
+      oauth(jwks.fetchImpl),
+    );
+
+    expect(res.status).toBe("ok");
+  });
+
+  test("fetches the key set once across many calls", async () => {
+    const keys = makeKeys();
+    const jwks = serveJwks([keys.publicJwk]);
+    const token = signToken(keys, { scope: "val:read" });
+    const config = oauth(jwks.fetchImpl);
+
+    await verifyValAccessToken(request(token), config);
+    await verifyValAccessToken(request(token), config);
+    await verifyValAccessToken(request(token), config);
+
+    // The cache has to outlive the request or it is not a cache: three calls
+    // that each fetched the issuer's keys would put a round trip on every tool
+    // call.
+    expect(jwks.calls()).toBe(1);
+  });
+
+  test("coalesces concurrent misses into one fetch", async () => {
+    const keys = makeKeys();
+    const jwks = serveJwks([keys.publicJwk]);
+    const token = signToken(keys, { scope: "val:read" });
+    const config = oauth(jwks.fetchImpl);
+
+    const results = await Promise.all([
+      verifyValAccessToken(request(token), config),
+      verifyValAccessToken(request(token), config),
+      verifyValAccessToken(request(token), config),
+    ]);
+
+    expect(results.every((res) => res.status === "ok")).toBe(true);
+    // A cold start serving a burst should not fetch the key set once per
+    // request in flight.
+    expect(jwks.calls()).toBe(1);
+  });
+});

--- a/packages/next/src/server/valAccessToken.ts
+++ b/packages/next/src/server/valAccessToken.ts
@@ -182,7 +182,9 @@ function readKeys(body: unknown): Jwk[] | null {
   if (typeof body !== "object" || body === null || !("keys" in body)) {
     return null;
   }
-  const keys = (body as { keys: unknown }).keys;
+  // `in` narrows the property into the type, so no assertion is needed to read
+  // it — and the `Array.isArray` below is what actually establishes the shape.
+  const keys: unknown = body.keys;
   if (!Array.isArray(keys)) {
     return null;
   }

--- a/packages/next/src/server/valAccessToken.ts
+++ b/packages/next/src/server/valAccessToken.ts
@@ -1,0 +1,456 @@
+import { createPublicKey, verify as cryptoVerify } from "node:crypto";
+import {
+  VAL_SCOPE_READ,
+  authorIdFromVerifiedSubject,
+  type ValToolAuth,
+} from "@valbuild/server";
+
+/**
+ * Verifying an OAuth access token, which is the whole of what makes this app a
+ * resource server rather than a relay.
+ *
+ * The token is issued by Val's authorization server and presented by an MCP
+ * client. This app holds no signing key for it and cannot mint one — it fetches
+ * the issuer's *public* keys and checks a signature. That asymmetry is the
+ * point: a verified `sub` is a fact about the token rather than a claim by
+ * whoever sent it, which is what lets the tools attribute a patch to that
+ * profile at all.
+ *
+ * ## Why this is not `jose`
+ *
+ * `jose` was the first choice and was rejected on a fact rather than a
+ * preference: version 6 is ESM-only (`"type": "module"`, no CJS export). This
+ * package is built by preconstruct and `require`d by Next.js server code, so an
+ * ESM-only dependency here is a runtime failure in consumers' apps, not a build
+ * inconvenience. Adding it would also put a dependency in every install of
+ * `@valbuild/next` for one function.
+ *
+ * The actual cryptography is still not hand-rolled — `node:crypto` does the
+ * ECDSA and the JWK import. What is written here is the JWS envelope and the
+ * claim checks, and the rules that keep that safe are worth stating because
+ * this repository has already shipped the counterexample (`decodeJwt`: `exp`
+ * never checked, a non-constant-time compare, verification skippable):
+ *
+ * - **`alg` is pinned**, not read from the token. The header is only consulted
+ *   for `kid`. A verifier that honours the token's own `alg` can be handed
+ *   `HS256` and will treat the *published* public key as a shared secret.
+ * - **Nothing is read from the payload before the signature verifies.** Claims
+ *   from an unverified token are attacker input.
+ * - **Keys come only from the configured issuer's JWKS**, never from the token.
+ * - **ECDSA JWS signatures are raw `r||s`** (RFC 7518), not DER, which is what
+ *   `dsaEncoding: "ieee-p1363"` below is for. Omit it and every valid signature
+ *   is rejected — or worse, a future change makes it accept the wrong thing.
+ */
+
+export type ValOAuthConfig = {
+  /**
+   * The authorization server, and therefore the expected `iss`.
+   *
+   * Also where the JWKS is fetched from, so it is the one value that decides
+   * which keys can produce a token this app accepts. Configuration, never
+   * request input — a request that could name its own issuer could name its own
+   * key.
+   */
+  issuer: string;
+  /**
+   * This endpoint's absolute URL, and therefore the expected `aud` (RFC 8707).
+   *
+   * Audience binding is what stops a token minted for one Val site being
+   * replayed against another: without it, any deployment the user has access to
+   * would accept a token issued for any other.
+   */
+  resource: string;
+  /**
+   * Clock skew allowance, in seconds.
+   *
+   * Servers disagree about the time by more than you would like, and a token
+   * refused for being a second early is indistinguishable, to the person using
+   * it, from a broken login.
+   */
+  clockToleranceSeconds?: number;
+  /** Test seam. Defaults to the global `fetch`. */
+  fetchImpl?: typeof fetch;
+};
+
+export type ValAccessTokenResult =
+  | { status: "ok"; auth: Extract<ValToolAuth, { type: "verified-profile" }> }
+  | {
+      status: "refused";
+      /** For the `WWW-Authenticate` challenge: RFC 6750 section 3.1. */
+      error: "invalid_request" | "invalid_token" | "insufficient_scope";
+      description: string;
+    };
+
+const DEFAULT_CLOCK_TOLERANCE_SECONDS = 60;
+/** How long a fetched key set is reused before it is fetched again. */
+const JWKS_TTL_MS = 5 * 60 * 1000;
+/**
+ * How long to wait before re-fetching after a failure.
+ *
+ * Shorter than the success TTL so a key rotation recovers quickly, but not zero:
+ * an unreachable issuer must not turn every tool call into another request to
+ * it.
+ */
+const JWKS_ERROR_TTL_MS = 30 * 1000;
+
+type Jwk = {
+  kty?: unknown;
+  crv?: unknown;
+  kid?: unknown;
+  alg?: unknown;
+  use?: unknown;
+  x?: unknown;
+  y?: unknown;
+};
+
+type JwksCacheEntry =
+  | { status: "keys"; keys: Jwk[]; fetchedAtMs: number }
+  | { status: "error"; failedAtMs: number };
+
+/**
+ * One cache per issuer, and it has to outlive the request or it is not a cache:
+ * a fetch per tool call would put a network round trip in front of every read.
+ */
+const jwksCache = new Map<string, JwksCacheEntry>();
+/** Concurrent misses share one fetch rather than starting several. */
+const inFlight = new Map<string, Promise<JwksCacheEntry>>();
+
+/** Test seam: a fresh process would have an empty cache anyway. */
+export function clearValAccessTokenCache(): void {
+  jwksCache.clear();
+  inFlight.clear();
+}
+
+function jwksUrl(issuer: string): string {
+  // Not discovered from the issuer's metadata document, deliberately:
+  // discovery would mean one more request on the hot path and one more thing
+  // that can be pointed elsewhere. The location is fixed by convention and by
+  // Val's own authorization server.
+  return new URL("/.well-known/jwks.json", issuer).toString();
+}
+
+async function loadJwks(
+  config: ValOAuthConfig,
+  nowMs: number,
+): Promise<JwksCacheEntry> {
+  const url = jwksUrl(config.issuer);
+  const cached = jwksCache.get(url);
+  if (cached) {
+    const age =
+      cached.status === "keys"
+        ? nowMs - cached.fetchedAtMs
+        : nowMs - cached.failedAtMs;
+    const ttl = cached.status === "keys" ? JWKS_TTL_MS : JWKS_ERROR_TTL_MS;
+    if (age < ttl) {
+      return cached;
+    }
+  }
+  const existing = inFlight.get(url);
+  if (existing) {
+    return existing;
+  }
+  const fetchImpl = config.fetchImpl ?? fetch;
+  const pending = (async (): Promise<JwksCacheEntry> => {
+    try {
+      const res = await fetchImpl(url, {
+        headers: { accept: "application/json" },
+      });
+      if (!res.ok) {
+        return { status: "error", failedAtMs: nowMs };
+      }
+      const body: unknown = await res.json();
+      const keys = readKeys(body);
+      if (keys === null) {
+        return { status: "error", failedAtMs: nowMs };
+      }
+      return { status: "keys", keys, fetchedAtMs: nowMs };
+    } catch {
+      return { status: "error", failedAtMs: nowMs };
+    }
+  })();
+  inFlight.set(url, pending);
+  try {
+    const entry = await pending;
+    jwksCache.set(url, entry);
+    return entry;
+  } finally {
+    inFlight.delete(url);
+  }
+}
+
+function readKeys(body: unknown): Jwk[] | null {
+  if (typeof body !== "object" || body === null || !("keys" in body)) {
+    return null;
+  }
+  const keys = (body as { keys: unknown }).keys;
+  if (!Array.isArray(keys)) {
+    return null;
+  }
+  return keys.filter(
+    (key): key is Jwk => typeof key === "object" && key !== null,
+  );
+}
+
+/**
+ * Read `Authorization: Bearer …`.
+ *
+ * Exported because the refusal needs to know whether a token was presented at
+ * all: RFC 6750 distinguishes "no credential" — a bare `401`, which is an
+ * invitation to authenticate — from "a bad credential", and a client that gets
+ * the second when it deserved the first will not start the authorization flow.
+ */
+export function readBearerToken(request: Request): string | null {
+  const header = request.headers.get("authorization");
+  if (!header) {
+    return null;
+  }
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
+  const token = match?.[1]?.trim();
+  return token ? token : null;
+}
+
+export async function verifyValAccessToken(
+  request: Request,
+  config: ValOAuthConfig,
+): Promise<ValAccessTokenResult> {
+  const token = readBearerToken(request);
+  if (token === null) {
+    return {
+      status: "refused",
+      error: "invalid_request",
+      description:
+        "This Val MCP endpoint needs an access token. Authorize with the Val authorization server and present it as `Authorization: Bearer`.",
+    };
+  }
+
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    return invalidToken("The access token is not a JWS.");
+  }
+  const [encodedHeader, encodedPayload, encodedSignature] = parts;
+
+  const header = decodeJsonSegment(encodedHeader);
+  if (header === null) {
+    return invalidToken("The access token's header could not be read.");
+  }
+  // Pinned. See the note at the top of this file: honouring the token's own
+  // `alg` is the algorithm-confusion bug, and `ES256` is what Val's
+  // authorization server signs with.
+  if (header.alg !== "ES256") {
+    return invalidToken(
+      "The access token is not signed with ES256, which is the only algorithm this server accepts.",
+    );
+  }
+  const kid = typeof header.kid === "string" ? header.kid : null;
+
+  const nowMs = Date.now();
+  const jwks = await loadJwks(config, nowMs);
+  if (jwks.status === "error") {
+    // Refusing is right — an unverifiable token is not a valid one — but the
+    // message says it may pass, because retrying is the correct client
+    // behaviour here and re-authorizing is not.
+    return invalidToken(
+      "The access token could not be verified because the Val authorization server's keys could not be fetched. This may be temporary.",
+    );
+  }
+
+  const candidates = jwks.keys.filter((key) => isVerifyingP256Key(key, kid));
+  if (candidates.length === 0) {
+    return invalidToken(
+      "The access token was signed with a key the Val authorization server does not publish.",
+    );
+  }
+
+  const signature = decodeBase64Url(encodedSignature);
+  if (signature === null) {
+    return invalidToken("The access token's signature could not be read.");
+  }
+  const signedData = Buffer.from(`${encodedHeader}.${encodedPayload}`, "ascii");
+  // Every published key is tried when the token names no `kid`, so a rotation
+  // that has not yet propagated to clients still verifies. With a `kid` the
+  // filter above leaves one.
+  const verified = candidates.some((key) =>
+    verifyWithJwk(key, signedData, signature),
+  );
+  if (!verified) {
+    return invalidToken("The access token's signature could not be verified.");
+  }
+
+  // Only now: everything below reads the payload, and before this line it was
+  // attacker input.
+  const payload = decodeJsonSegment(encodedPayload);
+  if (payload === null) {
+    return invalidToken("The access token's payload could not be read.");
+  }
+
+  const tolerance =
+    config.clockToleranceSeconds ?? DEFAULT_CLOCK_TOLERANCE_SECONDS;
+  const nowSeconds = Math.floor(nowMs / 1000);
+
+  if (typeof payload.exp !== "number") {
+    // A token with no expiry is not a token, it is a permanent grant.
+    return invalidToken("The access token has no expiry.");
+  }
+  if (payload.exp + tolerance <= nowSeconds) {
+    return invalidToken(
+      "The access token has expired. Refresh it and try again.",
+    );
+  }
+  if (typeof payload.nbf === "number" && payload.nbf - tolerance > nowSeconds) {
+    return invalidToken("The access token is not valid yet.");
+  }
+  if (payload.iss !== config.issuer) {
+    return invalidToken(
+      "The access token was not issued by this server's authorization server (iss claim).",
+    );
+  }
+  if (!audienceMatches(payload.aud, config.resource)) {
+    // The common misconfiguration, and the one worth naming precisely: the fix
+    // is to point the client at the right deployment.
+    return invalidToken(
+      "The access token is not valid for this server (aud claim).",
+    );
+  }
+  const subject = payload.sub;
+  if (typeof subject !== "string" || subject.length === 0) {
+    return invalidToken("The access token has no subject.");
+  }
+
+  const scopes = readScopes(payload.scope);
+  if (!scopes.includes(VAL_SCOPE_READ)) {
+    // Refused here rather than at the first tool: a token with no read scope
+    // cannot do anything at all, so treating it as authenticated would only
+    // move the failure somewhere less legible.
+    return {
+      status: "refused",
+      error: "insufficient_scope",
+      description: `The access token does not have the ${VAL_SCOPE_READ} scope, so it cannot read any content.`,
+    };
+  }
+
+  return {
+    status: "ok",
+    auth: {
+      type: "verified-profile",
+      profileId: authorIdFromVerifiedSubject(subject),
+      scopes,
+    },
+  };
+}
+
+function invalidToken(description: string): ValAccessTokenResult {
+  // Described by class, never by echoing the token or a raw error: a
+  // verification failure message is a place credentials leak into logs.
+  return { status: "refused", error: "invalid_token", description };
+}
+
+/**
+ * `aud` is a string or an array of strings (RFC 7519 section 4.1.3).
+ *
+ * A match on any member is a match, which is the spec's own rule — a token may
+ * legitimately be addressed to several resources.
+ */
+function audienceMatches(claim: unknown, resource: string): boolean {
+  if (typeof claim === "string") {
+    return claim === resource;
+  }
+  if (Array.isArray(claim)) {
+    return claim.some((entry) => entry === resource);
+  }
+  return false;
+}
+
+/**
+ * `scope` is a space-delimited string (RFC 6749 section 3.3).
+ *
+ * Anything else is read as no scopes rather than coerced. A token whose scope
+ * claim is the wrong shape is a token we do not understand, and understanding
+ * it generously is how a write gets authorized by an array someone sent.
+ */
+function readScopes(claim: unknown): string[] {
+  if (typeof claim !== "string") {
+    return [];
+  }
+  return claim.split(" ").filter((scope) => scope.length > 0);
+}
+
+function isVerifyingP256Key(key: Jwk, kid: string | null): boolean {
+  if (key.kty !== "EC" || key.crv !== "P-256") {
+    return false;
+  }
+  if (typeof key.x !== "string" || typeof key.y !== "string") {
+    return false;
+  }
+  // A key published for encryption is not a key to verify signatures with, and
+  // an `alg` that disagrees with what we verify is a key meant for something
+  // else.
+  if (key.use !== undefined && key.use !== "sig") {
+    return false;
+  }
+  if (key.alg !== undefined && key.alg !== "ES256") {
+    return false;
+  }
+  if (kid !== null && typeof key.kid === "string" && key.kid !== kid) {
+    return false;
+  }
+  return true;
+}
+
+function verifyWithJwk(
+  key: Jwk,
+  signedData: Buffer,
+  signature: Buffer,
+): boolean {
+  try {
+    const publicKey = createPublicKey({
+      key: { kty: "EC", crv: "P-256", x: String(key.x), y: String(key.y) },
+      format: "jwk",
+    });
+    return cryptoVerify(
+      "sha256",
+      signedData,
+      // `ieee-p1363` because a JWS ECDSA signature is the raw `r||s` pair, while
+      // node defaults to DER for EC keys. Getting this wrong rejects every
+      // valid signature.
+      { key: publicKey, dsaEncoding: "ieee-p1363" },
+      signature,
+    );
+  } catch {
+    // A malformed key in an otherwise good key set should not take down
+    // verification against the other keys.
+    return false;
+  }
+}
+
+function decodeBase64Url(segment: string | undefined): Buffer | null {
+  if (segment === undefined || !/^[A-Za-z0-9_-]*$/.test(segment)) {
+    return null;
+  }
+  try {
+    return Buffer.from(segment, "base64url");
+  } catch {
+    return null;
+  }
+}
+
+function decodeJsonSegment(
+  segment: string | undefined,
+): Record<string, unknown> | null {
+  const decoded = decodeBase64Url(segment);
+  if (decoded === null) {
+    return null;
+  }
+  try {
+    const parsed: unknown = JSON.parse(decoded.toString("utf8"));
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      return null;
+    }
+    return { ...parsed };
+  } catch {
+    return null;
+  }
+}

--- a/packages/next/src/server/valMcpMetadata.test.ts
+++ b/packages/next/src/server/valMcpMetadata.test.ts
@@ -89,6 +89,23 @@ describe("wwwAuthenticate", () => {
     );
   });
 
+  test("cannot be broken out of by a newline in the description", () => {
+    const header = wwwAuthenticate(OAUTH, SCOPES, {
+      error: "invalid_token",
+      description: "line one\r\nX-Injected: yes",
+    });
+
+    // Response splitting: a CR or LF ends the header line, so an
+    // attacker-influenced description could add a header of its own or a whole
+    // second response. Nothing interpolates request data into these strings
+    // today — this is what keeps that from becoming a vulnerability when
+    // something does.
+    expect(header).not.toContain("\r");
+    expect(header).not.toContain("\n");
+    expect(header).toContain("X-Injected: yes");
+    expect(header.split("\n")).toHaveLength(1);
+  });
+
   test("cannot be broken out of by a quote in the description", () => {
     const header = wwwAuthenticate(OAUTH, SCOPES, {
       error: "invalid_token",

--- a/packages/next/src/server/valMcpMetadata.test.ts
+++ b/packages/next/src/server/valMcpMetadata.test.ts
@@ -1,0 +1,106 @@
+import { createValMcpMetadata, wwwAuthenticate } from "./valMcpMetadata";
+import type { ValOAuthConfig } from "./valAccessToken";
+
+/**
+ * The discovery document and the challenge that points at it.
+ *
+ * Both are small, and both are the kind of small that fails silently: a missing
+ * `resource_metadata` parameter or an unanswered CORS preflight presents to the
+ * user as "this connector cannot authorize", with nothing anywhere to say why.
+ */
+
+const OAUTH: ValOAuthConfig = {
+  issuer: "https://admin.val.build",
+  resource: "https://acme.example.com/api/mcp",
+};
+const SCOPES = ["val:read", "val:write"];
+
+describe("createValMcpMetadata", () => {
+  test("names the resource and its authorization server", async () => {
+    const metadata = createValMcpMetadata(OAUTH, SCOPES);
+
+    const res = metadata.GET(new Request(OAUTH.resource));
+    const body: unknown = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      // The resource identifier a client sends as `resource` and gets back in
+      // `aud`. Same string the verifier checks against, so the two cannot
+      // drift.
+      resource: "https://acme.example.com/api/mcp",
+      authorization_servers: ["https://admin.val.build"],
+      scopes_supported: ["val:read", "val:write"],
+      bearer_methods_supported: ["header"],
+    });
+  });
+
+  test("is readable cross-origin, and answers the preflight", () => {
+    const metadata = createValMcpMetadata(OAUTH, SCOPES);
+
+    const get = metadata.GET(new Request(OAUTH.resource));
+    expect(get.headers.get("access-control-allow-origin")).toBe("*");
+
+    const preflight = metadata.OPTIONS(
+      new Request(OAUTH.resource, { method: "OPTIONS" }),
+    );
+    // Without an answer here the document is never read by a browser-based
+    // client, and the failure appears at authorization rather than at discovery.
+    expect(preflight.status).toBe(204);
+    expect(preflight.headers.get("access-control-allow-origin")).toBe("*");
+    expect(preflight.headers.get("access-control-allow-methods")).toContain(
+      "GET",
+    );
+  });
+
+  test("does not allow credentials alongside the wildcard origin", () => {
+    const metadata = createValMcpMetadata(OAUTH, SCOPES);
+
+    const res = metadata.GET(new Request(OAUTH.resource));
+
+    // `*` with `Allow-Credentials: true` is rejected by browsers outright, so
+    // pairing them would break the very clients this document exists for. The
+    // document is public and is never fetched with credentials.
+    expect(res.headers.get("access-control-allow-credentials")).toBeNull();
+  });
+});
+
+describe("wwwAuthenticate", () => {
+  test("points at the resource metadata document", () => {
+    const header = wwwAuthenticate(OAUTH, SCOPES);
+
+    // The load-bearing parameter: it is how a client that has never seen this
+    // server finds out where to authorize. A 401 without it is a dead end.
+    expect(header).toContain(
+      'resource_metadata="https://acme.example.com/.well-known/oauth-protected-resource"',
+    );
+    expect(header).toContain('scope="val:read val:write"');
+    expect(header.startsWith("Bearer ")).toBe(true);
+  });
+
+  test("carries the error code and description when there is one", () => {
+    const header = wwwAuthenticate(OAUTH, SCOPES, {
+      error: "invalid_token",
+      description: "The access token has expired.",
+    });
+
+    expect(header).toContain('error="invalid_token"');
+    expect(header).toContain(
+      'error_description="The access token has expired."',
+    );
+  });
+
+  test("cannot be broken out of by a quote in the description", () => {
+    const header = wwwAuthenticate(OAUTH, SCOPES, {
+      error: "invalid_token",
+      description: 'unexpected " and \\ characters',
+    });
+
+    // A quote would end the parameter early and produce a header some clients
+    // reject outright — so the value is stripped rather than trusted to be
+    // well-behaved.
+    expect(header).toContain('error_description="unexpected  and  characters"');
+    // Two quotes per parameter and four parameters: resource_metadata, scope,
+    // error, error_description. Anything else means a value closed early.
+    expect(header.match(/"/g)?.length).toBe(8);
+  });
+});

--- a/packages/next/src/server/valMcpMetadata.ts
+++ b/packages/next/src/server/valMcpMetadata.ts
@@ -1,0 +1,118 @@
+import type { ValOAuthConfig } from "./valAccessToken";
+
+/**
+ * The one document an MCP client needs before it can authorize: RFC 9728
+ * Protected Resource Metadata, served by the *resource* server.
+ *
+ * This is how a client discovers where to authorize. It asks the resource — this
+ * app — and the resource names its authorization server. Which is why this
+ * belongs here and the RFC 8414 *authorization server* metadata does not: that
+ * document lives at the issuer, describes the issuer's own endpoints, and is
+ * served by the issuer. An app serving a copy would be asserting the issuer's
+ * configuration on its behalf, and would be wrong the moment the issuer changed
+ * anything.
+ *
+ * The flow, so the split reads as a whole:
+ *
+ * 1. client → `{app}/api/mcp` with no token → `401` naming this document
+ * 2. client → `{app}/.well-known/oauth-protected-resource` → the issuer
+ * 3. client → `{issuer}/.well-known/oauth-authorization-server` → endpoints
+ * 4. client → issuer's `/authorize`, then `/token`
+ * 5. client → `{app}/api/mcp` with the token
+ */
+
+export type ValMcpMetadataHandlers = {
+  /** The metadata document. */
+  GET: (request: Request) => Response;
+  /**
+   * The CORS preflight.
+   *
+   * Required rather than defensive: the metadata document is fetched
+   * cross-origin by browser-based clients, and without a preflight answer the
+   * fetch fails before the document is read — which presents as "this connector
+   * cannot authorize" with nothing in any log to explain it.
+   */
+  OPTIONS: (request: Request) => Response;
+};
+
+const CORS_HEADERS: Record<string, string> = {
+  // The document is public and contains no secrets — it exists to be read by
+  // clients whose origin we cannot know in advance, so `*` is the correct value
+  // rather than a lazy one. Note there is no `Access-Control-Allow-Credentials`:
+  // with it, `*` would be rejected by browsers, and this document is never
+  // fetched with credentials.
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers":
+    "Content-Type, Authorization, MCP-Protocol-Version",
+  "Access-Control-Max-Age": "3600",
+};
+
+export function createValMcpMetadata(
+  oauth: ValOAuthConfig,
+  scopesSupported: string[],
+): ValMcpMetadataHandlers {
+  const document = {
+    // The resource identifier, which MUST be the value clients send as
+    // `resource` and the value that arrives back in `aud`. Same string as the
+    // audience this app verifies against — one value, so the two cannot drift.
+    resource: oauth.resource,
+    authorization_servers: [oauth.issuer],
+    scopes_supported: scopesSupported,
+    bearer_methods_supported: ["header"],
+  };
+  const body = JSON.stringify(document);
+
+  return {
+    GET(): Response {
+      return new Response(body, {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          // Cacheable: it changes only when the app is reconfigured, and a
+          // client that re-reads it on every authorization costs a round trip
+          // for nothing.
+          "Cache-Control": "public, max-age=3600",
+          ...CORS_HEADERS,
+        },
+      });
+    },
+    OPTIONS(): Response {
+      return new Response(null, { status: 204, headers: CORS_HEADERS });
+    },
+  };
+}
+
+/**
+ * The `WWW-Authenticate` value for a refusal (RFC 6750 section 3, RFC 9728
+ * section 5.1).
+ *
+ * `resource_metadata` is the load-bearing parameter: it is how a client that has
+ * never seen this server learns where to authorize. A `401` without it is a dead
+ * end — the client knows it needs a token and has no way to find out from where.
+ */
+export function wwwAuthenticate(
+  oauth: ValOAuthConfig,
+  scopesSupported: string[],
+  refusal?: { error: string; description: string },
+): string {
+  const metadataUrl = new URL(
+    "/.well-known/oauth-protected-resource",
+    oauth.resource,
+  ).toString();
+  const params = [
+    `resource_metadata="${metadataUrl}"`,
+    `scope="${scopesSupported.join(" ")}"`,
+  ];
+  if (refusal) {
+    params.push(`error="${refusal.error}"`);
+    // Quoted-string, so a quote or a backslash in the description would end the
+    // parameter early and produce a header a client may reject outright. The
+    // descriptions here are ours and contain neither, but that is a property of
+    // today's strings rather than of the type.
+    params.push(
+      `error_description="${refusal.description.replace(/["\\]/g, "")}"`,
+    );
+  }
+  return `Bearer ${params.join(", ")}`;
+}

--- a/packages/next/src/server/valMcpMetadata.ts
+++ b/packages/next/src/server/valMcpMetadata.ts
@@ -106,13 +106,29 @@ export function wwwAuthenticate(
   ];
   if (refusal) {
     params.push(`error="${refusal.error}"`);
-    // Quoted-string, so a quote or a backslash in the description would end the
-    // parameter early and produce a header a client may reject outright. The
-    // descriptions here are ours and contain neither, but that is a property of
-    // today's strings rather than of the type.
-    params.push(
-      `error_description="${refusal.description.replace(/["\\]/g, "")}"`,
-    );
+    params.push(`error_description="${headerSafe(refusal.description)}"`);
   }
   return `Bearer ${params.join(", ")}`;
+}
+
+/**
+ * Make a string safe to put inside a quoted header parameter.
+ *
+ * Three classes go, and the third is the one that matters most:
+ *
+ * - a **quote** would close the parameter early;
+ * - a **backslash** would start an escape the rest of the value does not
+ *   finish;
+ * - a **CR or LF** would end the header line, which is response splitting — an
+ *   attacker-influenced description could inject a header of their own, or a
+ *   whole second response.
+ *
+ * The descriptions passed here today are all literals from this package and
+ * contain none of it. That is a property of today's callers rather than of the
+ * type, and this function exists so it stays true when a future one interpolates
+ * something from a request.
+ */
+function headerSafe(value: string): string {
+  // eslint-disable-next-line no-control-regex -- the point is to remove them
+  return value.replace(/["\\]/g, "").replace(/[\u0000-\u001f\u007f]/g, " ");
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -5,7 +5,16 @@ export { createValApiRouter, createValServer, safeReadGit } from "./ValRouter";
 // browser. Nothing under `tools/` imports an MCP SDK, and the host that does
 // adapts `ValToolResult` at its own edge.
 export { createValTools } from "./tools";
+// The scope names and the one legitimate way to brand a verified subject: a
+// host that verifies an access token itself needs both, and neither should be
+// re-spelled at the edge where getting it wrong is a silent authorization bug.
+export {
+  VAL_SCOPE_READ,
+  VAL_SCOPE_WRITE,
+  authorIdFromVerifiedSubject,
+} from "./tools";
 export type {
+  ValToolAuth,
   ValToolContext,
   ValToolDefinition,
   ValToolDefinitionJson,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -14,6 +14,7 @@ export {
   authorIdFromVerifiedSubject,
 } from "./tools";
 export type {
+  ValScope,
   ValToolAuth,
   ValToolContext,
   ValToolDefinition,

--- a/packages/server/src/tools/createValTools.test.ts
+++ b/packages/server/src/tools/createValTools.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import type { ValServerConfig } from "../ValServer";
 import { createValTools } from "./createValTools";
+import { authorIdFromVerifiedSubject } from "./types";
 import type { ValToolContext, ValTools } from "./types";
 
 /**
@@ -17,9 +18,20 @@ import type { ValToolContext, ValTools } from "./types";
 
 const NO_AUTH: ValToolContext = { auth: null, sessionId: null };
 const WITH_PAT: ValToolContext = {
-  auth: { pat: "pat-not-a-real-token" },
+  auth: { type: "pat", pat: "pat-not-a-real-token" },
   sessionId: null,
 };
+
+function verified(...scopes: string[]): ValToolContext {
+  return {
+    auth: {
+      type: "verified-profile",
+      profileId: authorIdFromVerifiedSubject("profile-123"),
+      scopes,
+    },
+    sessionId: null,
+  };
+}
 
 function fsTools(): ValTools {
   const { config } = initVal();
@@ -106,5 +118,90 @@ describe("authorization", () => {
     const res = await fsTools().call("get_all_schema", {}, NO_AUTH);
 
     expect(res).toEqual({ status: "ok", data: {} });
+  });
+});
+
+describe("scopes", () => {
+  test("a write is refused when the token may only read", async () => {
+    const res = await httpTools().call(
+      "create_patch",
+      { moduleFilePath: "/test/pages.val.ts", patch: [] },
+      verified("val:read"),
+    );
+
+    // Refused here rather than by the backend, and that is the point of
+    // checking twice: a token that may only read never reaches the code that
+    // builds a patch.
+    expect(res).toEqual({
+      status: "error",
+      code: "forbidden",
+      message: expect.stringContaining("val:write"),
+    });
+  });
+
+  test("a write is allowed past the gate when the token has val:write", async () => {
+    const res = await httpTools().call(
+      "create_patch",
+      { moduleFilePath: "/test/pages.val.ts", patch: [] },
+      verified("val:read", "val:write"),
+    );
+
+    // It still fails — the backend URL is deliberately unreachable — but the
+    // failure must not be the authorization gate, or this test would pass just
+    // as well with the gate refusing everything.
+    expect(res.status).toBe("error");
+    expect(res.status === "error" && res.code).not.toBe("forbidden");
+  });
+
+  test("a read is allowed past the gate with only val:read", async () => {
+    const res = await httpTools().call(
+      "get_all_schema",
+      {},
+      verified("val:read"),
+    );
+
+    expect(res.status === "error" && res.code).not.toBe("forbidden");
+  });
+
+  test("the message says what was granted, so the fix is visible", async () => {
+    const res = await httpTools().call(
+      "create_patch",
+      { moduleFilePath: "/test/pages.val.ts", patch: [] },
+      verified("val:read"),
+    );
+
+    expect(res.status === "error" && res.message).toContain("val:read");
+  });
+
+  test("fs mode refuses a verified profile too", async () => {
+    const res = await fsTools().call(
+      "get_all_schema",
+      {},
+      verified("val:read", "val:write"),
+    );
+
+    // Same reasoning as the PAT case: a host that believes it is
+    // authenticating must not silently get direct filesystem access, and which
+    // *kind* of credential it holds does not change that.
+    expect(res).toEqual({
+      status: "error",
+      code: "unsupported",
+      message: expect.stringContaining("local filesystem mode"),
+    });
+  });
+
+  test("a PAT is not scope-checked here", async () => {
+    // A PAT carries no scopes in this process: the backend resolves it and
+    // decides. Inventing a default would be this app claiming an authority it
+    // does not have — so the gate must not refuse a write on a PAT for want of
+    // a scope it was never given.
+    const res = await httpTools().call(
+      "create_patch",
+      { moduleFilePath: "/test/pages.val.ts", patch: [] },
+      WITH_PAT,
+    );
+
+    expect(res.status).toBe("error");
+    expect(res.status === "error" && res.code).not.toBe("forbidden");
   });
 });

--- a/packages/server/src/tools/createValTools.test.ts
+++ b/packages/server/src/tools/createValTools.test.ts
@@ -173,6 +173,35 @@ describe("scopes", () => {
     expect(res.status === "error" && res.message).toContain("val:read");
   });
 
+  test("a read is refused when the token has write but not read", async () => {
+    const res = await httpTools().call(
+      "get_all_schema",
+      {},
+      verified("val:write"),
+    );
+
+    // Every call needs read, the writes included. The verifier refuses such a
+    // token before it reaches here, but `createValTools` is exported and
+    // another host may not — so the gate does not rely on that.
+    expect(res).toEqual({
+      status: "error",
+      code: "forbidden",
+      message: expect.stringContaining("val:read"),
+    });
+  });
+
+  test("a write needs both scopes, not just the wider one", async () => {
+    const res = await httpTools().call(
+      "create_patch",
+      { moduleFilePath: "/test/pages.val.ts", patch: [] },
+      verified("val:write"),
+    );
+
+    expect(res.status === "error" && res.code).toBe("forbidden");
+    // Names both, so the fix is not a guessing game.
+    expect(res.status === "error" && res.message).toContain("val:read");
+  });
+
   test("fs mode refuses a verified profile too", async () => {
     const res = await fsTools().call(
       "get_all_schema",

--- a/packages/server/src/tools/createValTools.ts
+++ b/packages/server/src/tools/createValTools.ts
@@ -7,12 +7,14 @@ import type { ValOps } from "../ValOps";
 import type { ValToolDeps, ValToolImpl, ValToolState } from "./defineTool";
 import { readTools } from "./readTools";
 import { writeTools } from "./writeTools";
-import type {
-  ValToolContext,
-  ValToolDefinition,
-  ValToolDefinitionJson,
-  ValToolResult,
-  ValTools,
+import {
+  VAL_SCOPE_READ,
+  VAL_SCOPE_WRITE,
+  type ValToolContext,
+  type ValToolDefinition,
+  type ValToolDefinitionJson,
+  type ValToolResult,
+  type ValTools,
 } from "./types";
 
 export type ValToolsOptions = ValServerConfig;
@@ -88,6 +90,11 @@ export function createValTools(
           code: "invalid-args",
           message: describeZodError(parsed.error),
         };
+      }
+
+      const insufficient = refuseInsufficientScope(tool, ctx);
+      if (insufficient) {
+        return insufficient;
       }
 
       const resolved = resolveOps(ctx);
@@ -173,6 +180,13 @@ function createOpsResolver(
   // instance holds the token regardless — but it keeps credentials out of the
   // key set, which is the thing that ends up in a heap dump or an error dump.
   const byPatHash = new Map<string, ValOps>();
+  /**
+   * One instance for every verified caller, and unlike the PAT map that is
+   * correct rather than a shortcut: this instance authenticates with the app's
+   * own API key, so there is nothing per-caller in it to keep apart. Who did
+   * what travels as the patch's `authorId` instead — see `writePath`.
+   */
+  let sharedOps: ValOps | null = null;
 
   return (ctx) => {
     if (!ctx.auth) {
@@ -182,9 +196,29 @@ function createOpsResolver(
           status: "error",
           code: "forbidden",
           message:
-            "This Val project talks to the Val content backend, so every call needs the caller's own personal access token. Run `val login` to get one.",
+            "This Val project talks to the Val content backend, so every call needs a credential: an access token from the Val authorization server, or the caller's own personal access token from `val login`.",
         },
       };
+    }
+    if (ctx.auth.type === "verified-profile") {
+      if (!options.apiKey) {
+        // Proxy mode is inferred from the api key being present, so this is
+        // unreachable through `initHandlerOptions`. It stays because the
+        // alternative to refusing is building ops with no credential at all.
+        return {
+          status: "error",
+          result: {
+            status: "error",
+            code: "forbidden",
+            message:
+              "This Val project has no API key configured, so a verified access token cannot be exchanged for backend access.",
+          },
+        };
+      }
+      if (!sharedOps) {
+        sharedOps = createValOps(valModules, options);
+      }
+      return { status: "ok", ops: sharedOps };
     }
     const key = createHash("sha256").update(ctx.auth.pat).digest("hex");
     const cached = byPatHash.get(key);
@@ -305,4 +339,39 @@ function describeZodError(error: z.ZodError): string {
       return path ? `${path}: ${issue.message}` : issue.message;
     })
     .join("; ");
+}
+
+/**
+ * Refuse a call the token was not granted, before anything is attempted.
+ *
+ * Derived from `readOnlyHint` rather than from a second list of tool names,
+ * because a second list is a thing that drifts. The derivation also fails in
+ * the safe direction: a tool that forgets the hint is treated as a write and
+ * demands the wider scope, rather than a write slipping through as a read.
+ *
+ * Only the verified-token path is checked. A PAT carries no scopes here by
+ * design — the backend resolves it and decides — so there is nothing to
+ * enforce, and inventing a default would be this app claiming an authority it
+ * does not have.
+ */
+function refuseInsufficientScope(
+  tool: ValToolDefinition,
+  ctx: ValToolContext,
+): ValToolResult | null {
+  if (ctx.auth?.type !== "verified-profile") {
+    return null;
+  }
+  const needed = tool.annotations?.readOnlyHint
+    ? VAL_SCOPE_READ
+    : VAL_SCOPE_WRITE;
+  if (ctx.auth.scopes.includes(needed)) {
+    return null;
+  }
+  return {
+    status: "error",
+    code: "forbidden",
+    message: `This access token does not have the ${needed} scope, which ${tool.name} requires. Granted: ${
+      ctx.auth.scopes.length > 0 ? ctx.auth.scopes.join(" ") : "(none)"
+    }.`,
+  };
 }

--- a/packages/server/src/tools/createValTools.ts
+++ b/packages/server/src/tools/createValTools.ts
@@ -10,6 +10,7 @@ import { writeTools } from "./writeTools";
 import {
   VAL_SCOPE_READ,
   VAL_SCOPE_WRITE,
+  type ValScope,
   type ValToolContext,
   type ValToolDefinition,
   type ValToolDefinitionJson,
@@ -361,17 +362,26 @@ function refuseInsufficientScope(
   if (ctx.auth?.type !== "verified-profile") {
     return null;
   }
-  const needed = tool.annotations?.readOnlyHint
-    ? VAL_SCOPE_READ
-    : VAL_SCOPE_WRITE;
-  if (ctx.auth.scopes.includes(needed)) {
+  // Read is needed by every call, including the writes: a tool that changes
+  // content reads it first, and `ValToolAuth` says as much. Checking only the
+  // wider scope would let a write-but-not-read token through here — today's
+  // verifier refuses such a token before this point, but `createValTools` is
+  // exported and another host may not.
+  const needed: ValScope[] = tool.annotations?.readOnlyHint
+    ? [VAL_SCOPE_READ]
+    : [VAL_SCOPE_READ, VAL_SCOPE_WRITE];
+  const granted = ctx.auth.scopes;
+  const missing = needed.filter((scope) => !granted.includes(scope));
+  if (missing.length === 0) {
     return null;
   }
   return {
     status: "error",
     code: "forbidden",
-    message: `This access token does not have the ${needed} scope, which ${tool.name} requires. Granted: ${
-      ctx.auth.scopes.length > 0 ? ctx.auth.scopes.join(" ") : "(none)"
+    message: `This access token does not have the ${missing.join(
+      " and ",
+    )} scope, which ${tool.name} requires. Granted: ${
+      granted.length > 0 ? granted.join(" ") : "(none)"
     }.`,
   };
 }

--- a/packages/server/src/tools/index.ts
+++ b/packages/server/src/tools/index.ts
@@ -1,5 +1,11 @@
 export { createValTools, type ValToolsOptions } from "./createValTools";
+export {
+  VAL_SCOPE_READ,
+  VAL_SCOPE_WRITE,
+  authorIdFromVerifiedSubject,
+} from "./types";
 export type {
+  ValToolAuth,
   ValToolContext,
   ValToolDefinition,
   ValToolDefinitionJson,

--- a/packages/server/src/tools/index.ts
+++ b/packages/server/src/tools/index.ts
@@ -5,6 +5,7 @@ export {
   authorIdFromVerifiedSubject,
 } from "./types";
 export type {
+  ValScope,
   ValToolAuth,
   ValToolContext,
   ValToolDefinition,

--- a/packages/server/src/tools/types.ts
+++ b/packages/server/src/tools/types.ts
@@ -1,3 +1,4 @@
+import type { AuthorId } from "../ValOps";
 import type { Json } from "@valbuild/core";
 import type { z } from "zod";
 
@@ -79,14 +80,59 @@ export type ValToolDefinitionJson = Omit<ValToolDefinition, "inputSchema"> & {
 };
 
 /**
- * Who is calling, established once per request by the host.
+ * How the caller was established, and it is a union because there are two
+ * genuinely different answers — with different consequences downstream.
  *
- * There is deliberately no identity field here, only the credential. In proxy
- * mode the caller's own personal access token authenticates every downstream
- * call, so the backend decides who the caller is (`docs/plans/mcp.md` D.2). An
- * `authorId` alongside it would have to be filled in by the host, and the host
- * has no way to verify a PAT — so the field would be an unverified claim that
- * looks like a checked one, which is the confused-deputy shape D.6 rejects.
+ * The distinction that matters is **who checked**. A PAT is forwarded to the
+ * backend unchecked, because the app cannot resolve one; an access token is
+ * verified by the app itself, against a public key it does not hold and
+ * therefore cannot forge. The first is a credential being relayed. The second
+ * is a signature that has already been checked.
+ */
+export type ValToolAuth =
+  | {
+      type: "pat";
+      /**
+       * The caller's PAT. Never log this, never put it in a URL, and never let
+       * it reach a tool result.
+       *
+       * Relayed to the backend as-is: this app is not the authority on what the
+       * token may do, and the backend that is decides. Nothing is derived from
+       * it here — see `docs/plans/mcp.md` D.2.
+       */
+      pat: string;
+    }
+  | {
+      type: "verified-profile";
+      /**
+       * The profile the host **verified** — the `sub` of an access token whose
+       * signature, issuer, audience and expiry were all checked against the
+       * authorization server's published key.
+       *
+       * This field is the reason this type became a union, and an earlier
+       * version of this file argued no identity field should exist at all. That
+       * argument was about a specific case and stated too broadly: an id the
+       * host *asserts* on the strength of a credential it cannot check is an
+       * unverified claim dressed as a checked one, and that is still refused —
+       * it is why the `pat` variant carries no profile. An id the host
+       * *verified* cryptographically is a different thing, and it is the same
+       * standing the Studio has when it re-signs a session it established
+       * itself.
+       */
+      profileId: AuthorId;
+      /**
+       * The token's granted scopes, as the authorization server issued them.
+       *
+       * Enforced here as well as by the backend, deliberately. Two checks on
+       * one grant is not redundancy for its own sake: this one can refuse a
+       * write before it is attempted, so a token that may only read never
+       * reaches the code that builds a patch.
+       */
+      scopes: string[];
+    };
+
+/**
+ * Who is calling, established once per request by the host.
  *
  * `null` means local fs mode, where there is no credential to hold and patches
  * are written with no author, exactly as the Studio does locally (D.1). In
@@ -95,16 +141,32 @@ export type ValToolDefinitionJson = Omit<ValToolDefinition, "inputSchema"> & {
  * would turn a missing credential into full access.
  */
 export type ValToolContext = {
-  auth: {
-    /**
-     * The caller's PAT. Never log this, never put it in a URL, and never let
-     * it reach a tool result.
-     */
-    pat: string;
-  } | null;
+  auth: ValToolAuth | null;
   /** Groups a run of related edits, when the host has such a notion. */
   sessionId: string | null;
 };
+
+/**
+ * Brand a verified subject as an {@link AuthorId}.
+ *
+ * `AuthorId` is a branded string so that an id cannot be conjured from any
+ * string that happens to be lying around — which is exactly the mistake this
+ * type is guarding against. That makes one assertion unavoidable at the boundary
+ * where a real id enters the system, so it lives here, once, with a name that
+ * says what makes it legitimate: the caller has *verified* this subject, not
+ * received it.
+ *
+ * Do not reach for this to satisfy a type. If you are holding a string you did
+ * not verify, the honest value is `null`.
+ */
+export function authorIdFromVerifiedSubject(subject: string): AuthorId {
+  return subject as AuthorId;
+}
+
+/** Read access. Every call needs it, including the read-only ones. */
+export const VAL_SCOPE_READ = "val:read";
+/** Write access. Needed by any tool not marked `readOnlyHint`. */
+export const VAL_SCOPE_WRITE = "val:write";
 
 export type ValToolResult =
   | { status: "ok"; data: Json }

--- a/packages/server/src/tools/types.ts
+++ b/packages/server/src/tools/types.ts
@@ -163,10 +163,12 @@ export function authorIdFromVerifiedSubject(subject: string): AuthorId {
   return subject as AuthorId;
 }
 
-/** Read access. Every call needs it, including the read-only ones. */
+/** Read access. Every call needs it, the writes included. */
 export const VAL_SCOPE_READ = "val:read";
-/** Write access. Needed by any tool not marked `readOnlyHint`. */
+/** Write access. Needed *in addition* by any tool not marked `readOnlyHint`. */
 export const VAL_SCOPE_WRITE = "val:write";
+
+export type ValScope = typeof VAL_SCOPE_READ | typeof VAL_SCOPE_WRITE;
 
 export type ValToolResult =
   | { status: "ok"; data: Json }

--- a/packages/server/src/tools/writePath.ts
+++ b/packages/server/src/tools/writePath.ts
@@ -308,13 +308,25 @@ export async function savePatch(
     unresolved = speculative.errors;
   }
 
-  // Always null, and deliberately so. The app cannot resolve a PAT to a
-  // profile, so any id it put here would be an unverified claim dressed up as a
-  // checked one — and the request already carries the caller's own token, which
-  // is a better answer to "who did this" than anything the app could assert.
-  // Attributing the patch from that token is a backend concern; see
-  // `docs/plans/mcp.md` D.3.
-  const authorId = null;
+  /**
+   * Null on the PAT path, and the verified profile on the token path.
+   *
+   * The PAT case is unchanged and still deliberate: the app cannot resolve a
+   * PAT, so any id it wrote here would be an unverified claim dressed up as a
+   * checked one — and the request already carries the caller's own token, which
+   * is a better answer to "who did this" than anything the app could assert.
+   * Attributing that patch is the backend's job.
+   *
+   * The token case is the opposite situation, which is why it gets the opposite
+   * answer. The host verified a signature over a key it does not hold, so the
+   * profile is checked rather than claimed, and the backend has no token of its
+   * own to attribute from — the call reaches it under the app's API key. If this
+   * stayed null, every edit made through a signed-in editor's own session would
+   * land with no author at all, which is worse than useless on a CMS whose
+   * review screen is organised by who changed what.
+   */
+  const authorId =
+    ctx.auth?.type === "verified-profile" ? ctx.auth.profileId : null;
   for (let attempt = 0; attempt < 2; attempt++) {
     const patchId = mintPatchId();
     // Re-derived on the retry rather than reused: reusing the ref that just


### PR DESCRIPTION
The resource-server half of moving MCP authorization to Val's own authorization server. **Nothing here issues a token** — this is the side that checks one, which is what turns `/api/mcp` from a credential relay into a resource server.

Inert until configured: leave `oauth` out and the endpoint behaves exactly as it does today.

```ts
const { valMcpAuthorize, valMcpTools, valMcpMetadata } = initValMcp(
  valModules,
  config,
  { oauth: { issuer: "https://admin.val.build", resource: "https://app.com/api/mcp" } },
);
```

## What a verified token buys, and why it is a change of kind

A PAT is relayed unread: the app cannot resolve one, so any identity it attached would be a claim dressed as a fact — which is why `authorId` was hardcoded to `null`. A signature verified against a key the app **does not hold** is different in kind, because the profile has been *checked*.

So `ValToolContext.auth` becomes a tagged union, and on the verified variant patches are attributed to that profile. This matters concretely: without it, an edit made by a signed-in editor from their phone lands with no author at all — worse than useless on a CMS whose review screen is organised by who changed what.

`types.ts` previously argued no identity field should exist. That argument was right about its case and stated too broadly. The comment now says which case is which, and the PAT variant still carries no profile.

## Scopes are enforced twice, deliberately

The backend will enforce them too. This check earns its place by being *earlier*: a token that may only read never reaches the code that builds a patch. Which tools need `val:write` is derived from `readOnlyHint` rather than a second list of tool names — a second list drifts — and the derivation fails safe, so a tool that forgets the hint is treated as a write.

## Not `jose`, and not by preference

`jose` was the first pick and is ESM-only at v6. This package is built by preconstruct and `require`d by Next.js server code, so an ESM-only dependency is a runtime failure in consumers' apps rather than a build inconvenience — and it would add a dependency to every install of `@valbuild/next` for one function. **Net new dependencies: none.**

`node:crypto` does the ECDSA and the JWK import; what is written here is the JWS envelope and the claim checks. The rules that keep that honest are stated at the top of the file, because this repository has already shipped the counterexample (`decodeJwt`: `exp` never checked, non-constant-time compare, verification skippable):

- **`alg` is pinned**, never read from the token — the header is consulted only for `kid`.
- **Nothing is read from the payload before the signature verifies.**
- **Keys come only from the configured issuer's JWKS**, never from the token.

The detail that would otherwise cost an afternoon: a JWS ECDSA signature is the raw `r||s` pair, not DER, so `dsaEncoding: "ieee-p1363"` is load bearing — omit it and every valid signature is rejected.

## Discovery

`valMcpMetadata` serves the RFC 9728 protected-resource document, with the CORS preflight — without an answer to that preflight the document is never read and the failure presents as "this connector cannot authorize" with nothing in any log. The RFC 8414 *authorization server* metadata is deliberately **not** served here: that document describes the issuer's endpoints and belongs at the issuer.

Refusals carry `WWW-Authenticate` with `resource_metadata`, which is how a client that has never seen this server learns where to authorize. `401` for a missing or bad token, `403` for insufficient scope — sending the wrong one puts a client in a loop.

## Verification

Full local CI: `lint`, `prettier --check`, recursive typecheck, **243 suites / 3068 tests**, root `build`, and the `examples/next` build — which also proves the `.well-known` route mounts in this Next version rather than assuming it does (it appears in the built route table).

**38 new tests**, aimed at the cases where a *wrong* verifier says yes: a token signed by a key the issuer does not publish, a payload swapped after signing, one minted for another deployment, one from another issuer, an expired one, one with **no expiry at all**, `alg: none`, and HS256 signed with the published public key. Real keypairs, real signatures; only the network is faked.

Also covered: audience arrays, clock-skew tolerance, key rotation with two published keys, one JWKS fetch across many calls, and concurrent misses coalescing into one fetch.

**Not covered by a test:** attribution end to end. There is no authorization server issuing tokens yet, so that becomes testable when the backend side lands.

## Next

This is P1 of the admin-as-AS plan. P2 (scopes derived from `member_role` and enforced in the content API) and P3/P4 (signing keys, JWKS, grants store) are backend work and land separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WM94UH5zxHP3yFoKdyvXaL

---
_Generated by [Claude Code](https://claude.ai/code/session_01WM94UH5zxHP3yFoKdyvXaL)_