### PR TITLE
Flatten richtext options structure

### DIFF
--- a/.changeset/richtext-flat-options.md
+++ b/.changeset/richtext-flat-options.md
@@ -1,0 +1,46 @@
+---
+"@valbuild/core": minor
+"@valbuild/react": minor
+"@valbuild/shared": minor
+"@valbuild/ui": minor
+"@valbuild/next": minor
+"@valbuild/init": minor
+"@valbuild/language-server": minor
+---
+
+**Breaking:** `s.richtext()` options are flat.
+
+The `style`, `block` and `inline` groups are gone — every option is a key of its
+own. The names are unchanged, so updating a schema is only a matter of removing
+the wrappers:
+
+```ts
+// before
+s.richtext({
+  style: { bold: true, italic: true },
+  block: { h1: true, ul: true },
+  inline: { a: true, img: s.image() },
+});
+
+// after
+s.richtext({
+  bold: true,
+  italic: true,
+  h1: true,
+  ul: true,
+  a: true,
+  img: s.image(),
+});
+```
+
+The groups never carried any meaning the option names did not already have, and
+they cost something real: an option name and its `ValRichText` theme key were
+spelled differently (`block.h1` vs `theme.h1`), so the type that keeps a theme
+exhaustive had to restate all thirteen options by hand. It is now a mapped type
+over the options themselves — which also fixes an inconsistency in it: enabling
+links with a schema (`a: s.route()`) rather than `a: true` now requires an `a`
+key in the theme, the way `img` always has.
+
+`ValRichText` themes were already flat and are unchanged. The serialized schema
+that the server sends the Studio is flat too, so a project must not mix
+`@valbuild/*` versions across this release.

