### PR TITLE
MCP: remove personal access token auth, require oauth config (+ Studio light mode)

### DIFF
--- a/.changeset/mcp-remove-pat-auth.md
+++ b/.changeset/mcp-remove-pat-auth.md
@@ -1,0 +1,54 @@
+---
+"@valbuild/next": minor
+"@valbuild/server": minor
+---
+
+MCP: remove personal access token auth. The endpoint now needs an `oauth`
+config, or local filesystem mode.
+
+Until now, an MCP endpoint with no `oauth` config accepted whatever bearer token
+a caller presented and relayed it to the Val content backend unread. The
+reasoning was that without an issuer the app has no key to check a token
+against, so it should not pretend to be the authority on what that token may
+do — and that much was right. The shape was not: a credential the app cannot
+check is one it cannot refuse either, so "a deployed endpoint that authenticates
+nobody" was a supported configuration, and an app could serve content-rewriting
+tools without ever being told where its callers should authorize.
+
+**If you run Val in proxy mode**, MCP now requires the `oauth` config that
+shipped in `0.120.0`. Callers authorize as themselves against the Val
+authorization server, this app verifies the token's signature, issuer, audience
+and expiry itself, and patches carry the verified profile as their author:
+
+```ts
+initValMcp(valModules, config, {
+  oauth: {
+    issuer: "https://admin.val.build",
+    resource: "https://your-app.com/api/mcp",
+  },
+});
+```
+
+Leave it out and the endpoint answers `500` naming the missing config, rather
+than serving the request.
+
+**If you run Val in local filesystem mode**, nothing changes. Local development
+still needs no `oauth` config and no authorization server: there is no backend
+to authenticate to, patches are written with no author, and a token presented
+to such a project is still refused rather than ignored.
+
+Two API changes if you built your own host on `createValTools`:
+
+- `ValToolContext.auth` no longer has a `{ type: "pat", pat }` variant.
+  `{ type: "verified-profile", profileId, scopes }` is the only credential the
+  registry accepts, and `null` still means local filesystem mode.
+- `createValOps` no longer takes an `auth` argument. `ValOpsHttp` still accepts
+  a personal access token directly — that is how `val debug` uses the token from
+  `val login` — but no server request builds one.
+
+Proxy mode also stops keeping one data layer per credential. Each personal
+access token needed its own `ValOpsHttp` to hold it, each of those cached the
+project's evaluated modules, and the bounded cache that kept the memory in
+check turned an eviction into a re-evaluation of every module on the next call.
+Verified callers all share one instance, because they all reach the backend
+under the app's own API key.

--- a/.changeset/mcp-remove-pat-auth.md
+++ b/.changeset/mcp-remove-pat-auth.md
@@ -34,8 +34,10 @@ than serving the request.
 
 **If you run Val in local filesystem mode**, nothing changes. Local development
 still needs no `oauth` config and no authorization server: there is no backend
-to authenticate to, patches are written with no author, and a token presented
-to such a project is still refused rather than ignored.
+to authenticate to, and patches are written with no author. A token presented
+to such a project is still refused rather than ignored — the endpoint answers
+`400` and says to take the credential out of the client's configuration, since
+what it reached was a working tree with no permission check in front of it.
 
 Two API changes if you built your own host on `createValTools`:
 

--- a/.changeset/studio-light-mode-less-bright.md
+++ b/.changeset/studio-light-mode-less-bright.md
@@ -1,0 +1,23 @@
+---
+"@valbuild/ui": patch
+---
+
+Studio: a calmer light mode.
+
+Light mode was built on full white. Panels, the rail, the bars and every field
+surface were `#ffffff`, and the canvas behind them sat 4% below that — so the
+Studio filled the viewport with one bright sheet, and the floating layout had
+almost no light to distinguish its layers with.
+
+Every neutral surface now sits one step down the ramp: floating chrome and
+fields at `#fcfcfc`, the canvas at `#f4f4f5`, raised and hover fills at a new
+`#eeeef0`. Nothing large is pure white any more. The luminance gap between a
+panel and the canvas roughly doubles, so panels read as floating rather than as
+part of the page while the chrome gives off noticeably less light.
+
+The panel hairline and muted text came down a nudge with the surfaces, because
+on a softer background the old values read washed out rather than quiet. Every
+foreground/background pair the chrome renders still meets WCAG AA, and with
+more headroom than before — `contrast.test.ts` holds that.
+
+Dark mode is unchanged.

--- a/packages/next/src/fallbackColors.ts
+++ b/packages/next/src/fallbackColors.ts
@@ -17,9 +17,9 @@
 /** `--bg-canvas`, dark. The studio's own background. */
 export const canvasDarkBg = "#08080a";
 /** `--bg-canvas`, light. */
-export const canvasLightBg = "#fafafa";
+export const canvasLightBg = "#f4f4f5";
 
 /** `--bg-float`, dark. Val's chrome, floating over the customer's page. */
 export const floatDarkBg = "#131316";
 /** `--bg-float`, light. */
-export const floatLightBg = "#ffffff";
+export const floatLightBg = "#fcfcfc";

--- a/packages/next/src/server/initValMcp.test.ts
+++ b/packages/next/src/server/initValMcp.test.ts
@@ -318,6 +318,30 @@ describe("credentials", () => {
     expect(res.status).toBe("refused");
   });
 
