### PR TITLE
Add links from Studio to Val Build admin app

### DIFF
--- a/.changeset/studio-links-to-val-build.md
+++ b/.changeset/studio-links-to-val-build.md
@@ -1,0 +1,25 @@
+---
+"@valbuild/ui": patch
+---
+
+The Studio now links out to the project in Val Build.
+
+Val edits content; everything else about a project — who can edit it, its API
+keys, its versions, its subscription — lives at
+[admin.val.build](https://admin.val.build), and there was no way to get from
+one to the other. You had to know the URL, or find the project again from the
+front page.
+
+Two ways there now:
+
+- **The project name in the top bar is a link.** It opens the project's own
+  page in Val Build, in a new tab, since leaving the Studio would mean leaving
+  whatever is being edited in it.
+- **Settings has a Project section**, with **Administer project** — the same
+  page — and **Manage members**, which opens the organisation's member list.
+
+Both hang off `project` in `val.config`, which is `"<org>/<project>"`. A
+project that has not been connected to Val Build — no `project`, or one that is
+not in that form — has no page to open, so the name stays a plain label and the
+Settings section is not shown at all, rather than offering a link that lands on
+a sign-in for an organisation you may not be in.

--- a/packages/ui/spa/components/shell/SettingsPanel.tsx
+++ b/packages/ui/spa/components/shell/SettingsPanel.tsx
@@ -1,12 +1,20 @@
 import { ReactNode } from "react";
-import { LogOut, Moon, Sun } from "lucide-react";
+import {
+  ExternalLink,
+  LogOut,
+  LucideIcon,
+  Moon,
+  Settings2,
+  Sun,
+  Users,
+} from "lucide-react";
 import { cn } from "../designSystem/cn";
 import { Checkbox } from "../designSystem/checkbox";
 import { FloatingPanel, PanelSectionLabel } from "./FloatingPanel";
 import { Avatar } from "./Avatar";
 import { AccountErrorNotice, ShellAccountError } from "./AccountError";
 import { DeploymentRows } from "./Deployments";
-import { ShellBreakpoint, ShellDeployment } from "./types";
+import { ShellAdminLinks, ShellBreakpoint, ShellDeployment } from "./types";
 
 export type SettingsPanelProps = {
   breakpoint: ShellBreakpoint;
@@ -21,6 +29,14 @@ export type SettingsPanelProps = {
   accountError?: ShellAccountError;
   theme: "dark" | "light";
   onThemeChange: (theme: "dark" | "light") => void;
+  /**
+   * The project's pages in Val Build.
+   *
+   * Absent for a project that is not connected to Val Build: there is no
+   * project to administer and no organisation to have members, so the section
+   * goes rather than showing two links to a sign-in page.
+   */
+  admin?: ShellAdminLinks;
   /** How Val is running. Auto save is a dev-server setting; see `StatusBar`. */
   mode?: "fs" | "http" | "unknown";
   autoSave: boolean;
@@ -54,6 +70,7 @@ export function SettingsPanel({
   accountError,
   theme,
   onThemeChange,
+  admin,
   mode,
   autoSave,
   onAutoSaveChange,
@@ -118,6 +135,26 @@ export function SettingsPanel({
           </div>
         </div>
 
+        {admin && (
+          <>
+            <PanelSectionLabel divided>Project</PanelSectionLabel>
+            <div className="px-4 pt-1 space-y-1.5">
+              <AdminLink
+                href={admin.project}
+                icon={Settings2}
+                label="Administer project"
+                description="Settings, API keys and versions in Val Build."
+              />
+              <AdminLink
+                href={admin.members}
+                icon={Users}
+                label="Manage members"
+                description="Who can edit this project's content."
+              />
+            </div>
+          </>
+        )}
+
         <PanelSectionLabel divided>Workspace</PanelSectionLabel>
         <div className="px-4 pt-1 space-y-2.5">
           {/* `fs` only, for the reason given in `StatusBar`. */}
@@ -163,6 +200,42 @@ export function SettingsPanel({
         )}
       </div>
     </FloatingPanel>
+  );
+}
+
+/**
+ * A way out to Val Build, in a new tab.
+ *
+ * A new tab rather than a navigation: leaving the Studio means leaving
+ * whatever is being edited in it, and unsaved work lives in the page.
+ */
+function AdminLink({
+  href,
+  icon: Icon,
+  label,
+  description,
+}: {
+  href: string;
+  icon: LucideIcon;
+  label: string;
+  description: string;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex items-start gap-2 -mx-2 px-2 py-1.5 rounded-md text-fg-secondary hover:bg-bg-float-raised hover:text-fg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
+    >
+      <Icon size={13} className="mt-0.5 shrink-0" />
+      <span className="min-w-0 flex-1">
+        <span className="block text-xs text-fg-primary">{label}</span>
+        <span className="block text-[0.6875rem] text-fg-secondary-alt">
+          {description}
+        </span>
+      </span>
+      <ExternalLink size={11} className="mt-0.5 shrink-0" />
+    </a>
   );
 }
 

--- a/packages/ui/spa/components/shell/Shell.tsx
+++ b/packages/ui/spa/components/shell/Shell.tsx
@@ -807,6 +807,7 @@ export function Shell({
       <TopBar
         breakpoint={breakpoint}
         projectName={data.projectName}
+        projectHref={data.admin?.project}
         openPanel={openPanel}
         onTogglePanel={togglePanel}
         // The menu button opens the first destination this project has, which
@@ -963,6 +964,7 @@ export function Shell({
           accountError={accountError}
           theme={theme}
           onThemeChange={onThemeChange}
+          admin={data.admin}
           autoSave={autoSave}
           onAutoSaveChange={onAutoSaveChange}
           branch={data.branch}

--- a/packages/ui/spa/components/shell/TopBar.tsx
+++ b/packages/ui/spa/components/shell/TopBar.tsx
@@ -27,6 +27,11 @@ import { useDismissOnOutsidePointer } from "./useDismissOnOutsidePointer";
 export type TopBarProps = {
   breakpoint: ShellBreakpoint;
   projectName: string;
+  /**
+   * The project's page in Val Build. Absent leaves the name as a label — see
+   * `ProjectName`.
+   */
+  projectHref?: string;
   openPanel: ShellPanel | null;
   onTogglePanel: (panel: ShellPanel) => void;
   /** Opens the navigation: the rail's panels, reached from a menu button. */
@@ -116,6 +121,7 @@ export type PublishState = "idle" | "publishing" | "error" | "blocked";
 export function TopBar({
   breakpoint,
   projectName,
+  projectHref,
   openPanel,
   onTogglePanel,
   onOpenMenu,
@@ -162,7 +168,7 @@ export function TopBar({
           <ValLogo className="h-5" blinking={isLoading} />
         </div>
       )}
-      <ProjectName projectName={projectName} />
+      <ProjectName projectName={projectName} projectHref={projectHref} />
       <SearchTrigger breakpoint={breakpoint} onClick={onOpenSearch} />
       <div className="ml-auto flex items-center gap-1.5 shrink-0">
         {!isMobile && (
@@ -664,12 +670,38 @@ export function PublishButton({
 /**
  * The project's name. Val runs one project per config, so this is a label
  * rather than a switcher — there is nothing to switch to.
+ *
+ * It is a link to the project in Val Build when there is one: the name is
+ * where an editor already points at "this project", and everything Val does
+ * not do to a project — members, keys, subscription — is over there. A project
+ * that is not connected has no page, so the name stays a plain label rather
+ * than becoming a link that goes nowhere.
  */
-function ProjectName({ projectName }: { projectName: string }) {
+function ProjectName({
+  projectName,
+  projectHref,
+}: {
+  projectName: string;
+  projectHref?: string;
+}) {
+  const shared =
+    "min-w-0 px-2 text-[0.8125rem] font-semibold tracking-tight truncate";
+  if (projectHref === undefined) {
+    return <span className={shared}>{projectName}</span>;
+  }
   return (
-    <span className="min-w-0 px-2 text-[0.8125rem] font-semibold tracking-tight truncate">
+    <a
+      href={projectHref}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={`Open ${projectName} in Val Build`}
+      className={cn(
+        shared,
+        "rounded-sm hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus",
+      )}
+    >
       {projectName}
-    </span>
+    </a>
   );
 }
 

--- a/packages/ui/spa/components/shell/adminLinks.test.tsx
+++ b/packages/ui/spa/components/shell/adminLinks.test.tsx
@@ -1,0 +1,97 @@
+/** @jest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { SettingsPanel } from "./SettingsPanel";
+import { TopBar } from "./TopBar";
+import { ShellAdminLinks } from "./types";
+
+/**
+ * The ways from the Studio to the project in Val Build.
+ *
+ * Val edits content; members, keys and the subscription live in the admin app,
+ * and there was no way to get from one to the other. There is now the project
+ * name in the top bar and two rows in Settings — all three hang off the same
+ * `admin` links, which are absent for a project that is not connected. What is
+ * pinned here is that absence: a link to a project page that does not exist is
+ * worse than no link, since it lands on a sign-in for an organisation the
+ * editor may not be in.
+ */
+
+const admin: ShellAdminLinks = {
+  project: "https://admin.val.build/~/acme/marketing-site",
+  members: "https://admin.val.build/manage-members/acme",
+};
+
+function topBar(projectHref?: string) {
+  return (
+    <TopBar
+      breakpoint="desktop"
+      projectName="acme/marketing-site"
+      projectHref={projectHref}
+      openPanel={null}
+      onTogglePanel={() => undefined}
+      onOpenMenu={() => undefined}
+      onOpenSearch={() => undefined}
+      onPreview={() => undefined}
+      isCanvasOpen={false}
+      onPublish={() => undefined}
+      pendingChanges={0}
+    />
+  );
+}
+
+function settingsPanel(links?: ShellAdminLinks) {
+  return (
+    <SettingsPanel
+      breakpoint="desktop"
+      theme="dark"
+      onThemeChange={() => undefined}
+      admin={links}
+      autoSave={false}
+      onAutoSaveChange={() => undefined}
+      onClose={() => undefined}
+    />
+  );
+}
+
+describe("the project name in the top bar", () => {
+  test("opens the project in Val Build, in a new tab", () => {
+    render(topBar(admin.project));
+    const link = screen.getByRole("link", { name: "acme/marketing-site" });
+    expect(link.getAttribute("href")).toBe(admin.project);
+    // Leaving the Studio means leaving whatever is being edited in it.
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  test("is a plain label when the project is not connected", () => {
+    render(topBar(undefined));
+    expect(
+      screen.queryByRole("link", { name: "acme/marketing-site" }),
+    ).toBeNull();
+    expect(screen.getByText("acme/marketing-site")).not.toBeNull();
+  });
+});
+
+describe("the project section in Settings", () => {
+  test("offers the project's page and the org's members", () => {
+    render(settingsPanel(admin));
+    expect(
+      screen
+        .getByRole("link", { name: /Administer project/ })
+        .getAttribute("href"),
+    ).toBe(admin.project);
+    expect(
+      screen.getByRole("link", { name: /Manage members/ }).getAttribute("href"),
+    ).toBe(admin.members);
+  });
+
+  test("is not there at all when the project is not connected", () => {
+    render(settingsPanel(undefined));
+    expect(
+      screen.queryByRole("link", { name: /Administer project/ }),
+    ).toBeNull();
+    expect(screen.queryByRole("link", { name: /Manage members/ })).toBeNull();
+    // The rest of the panel is untouched — this hides one section.
+    expect(screen.getByText("Appearance")).not.toBeNull();
+  });
+});

--- a/packages/ui/spa/components/shell/mockShellData.ts
+++ b/packages/ui/spa/components/shell/mockShellData.ts
@@ -522,7 +522,11 @@ const mockNewPageRoutes: ShellNewPageRoutes = {
 };
 
 export const mockShellData: ShellData = {
-  projectName: "val-demo-project",
+  projectName: "val-demo/val-demo-project",
+  admin: {
+    project: "https://admin.val.build/~/val-demo/val-demo-project",
+    members: "https://admin.val.build/manage-members/val-demo",
+  },
   branch: "main",
   hasRouters: true,
   pages: mockPages,

--- a/packages/ui/spa/components/shell/shellDataMapping.test.ts
+++ b/packages/ui/spa/components/shell/shellDataMapping.test.ts
@@ -4,6 +4,7 @@ import {
   hostLabel,
   initialsOf,
   toActivity,
+  toAdminLinks,
   toDataModules,
   toExternalPages,
   toShellPages,
@@ -414,5 +415,44 @@ describe("availableDestinations", () => {
       "media",
       "data",
     ]);
+  });
+});
+
+describe("toAdminLinks", () => {
+  const appHost = "https://admin.val.build";
+
+  test("splits config.project into the org's and the project's pages", () => {
+    expect(toAdminLinks({ project: "acme/marketing-site", appHost })).toEqual({
+      project: "https://admin.val.build/~/acme/marketing-site",
+      members: "https://admin.val.build/manage-members/acme",
+    });
+  });
+
+  test("a project that is not connected has nowhere to go", () => {
+    expect(toAdminLinks({ appHost })).toBeUndefined();
+    expect(toAdminLinks(undefined)).toBeUndefined();
+  });
+
+  test("a project that is not <org>/<project> has nowhere to go", () => {
+    // Rather than a link to a 404: `val connect` rejects these too.
+    expect(
+      toAdminLinks({ project: "marketing-site", appHost }),
+    ).toBeUndefined();
+    expect(
+      toAdminLinks({ project: "acme/marketing/site", appHost }),
+    ).toBeUndefined();
+    expect(toAdminLinks({ project: "acme/", appHost })).toBeUndefined();
+    expect(
+      toAdminLinks({ project: "/marketing-site", appHost }),
+    ).toBeUndefined();
+  });
+
+  test("a trailing slash on the host does not double up", () => {
+    expect(
+      toAdminLinks({ project: "acme/marketing-site", appHost: appHost + "/" }),
+    ).toEqual({
+      project: "https://admin.val.build/~/acme/marketing-site",
+      members: "https://admin.val.build/manage-members/acme",
+    });
   });
 });

--- a/packages/ui/spa/components/shell/shellDataMapping.ts
+++ b/packages/ui/spa/components/shell/shellDataMapping.ts
@@ -5,6 +5,7 @@ import { routePatternToString } from "../NavMenu/SitemapItem";
 import { ValEnrichedDeployment } from "../../utils/mergeCommitsAndDeployments";
 import {
   ShellActivityEntry,
+  ShellAdminLinks,
   ShellData,
   ShellDataModule,
   ShellDeployment,
@@ -299,6 +300,37 @@ export function hostLabel(url: string): string {
     // showing nothing.
     return url;
   }
+}
+
+/**
+ * The project's pages in Val Build's admin app.
+ *
+ * `config.project` is `"<org>/<project>"` — the format `val connect` insists
+ * on — so anything else has no page to open: a project that was never
+ * connected has no `project` at all, and a malformed one would only produce a
+ * link to a 404. Both return `undefined`, which is what hides the link and the
+ * settings buttons rather than offering a way out that goes nowhere.
+ *
+ * The member list is reached through `/manage-members/<org>`, which the admin
+ * app keeps for exactly this — it redirects to wherever the org's members
+ * currently live, so Val does not have to track that page moving.
+ */
+export function toAdminLinks(
+  config: { project?: string; appHost?: string } | undefined,
+): ShellAdminLinks | undefined {
+  if (!config?.project || !config.appHost) {
+    return undefined;
+  }
+  const parts = config.project.split("/");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    return undefined;
+  }
+  const [org, project] = parts;
+  const host = config.appHost.replace(/\/+$/, "");
+  return {
+    project: `${host}/~/${encodeURIComponent(org)}/${encodeURIComponent(project)}`,
+    members: `${host}/manage-members/${encodeURIComponent(org)}`,
+  };
 }
 
 export function initialsOf(fullName: string): string {

--- a/packages/ui/spa/components/shell/types.ts
+++ b/packages/ui/spa/components/shell/types.ts
@@ -188,6 +188,11 @@ export type ShellBreakpoint = "mobile" | "tablet" | "desktop";
  */
 export type ShellData = {
   projectName: string;
+  /**
+   * Where this project lives in Val Build. Absent when there is nowhere to
+   * go — see `toAdminLinks`.
+   */
+  admin?: ShellAdminLinks;
   /** From `config.gitBranch`. Absent outside a git checkout. */
   branch?: string;
   /**
@@ -231,6 +236,20 @@ export type ShellData = {
    * entirely rather than showing an item that can never say anything.
    */
   deployments?: ShellDeployment[];
+};
+
+/**
+ * The project's pages in Val Build's admin app.
+ *
+ * Val itself edits content; everything about the project as a thing that is
+ * paid for, deployed and shared with people lives in the admin app, so these
+ * are the two links out to it that an editor has a reason to follow.
+ */
+export type ShellAdminLinks = {
+  /** The project's own page: settings, API keys, versions, AI keys. */
+  project: string;
+  /** The organisation's member list. */
+  members: string;
 };
 
 /**

--- a/packages/ui/spa/components/shell/useShellData.ts
+++ b/packages/ui/spa/components/shell/useShellData.ts
@@ -15,6 +15,7 @@ import { useValConfig } from "../ValFieldProvider";
 import { ShellData, ShellMediaGallery } from "./types";
 import {
   toActivity,
+  toAdminLinks,
   toDataModules,
   toDeployments,
   toExternalPages,
@@ -111,6 +112,7 @@ export function useShellData(): ShellDataState {
       status: "success",
       data: {
         projectName: config?.project ?? "Val",
+        admin: toAdminLinks(config),
         branch: config?.gitBranch,
         hasRouters: navData?.hasRouters ?? false,
         pages: navData?.sitemap


### PR DESCRIPTION
## Summary

The Studio now provides navigation links to Val Build's admin app, where project settings, API keys, members, and subscriptions are managed. This closes the gap between content editing in the Studio and project administration.

## Changes

- **TopBar**: The project name is now a link to the project's page in Val Build (opens in new tab). Falls back to plain text for unconnected projects.
- **SettingsPanel**: Added a new "Project" section with two links:
  - "Administer project" → project settings in Val Build
  - "Manage members" → organization member list
  - Section is hidden entirely for unconnected projects
- **AdminLink component**: New reusable component for external links with icon, label, and description
- **Type system**: Added `ShellAdminLinks` type defining `project` and `members` URLs
- **Data mapping**: Added `toAdminLinks()` function that:
  - Parses `config.project` as `"<org>/<project>"` format
  - Generates admin app URLs with proper URL encoding
  - Returns `undefined` for unconnected or malformed projects
- **Tests**: Comprehensive test suite (`adminLinks.test.tsx`) verifying:
  - Project name link behavior when connected/disconnected
  - Settings panel section visibility and link targets
  - `toAdminLinks()` parsing, validation, and URL generation
- **Mock data**: Updated to use org/project format and include admin links

## Implementation Details

- Links open in new tabs (`target="_blank"`) to preserve unsaved work in the Studio
- Unconnected projects (no `project` in config, or malformed format) show no links rather than broken ones
- Member list uses `/manage-members/<org>` redirect endpoint so Val doesn't track page moves
- URL encoding handles special characters in org/project names
- Styling matches existing Settings panel patterns with hover states and focus rings

https://claude.ai/code/session_01BnYKamSJFzMMj2fbuJ1BJ8