--- a/examples/next/app/blogs/[blog]/page.val.ts
+++ b/examples/next/app/blogs/[blog]/page.val.ts
@@ -5,12 +5,8 @@ import { linkSchema } from "../../../components/link.val";
 const blogSchema = s.object({
   title: s.string(),
   content: s.richtext({
-    style: {
-      bold: true,
-    },
-    inline: {
-      a: s.route(),
-    },
+    bold: true,
+    a: s.route(),
   }),
   author: s.keyOf(authorsVal),
   link: linkSchema,

--- a/examples/next/app/page.val.ts
+++ b/examples/next/app/page.val.ts
@@ -30,18 +30,12 @@ export const schema = s.object({
     .richtext({
       // enables all features
       // styling:
-      style: {
-        bold: true, // enables bold, ...
-        italic: true,
-        lineThrough: true,
-      },
-      block: {
-        h2: true, // enables h2 blocks, ...
-        ul: true,
-      },
-      inline: {
-        a: true,
-      },
+      bold: true, // enables bold, ...
+      italic: true,
+      lineThrough: true,
+      h2: true, // enables h2 blocks, ...
+      ul: true,
+      a: true,
     })
     .nullable(),
   video: s.object({

--- a/examples/next/content/handbook.val.ts
+++ b/examples/next/content/handbook.val.ts
@@ -24,9 +24,11 @@ export const handbookSectionSchema = s
   .object({
     heading: s.string().minLength(2),
     body: s.richtext({
-      style: { bold: true, italic: true },
-      block: { h2: true, ul: true },
-      inline: { a: true },
+      bold: true,
+      italic: true,
+      h2: true,
+      ul: true,
+      a: true,
     }),
     /** A route this section points at, so route references have something to find. */
     seeAlso: s.route().nullable(),

--- a/packages/core/src/module.test.ts
+++ b/packages/core/src/module.test.ts
@@ -18,6 +18,9 @@ import { GetSource } from "./selector";
 import { newSelectorProxy } from "./selector/SelectorProxy";
 import { ModulePath, SourcePath } from "./val";
 import { literal } from "./schema/literal";
+import { richtext } from "./schema/richtext";
+import { route, RouteSchema } from "./schema/route";
+import { image, ImageSchema } from "./schema/image";
 
 // import { i18n as initI18nSchema } from "./schema/i18n";
 // import { i18n as initI18nSource } from "./source/i18n";
@@ -191,6 +194,52 @@ describe("module", () => {
         parentOfSourcePath(parentOfSourcePath(parentOfSourcePath(base))),
       ),
     ).toStrictEqual("/content/test");
+  });
+
+  /**
+   * Richtext content has no schema of its own per node, so resolving a path
+   * INTO it walks out to the richtext field and reads the option that governs
+   * that node: `a` for an anchor's href, `img` for an image's src. Both are
+   * reached through `instanceof RichTextSchema`, which narrows the options to
+   * `any` - so nothing here is checked by tsc, and a rename that misses one of
+   * these branches silently hands back the richtext schema instead.
+   */
+  test("resolvePath: an anchor href resolves to the schema its `a` option carries", () => {
+    const schema = object({
+      body: richtext({ a: route() }),
+    });
+    const { schema: resolved } = resolveAtPath(
+      '"body".0."children".0."href"' as ModulePath,
+      {
+        body: [
+          {
+            tag: "p",
+            children: [{ tag: "a", href: "/blogs/one", children: ["One"] }],
+          },
+        ],
+      } as SelectorOfSchema<typeof schema>,
+      schema,
+    );
+    expect(resolved).toBeInstanceOf(RouteSchema);
+  });
+
+  test("resolvePath: an image src resolves to the schema its `img` option carries", () => {
+    const schema = object({
+      body: richtext({ img: image() }),
+    });
+    const { schema: resolved } = resolveAtPath(
+      '"body".0."children".0."src"' as ModulePath,
+      {
+        body: [
+          {
+            tag: "p",
+            children: [{ tag: "img", src: { path: "/public/val/one.png" } }],
+          },
+        ],
+      } as SelectorOfSchema<typeof schema>,
+      schema,
+    );
+    expect(resolved).toBeInstanceOf(ImageSchema);
   });
 
   test("isValModule tells a module apart from what else a .val.ts might export", () => {

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -390,9 +390,9 @@ export function resolvePath<
       ) {
         resolvedSchema =
           resolvedSchema instanceof RichTextSchema
-            ? resolvedSchema["options"]?.inline?.a &&
-              typeof resolvedSchema["options"]?.inline?.a !== "boolean"
-              ? resolvedSchema["options"].inline.a
+            ? resolvedSchema["options"]?.a &&
+              typeof resolvedSchema["options"]?.a !== "boolean"
+              ? resolvedSchema["options"].a
               : resolvedSchema
             : resolvedSchema;
       }
@@ -663,9 +663,9 @@ export function safeResolvePath<
       ) {
         resolvedSchema =
           resolvedSchema instanceof RichTextSchema
-            ? resolvedSchema["options"]?.inline?.a &&
-              typeof resolvedSchema["options"]?.inline?.a !== "boolean"
-              ? resolvedSchema["options"].inline.a
+            ? resolvedSchema["options"]?.a &&
+              typeof resolvedSchema["options"]?.a !== "boolean"
+              ? resolvedSchema["options"].a
               : resolvedSchema
             : resolvedSchema;
       }

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -376,9 +376,9 @@ export function resolvePath<
       ) {
         resolvedSchema =
           resolvedSchema instanceof RichTextSchema
-            ? resolvedSchema["options"]?.inline?.img &&
-              typeof resolvedSchema["options"]?.inline?.img !== "boolean"
-              ? resolvedSchema["options"].inline.img
+            ? resolvedSchema["options"]?.img &&
+              typeof resolvedSchema["options"]?.img !== "boolean"
+              ? resolvedSchema["options"].img
               : resolvedSchema
             : resolvedSchema;
       }
@@ -649,9 +649,9 @@ export function safeResolvePath<
       ) {
         resolvedSchema =
           resolvedSchema instanceof RichTextSchema
-            ? resolvedSchema["options"]?.inline?.img &&
-              typeof resolvedSchema["options"]?.inline?.img !== "boolean"
-              ? resolvedSchema["options"].inline.img
+            ? resolvedSchema["options"]?.img &&
+              typeof resolvedSchema["options"]?.img !== "boolean"
+              ? resolvedSchema["options"].img
               : resolvedSchema
             : resolvedSchema;
       }

--- a/packages/core/src/schema/deserialize.ts
+++ b/packages/core/src/schema/deserialize.ts
@@ -1,6 +1,7 @@
 import { SerializedSchema, Schema } from ".";
 import { SelectorSource } from "../selector";
 import { ImageSource } from "../source/media";
+import { RichTextOptions } from "../source/richtext";
 import { SourcePath } from "../val";
 import { ArraySchema } from "./array";
 import { BooleanSchema } from "./boolean";
@@ -133,31 +134,23 @@ function deserializeSchemaImpl(
         serialized.render ?? null,
       );
     case "richtext": {
-      const deserializedOptions = {
+      const deserializedOptions: RichTextOptions & {
+        maxLength?: number;
+        minLength?: number;
+      } = {
         ...(serialized.options || {}),
-        inline:
-          typeof serialized.options?.inline?.img === "object" ||
-          typeof serialized.options?.inline?.a === "object"
-            ? {
-                a:
-                  typeof serialized.options?.inline?.a === "object"
-                    ? (deserializeSchema(serialized.options.inline.a) as
-                        | RouteSchema<string>
-                        | StringSchema<string>)
-                    : serialized.options?.inline?.a,
-                img:
-                  typeof serialized.options?.inline?.img === "object"
-                    ? (deserializeSchema(
-                        serialized.options.inline.img,
-                      ) as ImageSchema<ImageSource>)
-                    : serialized.options?.inline?.img,
-              }
-            : (serialized.options?.inline as
-                | undefined
-                | {
-                    a: boolean | undefined;
-                    img: boolean | undefined;
-                  }),
+        a:
+          typeof serialized.options?.a === "object"
+            ? (deserializeSchema(serialized.options.a) as
+                | RouteSchema<string>
+                | StringSchema<string>)
+            : serialized.options?.a,
+        img:
+          typeof serialized.options?.img === "object"
+            ? (deserializeSchema(
+                serialized.options.img,
+              ) as ImageSchema<ImageSource>)
+            : serialized.options?.img,
       };
       return new RichTextSchema(
         deserializedOptions,

--- a/packages/core/src/schema/hasRemoteFileSchema.test.ts
+++ b/packages/core/src/schema/hasRemoteFileSchema.test.ts
@@ -64,7 +64,7 @@ describe("hasRemoteFileSchema", () => {
       type: "richtext",
       opt: false,
       options: {
-        inline: { img: { type: "image", opt: false, remote: false } },
+        img: { type: "image", opt: false, remote: false },
       },
     };
     expect(hasRemoteFileSchema(schema)).toBe(false);
@@ -83,7 +83,7 @@ describe("hasRemoteFileSchema", () => {
     const schema: SerializedSchema = {
       type: "richtext",
       opt: false,
-      options: { inline: { img: { type: "image", opt: false, remote: true } } },
+      options: { img: { type: "image", opt: false, remote: true } },
     };
     expect(hasRemoteFileSchema(schema)).toBe(true);
   });

--- a/packages/core/src/schema/hasRemoteFileSchema.ts
+++ b/packages/core/src/schema/hasRemoteFileSchema.ts
@@ -40,8 +40,8 @@ export function hasRemoteFileSchema(schema: SerializedSchema): boolean {
   if (schema.type === "file" || schema.type === "image") {
     return !!schema.remote;
   } else if (schema.type === "richtext") {
-    if (typeof schema.options?.inline?.img === "object") {
-      return hasRemoteFileSchema(schema.options.inline.img);
+    if (typeof schema.options?.img === "object") {
+      return hasRemoteFileSchema(schema.options.img);
     }
     return false;
   } else if (schema.type === "array") {

--- a/packages/core/src/schema/richtext.test.ts
+++ b/packages/core/src/schema/richtext.test.ts
@@ -40,16 +40,10 @@ describe("RichTextSchema", () => {
 
   test("validate: basic green test", () => {
     const schema = richtext({
-      style: {
-        bold: true,
-      },
-      block: {
-        h1: true,
-        ul: true,
-      },
-      inline: {
-        a: string(),
-      },
+      bold: true,
+      h1: true,
+      ul: true,
+      a: string(),
     });
     expectedErrorAtPaths(
       schema["executeValidate"](
@@ -63,16 +57,10 @@ describe("RichTextSchema", () => {
 
   test("validate: basic green max / min length test", () => {
     const schema = richtext({
-      style: {
-        bold: true,
-      },
-      block: {
-        h1: true,
-        ul: true,
-      },
-      inline: {
-        a: string(),
-      },
+      bold: true,
+      h1: true,
+      ul: true,
+      a: string(),
     })
       .minLength(1)
       .maxLength(100);
@@ -88,16 +76,10 @@ describe("RichTextSchema", () => {
 
   test("validate: basic red min length test", () => {
     const schema = richtext({
-      style: {
-        bold: true,
-      },
-      block: {
-        h1: true,
-        ul: true,
-      },
-      inline: {
-        a: string(),
-      },
+      bold: true,
+      h1: true,
+      ul: true,
+      a: string(),
     }).minLength(100);
     expectedErrorAtPaths(
       schema["executeValidate"](
@@ -111,16 +93,10 @@ describe("RichTextSchema", () => {
 
   test("validate: basic red max length test", () => {
     const schema = richtext({
-      style: {
-        bold: true,
-      },
-      block: {
-        h1: true,
-        ul: true,
-      },
-      inline: {
-        a: string(),
-      },
+      bold: true,
+      h1: true,
+      ul: true,
+      a: string(),
     }).maxLength(10);
     expectedErrorAtPaths(
       schema["executeValidate"](
@@ -264,9 +240,7 @@ describe("RichTextSchema", () => {
   // Anchor href validation tests
   test("validate: a: true with valid route href (green test)", () => {
     const schema = richtext({
-      inline: {
-        a: true,
-      },
+      a: true,
     });
     const input = [
       {
@@ -294,9 +268,7 @@ describe("RichTextSchema", () => {
 
   test("validate: a: route() with explicit route schema", () => {
     const schema = richtext({
-      inline: {
-        a: route(),
-      },
+      a: route(),
     });
     const input = [
       {
@@ -324,9 +296,7 @@ describe("RichTextSchema", () => {
 
   test("validate: a: string().maxLength(30) with valid short URL (green test)", () => {
     const schema = richtext({
-      inline: {
-        a: string().maxLength(30),
-      },
+      a: string().maxLength(30),
     });
     const input = [
       {
@@ -350,9 +320,7 @@ describe("RichTextSchema", () => {
 
   test("validate: a: string().maxLength(30) with URL exceeding max length (red test)", () => {
     const schema = richtext({
-      inline: {
-        a: string().maxLength(30),
-      },
+      a: string().maxLength(30),
     });
     const input = [
       {
@@ -378,9 +346,7 @@ describe("RichTextSchema", () => {
 
   test("validate: a: route().include(/^\\/blog/) with matching route (green test)", () => {
     const schema = richtext({
-      inline: {
-        a: route().include(/^\/blog/),
-      },
+      a: route().include(/^\/blog/),
     });
     const input = [
       {
@@ -410,9 +376,7 @@ describe("RichTextSchema", () => {
 
   test("validate: a: route().exclude(/^\\/admin/) with excluded route (red test)", () => {
     const schema = richtext({
-      inline: {
-        a: route().exclude(/^\/admin/),
-      },
+      a: route().exclude(/^\/admin/),
     });
     const input = [
       {
@@ -442,9 +406,7 @@ describe("RichTextSchema", () => {
 
   test("validate: a tag without href attribute (red test)", () => {
     const schema = richtext({
-      inline: {
-        a: true,
-      },
+      a: true,
     });
     const input = [
       {
@@ -466,9 +428,7 @@ describe("RichTextSchema", () => {
 
   test("validate: a: string() allows external URLs", () => {
     const schema = richtext({
-      inline: {
-        a: string(),
-      },
+      a: string(),
     });
     const input = [
       {
@@ -492,9 +452,7 @@ describe("RichTextSchema", () => {
 
   test("validate: unsupported tag (red test)", () => {
     const schema = richtext({
-      block: {
-        h1: true,
-      },
+      h1: true,
     });
     const input = [
       { tag: "h1", children: ["Title"] },
@@ -512,9 +470,7 @@ describe("RichTextSchema", () => {
 
   test("validate: multiple unsupported tags (red test)", () => {
     const schema = richtext({
-      block: {
-        h1: true,
-      },
+      h1: true,
     });
     const input = [
       { tag: "h1", children: ["Title"] },
@@ -533,9 +489,7 @@ describe("RichTextSchema", () => {
 
   test("validate: a: string().regexp() validates URL patterns", () => {
     const schema = richtext({
-      inline: {
-        a: string().regexp(/^https?:\/\//),
-      },
+      a: string().regexp(/^https?:\/\//),
     });
     const inputValid = [
       {
@@ -572,9 +526,7 @@ describe("RichTextSchema", () => {
 
   test("validate: a: route() reports error at the correct index when anchor is not the first child", () => {
     const schema = richtext({
-      inline: {
-        a: route(),
-      },
+      a: route(),
     });
     const input = [
       {
@@ -600,9 +552,7 @@ describe("RichTextSchema", () => {
 
   test("validate: a: route() reports one error per invalid anchor sibling at distinct child indexes", () => {
     const schema = richtext({
-      inline: {
-        a: route(),
-      },
+      a: route(),
     });
     const input = [
       {
@@ -634,9 +584,7 @@ describe("RichTextSchema", () => {
 
   test("validate: maxLength counts nested string children exactly once", () => {
     const schema = richtext({
-      inline: {
-        a: string(),
-      },
+      a: string(),
     }).maxLength(7);
     // Total string length across the tree: "abc" (3) + "de" (2) + "fg" (2) = 7.
     // If the recursion change ever double- or under-counted, this hits the boundary.

--- a/packages/core/src/schema/richtext.ts
+++ b/packages/core/src/schema/richtext.ts
@@ -261,7 +261,7 @@ export class RichTextSchema<
           );
         }
         if (node.tag === "h1" && !this.options.h1) {
-          addError(path, `'h' block is not valid`, false);
+          addError(path, `'h1' block is not valid`, false);
         }
         if (node.tag === "h2" && !this.options.h2) {
           addError(path, `'h2' block is not valid`, false);
@@ -287,7 +287,7 @@ export class RichTextSchema<
         if (node.tag === "li" && !this.options.ul && !this.options.ol) {
           addError(
             path,
-            `'li' tag is invalid since neither 'ul' nor 'ol' block is not valid`,
+            `'li' tag is invalid since neither 'ul' nor 'ol' block is valid`,
             false,
           );
         }

--- a/packages/core/src/schema/richtext.ts
+++ b/packages/core/src/schema/richtext.ts
@@ -34,7 +34,7 @@ export type SerializedRichTextSchema = {
   /** Set when this schema declares a `preview`. The closure itself cannot serialize. */
   preview?: true;
   opt: boolean;
-  options?: SerializedRichTextOptions & ValidationOptions;
+  options?: SerializedRichTextOptions;
   customValidate?: boolean;
   readonly?: boolean;
   hidden?: boolean;
@@ -771,7 +771,7 @@ export class RichTextSchema<
         return this.options.a;
       }
     };
-    const serializedOptions: SerializedRichTextOptions & ValidationOptions = {
+    const serializedOptions: SerializedRichTextOptions = {
       maxLength: this.options.maxLength,
       minLength: this.options.minLength,
       bold: this.options.bold,

--- a/packages/core/src/schema/richtext.ts
+++ b/packages/core/src/schema/richtext.ts
@@ -260,35 +260,31 @@ export class RichTextSchema<
             true,
           );
         }
-        if (node.tag === "h1" && !this.options.block?.h1) {
+        if (node.tag === "h1" && !this.options.h1) {
           addError(path, `'h' block is not valid`, false);
         }
-        if (node.tag === "h2" && !this.options.block?.h2) {
+        if (node.tag === "h2" && !this.options.h2) {
           addError(path, `'h2' block is not valid`, false);
         }
-        if (node.tag === "h3" && !this.options.block?.h3) {
+        if (node.tag === "h3" && !this.options.h3) {
           addError(path, `'h3' block is not valid`, false);
         }
-        if (node.tag === "h4" && !this.options.block?.h4) {
+        if (node.tag === "h4" && !this.options.h4) {
           addError(path, `'h4' block is not valid`, false);
         }
-        if (node.tag === "h5" && !this.options.block?.h5) {
+        if (node.tag === "h5" && !this.options.h5) {
           addError(path, `'h5' block is not valid`, false);
         }
-        if (node.tag === "h6" && !this.options.block?.h6) {
+        if (node.tag === "h6" && !this.options.h6) {
           addError(path, `'h6' block is not valid`, false);
         }
-        if (node.tag === "ol" && !this.options.block?.ol) {
+        if (node.tag === "ol" && !this.options.ol) {
           addError(path, `'ol' block is not valid`, false);
         }
-        if (node.tag === "ul" && !this.options.block?.ul) {
+        if (node.tag === "ul" && !this.options.ul) {
           addError(path, `'ul' block is not valid`, false);
         }
-        if (
-          node.tag === "li" &&
-          !this.options.block?.ul &&
-          !this.options.block?.ol
-        ) {
+        if (node.tag === "li" && !this.options.ul && !this.options.ol) {
           addError(
             path,
             `'li' tag is invalid since neither 'ul' nor 'ol' block is not valid`,
@@ -296,9 +292,9 @@ export class RichTextSchema<
           );
         }
         if (node.tag === "a") {
-          if (!this.options.inline?.a) {
+          if (!this.options.a) {
             addError(path, `'a' inline is not valid`, false);
-          } else if (this.options.inline?.a) {
+          } else if (this.options.a) {
             if (!("href" in node)) {
               return {
                 [path]: [
@@ -311,9 +307,9 @@ export class RichTextSchema<
             }
             const hrefPath = unsafeCreateSourcePath(path, "href");
             const hrefSchema =
-              typeof this.options.inline?.a === "boolean"
+              typeof this.options.a === "boolean"
                 ? new RouteSchema()
-                : this.options.inline.a;
+                : this.options.a;
 
             const executeValidate = () => {
               if (hrefSchema instanceof RouteSchema) {
@@ -351,9 +347,9 @@ export class RichTextSchema<
         }
 
         if (node.tag === "img") {
-          if (!this.options.inline?.img) {
+          if (!this.options.img) {
             addError(path, `'img' inline is not valid`, false);
-          } else if (this.options.inline?.img) {
+          } else if (this.options.img) {
             if (!("src" in node)) {
               return {
                 [path]: [
@@ -365,7 +361,7 @@ export class RichTextSchema<
               };
             }
             const srcPath = unsafeCreateSourcePath(path, "src");
-            const imgSchema = this.options.inline?.img;
+            const imgSchema = this.options.img;
             const imageValidationErrors =
               typeof imgSchema === "object"
                 ? (imgSchema as ImageSchema<ImageSource>)["executeValidate"](
@@ -425,13 +421,13 @@ export class RichTextSchema<
                 ],
               };
             }
-            if (style === "bold" && !this.options.style?.bold) {
+            if (style === "bold" && !this.options.bold) {
               addError(currentStylePath, `Style 'bold' is not valid`, false);
             }
-            if (style === "italic" && !this.options.style?.italic) {
+            if (style === "italic" && !this.options.italic) {
               addError(currentStylePath, `Style 'italic' is not valid`, false);
             }
-            if (style === "lineThrough" && !this.options.style?.lineThrough) {
+            if (style === "lineThrough" && !this.options.lineThrough) {
               addError(
                 currentStylePath,
                 `Style 'lineThrough' is not valid`,
@@ -767,32 +763,33 @@ export class RichTextSchema<
       | SerializedStringSchema
       | boolean
       | undefined => {
-      if (this.options.inline?.a instanceof RouteSchema) {
-        return this.options.inline?.a[
-          "executeSerialize"
-        ]() as SerializedRouteSchema;
-      } else if (this.options.inline?.a instanceof StringSchema) {
-        return this.options.inline?.a[
-          "executeSerialize"
-        ]() as SerializedStringSchema;
+      if (this.options.a instanceof RouteSchema) {
+        return this.options.a["executeSerialize"]() as SerializedRouteSchema;
+      } else if (this.options.a instanceof StringSchema) {
+        return this.options.a["executeSerialize"]() as SerializedStringSchema;
       } else {
-        return this.options.inline?.a;
+        return this.options.a;
       }
     };
     const serializedOptions: SerializedRichTextOptions & ValidationOptions = {
       maxLength: this.options.maxLength,
       minLength: this.options.minLength,
-      style: this.options.style,
-      block: this.options.block,
-      inline: this.options.inline && {
-        a: serializeAnchorSchema(),
-        img:
-          this.options.inline.img && typeof this.options.inline.img === "object"
-            ? (this.options.inline.img[
-                "executeSerialize"
-              ]() as SerializedImageSchema)
-            : this.options.inline.img,
-      },
+      bold: this.options.bold,
+      italic: this.options.italic,
+      lineThrough: this.options.lineThrough,
+      h1: this.options.h1,
+      h2: this.options.h2,
+      h3: this.options.h3,
+      h4: this.options.h4,
+      h5: this.options.h5,
+      h6: this.options.h6,
+      ul: this.options.ul,
+      ol: this.options.ol,
+      a: serializeAnchorSchema(),
+      img:
+        this.options.img && typeof this.options.img === "object"
+          ? (this.options.img["executeSerialize"]() as SerializedImageSchema)
+          : this.options.img,
     };
     return {
       type: "richtext",

--- a/packages/core/src/schema/validation.test.ts
+++ b/packages/core/src/schema/validation.test.ts
@@ -296,7 +296,7 @@ const ValidationTestCases: {
     description: "basic richtext",
     input: [{ tag: "p", children: ["test"] }],
     expected: false,
-    schema: richtext({ style: { bold: true } }),
+    schema: richtext({ bold: true }),
   },
   // TODO: more richtext cases
   {

--- a/packages/core/src/source/richtext.ts
+++ b/packages/core/src/source/richtext.ts
@@ -24,6 +24,13 @@ export type RichTextOptions = Partial<{
   // custom: Record<string, Schema<SelectorSource>>;
 }>;
 export type SerializedRichTextOptions = Partial<{
+  /**
+   * `.maxLength()` / `.minLength()` are not authored in the options argument,
+   * but they serialize into the same object - so the wire type has to name
+   * them, or a parser that strips unknown keys drops them in transit.
+   */
+  maxLength: number;
+  minLength: number;
   bold: boolean;
   italic: boolean;
   lineThrough: boolean;

--- a/packages/core/src/source/richtext.ts
+++ b/packages/core/src/source/richtext.ts
@@ -4,91 +4,67 @@ import { StringSchema, SerializedStringSchema } from "../schema/string";
 import { ImageSource } from "./media";
 
 export type RichTextOptions = Partial<{
-  style: Partial<{
-    bold: boolean;
-    italic: boolean;
-    lineThrough: boolean;
-  }>;
-  block: Partial<{
-    h1: boolean;
-    h2: boolean;
-    h3: boolean;
-    h4: boolean;
-    h5: boolean;
-    h6: boolean;
-    ul: boolean;
-    ol: boolean;
-    // TODO:
-    // custom: Record<string, Schema<SelectorSource>>;
-  }>;
-  inline: Partial<{
-    a: boolean | RouteSchema<string> | StringSchema<string>;
-    img: boolean | ImageSchema<ImageSource>;
-    // custom: Record<string, Schema<SelectorSource>>;
-  }>;
+  // styles:
+  bold: boolean;
+  italic: boolean;
+  lineThrough: boolean;
+  // block-level tags:
+  h1: boolean;
+  h2: boolean;
+  h3: boolean;
+  h4: boolean;
+  h5: boolean;
+  h6: boolean;
+  ul: boolean;
+  ol: boolean;
+  // inline tags:
+  a: boolean | RouteSchema<string> | StringSchema<string>;
+  img: boolean | ImageSchema<ImageSource>;
+  // TODO:
+  // custom: Record<string, Schema<SelectorSource>>;
 }>;
 export type SerializedRichTextOptions = Partial<{
-  style: Partial<{
-    bold: boolean;
-    italic: boolean;
-    lineThrough: boolean;
-  }>;
-  block: Partial<{
-    h1: boolean;
-    h2: boolean;
-    h3: boolean;
-    h4: boolean;
-    h5: boolean;
-    h6: boolean;
-    ul: boolean;
-    ol: boolean;
-    // TODO:
-    // custom: Record<string, Schema<SelectorSource>>;
-  }>;
-  inline: Partial<{
-    a: boolean | SerializedRouteSchema | SerializedStringSchema;
-    img: boolean | SerializedImageSchema;
-    // custom: Record<string, Schema<SelectorSource>>;
-  }>;
+  bold: boolean;
+  italic: boolean;
+  lineThrough: boolean;
+  h1: boolean;
+  h2: boolean;
+  h3: boolean;
+  h4: boolean;
+  h5: boolean;
+  h6: boolean;
+  ul: boolean;
+  ol: boolean;
+  a: boolean | SerializedRouteSchema | SerializedStringSchema;
+  img: boolean | SerializedImageSchema;
+  // TODO:
+  // custom: Record<string, Schema<SelectorSource>>;
 }>;
 export type AllRichTextOptions = {
-  style: {
-    bold: true;
-    italic: true;
-    lineThrough: true;
-  };
-  block: {
-    h1: true;
-    h2: true;
-    h3: true;
-    h4: true;
-    h5: true;
-    h6: true;
-    ul: true;
-    ol: true;
-  };
-  inline: {
-    a: true;
-    img: true;
-  };
+  bold: true;
+  italic: true;
+  lineThrough: true;
+  h1: true;
+  h2: true;
+  h3: true;
+  h4: true;
+  h5: true;
+  h6: true;
+  ul: true;
+  ol: true;
+  a: true;
+  img: true;
 };
 
 //#region Classes
-export type LineThrough<O extends RichTextOptions> = NonNullable<
-  O["style"]
->["lineThrough"] extends true
-  ? "line-through"
-  : never;
+export type LineThrough<O extends RichTextOptions> =
+  O["lineThrough"] extends true ? "line-through" : never;
 
-export type Italic<O extends RichTextOptions> = NonNullable<
-  O["style"]
->["italic"] extends true
+export type Italic<O extends RichTextOptions> = O["italic"] extends true
   ? "italic"
   : never;
 
-export type Bold<O extends RichTextOptions> = NonNullable<
-  O["style"]
->["bold"] extends true
+export type Bold<O extends RichTextOptions> = O["bold"] extends true
   ? "bold"
   : never;
 
@@ -131,11 +107,9 @@ export type SpanNode<O extends RichTextOptions> = {
 };
 
 //#region Image
-export type ImageNode<O extends RichTextOptions> = NonNullable<
-  O["inline"]
->["img"] extends true
+export type ImageNode<O extends RichTextOptions> = O["img"] extends true
   ? { tag: "img"; src: ImageSource }
-  : NonNullable<O["inline"]>["img"] extends ImageSchema<infer Src>
+  : O["img"] extends ImageSchema<infer Src>
     ? Src extends ImageSource
       ? { tag: "img"; src: Src }
       : never
@@ -147,13 +121,9 @@ type LinkTagNode<O extends RichTextOptions> = {
   href: string;
   children: (string | SpanNode<O> | ImageNode<O> | CustomInlineNode<O>)[];
 };
-export type LinkNode<O extends RichTextOptions> = NonNullable<
-  O["inline"]
->["a"] extends true
+export type LinkNode<O extends RichTextOptions> = O["a"] extends true
   ? LinkTagNode<O>
-  : NonNullable<O["inline"]>["a"] extends
-        | RouteSchema<string>
-        | StringSchema<string>
+  : O["a"] extends RouteSchema<string> | StringSchema<string>
     ? LinkTagNode<O>
     : never;
 
@@ -162,17 +132,13 @@ type ListItemTagNode<O extends RichTextOptions> = {
   tag: "li";
   children: (ParagraphNode<O> | UnorderedListNode<O> | OrderedListNode<O>)[];
 };
-export type ListItemNode<O extends RichTextOptions> = NonNullable<
-  O["block"]
->["ul"] extends true
+export type ListItemNode<O extends RichTextOptions> = O["ul"] extends true
   ? ListItemTagNode<O>
-  : never | NonNullable<O["block"]>["ol"] extends true
+  : O["ol"] extends true
     ? ListItemTagNode<O>
     : never;
 
-export type UnorderedListNode<O extends RichTextOptions> = NonNullable<
-  O["block"]
->["ul"] extends true
+export type UnorderedListNode<O extends RichTextOptions> = O["ul"] extends true
   ? {
       tag: "ul";
       // dir?: "ltr" | "rtl"; TODO: add this
@@ -180,9 +146,7 @@ export type UnorderedListNode<O extends RichTextOptions> = NonNullable<
     }
   : never;
 
-export type OrderedListNode<O extends RichTextOptions> = NonNullable<
-  O["block"]
->["ol"] extends true
+export type OrderedListNode<O extends RichTextOptions> = O["ol"] extends true
   ? {
       tag: "ol";
       // dir?: "ltr" | "rtl"; TODO: add this
@@ -191,10 +155,11 @@ export type OrderedListNode<O extends RichTextOptions> = NonNullable<
   : never;
 
 //#region Heading
+export type HeadingTag = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
 export type HeadingTagOf<
-  S extends keyof NonNullable<NonNullable<O["block"]>>,
+  S extends HeadingTag,
   O extends RichTextOptions,
-> = NonNullable<NonNullable<O["block"]>>[S] extends true
+> = O[S] extends true
   ? {
       tag: S;
 
@@ -220,8 +185,8 @@ export type HeadingNode<O extends RichTextOptions> =
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export type CustomInlineNode<O extends RichTextOptions> = never;
 // export type CustomInlineNode<O extends RichTextOptions> = NonNullable<
-//   NonNullable<O["inline"]>["custom"]
-// >[keyof NonNullable<NonNullable<O["inline"]>["custom"]>] extends Schema<
+//   O["custom"]
+// >[keyof NonNullable<O["custom"]>] extends Schema<
 //   infer Src
 // >
 //   ? ReplaceRawStringWithString<Src>

--- a/packages/init/src/templates.ts
+++ b/packages/init/src/templates.ts
@@ -185,28 +185,21 @@ export const testSchema = s.object({
    */
   richText: s.richtext({
     // styling:
-    style: {
-      bold: true, // enables bold
-      italic: true, // enables italic text
-      lineThrough: true, // enables line/strike-through
-    },
-    // block-level elements:
-    block: {
-      // tags:
-      h1: true, // enables h1
-      h2: true,
-      h3: true,
-      h4: true,
-      h5: true,
-      h6: true,
-      ul: true, // enables unordered lists
-      ol: true, // enables ordered lists
-    },
-    // inline elements:
-    inline: {
-      a: true,
-      img: true,
-    },
+    bold: true, // enables bold
+    italic: true, // enables italic text
+    lineThrough: true, // enables line/strike-through
+    // block-level tags:
+    h1: true, // enables h1
+    h2: true,
+    h3: true,
+    h4: true,
+    h5: true,
+    h6: true,
+    ul: true, // enables unordered lists
+    ol: true, // enables ordered lists
+    // inline tags:
+    a: true,
+    img: true,
   }),
 
   /**

--- a/packages/language-server/src/completions.test.ts
+++ b/packages/language-server/src/completions.test.ts
@@ -555,7 +555,7 @@ export default c.define(
   test("offers routes for a richtext inline link href", async () => {
     // A richtext link is a plain `{ tag: "a", href }` node, which Val does not
     // describe with a schema, so the candidates come from the enclosing
-    // richtext's `inline.a` instead.
+    // richtext's `a` option instead.
     const file = path.join(
       EXAMPLE_APP,
       "app",

--- a/packages/language-server/src/completions.ts
+++ b/packages/language-server/src/completions.ts
@@ -505,11 +505,10 @@ function permitsInlineLinks(richtext: object): boolean {
   if (!("options" in richtext)) {
     return false;
   }
-  const options = (richtext as { options?: { inline?: { a?: unknown } } })
-    .options;
-  // `inline.a` is either `true` or the schema the href must satisfy; both mean
-  // links are allowed.
-  return Boolean(options?.inline?.a);
+  const options = (richtext as { options?: { a?: unknown } }).options;
+  // `a` is either `true` or the schema the href must satisfy; both mean links
+  // are allowed.
+  return Boolean(options?.a);
 }
 
 /** Schema at a module path, or undefined when it cannot be resolved. */

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -662,27 +662,21 @@ import { s, c } from "./val.config";
 
 export const schema = s.richtext({
   // styling
-  style: {
-    bold: true, // enables bold
-    italic: true, // enables italic text
-    lineThrough: true, // enables line/strike-through
-  },
+  bold: true, // enables bold
+  italic: true, // enables italic text
+  lineThrough: true, // enables line/strike-through
   // tags:
-  block: {
-    //ul: true, // enables unordered lists
-    //ol: true, // enables ordered lists
-    // headings:
-    h1: true,
-    h2: true,
-    // h3: true,
-    // h4: true,
-    // h5: true,
-    // h6: true
-  },
-  inline: {
-    //a: true, // enables links
-    //img: true, // enables images
-  },
+  //ul: true, // enables unordered lists
+  //ol: true, // enables ordered lists
+  // headings:
+  h1: true,
+  h2: true,
+  // h3: true,
+  // h4: true,
+  // h5: true,
+  // h6: true
+  //a: true, // enables links
+  //img: true, // enables images
 });
 
 export default c.define("/src/app/content", schema, [
@@ -713,9 +707,7 @@ export default function Page() {
     <main>
       <ValRichText
         theme={{
-          style: {
-            bold: "font-bold", // <- maps bold to a class. NOTE: tailwind classes are supported
-          },
+          bold: "font-bold", // <- maps bold to a class. NOTE: tailwind classes are supported
           //
         }}
         content={content}
@@ -739,7 +731,7 @@ To add classes to `ValRichText` you can use the theme property:
 />
 ```
 
-**NOTE**: if a theme is defined, you must define a mapping for every tag that the you get. What tags you have is decided based on the `options` defined on the `s.richtext()` schema. For example: `s.richtext({ style: { bold: true } })` requires that you add a `bold` theme.
+**NOTE**: if a theme is defined, you must define a mapping for every tag that the you get. What tags you have is decided based on the `options` defined on the `s.richtext()` schema. For example: `s.richtext({ bold: true, })` requires that you add a `bold` theme.
 
 ```tsx
 <ValRichText

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -674,7 +674,7 @@ export const schema = s.richtext({
   // h3: true,
   // h4: true,
   // h5: true,
-  // h6: true
+  // h6: true,
   //a: true, // enables links
   //img: true, // enables images
 });

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -731,7 +731,7 @@ To add classes to `ValRichText` you can use the theme property:
 />
 ```
 
-**NOTE**: if a theme is defined, you must define a mapping for every tag that the you get. What tags you have is decided based on the `options` defined on the `s.richtext()` schema. For example: `s.richtext({ bold: true, })` requires that you add a `bold` theme.
+**NOTE**: if a theme is defined, you must define a mapping for every tag you can get. What tags you have is decided based on the `options` defined on the `s.richtext()` schema. For example: `s.richtext({ bold: true })` requires that you add a `bold` theme.
 
 ```tsx
 <ValRichText

--- a/packages/react/src/internal/ValRichText.test.tsx
+++ b/packages/react/src/internal/ValRichText.test.tsx
@@ -1,0 +1,84 @@
+/** @jest-environment jsdom */
+import { initVal, StringSchema } from "@valbuild/core";
+import { render, screen } from "@testing-library/react";
+import { ThemeOptions, ValRichText } from "./ValRichText";
+import { stegaEncode } from "../stega/stegaEncode";
+
+const { s, c } = initVal();
+
+/**
+ * A theme has to name every tag and style the schema turned on - that is the
+ * whole point of typing it against the options - so these assertions are the
+ * ones that break if `ThemeOptions` ever goes back to being permissive.
+ */
+type Assert<T extends true> = T;
+type IsKey<K extends string, O> = K extends keyof O ? true : false;
+type IsRequired<K extends keyof O, O> = undefined extends O[K] ? false : true;
+
+type _EnabledOptionIsARequiredThemeKey = Assert<
+  IsRequired<"italic", ThemeOptions<{ bold: true; italic: true }>>
+>;
+type _DisabledOptionIsNotAThemeKey = Assert<
+  IsKey<"italic", ThemeOptions<{ bold: true }>> extends false ? true : false
+>;
+type _ListsBringLiWithThem = Assert<
+  IsRequired<"li", ThemeOptions<{ ol: true }>>
+>;
+type _NoListMeansNoLi = Assert<
+  IsKey<"li", ThemeOptions<{ bold: true }>> extends false ? true : false
+>;
+/** `a` is on when it carries a schema, not only when it is literally `true`. */
+type _SchemaBackedAnchorIsARequiredThemeKey = Assert<
+  IsRequired<"a", ThemeOptions<{ a: StringSchema<string> }>>
+>;
+/** Tags no option controls are always optional. */
+type _AlwaysOnTagsStayOptional = Assert<
+  IsRequired<"p", ThemeOptions<{ bold: true }>> extends false ? true : false
+>;
+
+describe("ValRichText", () => {
+  test("theme class names are applied per tag and per style", () => {
+    const schema = s.richtext({
+      bold: true,
+      italic: true,
+      h1: true,
+      ul: true,
+    });
+    const valModule = c.define("/richtext.val.ts", s.object({ text: schema }), {
+      text: [
+        { tag: "h1", children: ["Heading"] },
+        {
+          tag: "p",
+          children: [{ tag: "span", styles: ["bold"], children: ["Bold"] }],
+        },
+        {
+          tag: "ul",
+          children: [
+            { tag: "li", children: [{ tag: "p", children: ["Item"] }] },
+          ],
+        },
+      ],
+    });
+    const content = stegaEncode(valModule, {}).text;
+
+    render(
+      // `stegaEncode` is untyped, so the options are named here rather than
+      // inferred from the content - the inference path is covered by the app in
+      // `examples/next`, which typechecks its themes against real content.
+      <ValRichText<{ bold: true; italic: true; h1: true; ul: true }>
+        content={content}
+        theme={{
+          h1: "heading",
+          bold: "font-bold",
+          italic: "font-italic",
+          ul: "list",
+          li: "item",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Heading").className).toBe("heading");
+    expect(screen.getByText("Bold").className).toBe("font-bold");
+    expect(screen.getByText("Item").closest("li")?.className).toBe("item");
+  });
+});

--- a/packages/react/src/internal/ValRichText.tsx
+++ b/packages/react/src/internal/ValRichText.tsx
@@ -9,11 +9,23 @@ import {
 import React, { CSSProperties, type JSX, ReactNode } from "react";
 import { attrs, raw, RichText, StegaOfRichTextSource } from "../stega";
 
+/**
+ * The tags that are in every richtext, whatever the options say: no option
+ * turns them on, so a theme never has to mention them.
+ */
 type DefaultThemes = Partial<{
   br: string | null;
   p: string | null;
   span: string | null;
 }>;
+/**
+ * The class name of every tag or style that an option turns on. The keys are
+ * the option names themselves, which is what makes a theme exhaustive by
+ * construction: enable `italic` in the schema and `italic` becomes a required
+ * key here.
+ *
+ * `li` is the one key without an option of its own - it comes with `ul`/`ol`.
+ */
 type OptionalFields = {
   h1: string | null;
   h2: string | null;
@@ -31,28 +43,36 @@ type OptionalFields = {
   italic: string | null;
 };
 type AllThemes = DefaultThemes & OptionalFields;
-type ThemeOptions<O extends RichTextOptions = AllRichTextOptions> =
-  DefaultThemes &
-    Pick<
-      OptionalFields,
-      | (NonNullable<O["inline"]>["img"] extends true | Schema<SelectorSource>
-          ? "img"
-          : never)
-      | (NonNullable<O["inline"]>["a"] extends true ? "a" : never)
-      | (NonNullable<O["block"]>["ul"] extends true ? "ul" | "li" : never)
-      | (NonNullable<O["block"]>["ol"] extends true ? "ol" | "li" : never)
-      | (NonNullable<O["style"]>["lineThrough"] extends true
-          ? "lineThrough"
-          : never)
-      | (NonNullable<O["style"]>["bold"] extends true ? "bold" : never)
-      | (NonNullable<O["style"]>["italic"] extends true ? "italic" : never)
-      | (NonNullable<O["block"]>["h1"] extends true ? "h1" : never)
-      | (NonNullable<O["block"]>["h2"] extends true ? "h2" : never)
-      | (NonNullable<O["block"]>["h3"] extends true ? "h3" : never)
-      | (NonNullable<O["block"]>["h4"] extends true ? "h4" : never)
-      | (NonNullable<O["block"]>["h5"] extends true ? "h5" : never)
-      | (NonNullable<O["block"]>["h6"] extends true ? "h6" : never)
-    >;
+
+/** `a` and `img` are on when they carry a schema, not only when they are `true`. */
+type IsEnabled<T> = T extends true
+  ? true
+  : T extends Schema<SelectorSource>
+    ? true
+    : false;
+
+/** Every option name `O` turns on, plus `li` when it has a list. */
+type EnabledThemeKeys<O extends RichTextOptions> =
+  | {
+      [K in keyof OptionalFields & keyof RichTextOptions]: IsEnabled<
+        O[K]
+      > extends true
+        ? K
+        : never;
+    }[keyof OptionalFields & keyof RichTextOptions]
+  | (IsEnabled<O["ul"]> extends true
+      ? "li"
+      : IsEnabled<O["ol"]> extends true
+        ? "li"
+        : never);
+
+/**
+ * The `theme` a `ValRichText` accepts for a given set of richtext options: a
+ * class name for every tag or style those options turn on, and nothing more.
+ * Every key is required, so forgetting one is a type error naming it.
+ */
+export type ThemeOptions<O extends RichTextOptions = AllRichTextOptions> =
+  DefaultThemes & Pick<OptionalFields, EnabledThemeKeys<O>>;
 
 type RichTextNode = StegaOfRichTextSource<
   RichTextSourceNode<AllRichTextOptions>
@@ -83,12 +103,8 @@ type RichTextNode = StegaOfRichTextSource<
  *   <ValRichText
  *     content={content.myRichText}
  *     theme={{
- *        block: {
- *          h1: 'text-4xl font-bold',
- *        },
- *        inline: {
- *          img: 'rounded',
- *        }
+ *        h1: 'text-4xl font-bold',
+ *        img: 'rounded',
  *     }}
  *     transform={(node, className) => {
  *        if (node.tag === 'img') {

--- a/packages/react/src/stega/stegaEncode.test.ts
+++ b/packages/react/src/stega/stegaEncode.test.ts
@@ -561,7 +561,7 @@ describe("media is resolved from the schema, not from the value", () => {
     // would look like a plain object unless the inline image schema is passed
     // to it explicitly.
     const schema = s.object({
-      text: s.richtext({ inline: { img: true } }),
+      text: s.richtext({ img: true }),
     });
     const valModule = c.define("/richtext.val.ts", schema, {
       text: [

--- a/packages/react/src/stega/stegaEncode.ts
+++ b/packages/react/src/stega/stegaEncode.ts
@@ -323,7 +323,7 @@ function inlineImageSchemaOf(
   if (schema?.type !== "richtext") {
     return undefined;
   }
-  const img = schema.options?.inline?.img;
+  const img = schema.options?.img;
   if (!img) {
     return undefined;
   }

--- a/packages/react/src/stega/stegaEncode.ts
+++ b/packages/react/src/stega/stegaEncode.ts
@@ -313,7 +313,7 @@ function resolveLiteralUnionSchema(
 /**
  * The image schema of a richtext's inline images.
  *
- * `inline.img` serializes as `true` when the author did not pass a schema, so
+ * `img` serializes as `true` when the author did not pass a schema, so
  * there is nothing to hand down; a bare `{type: "image"}` is enough, since all
  * the media branch needs is to know that it is looking at media.
  */

--- a/packages/server/src/patch/jsonValuesPatch.test.ts
+++ b/packages/server/src/patch/jsonValuesPatch.test.ts
@@ -391,7 +391,7 @@ describe("applyJsonValuesEntryPatches", () => {
 
     test("richtext inline media is marked at its nestedFilePath", () => {
       const richtextSchema: SerializedSchema = s
-        .record(s.object({ body: s.richtext({ inline: { img: true } }) }))
+        .record(s.object({ body: s.richtext({ img: true }) }))
         .jsonValues()
         ["executeSerialize"]();
       const res = applyJsonValuesEntryPatches({

--- a/packages/shared/src/internal/aiTools/aiImageToolPatches.ts
+++ b/packages/shared/src/internal/aiTools/aiImageToolPatches.ts
@@ -120,7 +120,7 @@ export function getInlineImgInfo(
   richtextSchema: SerializedSchema,
 ): InlineImgInfo {
   if (richtextSchema.type !== "richtext") return { kind: "not-allowed" };
-  const img = richtextSchema.options?.inline?.img;
+  const img = richtextSchema.options?.img;
   if (!img) return { kind: "not-allowed" };
   if (img === true) return { kind: "allowed", remote: false };
   return { kind: "allowed", remote: img.remote === true };

--- a/packages/shared/src/internal/aiTools/aiSourceToolPatches.test.ts
+++ b/packages/shared/src/internal/aiTools/aiSourceToolPatches.test.ts
@@ -34,7 +34,7 @@ const nestedModule = serialize(
       title: s.string(),
       items: s.array(item),
       byKey: s.record(item),
-      body: s.richtext({ block: { h1: true } }),
+      body: s.richtext({ h1: true }),
       hero: s.image(),
       gallery: s.images({
         directory: "/public/val/images",

--- a/packages/shared/src/internal/zod/SerializedSchema.test.ts
+++ b/packages/shared/src/internal/zod/SerializedSchema.test.ts
@@ -1,0 +1,48 @@
+import { initVal, Schema, SelectorSource } from "@valbuild/core";
+import { SerializedSchema } from "./SerializedSchema";
+
+const { s } = initVal();
+
+/**
+ * These z.objects STRIP unknown keys, so anything the serialized schema carries
+ * but this parser does not declare is dropped between the server and the
+ * Studio - silently, and only for the field that forgot it. That is what these
+ * round-trips are here to catch.
+ */
+const serialize = (schema: Schema<SelectorSource>) =>
+  schema["executeSerialize"]();
+
+describe("SerializedSchema round-trips", () => {
+  test("richtext keeps its options", () => {
+    const parsed = SerializedSchema.safeParse(
+      serialize(s.richtext({ bold: true, ul: true, a: true })),
+    );
+    expect(parsed.success).toBe(true);
+    expect(parsed.success && parsed.data).toMatchObject({
+      type: "richtext",
+      options: { bold: true, ul: true, a: true },
+    });
+  });
+
+  test("richtext keeps maxLength and minLength", () => {
+    const parsed = SerializedSchema.safeParse(
+      serialize(s.richtext({ bold: true }).minLength(2).maxLength(10)),
+    );
+    expect(parsed.success).toBe(true);
+    expect(parsed.success && parsed.data).toMatchObject({
+      type: "richtext",
+      options: { minLength: 2, maxLength: 10 },
+    });
+  });
+
+  test("richtext keeps the schemas its `a` and `img` options carry", () => {
+    const parsed = SerializedSchema.safeParse(
+      serialize(s.richtext({ a: s.route(), img: s.image() })),
+    );
+    expect(parsed.success).toBe(true);
+    expect(parsed.success && parsed.data).toMatchObject({
+      type: "richtext",
+      options: { a: { type: "route" }, img: { type: "image" } },
+    });
+  });
+});

--- a/packages/shared/src/internal/zod/SerializedSchema.ts
+++ b/packages/shared/src/internal/zod/SerializedSchema.ts
@@ -177,6 +177,11 @@ export const SerializedImageSchema: z.ZodType<SerializedImageSchemaT> =
 export const RichTextOptions: z.ZodType<SerializedRichTextOptionsT> = z.lazy(
   () =>
     z.object({
+      // Set by `.maxLength()` / `.minLength()`, not by the options argument.
+      // These z.objects strip unknown keys, so leaving them out drops the
+      // length constraints in transit.
+      maxLength: z.number().optional(),
+      minLength: z.number().optional(),
       bold: z.boolean().optional(),
       italic: z.boolean().optional(),
       lineThrough: z.boolean().optional(),

--- a/packages/shared/src/internal/zod/SerializedSchema.ts
+++ b/packages/shared/src/internal/zod/SerializedSchema.ts
@@ -177,33 +177,21 @@ export const SerializedImageSchema: z.ZodType<SerializedImageSchemaT> =
 export const RichTextOptions: z.ZodType<SerializedRichTextOptionsT> = z.lazy(
   () =>
     z.object({
-      style: z
-        .object({
-          bold: z.boolean().optional(),
-          italic: z.boolean().optional(),
-          lineThrough: z.boolean().optional(),
-        })
+      bold: z.boolean().optional(),
+      italic: z.boolean().optional(),
+      lineThrough: z.boolean().optional(),
+      h1: z.boolean().optional(),
+      h2: z.boolean().optional(),
+      h3: z.boolean().optional(),
+      h4: z.boolean().optional(),
+      h5: z.boolean().optional(),
+      h6: z.boolean().optional(),
+      ul: z.boolean().optional(),
+      ol: z.boolean().optional(),
+      a: z
+        .union([z.boolean(), SerializedRouteSchema, SerializedStringSchema])
         .optional(),
-      block: z
-        .object({
-          h1: z.boolean().optional(),
-          h2: z.boolean().optional(),
-          h3: z.boolean().optional(),
-          h4: z.boolean().optional(),
-          h5: z.boolean().optional(),
-          h6: z.boolean().optional(),
-          ul: z.boolean().optional(),
-          ol: z.boolean().optional(),
-        })
-        .optional(),
-      inline: z
-        .object({
-          a: z
-            .union([z.boolean(), SerializedRouteSchema, SerializedStringSchema])
-            .optional(),
-          img: z.union([z.boolean(), SerializedImageSchema]).optional(),
-        })
-        .optional(),
+      img: z.union([z.boolean(), SerializedImageSchema]).optional(),
     }),
 );
 export const SerializedRichTextSchema: z.ZodType<SerializedRichTextSchemaT> =

--- a/packages/ui/spa/components/RichTextEditor/__tests__/fixedToolbarContent.test.ts
+++ b/packages/ui/spa/components/RichTextEditor/__tests__/fixedToolbarContent.test.ts
@@ -47,24 +47,24 @@ describe("the fixed toolbar is mounted only when it has content", () => {
   });
 
   test.each<[string, SerializedRichTextOptions]>([
-    ["bold", { style: { bold: true } }],
-    ["italic", { style: { italic: true } }],
-    ["lineThrough", { style: { lineThrough: true } }],
-    ["a bullet list", { block: { ul: true } }],
-    ["an ordered list", { block: { ol: true } }],
-    ["h1", { block: { h1: true } }],
-    ["h2", { block: { h2: true } }],
-    ["h3", { block: { h3: true } }],
-    ["links", { inline: { a: true } }],
-    ["images", { inline: { img: true } }],
+    ["bold", { bold: true }],
+    ["italic", { italic: true }],
+    ["lineThrough", { lineThrough: true }],
+    ["a bullet list", { ul: true }],
+    ["an ordered list", { ol: true }],
+    ["h1", { h1: true }],
+    ["h2", { h2: true }],
+    ["h3", { h3: true }],
+    ["links", { a: true }],
+    ["images", { img: true }],
   ])("%s: toolbar", (_name, options) => {
     expect(shows(options)).toBe(true);
   });
 
   test.each<[string, SerializedRichTextOptions]>([
-    ["h4", { block: { h4: true } }],
-    ["h5", { block: { h5: true } }],
-    ["h6", { block: { h6: true } }],
+    ["h4", { h4: true }],
+    ["h5", { h5: true }],
+    ["h6", { h6: true }],
   ])("%s alone: no toolbar, because it has no control", (_name, options) => {
     // `getBlockTypeItems` only offers levels 1-3, so h4-h6 are real features
     // with nothing in the bar to represent them. This is exactly why the
@@ -74,7 +74,7 @@ describe("the fixed toolbar is mounted only when it has content", () => {
   });
 
   test("an image field with nowhere to get an image from: no toolbar", () => {
-    const features = resolve({ inline: { img: true } });
+    const features = resolve({ img: true });
     const schema = buildSchema({ features });
     expect(
       hasFixedToolbarContent({ schema, features, canInsertImage: false }),

--- a/packages/ui/spa/components/RichTextEditor/convertOptions.ts
+++ b/packages/ui/spa/components/RichTextEditor/convertOptions.ts
@@ -7,21 +7,21 @@ export function serializedRichTextOptionsToFeatures(
   if (!options) return {};
   const features: Partial<EditorFeatures> = {};
 
-  features.bold = options.style?.bold ?? false;
-  features.italic = options.style?.italic ?? false;
-  features.strikethrough = options.style?.lineThrough ?? false;
+  features.bold = options.bold ?? false;
+  features.italic = options.italic ?? false;
+  features.strikethrough = options.lineThrough ?? false;
 
-  features.h1 = options.block?.h1 ?? false;
-  features.h2 = options.block?.h2 ?? false;
-  features.h3 = options.block?.h3 ?? false;
-  features.h4 = options.block?.h4 ?? false;
-  features.h5 = options.block?.h5 ?? false;
-  features.h6 = options.block?.h6 ?? false;
-  features.bulletList = options.block?.ul ?? false;
-  features.orderedList = options.block?.ol ?? false;
+  features.h1 = options.h1 ?? false;
+  features.h2 = options.h2 ?? false;
+  features.h3 = options.h3 ?? false;
+  features.h4 = options.h4 ?? false;
+  features.h5 = options.h5 ?? false;
+  features.h6 = options.h6 ?? false;
+  features.bulletList = options.ul ?? false;
+  features.orderedList = options.ol ?? false;
 
-  features.link = !!options.inline?.a;
-  features.image = !!options.inline?.img;
+  features.link = !!options.a;
+  features.image = !!options.img;
 
   features.hardBreak = true;
   features.fixedToolbar = true;

--- a/packages/ui/spa/components/RichTextEditor/useRichTextEditorConfig.ts
+++ b/packages/ui/spa/components/RichTextEditor/useRichTextEditorConfig.ts
@@ -29,18 +29,18 @@ export function useRichTextEditorConfig(options?: SerializedRichTextOptions): {
   );
 
   const isRouteLink =
-    options?.inline?.a === true ||
-    (typeof options?.inline?.a === "object" &&
-      "type" in options.inline.a &&
-      options.inline.a.type === "route");
+    options?.a === true ||
+    (typeof options?.a === "object" &&
+      "type" in options.a &&
+      options.a.type === "route");
 
   const routeSchema =
     isRouteLink &&
-    options?.inline?.a &&
-    typeof options.inline.a === "object" &&
-    "type" in options.inline.a &&
-    options.inline.a.type === "route"
-      ? options.inline.a
+    options?.a &&
+    typeof options.a === "object" &&
+    "type" in options.a &&
+    options.a.type === "route"
+      ? options.a
       : undefined;
 
   const includePattern = useMemo(
@@ -143,7 +143,7 @@ export function useRichTextEditorConfig(options?: SerializedRichTextOptions): {
   ]);
 
   const imageModulePath = useMemo((): ModuleFilePath | undefined => {
-    const img = options?.inline?.img;
+    const img = options?.img;
     if (
       img &&
       typeof img === "object" &&
@@ -158,7 +158,7 @@ export function useRichTextEditorConfig(options?: SerializedRichTextOptions): {
   }, [options]);
 
   const imageSchema = useMemo((): SerializedImageSchema | undefined => {
-    const img = options?.inline?.img;
+    const img = options?.img;
     if (
       img &&
       typeof img === "object" &&

--- a/packages/ui/spa/components/fields/RichTextField.tsx
+++ b/packages/ui/spa/components/fields/RichTextField.tsx
@@ -139,7 +139,7 @@ export function RichTextField({
   const { features, linkCatalog, imageModulePath, imageSchema } =
     useRichTextEditorConfig(schemaOptions);
 
-  const hasImageEnabled = !!schemaOptions?.inline?.img;
+  const hasImageEnabled = !!schemaOptions?.img;
 
   const imageReferencedModule = imageSchema?.referencedModule as
     | ModuleFilePath

--- a/packages/ui/spa/hooks/expandSessionKeysInPatch.test.ts
+++ b/packages/ui/spa/hooks/expandSessionKeysInPatch.test.ts
@@ -101,7 +101,7 @@ describe("planSessionKeyExpansion", () => {
         "/content/article.val.ts",
         s.object({
           body: s.richtext({
-            inline: { img: true },
+            img: true,
           }),
         }),
         { body: [] },

--- a/packages/ui/spa/hooks/expandSessionKeysInPatch.ts
+++ b/packages/ui/spa/hooks/expandSessionKeysInPatch.ts
@@ -351,7 +351,7 @@ export function planSessionKeyExpansion(args: {
     if (foundSiteCount > 0 && inlineImg.kind === "not-allowed") {
       return {
         kind: "error",
-        message: `Patch op #${opIndex} inserts an inline image into a richtext that does not allow inline images (options.inline.img is not enabled).`,
+        message: `Patch op #${opIndex} inserts an inline image into a richtext that does not allow inline images (options.img is not enabled).`,
       };
     }
   }

--- a/packages/ui/spa/hooks/useAI.ts
+++ b/packages/ui/spa/hooks/useAI.ts
@@ -164,7 +164,7 @@ const CREATE_PATCH_TOOL: AITool = {
     File field example:
     {"patch":[{"op":"replace","path":["brochure"],"value":{"key":"abc","filePath":"/public/val/files/brochure.pdf","_type":"ai_session_file","_tag":"file"}}]}
 
-    Richtext inline image example (richtext schema must have options.inline.img enabled):
+    Richtext inline image example (richtext schema must have options.img enabled):
     {"patch":[{"op":"add","path":["body","0","children","2"],"value":{"tag":"img","src":{"key":"abc","filePath":"/public/val/images/inline.png","_type":"ai_session_file","_tag":"image"}}}]}
 
     Multiple session keys can appear in a single patch.
@@ -2431,7 +2431,7 @@ Never tell the user to navigate manually — offer to navigate for them instead.
     - img: {tag:"img", src:{...}} — cannot be added via assistant (no file system access)
     - br: {tag:"br"}
   - example: [{tag:"p",children:["Hello ",{tag:"span",styles:["bold"],children:["World"]}]}]
-  - richtext schema has options, which tells you which type of tags you can use. Example: if options do not have block.ul: true, then ul is not allowed. The schema.options type is like this: style: Partial<{bold: boolean;italic: boolean;lineThrough: boolean;}>;block: Partial<{h1: boolean;h2: boolean;h3: boolean;h4: boolean;h5: boolean;h6: boolean;ul: boolean;ol: boolean;}>;inline: Partial<{a: boolean | SerializedRouteSchema | SerializedStringSchema;img: boolean | SerializedImageSchema;}>;
+  - richtext schema has options, which tells you which type of tags you can use. Example: if options do not have ul: true, then ul is not allowed. The schema.options type is like this: Partial<{bold: boolean;italic: boolean;lineThrough: boolean;h1: boolean;h2: boolean;h3: boolean;h4: boolean;h5: boolean;h6: boolean;ul: boolean;ol: boolean;a: boolean | SerializedRouteSchema | SerializedStringSchema;img: boolean | SerializedImageSchema;}>;
 - image / file: cannot be changed through this assistant (no file system access). If the user needs to add one, navigate to the matching media gallery.
 - union: a value that must match exactly one of several allowed shapes. Two kinds:
   - string union: key is a literal schema, all items are literals. The value is one fixed string chosen from a set (e.g. "draft", "published", "archived"). Patch by replacing the string with one of the allowed values.

--- a/packages/ui/spa/resolvePatchPath.test.ts
+++ b/packages/ui/spa/resolvePatchPath.test.ts
@@ -185,9 +185,12 @@ describe("resolvePatchPath", () => {
       s.record(
         s.object({
           text: s.richtext({
-            style: { bold: true, italic: true, lineThrough: true },
-            block: { h2: true, ul: true },
-            inline: { a: true },
+            bold: true,
+            italic: true,
+            lineThrough: true,
+            h2: true,
+            ul: true,
+            a: true,
           }),
         }),
       ),

--- a/packages/ui/spa/stores/workerSeam.test.ts
+++ b/packages/ui/spa/stores/workerSeam.test.ts
@@ -50,7 +50,7 @@ const project = () => {
         owner: s.keyOf(authors),
         hero: s.image(),
         link: s.route(),
-        body: s.richtext({ style: { bold: true }, block: { ul: true } }),
+        body: s.richtext({ bold: true, ul: true }),
         block: s.union(
           "type",
           s.object({ type: s.literal("a"), a: s.string() }),


### PR DESCRIPTION
**Summary**

Removes the nested `style`, `block`, and `inline` groupings from `RichTextOptions`, making all options flat top-level keys. This simplifies the API and fixes type inconsistencies in theme validation.

**Changes**

- **Type definitions**: Flattened `RichTextOptions` and `SerializedRichTextOptions` from nested objects to a single level with all 13 options as direct keys (`bold`, `italic`, `lineThrough`, `h1`–`h6`, `ul`, `ol`, `a`, `img`)

- **Type utilities**: Updated conditional types (`Bold`, `Italic`, `LineThrough`, `ImageNode`, `LinkNode`, `ListItemNode`, `UnorderedListNode`, `OrderedListNode`, `HeadingTagOf`) to access options directly instead of through `NonNullable<O["style"]>` / `NonNullable<O["block"]>` / `NonNullable<O["inline"]>` chains

- **Theme type (`ThemeOptions`)**: Rewrote as a mapped type over enabled options, fixing an inconsistency where `a: s.route()` (schema-backed) didn't require an `a` key in the theme the way `img` always did. Now both `a: true` and `a: s.route()` require the key.

- **Schema validation**: Updated `RichTextSchema.executeValidate()` to check options directly (e.g., `this.options.bold` instead of `this.options.style?.bold`)

- **Deserialization**: Simplified `deserializeSchema()` to handle flat options when reconstructing `RichTextSchema` from serialized form

- **Zod schema**: Flattened the serialized schema validation in `SerializedSchema.ts`

- **Tests and examples**: Updated all test cases and example schemas across `@valbuild/core`, `@valbuild/react`, `@valbuild/ui`, `@valbuild/next`, and `@valbuild/init` to use flat options

- **Documentation**: Updated README and inline examples to show flat syntax

**Breaking Change**

This is a minor version bump across all packages. Projects must update richtext schemas from:
```ts
s.richtext({
  style: { bold: true, italic: true },
  block: { h1: true, ul: true },
  inline: { a: true, img: s.image() }
})
```
to:
```ts
s.richtext({
  bold: true,
  italic: true,
  h1: true,
  ul: true,
  a: true,
  img: s.image()
})
```

**Implementation Notes**

- The nested structure never carried semantic meaning beyond what the option names already expressed
- Flattening enables `ThemeOptions` to be a proper mapped type, eliminating manual option restatement and fixing the schema-backed anchor inconsistency
- `li` remains a special case: it has no option of its own but appears in `ThemeOptions` when `ul` or `ol` is enabled

https://claude.ai/code/session_01BTGSLdSV5dLeutZiK8ZyfX