### PR TITLE
Fix AI model picker: show for single model, portal menu correctly

### DIFF
--- a/.changeset/ai-model-picker-dropdown.md
+++ b/.changeset/ai-model-picker-dropdown.md
@@ -1,0 +1,21 @@
+---
+"@valbuild/ui": patch
+---
+
+The AI model picker opens again, and shows even with one model on offer.
+
+Its menu was portalled to `document.body` — outside the shadow root the Studio
+renders in, where none of Val's styles reach it and nothing lifts it above the
+overlay. The menu did open; it was invisible behind the Studio, which reads as a
+trigger that does nothing. It now portals into the Studio's own container, like
+every other popup there.
+
+The picker also used to hide itself unless there were at least two models, so an
+account with one reachable model had nothing telling it which model was
+answering. It now renders whenever there is a model at all, and only disappears
+when there are none — which means AI is off, not that there is no choice.
+
+`DropdownMenuContent` now renders inline instead of portalling when it is given
+no container — the posture `TooltipContent` already took — so this cannot
+silently happen again: a clipped menu can be recovered from, an invisible one
+cannot.

--- a/architecture/quirks.md
+++ b/architecture/quirks.md
@@ -119,6 +119,18 @@ which is the path the event actually travelled — `useDismissOnOutsidePointer`
 does. This cost the Preview menu's "Open in a new tab" and every suggestion in
 the canvas address bar.
 
+**A Radix popup with no `container` opens OUTSIDE the shadow root, and that also
+reads as a dead button.** The default portal target is `document.body`, where
+none of Val's styles reach the menu and nothing gives it a stacking context
+above the overlay — so it opens, correctly positioned, invisible behind the
+Studio. Nothing is logged and the trigger's `data-state` flips to `open`, so the
+only symptom is a click that appears to do nothing. Every Studio popup therefore
+passes `container={useValPortal()}`; `DropdownMenuContent` and `TooltipContent`
+now render INLINE rather than portalling when they are not given one, because
+clipped is recoverable and invisible is not. This cost the AI chat's model
+picker, which was read as "the model switcher does not work", and the confirm in
+`UtilityPanel` before it.
+
 **A ref mutated during render survives a discarded render; the `setState` beside
 it does not.** So the "adjust state when a prop changes" pattern must hold the
 previous prop in **state**, never a ref:

--- a/packages/ui/spa/components/AIChat.tsx
+++ b/packages/ui/spa/components/AIChat.tsx
@@ -27,24 +27,17 @@ import {
   Paperclip,
   X,
   AlertTriangle,
-  ChevronDown,
-  Check,
 } from "lucide-react";
 import type { AISession } from "../hooks/useAIWebSocket";
 import type { AIContentBlock, AIMessageContent } from "./ValProvider";
 import { safeHref } from "../utils/safeHref";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "./designSystem/dropdown-menu";
 import type { AIModel, AIModelInfo } from "../hooks/useAIWebSocket";
 import { useValConfig } from "./ValFieldProvider";
 import { useValPortal } from "./ValPortalProvider";
 import { urlOf } from "@valbuild/shared/internal";
 import { CopyableCodeBlock } from "./designSystem/CopyableCodeBlock";
 import { AIChatEditor } from "./AIChatEditor";
