### PR TITLE
Do not offer a remote upload before it can succeed

### DIFF
--- a/e2e/http/remoteFiles.spec.ts
+++ b/e2e/http/remoteFiles.spec.ts
@@ -39,6 +39,36 @@ function picker(studio: Locator): Locator {
   return studio.locator('input[type="file"]:not([multiple])');
 }
 
+/**
+ * Wait until an upload can actually succeed, then hand over the file.
+ *
+ * A remote gallery cannot upload until `/remote/settings` has answered and a
+ * bucket has been picked from it, which is several async hops after intake -
+ * and `openHttpStudio` returns at intake. Setting the file before then makes
+ * `handleUpload` refuse it AND clear the input (`ev.target.value = ""`), so the
+ * upload never happens at all and the test fails 30s later polling for a ref
+ * that was never going to appear. That is the flake this replaces; CI caught it
+ * with `currentRemoteFileBucket: null, remoteFiles: { status: 'loading' }` -
+ * the request still in flight.
+ *
+ * The wait is on the upload button being enabled rather than on the response,
+ * because the button is downstream of BOTH the response and the effect that
+ * picks a bucket. Waiting for the response alone would still leave a render to
+ * race. It is also a boundary a person can see - the Studio does not offer the
+ * control until it works - rather than a reach into the client's state.
+ *
+ * `setInputFiles` does NOT wait for this on its own: measured, it sets files on
+ * a disabled input immediately, and the disabled input still fires `change`.
+ * So the wait has to be explicit.
+ */
+async function uploadWhenReady(studio: Locator, file: string): Promise<void> {
+  await expect(
+    studio.getByTitle("Upload file"),
+    "the gallery never became ready to upload",
+  ).toBeEnabled({ timeout: 30_000 });
+  await picker(studio).first().setInputFiles(file);
+}
+
 /** Every `file` op path in the chain: where an upload decided to store itself. */
 function uploadedRefs(page: Page): Promise<string[]> {
   return page.evaluate(() => {
@@ -97,7 +127,7 @@ test.describe("remote files", () => {
   }) => {
     await openHttpStudio(page, `/val/~${MODULE}`);
     const studio = page.locator("#val-shadow-root");
-    await picker(studio).first().setInputFiles(IMAGE);
+    await uploadWhenReady(studio, IMAGE);
 
     // A remote ref, not a repo path: `https://remote.val.build/file/p/...`, with
     // the project, bucket and hashes the content service handed out.
@@ -146,7 +176,7 @@ test.describe("remote files", () => {
   }) => {
     await openHttpStudio(page, `/val/~${MODULE}`);
     const studio = page.locator("#val-shadow-root");
-    await picker(studio).first().setInputFiles(IMAGE);
+    await uploadWhenReady(studio, IMAGE);
     await expect
       .poll(() => uploadedRefs(page), { timeout: 30_000 })
       .toHaveLength(1);
@@ -187,7 +217,7 @@ test.describe("remote files", () => {
   test("deletes a remote entry it just uploaded", async ({ page }) => {
     await openHttpStudio(page, `/val/~${MODULE}`);
     const studio = page.locator("#val-shadow-root");
-    await picker(studio).first().setInputFiles(OTHER_IMAGE);
+    await uploadWhenReady(studio, OTHER_IMAGE);
 
     const tile = studio.locator('img[src*="green-8x8_"]');
     await expect(tile).toHaveCount(1);

--- a/packages/ui/spa/components/FileGallery/FileGallery.tsx
+++ b/packages/ui/spa/components/FileGallery/FileGallery.tsx
@@ -38,6 +38,7 @@ export function FileGallery({
   disabled = false,
   onUploadClick,
   uploading = false,
+  uploadDisabled = false,
   defaultOpenFileRef,
   isDraggingOver = false,
 }: FileGalleryProps) {
@@ -191,7 +192,11 @@ export function FileGallery({
             <button
               type="button"
               onClick={onUploadClick}
-              disabled={uploading}
+              // `uploadDisabled` is a remote gallery waiting on
+              // `/remote/settings`: an upload started now can only fail, so the
+              // control is not offered until it can work. The title is left
+              // alone so it stays the same thing to look for either way.
+              disabled={uploading || uploadDisabled}
               className="rounded p-1.5 transition-colors text-fg-secondary hover:bg-bg-secondary hover:text-fg-primary disabled:opacity-50"
               title="Upload file"
             >

--- a/packages/ui/spa/components/FileGallery/types.ts
+++ b/packages/ui/spa/components/FileGallery/types.ts
@@ -44,6 +44,15 @@ export interface FileGalleryProps {
   disabled?: boolean;
   onUploadClick?: () => void;
   uploading?: boolean;
+  /**
+   * The upload control cannot succeed yet, so it is not offered.
+   *
+   * Distinct from `uploading` (a request is in flight) and from `disabled` (the
+   * whole gallery is inert): this is specifically "the preconditions for an
+   * upload are not in place", which today means a remote gallery still waiting
+   * on `/remote/settings`.
+   */
+  uploadDisabled?: boolean;
   defaultOpenFileRef?: string;
   isDraggingOver?: boolean;
 }

--- a/packages/ui/spa/components/fields/ModuleGallery.tsx
+++ b/packages/ui/spa/components/fields/ModuleGallery.tsx
@@ -153,6 +153,26 @@ export function ModuleGallery({
         }
       : null;
 
+  /**
+   * Whether an upload can succeed RIGHT NOW.
+   *
+   * A remote gallery cannot upload until `/remote/settings` has answered and a
+   * bucket has been picked from it - which is several async hops after intake:
+   * schemas arrive, that sets `requiresRemoteFiles`, that fires the request, and
+   * `useCurrentRemoteFileBucket` picks a bucket in an effect after the response.
+   * Until then `remoteData` is null and `handleUpload` can only refuse.
+   *
+   * Exposed so the button is not offered before it can work. It is also the only
+   * signal anything outside this component can wait on - `remoteFiles` and the
+   * bucket are both context state with no DOM of their own - which is what
+   * `e2e/http/remoteFiles.spec.ts` waits for instead of racing the request.
+   */
+  const canUpload = !requireRemote || remoteData !== null;
+  /** Loading is transient and about to resolve; inactive is a real failure. */
+  const remoteSettingsPending =
+    requireRemote === true &&
+    (remoteFiles.status === "loading" || remoteFiles.status === "not-asked");
+
   const files: GalleryFile[] = rawSource
     ? Object.entries(rawSource).map(([ref, meta]) => {
         const mimeType = typeof meta.mimeType === "string" ? meta.mimeType : "";
@@ -361,6 +381,21 @@ export function ModuleGallery({
       setUploadError(null);
       if (requireRemote && (!remoteData || !currentRemoteFileBucket)) {
         if (!currentRemoteFileBucket) {
+          /**
+           * Still loading is NOT the same as unavailable.
+           *
+           * Both used to land on "contact support", so an editor quick enough to
+           * pick a file while `/remote/settings` was still in flight was told
+           * their upload had failed permanently - for a state that resolves in
+           * milliseconds. The button is disabled until `canUpload`, so this is
+           * now only reachable by something that bypasses it (a drop, or a test
+           * driving the hidden input), and it says what is actually true.
+           */
+          if (remoteSettingsPending) {
+            setUploadError("Preparing remote uploads - try again in a moment.");
+            ev.target.value = "";
+            return;
+          }
           console.error("Current remote file bucket is not available", {
             remoteFiles,
             currentRemoteFileBucket,
@@ -702,6 +737,7 @@ export function ModuleGallery({
         }
         onFileDelete={readonly ? undefined : handleFileDelete}
         onUploadClick={readonly ? undefined : () => inputRef.current?.click()}
+        uploadDisabled={!canUpload}
         uploading={uploading}
         defaultOpenFileRef={showChildRef ?? undefined}
         isDraggingOver={isDraggingOver}

--- a/packages/ui/spa/components/fields/ModuleGallery.tsx
+++ b/packages/ui/spa/components/fields/ModuleGallery.tsx
@@ -541,6 +541,7 @@ export function ModuleGallery({
       schema,
       remoteFiles,
       encode,
+      remoteSettingsPending,
     ],
   );
 
@@ -550,8 +551,17 @@ export function ModuleGallery({
       dragCounterRef.current = 0;
       setIsDraggingOver(false);
       if (requireRemote && (!remoteData || !currentRemoteFileBucket)) {
+        /**
+         * Same distinction as `handleUpload`, and this is the path that needs
+         * it most: a drop has no button to disable, so `canUpload` cannot keep
+         * anyone out of here. Dropping a file while `/remote/settings` is still
+         * in flight is the one way an editor can still meet this, and it is
+         * transient - saying "not available" would be false.
+         */
         setUploadError(
-          "Remote uploads are not available. Please try again later.",
+          remoteSettingsPending
+            ? "Preparing remote uploads - try again in a moment."
+            : "Remote uploads are not available. Please try again later.",
         );
         return;
       }
@@ -677,6 +687,11 @@ export function ModuleGallery({
       computeRef,
       handleProgress,
       encode,
+      // Derived from `remoteFiles`, which is NOT otherwise a dependency here.
+      // On loading -> inactive neither `remoteData` nor the bucket changes
+      // (both stay null), so without this the flag stays stale at `true` and a
+      // genuinely unavailable remote would keep saying "try again in a moment".
+      remoteSettingsPending,
     ],
   );
 


### PR DESCRIPTION
Investigation of the `remoteFiles.spec.ts` CI flake. It turned out to be **half test race, half real product defect**, and the product half is the more serious one.

## The mechanism

CI's browser log named it exactly:

```
Current remote file bucket is not available
  { currentRemoteFileBucket: null, remoteFiles: { status: 'loading' } }
```

`status: 'loading'` means the `GET /remote/settings` request was **still in flight** when the file was picked — evidence, not inference.

A remote gallery cannot upload until several things have happened after intake:

1. schemas arrive (`schema:init`)
2. an effect computes `requiresRemoteFiles`
3. an effect fires `GET /remote/settings` and sets `status: "loading"`
4. the response sets `status: "ready"`
5. `useCurrentRemoteFileBucket` picks a bucket **in a further effect**

`openHttpStudio` returns at step 0. All three upload tests in the file then call `setInputFiles` immediately, so all three carry the race — one happened to lose.

## The product defect

`ModuleGallery.handleUpload` did two bad things when the bucket wasn't ready yet:

- **Cleared the input** (`ev.target.value = ""`), so the upload was *lost*, not delayed. There is no retry.
- Told the editor **"contact support"** for a state that resolves in milliseconds.

A real user quick enough to click the upload button during that window hits this. Measured with `/remote/settings` held for 5 s: **zero uploads after 15 s**, error banner shown.

Fixed by distinguishing the states — `loading`/`not-asked` is transient and now says so, `inactive` remains a real error — and by not offering the control at all until an upload can work (`uploadDisabled` on the gallery's upload button).

## The test fix

`uploadWhenReady` waits for the upload button to be enabled before handing over the file.

The button rather than the response, deliberately: it is downstream of **both** the response and the bucket-picking effect, so waiting on the response alone would still leave a render to race. It is also a boundary a person can see — the Studio does not offer the control until it works — rather than a reach into client state, per `e2e/README.md`.

## Verification

Two assumptions I had to measure rather than assume, both of which turned out **false** and would have produced a broken fix:

| assumption | measured |
|---|---|
| `setInputFiles` waits for `disabled` to clear | **No** — sets files on a disabled input after 95 ms |
| a disabled file input won't fire `change` | **It does** — `handleUpload` runs anyway |

So disabling the input alone would have fixed nothing for the test. The explicit wait is required.

Mechanism and fix proven under identical conditions, with `/remote/settings` held 5 s:

| | result |
|---|---|
| old shape (`setInputFiles` immediately) | `refs=[]` after 15 s, error banner shown |
| new shape (`uploadWhenReady`) | uploads, gets a proper `https://remote.val.build/file/p/…` ref |

Also green: full `chromium-http` `remoteFiles.spec.ts` (4/4), and `media.spec.ts` + `gallery-backed-image.spec.ts` (23 tests) — local galleries are unaffected because `canUpload` is `true` wherever remote is not required. `lint`, `format`, `typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEwy4V5s5BSJQmasskbj4M

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEwy4V5s5BSJQmasskbj4M)_