### PR TITLE
Stamp locally created patches with current author ID

### DIFF
--- a/.changeset/patch-author-in-session.md
+++ b/.changeset/patch-author-in-session.md
@@ -1,0 +1,20 @@
+---
+"@valbuild/ui": patch
+---
+
+Show your own name on the changes you have just made.
+
+In a hosted project, a change made in the Studio showed up under "Unknown
+author" as soon as it was made, next to earlier changes that were correctly
+attributed. Reloading the page fixed it, which is what made it look arbitrary:
+whether a change had an author depended on whether it had been fetched from the
+server or made in the tab you were looking at.
+
+A patch created in the browser carried no author at all. The server stamps one
+from your session when the patch is saved, but the Studio never re-fetches a
+patch it made itself, so nothing in the tab ever learned who wrote it — the
+change history, the author avatars on a field and the review screen all grouped
+it under an author they could not name.
+
+Such a patch is now stamped with the current profile as it is created, which is
+the same author the server records for it.

--- a/e2e/http/attribution.spec.ts
+++ b/e2e/http/attribution.spec.ts
@@ -1,0 +1,133 @@
+import { expect, test, type Locator } from "@playwright/test";
+import { contextAs, mock, openHttpStudio } from "./httpMode";
+
+/**
+ * Whose change is this?
+ *
+ * `fs` mode cannot ask: one writer, no session, and the Studio says "Local
+ * changes". In proxy mode every patch carries an author, the Studio names it
+ * from `/profiles`, and a patch with no author it can name reads as "Unknown
+ * author" — so this is the one mode where getting it wrong is visible, and it
+ * was wrong in exactly one direction.
+ *
+ * A patch made in the browser carried no author at all. The server stamps one
+ * from the session cookie on `PUT /patches`, but the Studio fetches ops only for
+ * ids it has no data for — so a record it made itself is never re-fetched and
+ * never learned who wrote it. Every change went anonymous the moment it was
+ * made, beside the ones already on the server, which were attributed correctly,
+ * and a reload "fixed" it.
+ *
+ * Asserted on the NAME the review view shows rather than on the record, because
+ * the name is the thing that was wrong: a record carrying the right author that
+ * the Studio cannot put a name to is the same bug from the editor's side.
+ */
+
+const KB_ENTRY = "/val/~/content/kb.val.ts?p=%22kb-000%22";
+
+/** What the mock's `/profiles` calls `profile-ada`, whose session these run as. */
+const ADA = "Ada Lovelace";
+
+/** What an avatar with no profile behind it says in proxy mode. */
+const UNKNOWN = "Unknown author";
+
+/**
+ * Open the review view and the change history of the change in it.
+ *
+ * The history popover is where a name is written out rather than reduced to
+ * initials or an id — `FieldPatchAuthorsPure` prints the profile's full name, or
+ * the fallback this test is about. The avatars beside it carry the same name as
+ * a `title`, but several of them are rendered offscreen for the collapsed
+ * stacks, so the popover is the honest thing to assert on.
+ *
+ * Reached by clicking, the way an editor reaches it: Review only appears once
+ * there is something to review, so this is also the wait for the edit having
+ * become a patch.
+ */
+async function openChangeHistory(studio: Locator): Promise<void> {
+  const review = studio.getByRole("button", { name: /Review \d+ change/ });
+  await expect(review).toBeVisible({ timeout: 30000 });
+  await review.click();
+  const history = studio
+    .getByRole("button", { name: "Change history" })
+    .first();
+  await expect(history).toBeVisible({ timeout: 30000 });
+  await history.click();
+}
+
+test.describe.configure({ mode: "serial" });
+
+test.beforeEach(async () => {
+  await mock.reset();
+});
+
+test.describe("attribution of your own changes", () => {
+  test("a change you have just made is credited to you, with no reload", async ({
+    browser,
+  }) => {
+    const context = await contextAs(browser, "ada");
+    const page = await context.newPage();
+    try {
+      await openHttpStudio(page, KB_ENTRY);
+      const studio = page.locator("#val-shadow-root");
+
+      const editor = studio.getByRole("textbox").first();
+      await expect(editor).toBeVisible({ timeout: 30000 });
+      await editor.fill("Ada typed this");
+
+      await openChangeHistory(studio);
+
+      // Ada is logged in as `profile-ada`, and the mock's `/profiles` gives that
+      // id the name below — so this is the whole round trip: session cookie to
+      // author id to a name on screen.
+      await expect(studio.getByText(ADA).first()).toBeVisible({
+        timeout: 30000,
+      });
+      await expect(studio.getByText(UNKNOWN)).toHaveCount(0);
+    } finally {
+      await context.close();
+    }
+  });
+
+  /**
+   * The name does not change when the page comes back from the server.
+   *
+   * The client stamps the author it believes it is; the server stamps the one on
+   * the session cookie. They are supposed to be the same author, and a reload is
+   * what makes them comparable — after it, the record is the server's. A stamp
+   * that guessed differently would show one name before the reload and another
+   * after, which is worse than showing none.
+   */
+  test("and is still credited to you once the record comes from the server", async ({
+    browser,
+  }) => {
+    const context = await contextAs(browser, "ada");
+    const page = await context.newPage();
+    try {
+      await openHttpStudio(page, KB_ENTRY);
+      const studio = page.locator("#val-shadow-root");
+
+      const editor = studio.getByRole("textbox").first();
+      await expect(editor).toBeVisible({ timeout: 30000 });
+      await editor.fill("Ada typed this too");
+      // The patch has to be ON the server before the reload, or there is nothing
+      // to come back.
+      await expect
+        .poll(async () => (await mock.state()).patches.length, {
+          message: "the edit never reached the content service",
+          timeout: 30000,
+        })
+        .toBeGreaterThan(0);
+
+      await openHttpStudio(page, KB_ENTRY);
+      const reloaded = page.locator("#val-shadow-root");
+      await openChangeHistory(reloaded);
+
+      await expect(reloaded.getByText(ADA).first()).toBeVisible({
+        timeout: 30000,
+      });
+      await expect(reloaded.getByText(UNKNOWN)).toHaveCount(0);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/packages/ui/spa/components/ValProvider.tsx
+++ b/packages/ui/spa/components/ValProvider.tsx
@@ -418,6 +418,15 @@ export function ValProvider({
     "data" in stat && stat.data ? stat.data.patches : undefined;
   const statMode = "data" in stat && stat.data ? stat.data.mode : undefined;
   /**
+   * Who the person at the keyboard is. `/stat` is the only thing that says.
+   *
+   * The same value `useCurrentAuthorId` reads out of context, kept as one
+   * expression here so the store system and the review UI cannot end up
+   * disagreeing about who you are.
+   */
+  const statProfileId =
+    "data" in stat && stat.data ? stat.data.profileId : null;
+  /**
    * Unpublished changes the server threw away because it could not read them.
    *
    * Cleared by the next stat, because the server drains the notice when it hands
@@ -501,6 +510,16 @@ export function ValProvider({
       system.setMode(statMode);
     }
   }, [system, statMode]);
+  /**
+   * Pushed in like the mode, and for the same reason — see `System.setAuthorId`.
+   *
+   * Without this a patch created here carried no author, and a locally created
+   * record is never re-fetched: every change made in the session showed as
+   * "Unknown author" next to the ones already on the server, until a reload.
+   */
+  useEffect(() => {
+    system.setAuthorId(statProfileId);
+  }, [system, statProfileId]);
 
   const [deployments, setDeployments] = useState<ValEnrichedDeployment[]>([]);
   const dismissedDeploymentsRef = useRef<Set<string>>(new Set());
@@ -725,7 +744,7 @@ export function ValProvider({
         client,
         publishSummaryState,
         setPublishSummaryState,
-        profileId: "data" in stat && stat.data ? stat.data.profileId : null,
+        profileId: statProfileId,
         mode: "data" in stat && stat.data ? stat.data.mode : "unknown",
         profileAuthError:
           profilesData.status === "auth-error" ? profilesData.error : null,

--- a/packages/ui/spa/stores/PatchStore.ts
+++ b/packages/ui/spa/stores/PatchStore.ts
@@ -311,6 +311,19 @@ export class PatchStore {
    */
   private parentRefSource: () => ParentRef | null = () => null;
 
+  /**
+   * Who the person at the keyboard is, as an author id.
+   *
+   * A source rather than a value for the same reason {@link parentRefSource} is
+   * one: it arrives from `/stat`, which lands after the system is built, and a
+   * system rebuilt when it does would take its patches with it.
+   *
+   * `null` — no session, so nobody — is the honest default and is what `fs` mode
+   * stays on: there the review UI reads a missing author as "Local changes",
+   * which is true, rather than as a person it cannot name.
+   */
+  private authorSource: () => string | null = () => null;
+
   /** See {@link parentRefSource}. */
   /** See {@link publishInFlight}. */
   setPublishInFlight(isPublishing: () => boolean): void {
@@ -319,6 +332,11 @@ export class PatchStore {
 
   setParentRefSource(source: () => ParentRef | null): void {
     this.parentRefSource = source;
+  }
+
+  /** See {@link authorSource}. */
+  setAuthorSource(source: () => string | null): void {
+    this.authorSource = source;
   }
 
   constructor(
@@ -893,6 +911,17 @@ export class PatchStore {
       patch: patchOps,
       meta,
       createdAt: new Date().toISOString(),
+      // Stamped for the same reason `createdAt` is, and with the same value the
+      // server is about to record: `PUT /patches` takes the author from the
+      // session cookie this client is authenticated with, so the two agree.
+      //
+      // Without it a patch made here had no author until the page was reloaded,
+      // and a locally created record is never re-fetched — `onStatPatchIds` asks
+      // only for ids it has no data for. So in `http` mode every change the user
+      // had just made showed as "Unknown author" beside the ones they made
+      // before, which is the one reading of the review screen that is never
+      // true.
+      authorId: this.authorSource(),
     };
     this.dataById.set(patchId, record);
     this.originById.set(patchId, "internal");

--- a/packages/ui/spa/stores/createSystem.ts
+++ b/packages/ui/spa/stores/createSystem.ts
@@ -243,6 +243,17 @@ export type System = HostRealm &
      * keeps running, and any patch created in that window goes with it.
      */
     setMode(mode: "fs" | "http"): void;
+    /**
+     * Tell the system who is editing, so a patch made here is stamped with it.
+     *
+     * A setter for the same reason {@link System.setMode} is one: the answer
+     * comes from `/stat`, which lands after the Studio has mounted and taken the
+     * project in, and rebuilding the system when it arrives discards the first
+     * one along with any patch created in that window.
+     *
+     * `null` means nobody is known — the default, and where `fs` mode stays.
+     */
+    setAuthorId(authorId: string | null): void;
     dispose(): void;
   };
 
@@ -495,6 +506,15 @@ export function createSystem(options: SystemOptions): System {
   // See `PatchStore.publishInFlight`: a stat landing mid-publish would otherwise
   // reconcile away the patches `/save` has just deleted server-side.
   patchStore.setPublishInFlight(() => publishing);
+  /**
+   * Who is editing, as `/stat` last said. See {@link System.setAuthorId}.
+   *
+   * Held here and read through a closure rather than pushed into the store, so
+   * that a patch created before the first stat and one created after it each get
+   * the answer that was true when they were made.
+   */
+  let authorId: string | null = null;
+  patchStore.setAuthorSource(() => authorId);
 
   /**
    * How many times each patch has been through {@link discardUnapplicable}.
@@ -1412,6 +1432,9 @@ export function createSystem(options: SystemOptions): System {
     },
     setMode(next) {
       mode = next;
+    },
+    setAuthorId(next) {
+      authorId = next;
     },
     dispose() {
       for (const off of unsubscribe) off();

--- a/packages/ui/spa/stores/patchAuthor.test.ts
+++ b/packages/ui/spa/stores/patchAuthor.test.ts
@@ -1,0 +1,100 @@
+import { initVal, type PatchId } from "@valbuild/core";
+import { createSystem } from "./createSystem";
+import { mfp } from "./testSystem";
+
+/**
+ * Who a patch made in THIS session belongs to.
+ *
+ * The review UI groups by `authorId` and names each group from `/profiles`, so a
+ * record with no author renders as "Unknown author" in `http` mode. A locally
+ * created record is never re-fetched — `onStatPatchIds` asks only for ids it has
+ * no data for — so an unstamped patch stayed unknown for the life of the page,
+ * beside the ones already on the server, which showed the right name. That is
+ * the shape of the bug: your own changes turn anonymous as you make them.
+ */
+const module = () => {
+  const { c, s } = initVal();
+  return c.define("/t.val.ts", s.object({ title: s.string() }), {
+    title: "a",
+  });
+};
+
+function build(fetchPatches = async () => ({ patches: [] })) {
+  const system = createSystem({ fetchPatches });
+  system.host.receive([module()]);
+  return system;
+}
+
+async function type(
+  system: ReturnType<typeof build>,
+  value: string,
+): Promise<PatchId> {
+  const res = await system.patchStore.createPatch(mfp("/t.val.ts"), [
+    { op: "replace", path: ["title"], value },
+  ]);
+  if (res.status !== "created") {
+    throw new Error(`Expected the patch to be created, got ${res.status}`);
+  }
+  return res.record.patchId;
+}
+
+function authorOf(
+  system: ReturnType<typeof build>,
+  patchId: PatchId,
+): string | null | undefined {
+  return system.patchStore.recordsFor([patchId])[0]?.authorId;
+}
+
+describe("the author of a locally created patch", () => {
+  it("is nobody until something says who is editing", async () => {
+    const system = build();
+
+    const patchId = await type(system, "typed");
+
+    // `fs` mode never leaves this state: there is no session to have a profile,
+    // and the review UI reads a missing author there as "Local changes".
+    expect(authorOf(system, patchId)).toBe(null);
+    system.dispose();
+  });
+
+  it("is the id the system was told, so the studio can name you at once", async () => {
+    const system = build();
+    system.setAuthorId("profile-a");
+
+    const patchId = await type(system, "typed");
+
+    expect(authorOf(system, patchId)).toBe("profile-a");
+    system.dispose();
+  });
+
+  it("survives the stat that announces it, which does not re-fetch the record", async () => {
+    const fetchPatches = jest.fn(async () => ({ patches: [] }));
+    const system = build(fetchPatches);
+    system.setAuthorId("profile-a");
+    const patchId = await type(system, "typed");
+
+    // The server now names it. Nothing is fetched — the record is already here —
+    // so the stamp is the only thing that can carry the author until a reload.
+    system.stat.receiveStat({ patches: [patchId], baseSha: "sha" });
+    await Promise.resolve();
+
+    expect(fetchPatches).not.toHaveBeenCalled();
+    expect(authorOf(system, patchId)).toBe("profile-a");
+    system.dispose();
+  });
+
+  it("is whoever was editing when the patch was made", async () => {
+    const system = build();
+    system.setAuthorId("profile-a");
+    const first = await type(system, "typed");
+
+    // A later answer must not rewrite the history of an earlier patch: the
+    // server recorded the author it had at the time of each `PUT`.
+    system.setAuthorId("profile-b");
+    const second = await type(system, "typed again");
+
+    expect(authorOf(system, first)).toBe("profile-a");
+    expect(authorOf(system, second)).toBe("profile-b");
+    system.dispose();
+  });
+});


### PR DESCRIPTION
## Summary

Patches created in the browser are now stamped with the current author ID as they are created, fixing a bug where locally created patches showed as "Unknown author" until the page was reloaded.

## Problem

In hosted projects, a change made in the Studio appeared under "Unknown author" immediately after creation, while earlier changes were correctly attributed. This happened because:

1. Patches created locally had no author ID attached
2. The server stamps an author from the session cookie when saving, but the Studio never re-fetches patches it created itself
3. Since locally created records are never re-fetched, the author information never reached the UI

This made the change history, author avatars, and review screen all show locally created patches as anonymous until a page reload.

## Changes

- **PatchStore**: Added `authorSource` (a closure-based source like `parentRefSource`) to capture the current author ID when a patch is created. The author ID is now included in the patch record's `authorId` field at creation time.

- **createSystem**: Added `setAuthorId()` method to allow setting the current author ID. The ID is held in a closure and read through `authorSource` so patches created before and after the first stat each get the correct author that was true when they were made.

- **ValProvider**: Extracts `statProfileId` from the `/stat` response and calls `system.setAuthorId()` when it changes, keeping the store system and review UI in sync about the current author.

- **Tests**: Added comprehensive test suite (`patchAuthor.test.ts`) covering:
  - Default state (no author until set)
  - Setting and using an author ID
  - Survival through stat updates without re-fetching
  - Multiple patches with different authors based on when they were created

## Implementation Details

The author ID is captured at patch creation time using the same pattern as `publishInFlight` and `parentRefSource`: a closure-based source that is read when needed rather than pushed into the store. This ensures patches created before the first stat and patches created after each get the author ID that was current at their creation time, not a later value.

The changeset notes that this fix ensures patches are stamped with the same author the server records from the session cookie, making the two agree.

https://claude.ai/code/session_01FGCFKftRDSsLY7crVRFFsv