### PR TITLE
Release the packages 0.120.1 never published

### DIFF
--- a/.agent/rules.md
+++ b/.agent/rules.md
@@ -556,6 +556,57 @@ until someone bumps it. So, once the new version is on npm:
    shows up here first, and this is the last place to catch it before it is what
    every new project starts from.
 
+### The Release job fails with `E401 … Failed to generate Web Auth URLs`
+
+Symptom: `changeset publish` publishes some packages and then fails on one:
+
+```
+@valbuild/language-server@0.120.1
+└ E401: 401 Unauthorized - PUT https://registry.npmjs.org/@valbuild%2flanguage-server - Failed to generate Web Auth URLs due to error: BadRequestError: token is invalid
+```
+
+Re-running the job does not help; the same package now fails with
+
+```
+└ E409: 409 Conflict - PUT https://registry.npmjs.org/@valbuild%2flanguage-server - Cannot publish over previously staged version "0.120.1".
+```
+
+and the packages that depend on it (`cli`, `next`) are never attempted.
+
+→ Nothing is wrong with the token or the workflow. The Release workflow publishes
+with npm trusted publishing (OIDC — note the `id-token: write` permission and the
+absence of an `NPM_TOKEN`), and every `@valbuild/*` package has a trusted
+publisher configuration on npmjs.com pointing at `valbuild/val` +
+`release.yml`. Since May 2026 that configuration carries an **Allowed actions**
+choice: `npm stage publish` is always allowed, and `npm publish` (direct
+publishing) is a separate checkbox. Configurations created before that date
+were grandfathered to allow `npm publish`; newer ones are not unless the box was
+ticked. When the workflow runs `npm publish` against a package whose
+configuration only allows staging, the registry **stages** the version and then
+tries to complete the publish with a web-auth 2FA prompt, which an OIDC token
+cannot answer — hence the 401. The tarball stays in the staging area, so every
+re-run gets the 409.
+
+Fix, in this order:
+
+1. On npmjs.com, open the **Staged Packages** tab and either **Approve** the
+   staged version (2FA; this publishes it with the provenance from the original
+   run, which is what happened for `language-server@0.120.0`) or **Reject** it
+   so the version number is free again. `npm stage approve <stage-id>` from a
+   laptop with 2FA does the same; OIDC tokens cannot approve.
+2. Fix the configuration so it does not happen next release: npmjs.com →
+   the package → Settings → Trusted publishing. Connections cannot be edited,
+   so delete the GitHub Actions one and add it back (organization `valbuild`,
+   repository `val`, workflow filename `release.yml`, no environment) with
+   **`npm publish` ticked under Allowed actions**. Configurations created after
+   2026-09-03 default to stage-only, so the box has to be ticked explicitly.
+3. Re-run the failed Release job. `changeset publish` skips versions already on
+   the registry, so it picks up exactly the packages that are still missing.
+
+A newly added package is the usual trigger: its trusted publisher gets created
+long after everyone else's, with the newer default. Tick the `npm publish` box
+when you set it up, and expect this failure on the first release if you forget.
+
 ## Common Fixes
 
 ### `prettier --check` fails on a file `prettier --write` just wrote

--- a/.changeset/republish-missing-0-120-1.md
+++ b/.changeset/republish-missing-0-120-1.md
@@ -1,0 +1,17 @@
+---
+"@valbuild/language-server": patch
+"@valbuild/cli": patch
+"@valbuild/next": patch
+---
+
+Publish the packages that 0.120.1 did not reach.
+
+`@valbuild/server@0.120.1` made it to npm, but `@valbuild/cli`,
+`@valbuild/language-server` and `@valbuild/next` did not — the release job
+failed part-way through, and the version numbers it had already claimed could
+not be reused. This release carries the same contents for those three packages:
+they pick up the MCP signing-key rotation fix from `@valbuild/server@0.120.1`,
+and there is nothing else in it.
+
+If you are on 0.120.0, upgrade straight to this version. There is no 0.120.1 of
+these three packages, and there will not be one.


### PR DESCRIPTION
`@valbuild/server@0.120.1` reached npm. `@valbuild/cli`, `@valbuild/language-server` and `@valbuild/next` did not — the Release job died part-way through, and those three version numbers are now spent: `language-server@0.120.1` is sitting in npm's staging area, so every re-run of the job gets `E409 Cannot publish over previously staged version`.

This bumps the three past it rather than trying to reclaim 0.120.1.

### Changes

- **`.changeset/republish-missing-0-120-1.md`** — a patch changeset for `cli`, `language-server` and `next`. `changeset status` confirms it bumps exactly those three, 0.120.1 → 0.120.2. Nothing else moves: `server` stays at the published 0.120.1, and `core`/`shared`/`ui`/`react` stay at 0.120.0. Since `workspace:*` publishes as an exact pin, the new versions pin `server@0.120.1` and `core@0.120.0`, both already on the registry.
- **`.agent/rules.md`** — documents the failure mode under Releasing, so the next person who adds a package recognises it. The root cause is not the token or the workflow: a trusted publisher configuration created after May 2026 does not permit direct `npm publish` unless the box is ticked, so the registry stages the version and then asks for a web-auth 2FA prompt that an OIDC token cannot answer — the `E401 … Failed to generate Web Auth URLs`. `language-server` was added to npm on 2026-08-21, which is why it alone was affected.

### Releasing this

Merging opens the usual Version Packages PR; merging that publishes 0.120.2. The trusted publisher config for `language-server` has since been updated to allow `npm publish`, so this release is also the test of that.

The staged `language-server@0.120.1` is still out there and does not block anything now, but it is worth rejecting on npmjs.com so the version number cannot go live later by accident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019xBVfjewL6cQUKjQiH5sN6

---
_Generated by [Claude Code](https://claude.ai/code/session_019xBVfjewL6cQUKjQiH5sN6)_