+  test("local filesystem mode refuses a token rather than ignoring it", async () => {
+    // The developer did nothing dangerous — they left a credential in a client
+    // config — but a token that reaches a working tree was checked by nothing,
+    // and silence is what would let them believe otherwise. There is no `oauth`
+    // config here, so this refusal has to happen at the endpoint: no verified
+    // credential reaches `createValTools` for it to refuse.
+    const res = await withNodeEnv("development", async () =>
+      mcp().valMcpAuthorize(
+        request({
+          host: "localhost:3000",
+          authorization: "Bearer pat-not-a-real-token",
+        }),
+      ),
+    );
+
+    if (res.status !== "refused") {
+      throw new Error("expected a refusal");
+    }
+    expect(res.response.status).toBe(400);
+    const body = await res.response.text();
+    expect(body).toContain("local filesystem mode");
+    expect(body).not.toContain("pat-not-a-real-token");
+  });
+
   test("local filesystem mode still needs no config at all", async () => {
     // The one case that is genuinely credential-free, and it has to stay a
     // one-liner: there is no authorization server to point local development

--- a/packages/next/src/server/initValMcp.test.ts
+++ b/packages/next/src/server/initValMcp.test.ts
@@ -253,7 +253,7 @@ describe("cross-origin requests", () => {
 });
 
 describe("credentials", () => {
-  test("proxy mode passes the caller's bearer token through unread", async () => {
+  test("proxy mode with no oauth config refuses instead of relaying a token", async () => {
     const res = await withEnv(httpModeEnv(), async () =>
       withNodeEnv("production", async () =>
         mcp().valMcpAuthorize(
@@ -265,57 +265,71 @@ describe("credentials", () => {
       ),
     );
 
-    // Verbatim: this app is not the authority on what the token may do, so it
-    // must not normalise, truncate or interpret it on the way to the backend.
-    expect(res.status === "ok" && res.ctx.auth).toEqual({
-      type: "pat",
-      pat: "pat-from-the-caller",
+    // This is the configuration that used to serve MCP to whoever presented a
+    // bearer token: with no issuer the app has no key to check one against, so
+    // it forwarded it unread and let the backend decide. The reasoning was
+    // sound and the shape was not — it made an endpoint that authenticates
+    // nobody a supported deployment. A credential the app cannot check is one
+    // it cannot refuse either, which is the whole problem.
+    expect(res.status).toBe("refused");
+    if (res.status !== "refused") {
+      throw new Error("expected a refusal");
+    }
+    expect(res.response.status).toBe(500);
+    // 500 rather than 401: nothing the client can present will help, so
+    // inviting it to authorize would send it round a loop. The app is
+    // misconfigured, and the body has to say which config is missing or this
+    // is a wall with no door.
+    const body = await res.response.json();
+    expect(body.error).toContain("oauth");
+    expect(body.error).toContain("initValMcp");
+  });
+
+  test("the token is never echoed back in the refusal", async () => {
+    // It cannot be checked, so it must not be repeated: an error body reaches
+    // logs, terminals and bug reports, and a relayed credential in one is a
+    // credential leaked to all three.
+    const res = await withEnv(httpModeEnv(), async () =>
+      withNodeEnv("production", async () =>
+        mcp().valMcpAuthorize(
+          request({
+            host: "example.com",
+            authorization: "Bearer pat-not-a-real-token",
+          }),
+        ),
+      ),
+    );
+
+    if (res.status !== "refused") {
+      throw new Error("expected a refusal");
+    }
+    expect(await res.response.text()).not.toContain("pat-not-a-real-token");
+  });
+
+  test("proxy mode with no oauth config refuses even with no token at all", async () => {
+    // The refusal is about the app's configuration, not the request, so it
+    // cannot be reached or avoided by choosing what to send.
+    const res = await withEnv(httpModeEnv(), async () =>
+      withNodeEnv("production", async () =>
+        mcp().valMcpAuthorize(request({ host: "example.com" })),
+      ),
+    );
+
+    expect(res.status).toBe("refused");
+  });
+
+  test("local filesystem mode still needs no config at all", async () => {
+    // The one case that is genuinely credential-free, and it has to stay a
+    // one-liner: there is no authorization server to point local development
+    // at, and no backend for a token to mean anything to.
+    const res = await withNodeEnv("development", async () =>
+      mcp().valMcpAuthorize(request({ host: "localhost:3000" })),
+    );
+
+    expect(res.status === "ok" && res.ctx).toEqual({
+      auth: null,
+      sessionId: null,
     });
-  });
-
-  test("proxy mode serves a deployed host without a loopback check", async () => {
-    // The loopback requirement is specific to fs mode. In proxy mode the
-    // caller's own token is the check, and the endpoint has to work on a real
-    // hostname or it is useless.
-    const res = await withEnv(httpModeEnv(), async () =>
-      withNodeEnv("production", async () =>
-        mcp().valMcpAuthorize(
-          request({ host: "example.com", authorization: "Bearer pat" }),
-        ),
-      ),
-    );
-
-    expect(res.status).toBe("ok");
-  });
-
-  test("the bearer scheme is matched case-insensitively", async () => {
-    const res = await withEnv(httpModeEnv(), async () =>
-      withNodeEnv("production", async () =>
-        mcp().valMcpAuthorize(
-          request({ host: "example.com", authorization: "bearer pat" }),
-        ),
-      ),
-    );
-
-    expect(res.status === "ok" && res.ctx.auth).toEqual({
-      type: "pat",
-      pat: "pat",
-    });
-  });
-
-  test("a non-bearer Authorization header is not treated as a credential", async () => {
-    // Reported as absent rather than passed on: the registry then refuses the
-    // call in proxy mode, which is the right answer for a scheme we did not
-    // agree to.
-    const res = await withEnv(httpModeEnv(), async () =>
-      withNodeEnv("production", async () =>
-        mcp().valMcpAuthorize(
-          request({ host: "example.com", authorization: "Basic dXNlcjpwdw==" }),
-        ),
-      ),
-    );
-
-    expect(res.status === "ok" && res.ctx.auth).toBeNull();
   });
 });
 
@@ -394,10 +408,11 @@ describe("oauth mode", () => {
     clearValAccessTokenCache();
   });
 
-  test("no config means nothing changes, and no metadata is published", async () => {
+  test("no config publishes no metadata document", async () => {
     // A project that has not been told where to authorize must not publish a
-    // document claiming it knows — and must keep working, because local
-    // development has no authorization server to point at.
+    // document claiming it knows. Leaving the config out is only viable in
+    // local filesystem mode now — see the credentials cases — and there is
+    // nothing to point such a project's clients at.
     expect(mcp().valMcpMetadata).toBeNull();
   });
 
@@ -500,6 +515,27 @@ describe("oauth mode", () => {
       resource: harness.resource,
       authorization_servers: [harness.issuer],
     });
+  });
+
+  test("a deployed host is served without a loopback check", async () => {
+    // The loopback requirement is specific to fs mode. In proxy mode the
+    // verified token is the check, and the endpoint has to work on a real
+    // hostname or it is useless — so the host must not be what refuses it.
+    const harness = oauthHarness();
+    const res = await withEnv(httpModeEnv(), () =>
+      withNodeEnv("production", () =>
+        initValMcp({ config, modules: [] }, config, {
+          oauth: harness,
+        }).valMcpAuthorize(
+          request({
+            host: "example.com",
+            authorization: `Bearer ${harness.signToken()}`,
+          }),
+        ),
+      ),
+    );
+
+    expect(res.status).toBe("ok");
   });
 
   test("a cross-origin request is still refused before the token is looked at", async () => {

--- a/packages/next/src/server/initValMcp.ts
+++ b/packages/next/src/server/initValMcp.ts
@@ -8,11 +8,7 @@ import {
   type ValTools,
 } from "@valbuild/server";
 import { VERSION } from "../version";
-import {
-  readBearerToken,
-  verifyValAccessToken,
-  type ValOAuthConfig,
-} from "./valAccessToken";
+import { verifyValAccessToken, type ValOAuthConfig } from "./valAccessToken";
 import {
   createValMcpMetadata,
   wwwAuthenticate,
@@ -72,11 +68,11 @@ export function initValMcp(
     /**
      * Where to authorize, and what audience to expect.
      *
-     * Omit it and nothing changes: the endpoint behaves exactly as it did
-     * before OAuth existed, which keeps local development a one-liner and keeps
-     * an app that has not been reconfigured working. Provide it and every call
-     * needs a verified access token — including in fs mode, where a token is
-     * refused rather than ignored, because a host that thinks it is
+     * Required for proxy mode, and only omittable in local filesystem mode —
+     * where there is no authorization server to talk to and no backend to
+     * authenticate to, so local development stays a one-liner. Provide it and
+     * every call needs a verified access token, including in fs mode, where a
+     * token is refused rather than ignored: a host that thinks it is
      * authenticating should never silently get unauthenticated local access.
      */
     oauth?: ValOAuthConfig;
@@ -158,57 +154,69 @@ export function initValMcp(
         return { status: "refused", response: refusal };
       }
 
-      // Not the MCP session id, in either branch below. Val's patch `sessionId`
+      // Not the MCP session id, in any branch below. Val's patch `sessionId`
       // names a Val AI session, and putting an unrelated id in it would claim a
       // relationship that does not exist.
       const sessionId = null;
 
-      if (oauth) {
-        const verified = await verifyValAccessToken(request, oauth);
-        if (verified.status === "refused") {
-          // 401 for a missing or bad token, 403 once the token is good but does
-          // not carry the scope: RFC 6750 section 3.1, and the distinction is
-          // what tells a client whether to authorize again or to give up.
-          const status = verified.error === "insufficient_scope" ? 403 : 401;
+      if (!oauth) {
+        if (setup.mode !== "fs") {
+          // Reachable only by configuring proxy mode and leaving `oauth` out,
+          // which used to serve MCP to whoever presented a bearer token: the
+          // app relayed it unread, because without an issuer it has no key to
+          // check anything against. It was a supported configuration and should
+          // not have been — "I cannot check this" is not a reason to forward a
+          // credential, it is the reason to refuse it. So the endpoint now says
+          // what is missing instead of answering. `refuseUnsafeRequest` covers
+          // the mirror image, fs mode on a deployed host.
           return {
             status: "refused",
-            response: new Response(
-              JSON.stringify({
-                error: verified.error,
-                error_description: verified.description,
-              }),
-              {
-                status,
-                headers: {
-                  "Content-Type": "application/json",
-                  "WWW-Authenticate": wwwAuthenticate(oauth, scopesSupported, {
-                    error: verified.error,
-                    description: verified.description,
-                  }),
-                },
-              },
-            ),
+            response: jsonResponse(500, {
+              error:
+                "Val: this MCP endpoint has no `oauth` config, and this project is configured to talk to the Val content backend. Pass `oauth` to `initValMcp` with the authorization server's URL and this endpoint's own URL, so callers authorize as themselves.",
+            }),
           };
         }
+        // Local filesystem mode: no credential to hold, and patches are written
+        // with no author, exactly as the Studio does locally. A token presented
+        // to such a project is refused in `createValTools` rather than ignored.
         return {
           status: "ok",
           tools: setup.tools,
-          ctx: { auth: verified.auth, sessionId },
+          ctx: { auth: null, sessionId },
         };
       }
 
-      const pat = readBearerToken(request);
+      const verified = await verifyValAccessToken(request, oauth);
+      if (verified.status === "refused") {
+        // 401 for a missing or bad token, 403 once the token is good but does
+        // not carry the scope: RFC 6750 section 3.1, and the distinction is
+        // what tells a client whether to authorize again or to give up.
+        const status = verified.error === "insufficient_scope" ? 403 : 401;
+        return {
+          status: "refused",
+          response: new Response(
+            JSON.stringify({
+              error: verified.error,
+              error_description: verified.description,
+            }),
+            {
+              status,
+              headers: {
+                "Content-Type": "application/json",
+                "WWW-Authenticate": wwwAuthenticate(oauth, scopesSupported, {
+                  error: verified.error,
+                  description: verified.description,
+                }),
+              },
+            },
+          ),
+        };
+      }
       return {
         status: "ok",
         tools: setup.tools,
-        ctx: {
-          // Passed through unverified, deliberately: without an `oauth` config
-          // this app has no key to check anything against, so it is not the
-          // authority on what the token may do and the registry sends it to the
-          // backend that is. See `docs/plans/mcp.md` D.2.
-          auth: pat === null ? null : { type: "pat", pat },
-          sessionId,
-        },
+        ctx: { auth: verified.auth, sessionId },
       };
     },
   };
@@ -224,7 +232,8 @@ export function initValMcp(
  *    that is unauthenticated write access to the site's content for anyone who
  *    can reach the port. There is no configuration that makes it safe, so there
  *    is no flag to turn this off — a project that wants MCP in production wants
- *    proxy mode, where every call carries its caller's own token.
+ *    proxy mode with an `oauth` config, where every call carries an access
+ *    token this app verified itself.
  *
  * 2. **A browser driving the local server.** A page on any origin can `fetch`
  *    `http://localhost:3000/api/mcp` while a developer has the app running, and
@@ -293,9 +302,9 @@ const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
  *
  * The cost is that behind a proxy that rewrites `Host`, a *browser* request
  * whose `Origin` is the public name no longer matches. That is acceptable: such
- * a request carries no personal access token, so proxy mode refuses it anyway,
- * and a non-browser MCP client sends no `Origin` and never reaches the
- * comparison. Trusting the forwarded header would need an explicit trusted-proxy
+ * a request carries no access token, so proxy mode refuses it anyway, and a
+ * non-browser MCP client sends no `Origin` and never reaches the comparison.
+ * Trusting the forwarded header would need an explicit trusted-proxy
  * configuration, which is a bigger thing than this needs.
  */
 function requestHost(request: Request): string | null {

--- a/packages/next/src/server/initValMcp.ts
+++ b/packages/next/src/server/initValMcp.ts
@@ -8,7 +8,11 @@ import {
   type ValTools,
 } from "@valbuild/server";
 import { VERSION } from "../version";
-import { verifyValAccessToken, type ValOAuthConfig } from "./valAccessToken";
+import {
+  readBearerToken,
+  verifyValAccessToken,
+  type ValOAuthConfig,
+} from "./valAccessToken";
 import {
   createValMcpMetadata,
   wwwAuthenticate,
@@ -177,9 +181,25 @@ export function initValMcp(
             }),
           };
         }
+        if (readBearerToken(request) !== null) {
+          // Refused rather than ignored, which is the same rule
+          // `createValTools` applies to the configured-for-oauth case and has
+          // to be applied here too: with no `oauth` config there is no verified
+          // credential for it to see, so this is the last place the token
+          // exists. Dropping it silently would leave a developer whose client
+          // is configured with a token believing it was checked by something,
+          // when what it reached was a working tree with no permission check
+          // anywhere in front of it.
+          return {
+            status: "refused",
+            response: jsonResponse(400, {
+              error:
+                "Val: this project is running in local filesystem mode, where there is nothing to authenticate against — the tools read and write this working tree directly. Remove the credential from this MCP client's configuration: a token sent here is checked by nothing.",
+            }),
+          };
+        }
         // Local filesystem mode: no credential to hold, and patches are written
-        // with no author, exactly as the Studio does locally. A token presented
-        // to such a project is refused in `createValTools` rather than ignored.
+        // with no author, exactly as the Studio does locally.
         return {
           status: "ok",
           tools: setup.tools,

--- a/packages/server/src/tools/createValTools.test.ts
+++ b/packages/server/src/tools/createValTools.test.ts
@@ -17,10 +17,6 @@ import type { ValToolContext, ValTools } from "./types";
  */
 
 const NO_AUTH: ValToolContext = { auth: null, sessionId: null };
-const WITH_PAT: ValToolContext = {
-  auth: { type: "pat", pat: "pat-not-a-real-token" },
-  sessionId: null,
-};
 
 function verified(...scopes: string[]): ValToolContext {
   return {
@@ -73,8 +69,12 @@ describe("authorization", () => {
     expect(res).toEqual({
       status: "error",
       code: "forbidden",
-      message: expect.stringContaining("personal access token"),
+      message: expect.stringContaining("access token"),
     });
+    // And that the message names the config a caller cannot supply, because
+    // the usual cause of an absent credential in proxy mode is an endpoint that
+    // never asked for one.
+    expect(res.status === "error" && res.message).toContain("oauth");
   });
 
   test("proxy mode refuses a write with no credential too", async () => {
@@ -97,25 +97,6 @@ describe("authorization", () => {
     const res = await httpTools().call("nope", {}, NO_AUTH);
 
     expect(res.status === "error" && res.code).toBe("unknown-tool");
-  });
-
-  test("fs mode refuses a credential rather than ignoring it", async () => {
-    const res = await fsTools().call("get_all_schema", {}, WITH_PAT);
-
-    // A host that believes it is authenticating must not silently get direct
-    // filesystem access instead: fs mode writes straight to the working tree,
-    // with no backend permission check anywhere in the path.
-    expect(res).toEqual({
-      status: "error",
-      code: "unsupported",
-      message: expect.stringContaining("local filesystem mode"),
-    });
-    // A PAT is something the caller chose to send, so the fix is on their side
-    // and the message says so without dragging in config they never touched.
-    expect(res.status === "error" && res.message).toContain(
-      "Do not send a credential",
-    );
-    expect(res.status === "error" && res.message).not.toContain("oauth");
   });
 
   test("fs mode serves a call with no credential", async () => {
@@ -208,16 +189,16 @@ describe("scopes", () => {
     expect(res.status === "error" && res.message).toContain("val:read");
   });
 
-  test("fs mode refuses a verified profile too", async () => {
+  test("fs mode refuses a credential rather than ignoring it", async () => {
     const res = await fsTools().call(
       "get_all_schema",
       {},
       verified("val:read", "val:write"),
     );
 
-    // Same reasoning as the PAT case: a host that believes it is
-    // authenticating must not silently get direct filesystem access, and which
-    // *kind* of credential it holds does not change that.
+    // A host that believes it is authenticating must not silently get direct
+    // filesystem access instead: fs mode writes straight to the working tree,
+    // with no backend permission check anywhere in the path.
     expect(res).toEqual({
       status: "error",
       code: "unsupported",
@@ -232,18 +213,22 @@ describe("scopes", () => {
     expect(res.status === "error" && res.message).toContain("VAL_OAUTH_ISSUER");
   });
 
-  test("a PAT is not scope-checked here", async () => {
-    // A PAT carries no scopes in this process: the backend resolves it and
-    // decides. Inventing a default would be this app claiming an authority it
-    // does not have — so the gate must not refuse a write on a PAT for want of
-    // a scope it was never given.
+  test("an unverified credential cannot reach the scope gate at all", async () => {
+    // There is no longer a credential that arrives without scopes. A personal
+    // access token used to, and the gate had to let it past unchecked because
+    // only the backend could resolve it — so the registry accepted a caller it
+    // could not describe. Now the only auth it accepts carries its own scopes,
+    // which is what makes checking them here meaningful rather than optional.
     const res = await httpTools().call(
       "create_patch",
       { moduleFilePath: "/test/pages.val.ts", patch: [] },
-      WITH_PAT,
+      { auth: null, sessionId: null },
     );
 
-    expect(res.status).toBe("error");
-    expect(res.status === "error" && res.code).not.toBe("forbidden");
+    expect(res).toEqual({
+      status: "error",
+      code: "forbidden",
+      message: expect.stringContaining("access token"),
+    });
   });
 });

--- a/packages/server/src/tools/createValTools.ts
+++ b/packages/server/src/tools/createValTools.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import type { ValModules } from "@valbuild/core";
 import { z } from "zod";
 import type { ValServerConfig } from "../ValServer";
@@ -19,17 +18,6 @@ import {
 } from "./types";
 
 export type ValToolsOptions = ValServerConfig;
-
-/**
- * How many callers' data layers to keep around in proxy mode.
- *
- * Each entry holds one `ValOpsHttp`, and each of those caches the project's
- * evaluated modules once `initSources` has run — so this bounds memory, not just
- * entry count. Small on purpose: the cost of a miss is re-evaluating the
- * modules on the next call, which is what happened on *every* call before this
- * cache existed.
- */
-const MAX_CACHED_OPS = 8;
 
 /**
  * Val's server-side tool registry.
@@ -136,17 +124,25 @@ export function createValTools(
  * Pick the data layer for a call, which in proxy mode means picking whose
  * credential the backend will see.
  *
- * This is the one place authorization is decided, and it decides it by *not*
- * deciding: in proxy mode the caller's own personal access token goes to the
- * backend, which is the only party that can say what that token may do. The app
- * never inspects it, never caches a verdict about it, and never substitutes its
- * own API key for a missing one — see `docs/plans/mcp.md` D.2.
+ * This is the one place authorization is decided, and in proxy mode there is
+ * exactly one credential it will act on: an access token whose signature,
+ * issuer, audience and expiry the host verified against the authorization
+ * server's published key. Anything less is refused here rather than forwarded.
  *
- * The alternative shape, and the reason this function exists at all, is an
- * `authenticate()` that checks the PAT once and then acts under the app's key.
- * That reads as more secure and is strictly less so: the check happens in the
- * app, so every bug in it becomes full access to every project the app's key
- * can reach, and the backend's own permission model stops being consulted (D.6).
+ * There used to be a second route — the caller's personal access token, passed
+ * through unread on the reasoning that the backend, not the app, is the
+ * authority on what it may do. That was true, and it was still the wrong shape:
+ * it made an unauthenticated bearer token on a deployed endpoint a supported
+ * configuration, and it meant `initValMcp` had a path where an app served MCP
+ * without ever being told where to authorize. A host that has not verified
+ * anything now gets a refusal that names the missing `oauth` config.
+ *
+ * What has *not* changed is why a verified token does not become the app's own
+ * API key by some other name. The app authenticates to the backend with its own
+ * key here, and who did what travels as the patch's `authorId` — so the
+ * profile has to be one the host checked cryptographically, never one it was
+ * handed. An `authenticate()` that decided a credential's rights inside the app
+ * would make every bug in it full access to every project that key can reach.
  */
 function createOpsResolver(
   valModules: ValModules,
@@ -163,21 +159,18 @@ function createOpsResolver(
         // and the difference matters, because fs mode writes straight to disk
         // with no backend permission check at all.
         //
-        // The two credentials get different messages because they arrive here
-        // for different reasons. A PAT is something the caller chose to send. A
-        // verified access token is not: it only exists because this app
-        // advertised an authorization server, so the developer seeing this did
-        // not do anything wrong — a config file did, and naming it is the
-        // difference between a two-minute fix and an afternoon.
+        // A verified access token is not something the caller chose to send: it
+        // only exists because this app advertised an authorization server, so
+        // the developer seeing this did not do anything wrong — a config file
+        // did, and naming it is the difference between a two-minute fix and an
+        // afternoon.
         return {
           status: "error",
           result: {
             status: "error",
             code: "unsupported",
             message:
-              ctx.auth.type === "verified-profile"
-                ? "This Val project is running in local filesystem mode, so there is nothing to authenticate against, but it is configured with an `oauth` issuer and is therefore asking clients for an access token it cannot use. Remove the `oauth` config (or `VAL_OAUTH_ISSUER` from your local `.env`) for local development."
-                : "This Val project is running in local filesystem mode, where there is nothing to authenticate against. Do not send a credential.",
+              "This Val project is running in local filesystem mode, so there is nothing to authenticate against, but it is configured with an `oauth` issuer and is therefore asking clients for an access token it cannot use. Remove the `oauth` config (or `VAL_OAUTH_ISSUER` from your local `.env`) for local development.",
           },
         };
       }
@@ -185,71 +178,50 @@ function createOpsResolver(
     };
   }
 
-  // Keyed by a hash of the PAT, so the same caller reuses their own instance and
-  // two callers can never share one. Hashing is not a security boundary — the
-  // instance holds the token regardless — but it keeps credentials out of the
-  // key set, which is the thing that ends up in a heap dump or an error dump.
-  const byPatHash = new Map<string, ValOps>();
   /**
-   * One instance for every verified caller, and unlike the PAT map that is
-   * correct rather than a shortcut: this instance authenticates with the app's
-   * own API key, so there is nothing per-caller in it to keep apart. Who did
-   * what travels as the patch's `authorId` instead — see `writePath`.
+   * One instance for every verified caller, and that is correct rather than a
+   * shortcut: this instance authenticates with the app's own API key, so there
+   * is nothing per-caller in it to keep apart. Who did what travels as the
+   * patch's `authorId` instead — see `writePath`.
+   *
+   * One instance is also all proxy mode keeps now. It could not share while a
+   * personal access token reached this function: each token needed its own
+   * `ValOpsHttp` to hold it, each of those cached the project's evaluated
+   * modules, and the bounded cache that kept that memory in check turned an
+   * eviction into a re-evaluation of every module on the next call.
    */
   let sharedOps: ValOps | null = null;
 
   return (ctx) => {
-    if (!ctx.auth) {
+    if (ctx.auth?.type !== "verified-profile") {
       return {
         status: "error",
         result: {
           status: "error",
           code: "forbidden",
           message:
-            "This Val project talks to the Val content backend, so every call needs a credential: an access token from the Val authorization server, or the caller's own personal access token from `val login`.",
+            "This Val project talks to the Val content backend, so every call needs an access token from the Val authorization server. If this endpoint is not asking clients to authorize, it has no `oauth` config — give `initValMcp` one, or run the project in local filesystem mode for development.",
         },
       };
     }
-    if (ctx.auth.type === "verified-profile") {
-      if (!options.apiKey) {
-        // Proxy mode is inferred from the api key being present, so this is
-        // unreachable through `initHandlerOptions`. It stays because the
-        // alternative to refusing is building ops with no credential at all.
-        return {
+    if (!options.apiKey) {
+      // Proxy mode is inferred from the api key being present, so this is
+      // unreachable through `initHandlerOptions`. It stays because the
+      // alternative to refusing is building ops with no credential at all.
+      return {
+        status: "error",
+        result: {
           status: "error",
-          result: {
-            status: "error",
-            code: "forbidden",
-            message:
-              "This Val project has no API key configured, so a verified access token cannot be exchanged for backend access.",
-          },
-        };
-      }
-      if (!sharedOps) {
-        sharedOps = createValOps(valModules, options);
-      }
-      return { status: "ok", ops: sharedOps };
+          code: "forbidden",
+          message:
+            "This Val project has no API key configured, so a verified access token cannot be exchanged for backend access.",
+        },
+      };
     }
-    const key = createHash("sha256").update(ctx.auth.pat).digest("hex");
-    const cached = byPatHash.get(key);
-    if (cached) {
-      // Re-inserted so eviction drops the least recently used rather than the
-      // oldest — a long-running caller should not be evicted by a burst of
-      // one-off ones.
-      byPatHash.delete(key);
-      byPatHash.set(key, cached);
-      return { status: "ok", ops: cached };
+    if (!sharedOps) {
+      sharedOps = createValOps(valModules, options);
     }
-    const ops = createValOps(valModules, options, { pat: ctx.auth.pat });
-    byPatHash.set(key, ops);
-    while (byPatHash.size > MAX_CACHED_OPS) {
-      const oldest = byPatHash.keys().next();
-      if (oldest.done) {
-        break;
-      }
-      byPatHash.delete(oldest.value);
-    }
-    return { status: "ok", ops };
+    return { status: "ok", ops: sharedOps };
   };
 }
 

--- a/packages/server/src/tools/createValTools.ts
+++ b/packages/server/src/tools/createValTools.ts
@@ -335,10 +335,11 @@ function describeZodError(error: z.ZodError): string {
  * the safe direction: a tool that forgets the hint is treated as a write and
  * demands the wider scope, rather than a write slipping through as a read.
  *
- * Only the verified-token path is checked. A PAT carries no scopes here by
- * design — the backend resolves it and decides — so there is nothing to
- * enforce, and inventing a default would be this app claiming an authority it
- * does not have.
+ * The early return is local filesystem mode and nothing else. `auth` is null
+ * there because there was no credential to carry scopes, and a project that
+ * writes a developer's own working tree has no wider authority to withhold.
+ * Every other caller arrives as a verified profile, carrying the scopes its
+ * token was issued with.
  */
 function refuseInsufficientScope(
   tool: ValToolDefinition,

--- a/packages/server/src/tools/createValTools.ts
+++ b/packages/server/src/tools/createValTools.ts
@@ -335,11 +335,14 @@ function describeZodError(error: z.ZodError): string {
  * the safe direction: a tool that forgets the hint is treated as a write and
  * demands the wider scope, rather than a write slipping through as a read.
  *
- * The early return is local filesystem mode and nothing else. `auth` is null
- * there because there was no credential to carry scopes, and a project that
- * writes a developer's own working tree has no wider authority to withhold.
- * Every other caller arrives as a verified profile, carrying the scopes its
- * token was issued with.
+ * The early return is a call carrying no verified credential, and there is no
+ * scope to check because nothing granted one. In Val's own host that means
+ * local filesystem mode, where a project writing a developer's own working tree
+ * has no wider authority to withhold. A host assembling its own context can
+ * also reach it with an unauthenticated proxy-mode call — refused a few lines
+ * later, by `resolveOps`, for the credential rather than the scope. Every other
+ * caller arrives as a verified profile, carrying the scopes its token was
+ * issued with.
  */
 function refuseInsufficientScope(
   tool: ValToolDefinition,

--- a/packages/server/src/tools/types.ts
+++ b/packages/server/src/tools/types.ts
@@ -80,56 +80,45 @@ export type ValToolDefinitionJson = Omit<ValToolDefinition, "inputSchema"> & {
 };
 
 /**
- * How the caller was established, and it is a union because there are two
- * genuinely different answers — with different consequences downstream.
+ * How the caller was established, and there is one acceptable answer: the host
+ * **checked a signature**.
  *
- * The distinction that matters is **who checked**. A PAT is forwarded to the
- * backend unchecked, because the app cannot resolve one; an access token is
- * verified by the app itself, against a public key it does not hold and
- * therefore cannot forge. The first is a credential being relayed. The second
- * is a signature that has already been checked.
+ * A union of one, deliberately. It carried a second variant — a personal access
+ * token relayed to the backend unchecked, on the reasoning that the app cannot
+ * resolve one and the backend can. The reasoning held; the shape did not. A
+ * credential the host cannot check is one it also cannot refuse, so accepting
+ * one made "a deployed endpoint that authenticates nobody" a supported
+ * configuration, and it let a host serve these tools without ever being told
+ * where callers should authorize. The discriminant stays so that adding a
+ * second *verified* kind stays a one-line change at every call site.
  */
-export type ValToolAuth =
-  | {
-      type: "pat";
-      /**
-       * The caller's PAT. Never log this, never put it in a URL, and never let
-       * it reach a tool result.
-       *
-       * Relayed to the backend as-is: this app is not the authority on what the
-       * token may do, and the backend that is decides. Nothing is derived from
-       * it here — see `docs/plans/mcp.md` D.2.
-       */
-      pat: string;
-    }
-  | {
-      type: "verified-profile";
-      /**
-       * The profile the host **verified** — the `sub` of an access token whose
-       * signature, issuer, audience and expiry were all checked against the
-       * authorization server's published key.
-       *
-       * This field is the reason this type became a union, and an earlier
-       * version of this file argued no identity field should exist at all. That
-       * argument was about a specific case and stated too broadly: an id the
-       * host *asserts* on the strength of a credential it cannot check is an
-       * unverified claim dressed as a checked one, and that is still refused —
-       * it is why the `pat` variant carries no profile. An id the host
-       * *verified* cryptographically is a different thing, and it is the same
-       * standing the Studio has when it re-signs a session it established
-       * itself.
-       */
-      profileId: AuthorId;
-      /**
-       * The token's granted scopes, as the authorization server issued them.
-       *
-       * Enforced here as well as by the backend, deliberately. Two checks on
-       * one grant is not redundancy for its own sake: this one can refuse a
-       * write before it is attempted, so a token that may only read never
-       * reaches the code that builds a patch.
-       */
-      scopes: string[];
-    };
+export type ValToolAuth = {
+  type: "verified-profile";
+  /**
+   * The profile the host **verified** — the `sub` of an access token whose
+   * signature, issuer, audience and expiry were all checked against the
+   * authorization server's published key.
+   *
+   * This field is why an identity field exists at all, and an earlier version
+   * of this file argued none should. That argument was about a specific case
+   * and stated too broadly: an id the host *asserts* on the strength of a
+   * credential it cannot check is an unverified claim dressed as a checked one,
+   * and that is still refused — it is why a relayed token never carried a
+   * profile, and now cannot reach here at all. An id the host *verified*
+   * cryptographically is a different thing, and it is the same standing the
+   * Studio has when it re-signs a session it established itself.
+   */
+  profileId: AuthorId;
+  /**
+   * The token's granted scopes, as the authorization server issued them.
+   *
+   * Enforced here as well as by the backend, deliberately. Two checks on one
+   * grant is not redundancy for its own sake: this one can refuse a write
+   * before it is attempted, so a token that may only read never reaches the
+   * code that builds a patch.
+   */
+  scopes: string[];
+};
 
 /**
  * Who is calling, established once per request by the host.

--- a/packages/server/src/tools/writePath.ts
+++ b/packages/server/src/tools/writePath.ts
@@ -309,21 +309,22 @@ export async function savePatch(
   }
 
   /**
-   * Null on the PAT path, and the verified profile on the token path.
+   * The verified profile, or null when there was nothing to verify.
    *
-   * The PAT case is unchanged and still deliberate: the app cannot resolve a
-   * PAT, so any id it wrote here would be an unverified claim dressed up as a
-   * checked one — and the request already carries the caller's own token, which
-   * is a better answer to "who did this" than anything the app could assert.
-   * Attributing that patch is the backend's job.
+   * An author is written only when somebody checked it. On the token path the
+   * host verified a signature over a key it does not hold, so the profile is
+   * checked rather than claimed, and the backend has no token of its own to
+   * attribute from — the call reaches it under the app's API key. If this
+   * stayed null there, every edit made through a signed-in editor's own session
+   * would land with no author at all, which is worse than useless on a CMS
+   * whose review screen is organised by who changed what.
    *
-   * The token case is the opposite situation, which is why it gets the opposite
-   * answer. The host verified a signature over a key it does not hold, so the
-   * profile is checked rather than claimed, and the backend has no token of its
-   * own to attribute from — the call reaches it under the app's API key. If this
-   * stayed null, every edit made through a signed-in editor's own session would
-   * land with no author at all, which is worse than useless on a CMS whose
-   * review screen is organised by who changed what.
+   * Null is what local filesystem mode gets, where there is no credential to
+   * resolve, exactly as the Studio does locally. It is also what the removed
+   * personal-access-token path got, and for a reason worth keeping in view: an
+   * id derived from a credential the app cannot resolve is an unverified claim
+   * dressed up as a checked one. Should another unverified credential ever
+   * reach here, null remains its only honest author.
    */
   const authorId =
     ctx.auth?.type === "verified-profile" ? ctx.auth.profileId : null;

--- a/packages/server/src/tools/writeTools.test.ts
+++ b/packages/server/src/tools/writeTools.test.ts
@@ -328,14 +328,13 @@ describe("who a patch is attributed to", () => {
   /**
    * The rule, in one place: an author is written only when somebody checked it.
    *
-   * A PAT is relayed to the backend unresolved, so this app knows nothing about
-   * whose it is; an access token was verified here against a key this app does
-   * not hold, so the `sub` in it is a fact rather than a claim. Getting this
-   * backwards in either direction is bad in its own way — inventing an author
-   * from a PAT would put an unchecked name on a change, and dropping the
-   * verified one would leave every edit made through a signed-in editor's
-   * session with no author at all, on a review screen organised by who changed
-   * what.
+   * An access token is verified here against a key this app does not hold, so
+   * the `sub` in it is a fact rather than a claim, and it is written. Local
+   * filesystem mode has no credential to check, so it writes nothing. Getting
+   * this backwards in either direction is bad in its own way — inventing an
+   * author would put an unchecked name on a change, and dropping the verified
+   * one would leave every edit made through a signed-in editor's session with
+   * no author at all, on a review screen organised by who changed what.
    */
 
   const PROFILE = authorIdFromVerifiedSubject("profile-abc");
@@ -364,28 +363,6 @@ describe("who a patch is attributed to", () => {
     // a profile, so asserting an author would be a claim it has not checked.
     expect(patches).toMatchObject([{ authorId: null, published: false }]);
     expect(CTX.auth).toBeNull();
-  });
-
-  test("a PAT still lands no author", async () => {
-    const { tools, depsFor } = setup();
-
-    const res = await savePatch(
-      await depsFor({
-        auth: { type: "pat", pat: "pat-not-a-real-token" },
-        sessionId: null,
-      }),
-      PAGES_PATH,
-      [{ op: "replace", path: ["home", "title"], value: "Renamed" }],
-    );
-
-    expect(res.status).toBe("ok");
-    // A PAT is forwarded, never resolved. Anything written here would be this
-    // app asserting an identity it has not established — and the request
-    // already carries the caller's own token, which is a better answer to "who
-    // did this" than anything this side could make up.
-    expect(await callOk(tools, "get_patches", {})).toMatchObject([
-      { authorId: null },
-    ]);
   });
 
   test("a verified profile is written onto the patch it made", async () => {

--- a/packages/server/src/valServerConfig.ts
+++ b/packages/server/src/valServerConfig.ts
@@ -122,28 +122,33 @@ export async function initHandlerOptions(
 /**
  * Build the data layer a {@link ValServerConfig} calls for.
  *
- * `auth` decides *whose* credential the http backend sees. Left out, it is the
- * app's own API key — which is what the Studio wants, because there the app has
- * already verified a session cookie and is acting on the user's behalf under its
- * own authority.
+ * The http backend always sees the app's own API key. That is what the Studio
+ * wants — there the app has already verified a session cookie and is acting on
+ * the user's behalf under its own authority — and it is now the only shape:
+ * every caller that reaches here has been authenticated by the app itself, so
+ * there is no request left on which the app is a pipe rather than an authority.
  *
- * A caller acting for a user it has *not* authenticated itself must pass that
- * user's personal access token instead, so the backend is the one that decides
- * what the caller may do. That is the whole of `docs/plans/mcp.md` D.2: the app
- * stops being an authority and goes back to being a pipe. Passing the app's API
- * key on such a request is the D.6 confused deputy, and it is worth being blunt
- * about why it is tempting — it works, and it works for every project the key
- * can reach, including the ones the caller cannot.
+ * This took a parameter for the other case: a caller acting for a user it had
+ * *not* authenticated passed that user's personal access token, and the backend
+ * decided what the caller could do. `ValOpsHttp` still accepts such a token —
+ * the CLI's `debug` command uses the developer's own from `val login` — but no
+ * server request builds one any more, because a request the app cannot
+ * authenticate is now refused instead of relayed.
+ *
+ * What has not changed is why the API key must never stand in for a credential
+ * that was merely *absent*: it works, and it works for every project the key
+ * can reach, including the ones the caller cannot. Callers are refused for a
+ * missing credential well before this point.
  */
 export function createValOps(
   valModules: ValModules,
   options: ValServerConfig,
-  auth?: { pat: string },
 ): ValOpsFS | ValOpsHttp {
   if (options.mode === "fs") {
     // No credential in fs mode: this reads and writes the developer's own
-    // working tree, and there is no backend to authenticate to. A PAT handed in
-    // here is not ignored quietly — the caller is told, in createValTools.
+    // working tree, and there is no backend to authenticate to. A credential
+    // that arrives for such a project is not ignored quietly — the caller is
+    // told, in createValTools.
     return new ValOpsFS(options.valContentUrl, options.cwd, valModules, {
       formatter: options.formatter,
       config: options.config,
@@ -155,7 +160,7 @@ export function createValOps(
       options.project,
       options.commit,
       options.branch,
-      auth ?? { apiKey: options.apiKey },
+      { apiKey: options.apiKey },
       valModules,
       {
         formatter: options.formatter,

--- a/packages/server/src/valServerConfig.ts
+++ b/packages/server/src/valServerConfig.ts
@@ -148,7 +148,9 @@ export function createValOps(
     // No credential in fs mode: this reads and writes the developer's own
     // working tree, and there is no backend to authenticate to. A credential
     // that arrives for such a project is not ignored quietly — the caller is
-    // told, in createValTools.
+    // told, by `createValTools` when the project is configured for oauth and by
+    // `initValMcp` when it is not, since with no issuer there is no verified
+    // credential left for the registry to see.
     return new ValOpsFS(options.valContentUrl, options.cwd, valModules, {
       formatter: options.formatter,
       config: options.config,

--- a/packages/ui/spa/index.css
+++ b/packages/ui/spa/index.css
@@ -24,10 +24,11 @@
     --colors-base-white: #ffffff;
 
     --colors-gray-light-mode-gray-100: #f4f4f5;
+    --colors-gray-light-mode-gray-150: #eeeef0;
     --colors-gray-light-mode-gray-200: #e8e8ea;
-    --colors-gray-light-mode-gray-300: #ccccd2;
+    --colors-gray-light-mode-gray-300: #c6c6ce;
     --colors-gray-light-mode-gray-400: #86868f;
-    --colors-gray-light-mode-gray-500: #6b6b74;
+    --colors-gray-light-mode-gray-500: #66666f;
     --colors-gray-light-mode-gray-600: #52525a;
     --colors-gray-light-mode-gray-700: #3f3f46;
     --colors-gray-light-mode-gray-800: #27272a;
@@ -105,21 +106,21 @@
     --text-selection: var(--colors-gray-light-mode-gray-900);
 
     /* Primary colors */
-    --bg-primary: var(--colors-base-white);
-    --bg-primary-hover: var(--colors-gray-light-mode-gray-100);
+    --bg-primary: var(--colors-gray-light-mode-gray-25);
+    --bg-primary-hover: var(--colors-gray-light-mode-gray-150);
     --fg-primary: var(--colors-gray-light-mode-gray-900);
     --fg-primary-alt: var(--colors-gray-light-mode-gray-500);
     --border-primary: var(--colors-gray-light-mode-gray-300);
 
     /* Secondary colors */
-    --bg-secondary: var(--colors-gray-light-mode-gray-50);
-    --bg-secondary-hover: var(--colors-gray-light-mode-gray-100);
+    --bg-secondary: var(--colors-gray-light-mode-gray-100);
+    --bg-secondary-hover: var(--colors-gray-light-mode-gray-150);
     --fg-secondary: var(--colors-gray-light-mode-gray-700);
     --fg-secondary-alt: var(--colors-gray-light-mode-gray-500);
     --border-secondary: var(--colors-gray-light-mode-gray-200);
 
     /* Tertiary colors */
-    --bg-tertiary: var(--colors-gray-light-mode-gray-100);
+    --bg-tertiary: var(--colors-gray-light-mode-gray-150);
     --fg-tertiary: var(--colors-gray-light-mode-gray-600);
 
     /* Brand colors */
@@ -185,16 +186,32 @@
 
     /* Shell surfaces: the canvas the editor sits on, and the floating
        surfaces (rail, panels, bars) that hover above it. In light mode the
-       canvas is tinted and floating surfaces are white; in dark mode the
-       relationship inverts. */
-    --bg-canvas: var(--colors-gray-light-mode-gray-50);
-    --bg-surface: var(--colors-base-white);
-    --bg-float: var(--colors-base-white);
-    --bg-float-raised: var(--colors-gray-light-mode-gray-100);
+       canvas is tinted and floating surfaces sit above it; in dark mode the
+       relationship inverts.
+
+       Note that nothing here is `--colors-base-white`, and that is the point.
+       The Studio fills the viewport, so a surface at full white is a lamp
+       rather than a background — and with the canvas only 4% below it, the
+       whole shell read as one bright sheet. Every neutral surface therefore
+       sits one step down the light ramp: floats at gray-25, the canvas at
+       gray-100, raised fills at gray-150. The luminance gap between a panel
+       and the canvas roughly doubles, so the floating layout reads as
+       layered while the total light coming off the chrome drops.
+
+       `contrast.test.ts` holds the consequences: muted text and the panel
+       hairline both had to come down a nudge with the surfaces (gray-500 and
+       gray-300), because on a softer background yesterday's values go
+       washed out rather than quiet. Darken these surfaces further and
+       `--fg-secondary-alt` on `--bg-float-raised` is the pair that fails
+       first. */
+    --bg-canvas: var(--colors-gray-light-mode-gray-100);
+    --bg-surface: var(--colors-gray-light-mode-gray-25);
+    --bg-float: var(--colors-gray-light-mode-gray-25);
+    --bg-float-raised: var(--colors-gray-light-mode-gray-150);
     --border-float: var(--colors-gray-light-mode-gray-300);
 
     /* Disabled colors */
-    --bg-disabled: var(--colors-gray-light-mode-gray-100);
+    --bg-disabled: var(--colors-gray-light-mode-gray-150);
     --fg-disabled: var(--colors-gray-light-mode-gray-400);
   }
 


### PR DESCRIPTION
## Summary

Removes support for relaying personal access tokens (PATs) in MCP endpoints. The endpoint now requires an `oauth` config in proxy mode, or must run in local filesystem mode. This closes a security gap where deployed endpoints could authenticate nobody while appearing to authenticate callers.

**This branch also carries an unrelated commit**, `1c8b7fd` "Make the Studio's light mode less bright" (`packages/ui/spa/index.css`, `packages/next/src/fallbackColors.ts`), which rode along from the base it was branched from. It has its own changeset, so it lands as its own changelog entry; it is named here so the diff holds no surprises.

## Changes

**Authentication model:**
- `ValToolAuth` type is no longer a union — it now only accepts `{ type: "verified-profile", profileId, scopes }` or `null`
- Removed the `{ type: "pat", pat }` variant that was relayed to the backend unread
- Proxy mode now requires `oauth` config; endpoints without it return 500 with a message naming the missing configuration
- Local filesystem mode remains unchanged: no credential required, no `oauth` config needed

**MCP endpoint behavior:**
- `initValMcp` now refuses requests in proxy mode if `oauth` is not configured, rather than relaying an unverified bearer token
- The refusal message names the missing `oauth` config and `initValMcp` parameter, making misconfiguration obvious
- Credentials are never echoed in error responses (prevents leaking tokens to logs)
- Verified access tokens are the only credential accepted; they carry their own scopes and profile
- In fs mode with no `oauth` config, a presented bearer token is refused with a `400` naming the client's own configuration rather than silently ignored — with no issuer there is no verified credential for `createValTools` to refuse, so the endpoint is the last place the token exists

**Data layer simplification:**
- Removed `MAX_CACHED_OPS` constant and the per-PAT credential cache in `createOpsResolver`
- All verified callers now share a single `ValOps` instance that authenticates with the app's own API key
- Patches carry the verified profile as `authorId` instead of relying on the backend to resolve a forwarded token
- `createValOps` no longer accepts an `auth` parameter

**Test updates:**
- Replaced tests that verified PAT pass-through with tests confirming the refusal
- Updated scope checking tests to reflect that only verified tokens reach the scope gate
- Confirmed local filesystem mode still works without any credential or config, and that a token presented to it is refused
- Added test for deployed hosts being served without loopback checks when `oauth` is configured

## Rationale

A credential the app cannot check is one it cannot refuse either. The old model made "a deployed endpoint that authenticates nobody" a supported configuration, and allowed apps to serve content-rewriting tools without ever being told where callers should authorize. By requiring `oauth` config in proxy mode, every call now carries a token the app verified itself, and patches are properly attributed to verified profiles rather than relying on backend resolution of forwarded credentials.

## Known consequence

MCP now works only where a project's registered production URL is. The authorization server resolves a `resource` to a project by origin equality against that URL, so preview deployments, localhost in proxy mode, and headless clients with no browser (the AS offers `authorization_code` and `refresh_token`, no device grant) have no way to obtain a token. `val login` PATs remain in use elsewhere — `ValOpsHttp` still accepts one, which is how `val debug` works.

https://claude.ai/code/session_011G7D5JyY3BHVcEwXKHaPXJ