+import { AIChatModelPicker } from "./AIChatModelPicker";
 import type {
   ChatBlockNode,
   ChatDocument,
@@ -1332,56 +1325,16 @@ export const AIChat = forwardRef<AIChatHandle, AIChatProps>(function AIChat(
                   Beside the composer rather than in a settings panel: which
                   model answers is a per-message decision — a cheap one for a
                   quick edit, a strong one for a hard question — so it belongs
-                  where the message is written. Hidden when there is nothing to
-                  choose between.
+                  where the message is written.
                 */}
-                {models && models.length > 1 && onSelectModel && (
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        disabled={isStreaming}
-                        className="h-7 px-2 text-xs text-fg-secondary gap-1"
-                        aria-label={
-                          // Not "Model: <label>": with nothing selected the
-                          // label is itself "Model", and a screen reader would
-                          // read "Model: Model".
-                          selectedLabel(models, selectedModel) === MODEL_UNSET
-                            ? "Choose a model"
-                            : `Change model, currently ${selectedLabel(models, selectedModel)}`
-                        }
-                      >
-                        {selectedLabel(models, selectedModel)}
-                        <ChevronDown className="h-3 w-3" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent
-                      align="start"
-                      className="max-h-72 overflow-y-auto"
-                    >
-                      {models.map((info) => {
-                        const isSelected =
-                          selectedModel?.provider === info.ref.provider &&
-                          selectedModel?.model === info.ref.model;
-                        return (
-                          <DropdownMenuItem
-                            key={`${info.ref.provider}:${info.ref.model}`}
-                            onSelect={() => onSelectModel(info.ref)}
-                            className="text-xs"
-                          >
-                            <Check
-                              className={cn(
-                                "h-3 w-3 mr-2",
-                                isSelected ? "opacity-100" : "opacity-0",
-                              )}
-                            />
-                            {info.label}
-                          </DropdownMenuItem>
-                        );
-                      })}
-                    </DropdownMenuContent>
-                  </DropdownMenu>
+                {models && onSelectModel && (
+                  <AIChatModelPicker
+                    models={models}
+                    selectedModel={selectedModel}
+                    onSelectModel={onSelectModel}
+                    disabled={isStreaming}
+                    portalContainer={portalContainer}
+                  />
                 )}
                 {isStreaming && onCancel ? (
                   <Button
@@ -1729,23 +1682,6 @@ function MessageBubble({
       )}
     </div>
   );
-}
-
-/** What the picker button says: the chosen model's label, or a prompt. */
-const MODEL_UNSET = "Model";
-
-function selectedLabel(
-  models: AIModelInfo[],
-  selected: AIModel | null | undefined,
-): string {
-  const match = selected
-    ? models.find(
-        (info) =>
-          info.ref.provider === selected.provider &&
-          info.ref.model === selected.model,
-      )
-    : undefined;
-  return match?.label ?? MODEL_UNSET;
 }
 
 function StreamingCursor() {

--- a/packages/ui/spa/components/AIChatModelPicker.test.tsx
+++ b/packages/ui/spa/components/AIChatModelPicker.test.tsx
@@ -1,0 +1,111 @@
+/** @jest-environment jsdom */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { AIChatModelPicker } from "./AIChatModelPicker";
+import type { AIModelInfo } from "../hooks/useAIWebSocket";
+
+/**
+ * The picker looked broken in two separate ways, and both are regressions worth
+ * a test.
+ *
+ * It HID ITSELF for a single model, so an account with one reachable model got
+ * no indication of which model was answering — and no clue that a picker
+ * existed at all.
+ *
+ * And its menu was portalled to `document.body`, outside the Studio's shadow
+ * root, where none of Val's styles reach it and nothing lifts it above the
+ * overlay. Radix opened it; it was simply invisible, which reads as a dead
+ * button. So the test asserts the menu lands INSIDE the container it was
+ * given, not merely that it exists somewhere in the document.
+ */
+
+const SONNET: AIModelInfo = {
+  ref: { provider: "anthropic", model: "claude-sonnet-5" },
+  label: "Claude Sonnet 5",
+};
+const OPUS: AIModelInfo = {
+  ref: { provider: "anthropic", model: "claude-opus-5" },
+  label: "Claude Opus 5",
+};
+
+/**
+ * Opened with the keyboard, not a click. Radix's trigger opens on
+ * `pointerdown`, and jsdom has no pointer events to dispatch — so the keyboard
+ * path is the one a test can drive, and it is the same open.
+ */
+function openMenu(trigger: HTMLElement) {
+  fireEvent.keyDown(trigger, { key: "Enter" });
+}
+
+function renderPicker(
+  models: AIModelInfo[],
+  onSelectModel: (model: AIModelInfo["ref"]) => void = () => {},
+  withContainer = true,
+) {
+  const portalContainer = document.createElement("div");
+  document.body.appendChild(portalContainer);
+  const rendered = render(
+    <AIChatModelPicker
+      models={models}
+      selectedModel={models[0]?.ref ?? null}
+      onSelectModel={onSelectModel}
+      portalContainer={withContainer ? portalContainer : null}
+    />,
+  );
+  // Named, not spread alongside RTL's own `container` — that one is the render
+  // root, and it would quietly shadow this one.
+  return { portalContainer, ...rendered };
+}
+
+test("offers the picker for a single model", () => {
+  renderPicker([SONNET]);
+  expect(
+    screen.getByRole("button", {
+      name: "Change model, currently Claude Sonnet 5",
+    }),
+  ).toBeTruthy();
+});
+
+test("renders nothing when no model is on offer", () => {
+  const { container } = renderPicker([]);
+  expect(screen.queryByRole("button")).toBeNull();
+  expect(container.textContent).toBe("");
+});
+
+test("opens the menu inside the container it was given", () => {
+  const { portalContainer } = renderPicker([SONNET, OPUS]);
+  openMenu(
+    screen.getByRole("button", {
+      name: "Change model, currently Claude Sonnet 5",
+    }),
+  );
+  const item = screen.getByRole("menuitem", { name: "Claude Opus 5" });
+  expect(portalContainer.contains(item)).toBe(true);
+});
+
+test("reports the model that was chosen", () => {
+  const chosen: AIModelInfo["ref"][] = [];
+  renderPicker([SONNET, OPUS], (model) => chosen.push(model));
+  openMenu(
+    screen.getByRole("button", {
+      name: "Change model, currently Claude Sonnet 5",
+    }),
+  );
+  fireEvent.click(screen.getByRole("menuitem", { name: "Claude Opus 5" }));
+  expect(chosen).toEqual([OPUS.ref]);
+});
+
+test("keeps the menu in the tree when there is no container yet", () => {
+  // The portal node arrives a render late — `ValPortalProvider` holds it in
+  // state and it is an element only after that provider's own commit — so the
+  // picker can be opened in that window.
+  // Rendering inline is the fallback `DropdownMenuContent` takes there, and it
+  // beats portalling out of the shadow root and being invisible.
+  const { container } = renderPicker([SONNET, OPUS], () => {}, false);
+  openMenu(
+    screen.getByRole("button", {
+      name: "Change model, currently Claude Sonnet 5",
+    }),
+  );
+  const item = screen.getByRole("menuitem", { name: "Claude Opus 5" });
+  expect(container.contains(item)).toBe(true);
+});

--- a/packages/ui/spa/components/AIChatModelPicker.test.tsx
+++ b/packages/ui/spa/components/AIChatModelPicker.test.tsx
@@ -36,6 +36,22 @@ function openMenu(trigger: HTMLElement) {
   fireEvent.keyDown(trigger, { key: "Enter" });
 }
 
+/**
+ * The portal nodes this file has made.
+ *
+ * They are appended to `document.body`, which Testing Library's cleanup does
+ * not touch — it unmounts the roots it created and nothing else. Left alone
+ * they accumulate one empty `div` per test, in the tree every `screen` query
+ * searches. Removed here so each test starts in the body it expects.
+ */
+const portalContainers: HTMLElement[] = [];
+
+afterEach(() => {
+  for (const node of portalContainers.splice(0)) {
+    node.remove();
+  }
+});
+
 function renderPicker(
   models: AIModelInfo[],
   onSelectModel: (model: AIModelInfo["ref"]) => void = () => {},
@@ -43,6 +59,7 @@ function renderPicker(
 ) {
   const portalContainer = document.createElement("div");
   document.body.appendChild(portalContainer);
+  portalContainers.push(portalContainer);
   const rendered = render(
     <AIChatModelPicker
       models={models}

--- a/packages/ui/spa/components/AIChatModelPicker.tsx
+++ b/packages/ui/spa/components/AIChatModelPicker.tsx
@@ -1,0 +1,113 @@
+import { Check, ChevronDown } from "lucide-react";
+import { AIModel, AIModelInfo } from "../hooks/useAIWebSocket";
+import { Button } from "./designSystem/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "./designSystem/dropdown-menu";
+import { cn } from "./designSystem/cn";
+
+/** What the picker button says: the chosen model's label, or a prompt. */
+export const MODEL_UNSET = "Model";
+
+export function selectedModelLabel(
+  models: AIModelInfo[],
+  selected: AIModel | null | undefined,
+): string {
+  const match = selected
+    ? models.find(
+        (info) =>
+          info.ref.provider === selected.provider &&
+          info.ref.model === selected.model,
+      )
+    : undefined;
+  return match?.label ?? MODEL_UNSET;
+}
+
+/**
+ * Which model answers the next message.
+ *
+ * Two things here are the fix for a picker that looked broken:
+ *
+ * It renders for a SINGLE model too. It used to hide itself below two entries,
+ * on the reasoning that a picker with nothing to pick is noise — but which
+ * model is answering is worth knowing even when it cannot be changed, and a
+ * control that appears only once a second model shows up reads as a missing
+ * feature rather than as an honest UI. Nothing renders when the list is empty,
+ * which is "AI is off" and not "one choice".
+ *
+ * And the menu is PORTALLED INTO THE STUDIO's container. The Studio renders in
+ * a shadow root, and a Radix portal with no `container` lands in
+ * `document.body`, outside it — where none of Val's styles reach it and nothing
+ * gives it a stacking context above the overlay. The menu did open; it was just
+ * invisible behind the Studio, which is what made the button look dead. Every
+ * other Studio popup passes this; this one did not. See `ValPortalProvider`.
+ */
+export function AIChatModelPicker({
+  models,
+  selectedModel,
+  onSelectModel,
+  disabled,
+  portalContainer,
+}: {
+  models: AIModelInfo[];
+  selectedModel: AIModel | null | undefined;
+  onSelectModel: (model: AIModel) => void;
+  disabled?: boolean;
+  portalContainer: HTMLElement | null;
+}) {
+  if (models.length === 0) {
+    return null;
+  }
+  const label = selectedModelLabel(models, selectedModel);
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          disabled={disabled}
+          className="h-7 px-2 text-xs text-fg-secondary gap-1"
+          aria-label={
+            // Not "Model: <label>": with nothing selected the label is itself
+            // "Model", and a screen reader would read "Model: Model".
+            label === MODEL_UNSET
+              ? "Choose a model"
+              : `Change model, currently ${label}`
+          }
+        >
+          {label}
+          <ChevronDown className="h-3 w-3" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="start"
+        container={portalContainer}
+        className="max-h-72 overflow-y-auto"
+      >
+        {models.map((info) => {
+          const isSelected =
+            selectedModel?.provider === info.ref.provider &&
+            selectedModel?.model === info.ref.model;
+          return (
+            <DropdownMenuItem
+              key={`${info.ref.provider}:${info.ref.model}`}
+              onSelect={() => onSelectModel(info.ref)}
+              className="text-xs"
+            >
+              <Check
+                className={cn(
+                  "h-3 w-3 mr-2",
+                  isSelected ? "opacity-100" : "opacity-0",
+                )}
+              />
+              {info.label}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/ui/spa/components/designSystem/dropdown-menu.tsx
+++ b/packages/ui/spa/components/designSystem/dropdown-menu.tsx
@@ -57,10 +57,14 @@ DropdownMenuSubContent.displayName =
 const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> & {
+    /**
+     * Render the menu inside this element — the Studio's portal node, in
+     * practice. Needed whenever an ancestor clips overflow.
+     */
     container?: HTMLElement | null;
   }
->(({ className, sideOffset = 4, container, ...props }, ref) => (
-  <DropdownMenuPrimitive.Portal container={container}>
+>(({ className, sideOffset = 4, container, ...props }, ref) => {
+  const content = (
     <DropdownMenuPrimitive.Content
       ref={ref}
       sideOffset={sideOffset}
@@ -70,8 +74,24 @@ const DropdownMenuContent = React.forwardRef<
       )}
       {...props}
     />
-  </DropdownMenuPrimitive.Portal>
-));
+  );
+  // Only portal when we are given somewhere to portal to. Radix's default
+  // container is `document.body`, which is OUTSIDE the shadow root that
+  // carries our styles: the menu opens, unstyled and with no stacking context
+  // of its own, behind the Studio — which looks exactly like a trigger that
+  // does nothing. That has now cost us the same bug twice, so the safe
+  // fallback lives here rather than in every call site. Inline can be clipped
+  // by an `overflow-hidden` ancestor; invisible cannot be recovered from.
+  // `TooltipContent` does the same, for the same reason.
+  if (!container) {
+    return content;
+  }
+  return (
+    <DropdownMenuPrimitive.Portal container={container}>
+      {content}
+    </DropdownMenuPrimitive.Portal>
+  );
+});
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
 
 const DropdownMenuItem = React.forwardRef<


### PR DESCRIPTION
## Summary

Fixes two regressions in the AI chat model picker that made it appear non-functional:

1. **Menu was invisible**: The dropdown menu was portalled to `document.body`, outside the Studio's shadow root where Val's styles don't reach it and no stacking context lifts it above the overlay. The menu opened but rendered invisible behind the Studio.

2. **Picker hid itself for single model**: The picker only rendered when there were 2+ models, so accounts with one reachable model had no indication of which model was answering or that a picker existed.

## Changes

- **New component `AIChatModelPicker`**: Extracted model picker logic from `AIChat.tsx` into a dedicated, reusable component that:
  - Renders for any non-empty model list (including single models)
  - Accepts a `portalContainer` prop to portal the menu into the Studio's container
  - Includes comprehensive JSDoc explaining both fixes
  - Exports `selectedModelLabel()` helper for consistent label rendering

- **Updated `AIChat.tsx`**: 
  - Removed inline picker implementation (40+ lines)
  - Now uses `AIChatModelPicker` component
  - Passes `portalContainer` from `useValPortal()` hook
  - Removed `models.length > 1` guard so picker shows for single model

- **Enhanced `DropdownMenuContent`**:
  - Added `container` parameter documentation
  - Now renders **inline** (not portalled) when `container` is `null`
  - Fallback prevents invisible menus: clipped is recoverable, invisible is not
  - Matches pattern already used in `TooltipContent`

- **Added comprehensive tests** (`AIChatModelPicker.test.tsx`):
  - Verifies picker renders for single model
  - Confirms menu portals into provided container (not `document.body`)
  - Tests fallback behavior when container is unavailable
  - Validates model selection callback

- **Updated `architecture/quirks.md`**: Documented the shadow root portal issue as a known quirk to prevent future regressions

## Implementation Details

The picker now properly handles the Studio's shadow DOM constraints by accepting an explicit portal target. The `DropdownMenuContent` fallback to inline rendering ensures graceful degradation during the brief window before the portal container is available (held in `ValPortalProvider` state).

https://claude.ai/code/session_0121J9UXCHVJ9DFUCi3E2HDL