### PR TITLE
Add a referenced entry from a keyOf field

### DIFF
--- a/.changeset/keyof-create-referenced-entry.md
+++ b/.changeset/keyof-create-referenced-entry.md
@@ -1,0 +1,23 @@
+---
+"@valbuild/ui": patch
+---
+
+Add a referenced entry from a `s.keyOf()` field
+
+A `keyOf` field can now create the entry it is about to point at. Where the
+author you want is not in the authors record yet, name them here: the entry is
+added to the referenced record, the field points at it, and you are taken to the
+new entry to fill it in — instead of leaving the page you were editing to create
+it and coming back to link it.
+
+- Two ways in, as reference fields normally have: **New entry** at the foot of
+  the dropdown, and a **+** beside it for when you have not opened the dropdown.
+- The key you searched for is what the new entry is named, and the option stays
+  offered when the search matches nothing — which is how you got there.
+- The key box says what a key is here, from the record's `key` description (or
+  the field's own).
+- A key that already exists is refused rather than overwriting that entry.
+- Where the field renders the entry inline, it stays put: the new entry's fields
+  are already on screen.
+- Only for a record — an object's keys are its schema. A router record asks for
+  the new key per route segment, the same form the sitemap's "Add page" uses.

--- a/architecture/quirks.md
+++ b/architecture/quirks.md
@@ -175,6 +175,16 @@ clip` creates no scroll port at all, so there is no offset to write to; that,
 and the panes being a `transform` rather than a scroll position, is what
 `PageWorkspace` relies on now.
 
+**cmdk hides a GROUP whose items do not match the search, and a separator while
+there is any search at all.** So an item that has to stay — "New page" in
+`RouteSelector`, "New entry" in `KeySelector` — needs more than its own
+`forceMount`: inside a group that cmdk has hidden it is still invisible, and the
+option is gone exactly when the editor has just established that the thing they
+are searching for does not exist. Put `forceMount` on the `CommandGroup` (it
+reaches the items through cmdk's context) and `alwaysRender` on the
+`CommandSeparator`. jsdom does not compute visibility, so a jest test clicks a
+hidden item quite happily; `e2e/keyof-create.spec.ts` is what caught it.
+
 ## Remote files and proxy mode
 
 **"Does this project use remote files" is `hasRemoteFileSchema` in

--- a/e2e/keyof-create.spec.ts
+++ b/e2e/keyof-create.spec.ts
@@ -1,0 +1,133 @@
+import { expect } from "@playwright/test";
+import type { APIRequestContext, Locator, Page } from "@playwright/test";
+import { openStudio, test } from "./studio";
+
+/**
+ * Referencing an author who does not exist yet, from the blog post.
+ *
+ * The point is WHERE the writes land. Adding a key from a `keyOf` field is the
+ * only edit in the Studio that has to write to a module the field is not in:
+ * the entry belongs to the authors record, and only the selection belongs to
+ * the post. A version that adds the key to the post's own module renders
+ * exactly the same until the source comes back, and `KeyOfField.test.tsx` pins
+ * that at the hook. What it cannot see is whether either patch reached the
+ * server at all - the bug class `studio.spec.ts` exists for, where the
+ * optimistic update looks perfect and nothing is persisted - so both are read
+ * back out of the chain here, per `e2e/README.md`.
+ *
+ * It also caught what jsdom cannot: cmdk hides the GROUP an item is in when the
+ * search matches nothing, which is precisely when the create option is needed,
+ * and a hidden element is still clickable in jsdom.
+ */
+const BLOG_MODULE = "/app/blogs/[blog]/page.val.ts";
+const AUTHORS_MODULE = "/content/authors.val.ts";
+const PAGE = `/val/~${BLOG_MODULE}?p=%22%2Fblogs%2Fblog1%22`;
+
+const NEW_AUTHOR = "sindre";
+
+/** What the SERVER holds, as one flat list of (module, op, path). */
+async function serverOps(
+  request: APIRequestContext,
+): Promise<{ module: string; op: string; path: string[] }[]> {
+  const res = await request.get("/api/val/patches");
+  expect(res.ok(), `the server refused the request: ${res.status()}`).toBe(
+    true,
+  );
+  const body = (await res.json()) as {
+    patches: { path: string; patch?: { op: string; path: string[] }[] }[];
+  };
+  return body.patches.flatMap((patch) =>
+    (patch.patch ?? []).map((op) => ({
+      module: patch.path,
+      op: op.op,
+      path: op.path,
+    })),
+  );
+}
+
+/** The author field's dropdown, which is the only `keyOf` on this page. */
+function authorField(studio: Locator): Locator {
+  return studio.locator(`[data-val-studio-path*='"author"']`);
+}
+
+async function openBlogPost(page: Page): Promise<Locator> {
+  await openStudio(page, PAGE);
+  const studio = page.locator("#val-shadow-root");
+  await expect(
+    authorField(studio).getByRole("combobox"),
+    "the author field never rendered",
+  ).toHaveCount(1, { timeout: 30000 });
+  return studio;
+}
+
+test.describe("creating a referenced entry from a keyOf field", () => {
+  test("writes the entry to the authors module, the reference to the post, and goes to the entry", async ({
+    page,
+    request,
+  }) => {
+    const studio = await openBlogPost(page);
+    await expect(authorField(studio).getByRole("combobox")).toContainText(
+      "Fredrik Ekholdt",
+    );
+
+    await authorField(studio).getByRole("combobox").click();
+    // Searching first, because this is the state the option exists for: the
+    // author is not in the list, which is how the editor gets here at all.
+    await studio.getByPlaceholder("Search key...").fill(NEW_AUTHOR);
+    await studio.getByText("New entry").click();
+    // ...and the key is already what was searched for, under the key schema's
+    // own description of what a key is.
+    await expect(studio.getByPlaceholder("Key")).toHaveValue(NEW_AUTHOR);
+    await expect(
+      studio.getByText("Unique identifier for the author"),
+    ).toBeVisible();
+    await studio.getByRole("button", { name: "Create" }).click();
+
+    // Both writes are on the server, each in ITS OWN module.
+    await expect
+      .poll(() => serverOps(request), {
+        message: "the entry and the reference did not both reach the chain",
+      })
+      .toEqual(
+        expect.arrayContaining([
+          { module: AUTHORS_MODULE, op: "add", path: [NEW_AUTHOR] },
+          {
+            module: BLOG_MODULE,
+            op: "replace",
+            path: ["/blogs/blog1", "author"],
+          },
+        ]),
+      );
+
+    // And the editor is standing in the new author, which is empty: what was
+    // created is a key and a shape, and they still have to say who this is.
+    // Pathname and `p` only: the studio also carries its own canvas state in
+    // the query, which is not what this asserts.
+    await expect
+      .poll(
+        () => {
+          const url = new URL(page.url());
+          return `${url.pathname}?p=${url.searchParams.get("p")}`;
+        },
+        { message: "the studio did not navigate to the new entry" },
+      )
+      .toBe(`/val/~${AUTHORS_MODULE}?p="${NEW_AUTHOR}"`);
+    await expect(
+      studio.locator(`[data-val-studio-path*='"name"']`).getByRole("textbox"),
+      "the new author's own fields are not on screen",
+    ).toHaveValue("");
+  });
+
+  test("the + beside the dropdown opens the same form", async ({ page }) => {
+    const studio = await openBlogPost(page);
+
+    // Without opening the list at all: the second entry point is there for the
+    // editor who has not.
+    await authorField(studio)
+      .getByRole("button", { name: "New entry" })
+      .click();
+
+    await expect(studio.getByPlaceholder("Key")).toBeVisible();
+    await expect(studio.getByPlaceholder("Search key...")).toHaveCount(0);
+  });
+});

--- a/e2e/keyof-create.spec.ts
+++ b/e2e/keyof-create.spec.ts
@@ -118,6 +118,33 @@ test.describe("creating a referenced entry from a keyOf field", () => {
     ).toHaveValue("");
   });
 
+  test("the menu renders in the Studio's portal, above the combobox", async ({
+    page,
+  }) => {
+    const studio = await openBlogPost(page);
+    await authorField(studio).getByRole("combobox").click();
+
+    // In the Studio's own portal node, which is INSIDE the shadow root: a
+    // popover portalled to `document.body` lands outside it and loses every
+    // Val style, and one left in the field's own box is clipped by it.
+    const panel = studio.locator("[data-val-portal] [data-side]");
+    await expect(panel, "the menu is not in the Studio's portal").toHaveCount(
+      1,
+    );
+    // Above the row, so it does not cover the fields below it or this row's own
+    // "+" and go-to-reference link.
+    await expect(panel).toHaveAttribute("data-side", "top");
+    // And the portal node is not also sitting on the panel as a DOM attribute,
+    // which is what reading it off `props` and spreading the rest did.
+    expect(await panel.getAttribute("container")).toBeNull();
+
+    const trigger = await authorField(studio)
+      .getByRole("combobox")
+      .boundingBox();
+    const menu = await panel.boundingBox();
+    expect(trigger && menu && menu.y + menu.height <= trigger.y + 1).toBe(true);
+  });
+
   test("the + beside the dropdown opens the same form", async ({ page }) => {
     const studio = await openBlogPost(page);
 

--- a/packages/ui/spa/components/creatableRouters.ts
+++ b/packages/ui/spa/components/creatableRouters.ts
@@ -46,6 +46,24 @@ function patternStringOf(routePattern: RoutePattern[]): string {
     .join("");
 }
 
+/** Whether a router id is that of the external page router. */
+export function isExternalRouter(routerId: string): boolean {
+  return routerId === EXTERNAL_ROUTER_ID;
+}
+
+/**
+ * The route pattern a router module serves, e.g. `/blogs/[blog]`.
+ *
+ * Exported because a key of a router record IS a route: anything that lets an
+ * editor create one - the sitemap, a `s.route()` field, a `s.keyOf()` field
+ * pointing at a router - needs the pattern to know which segments to ask for.
+ */
+export function routePatternOfRouterModule(
+  moduleFilePath: ModuleFilePath,
+): RoutePattern[] {
+  return parseRoutePattern(routePatternSourceOf(moduleFilePath));
+}
+
 /**
  * A next-app-router module lives at the route it serves, so the route pattern is
  * the module path with the Val and Next.js file conventions stripped.
@@ -80,9 +98,7 @@ export function collectCreatableRouters(
       source && typeof source === "object" && !Array.isArray(source)
         ? Object.keys(source)
         : [];
-    const routePattern = parseRoutePattern(
-      routePatternSourceOf(moduleFilePath),
-    );
+    const routePattern = routePatternOfRouterModule(moduleFilePath);
     const entry: CreatableRouter = {
       moduleFilePath,
       routerId: schema.router,
@@ -91,7 +107,7 @@ export function collectCreatableRouters(
       existingKeys,
       keyDescription: schema.key?.description,
     };
-    if (schema.router === EXTERNAL_ROUTER_ID) {
+    if (isExternalRouter(schema.router)) {
       // At most one external router per project, as elsewhere in the studio.
       externalRouter = externalRouter ?? entry;
     } else {

--- a/packages/ui/spa/components/designSystem/popover.tsx
+++ b/packages/ui/spa/components/designSystem/popover.tsx
@@ -14,20 +14,31 @@ const PopoverContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> & {
     container?: HTMLElement | null;
   }
->(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
-  <PopoverPrimitive.Portal container={props.container}>
-    <PopoverPrimitive.Content
-      ref={ref}
-      align={align}
-      sideOffset={sideOffset}
-      className={cn(
-        "z-50 w-72 rounded-md border border-border-primary bg-bg-primary p-4 text-fg-primary shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-        className,
-      )}
-      {...props}
-    />
-  </PopoverPrimitive.Portal>
-));
+>(
+  (
+    { className, align = "center", sideOffset = 4, container, ...props },
+    ref,
+  ) => (
+    // `container` is destructured OUT, like every other primitive here
+    // (`tooltip`, `dropdown-menu`, `hover-card`) does. Read off `props` and left
+    // in it, as it was, the portal node is also spread onto the content div as a
+    // DOM prop - React drops it with an "Invalid value for prop `container`"
+    // warning, so nothing looked broken, but the popover carried the whole
+    // portal element as an attribute value on every render.
+    <PopoverPrimitive.Portal container={container}>
+      <PopoverPrimitive.Content
+        ref={ref}
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-72 rounded-md border border-border-primary bg-bg-primary p-4 text-fg-primary shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          className,
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  ),
+);
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
 export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor };

--- a/packages/ui/spa/components/designSystem/popover.tsx
+++ b/packages/ui/spa/components/designSystem/popover.tsx
@@ -21,10 +21,10 @@ const PopoverContent = React.forwardRef<
   ) => (
     // `container` is destructured OUT, like every other primitive here
     // (`tooltip`, `dropdown-menu`, `hover-card`) does. Read off `props` and left
-    // in it, as it was, the portal node is also spread onto the content div as a
-    // DOM prop - React drops it with an "Invalid value for prop `container`"
-    // warning, so nothing looked broken, but the popover carried the whole
-    // portal element as an attribute value on every render.
+    // in it, as it was, the portal node was also handed to the content div as a
+    // DOM prop - which React refuses, with "Invalid value for prop `container`
+    // on <div> tag". So it never reached the DOM and nothing looked broken; the
+    // cost was that warning, on every popover the Studio opens.
     <PopoverPrimitive.Portal container={container}>
       <PopoverPrimitive.Content
         ref={ref}

--- a/packages/ui/spa/components/fields/KeyOfField.test.tsx
+++ b/packages/ui/spa/components/fields/KeyOfField.test.tsx
@@ -1,0 +1,248 @@
+/** @jest-environment jsdom */
+// FIRST, and it must stay first: the field pulls in the shared bundle, which
+// builds a `TextEncoder` at module scope.
+import "../../stores/react/testPolyfills";
+import { fireEvent, render, screen } from "@testing-library/react";
+import {
+  Internal,
+  ModuleFilePath,
+  SourcePath,
+  initVal,
+  type SerializedSchema,
+  type Source,
+} from "@valbuild/core";
+
+/**
+ * Adding an entry to the REFERENCED module from the site of the reference.
+ *
+ * Which module each write lands in is the whole claim: selecting a key writes
+ * to the field, but creating one has to write to the module the key belongs
+ * to - `addModuleFilePatch`, not `addPatch`. A version that added the key to
+ * the referring module instead type-checks, looks right on screen until the
+ * source comes back, and quietly writes an entry nobody can reference.
+ */
+const { s, c } = initVal();
+
+const mockSchemas = jest.fn();
+const mockSources = jest.fn();
+const mockAddPatch = jest.fn();
+const mockAddModuleFilePatch = jest.fn();
+const mockNavigate = jest.fn();
+
+jest.mock("../ValFieldProvider", () => ({
+  __esModule: true,
+  useSchemaAtPath: (path: string) => mockSchemas()[path],
+  useShallowSourceAtPath: (path: string) => mockSources()[path],
+  usePreviewAtPath: () => undefined,
+  useAddPatch: () => ({
+    patchPath: ["author"],
+    addPatch: mockAddPatch,
+    addModuleFilePatch: mockAddModuleFilePatch,
+  }),
+}));
+
+jest.mock("../ValPortalProvider", () => ({
+  __esModule: true,
+  useValPortal: () => null,
+}));
+
+jest.mock("../../components/ValRouter", () => ({
+  __esModule: true,
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+// The generic dispatchers, which would otherwise drag in the whole field tree
+// (and, through `ValProvider`, a worker URL jest cannot parse).
+jest.mock("../AnyField", () => ({
+  __esModule: true,
+  AnyField: () => <div data-testid="any-field" />,
+}));
+
+jest.mock("../../components/Preview", () => ({
+  __esModule: true,
+  PreviewLoading: () => <div data-testid="preview-loading" />,
+  PreviewNull: () => <div data-testid="preview-null" />,
+}));
+
+import { KeyOfField } from "./KeyOfField";
+
+const AUTHORS = "/content/authors.val.ts" as ModuleFilePath;
+const FIELD = '/content/blog.val.ts?p="author"' as SourcePath;
+
+/** The serialized schema and source the Studio actually has for a module. */
+function serialize(valModule: ReturnType<typeof c.define>) {
+  const schema = Internal.getSchema(valModule)?.["executeSerialize"]();
+  if (!schema) throw new Error("Schema not found");
+  return {
+    schema: schema as SerializedSchema,
+    source: Internal.getSource(valModule) as Source,
+  };
+}
+
+const authorsRecord = serialize(
+  c.define(
+    AUTHORS,
+    s.record(s.object({ name: s.string(), title: s.string() })),
+    { freekh: { name: "Fredrik Ekholdt", title: "CTO" } },
+  ),
+);
+const authorsObject = serialize(
+  c.define(AUTHORS, s.object({ freekh: s.string(), teddy: s.string() }), {
+    freekh: "Fredrik Ekholdt",
+    teddy: "Theodor René Carlsen",
+  }),
+);
+
+function mount(
+  referenced: { schema: SerializedSchema; source: Source },
+  options?: { selected?: string | null; readonly?: boolean; inline?: boolean },
+) {
+  mockSchemas.mockReturnValue({
+    [FIELD]: {
+      status: "success",
+      data: {
+        type: "keyOf",
+        path: AUTHORS,
+        schema:
+          referenced.schema.type === "record"
+            ? { type: "record" }
+            : { type: "object", keys: ["freekh", "teddy"] },
+        opt: false,
+        values: "string",
+        render: options?.inline ? { as: "inline" } : undefined,
+      },
+    },
+    [AUTHORS]: { status: "success", data: referenced.schema },
+  });
+  mockSources.mockReturnValue({
+    [FIELD]: { status: "success", data: options?.selected ?? null },
+    [AUTHORS]: { status: "success", data: referenced.source },
+  });
+  return render(<KeyOfField path={FIELD} readonly={options?.readonly} />);
+}
+
+function openDropdown() {
+  fireEvent.click(screen.getByRole("combobox"));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // What cmdk needs from a browser and jsdom does not have: it measures the
+  // list, and scrolls the active item into view.
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+  Element.prototype.scrollIntoView = jest.fn();
+});
+
+describe("KeyOfField", () => {
+  it("adds the new entry to the referenced module, and references it", () => {
+    mount(authorsRecord, { selected: "freekh" });
+    openDropdown();
+
+    fireEvent.click(screen.getByText("New entry"));
+    fireEvent.change(screen.getByPlaceholderText("Key"), {
+      target: { value: "sindre" },
+    });
+    fireEvent.click(screen.getByText("Create"));
+
+    // The entry goes to the authors module, built from ITS item schema.
+    expect(mockAddModuleFilePatch).toHaveBeenCalledWith(
+      AUTHORS,
+      [{ op: "add", path: ["sindre"], value: { name: "", title: "" } }],
+      "record",
+    );
+    // ...the field now points at it, which is what the editor came for...
+    expect(mockAddPatch).toHaveBeenCalledWith(
+      [{ op: "replace", path: ["author"], value: "sindre" }],
+      "keyOf",
+    );
+    // ...and the editor is taken to the entry, which is empty until they say
+    // who this author is.
+    expect(mockNavigate).toHaveBeenCalledWith(`${AUTHORS}?p="sindre"`);
+  });
+
+  it("stays put when the referenced entry renders inline", () => {
+    mount(authorsRecord, { inline: true });
+    openDropdown();
+    fireEvent.click(screen.getByText("New entry"));
+    fireEvent.change(screen.getByPlaceholderText("Key"), {
+      target: { value: "sindre" },
+    });
+    fireEvent.click(screen.getByText("Create"));
+
+    // The entry is rendered under the selector, so it was created and
+    // referenced without going anywhere: navigating away from it is the one
+    // thing an inline render exists to avoid.
+    expect(mockAddModuleFilePatch).toHaveBeenCalled();
+    expect(mockAddPatch).toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("reaches the same form from the + beside the dropdown", () => {
+    mount(authorsRecord, { selected: "freekh" });
+
+    // Without opening the list first: the second entry point exists for the
+    // editor who has not opened it.
+    fireEvent.click(screen.getByRole("button", { name: "New entry" }));
+    fireEvent.change(screen.getByPlaceholderText("Key"), {
+      target: { value: "sindre" },
+    });
+    fireEvent.click(screen.getByText("Create"));
+
+    expect(mockAddModuleFilePatch).toHaveBeenCalledWith(
+      AUTHORS,
+      [{ op: "add", path: ["sindre"], value: { name: "", title: "" } }],
+      "record",
+    );
+  });
+
+  it("starts the new key from what was searched for", () => {
+    mount(authorsRecord);
+    openDropdown();
+    fireEvent.change(screen.getByPlaceholderText("Search key..."), {
+      target: { value: "sindre" },
+    });
+    // The search matched nothing, which is exactly when creating is wanted, so
+    // the option has to still be there (`forceMount`).
+    fireEvent.click(screen.getByText("New entry"));
+
+    expect(screen.getByPlaceholderText<HTMLInputElement>("Key").value).toBe(
+      "sindre",
+    );
+  });
+
+  it("refuses a key that already exists, rather than overwriting that entry", () => {
+    mount(authorsRecord);
+    openDropdown();
+    fireEvent.click(screen.getByText("New entry"));
+    fireEvent.change(screen.getByPlaceholderText("Key"), {
+      target: { value: "freekh" },
+    });
+
+    expect(screen.getByText("This key already exists")).toBeDefined();
+    fireEvent.click(screen.getByText("Create"));
+    expect(mockAddModuleFilePatch).not.toHaveBeenCalled();
+    expect(mockAddPatch).not.toHaveBeenCalled();
+  });
+
+  it("offers no create option for an object reference: its keys ARE its schema", () => {
+    mount(authorsObject, { selected: "freekh" });
+    openDropdown();
+
+    // The dropdown IS open: the object's keys are listed, there is just no way
+    // to add one.
+    expect(screen.getByText("teddy")).toBeDefined();
+    expect(screen.queryByText("New entry")).toBeNull();
+  });
+
+  it("offers no create option when the field is readonly", () => {
+    mount(authorsRecord, { selected: "freekh", readonly: true });
+    openDropdown();
+
+    expect(screen.queryByText("New entry")).toBeNull();
+    expect(screen.queryByRole("button", { name: "New entry" })).toBeNull();
+  });
+});

--- a/packages/ui/spa/components/fields/KeyOfField.test.tsx
+++ b/packages/ui/spa/components/fields/KeyOfField.test.tsx
@@ -214,6 +214,23 @@ describe("KeyOfField", () => {
     );
   });
 
+  it("does not carry a search into the next time the menu is opened", () => {
+    mount(authorsRecord);
+    openDropdown();
+    fireEvent.change(screen.getByPlaceholderText("Search key..."), {
+      target: { value: "free" },
+    });
+    // Picking an existing key closes the menu. Radix only reports ITS own
+    // closes through `onOpenChange`, so closing programmatically here used to
+    // skip the reset - and the create form, which starts from the search, then
+    // opened prefilled with what was typed the time before.
+    fireEvent.click(screen.getByText("freekh"));
+
+    openDropdown();
+    fireEvent.click(screen.getByText("New entry"));
+    expect(screen.getByPlaceholderText<HTMLInputElement>("Key").value).toBe("");
+  });
+
   it("refuses a key that already exists, rather than overwriting that entry", () => {
     mount(authorsRecord);
     openDropdown();

--- a/packages/ui/spa/components/fields/KeyOfField.tsx
+++ b/packages/ui/spa/components/fields/KeyOfField.tsx
@@ -187,6 +187,16 @@ export function KeySelector({
       <PopoverContent
         className="w-[var(--radix-popover-trigger-width)] p-0"
         container={portalContainer}
+        /**
+         * Above the combobox, and the field it belongs to.
+         *
+         * A reference is usually set from inside a form, so opening downwards
+         * puts the list over the fields the editor has not filled in yet - and
+         * over the "+" and the go-to-reference link on this same row. Radix
+         * keeps collision detection on, so it still flips below when there is
+         * no room above.
+         */
+        side="top"
       >
         {creating && onCreate !== undefined ? (
           createRoutePattern ? (

--- a/packages/ui/spa/components/fields/KeyOfField.tsx
+++ b/packages/ui/spa/components/fields/KeyOfField.tsx
@@ -244,7 +244,13 @@ export function KeySelector({
                         value={filterValue}
                         onSelect={() => {
                           onChange(key);
-                          setOpen(false);
+                          // `closeAndReset`, not `setOpen(false)`: Radix calls
+                          // `onOpenChange` for ITS own closes, not for a
+                          // programmatic one, so closing this way skipped the
+                          // reset and left the search text in state - and the
+                          // create form, which starts from it, then opened
+                          // prefilled with whatever was typed the time before.
+                          closeAndReset();
                         }}
                         className="flex items-center gap-2"
                       >

--- a/packages/ui/spa/components/fields/KeyOfField.tsx
+++ b/packages/ui/spa/components/fields/KeyOfField.tsx
@@ -24,15 +24,24 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
+  CommandSeparator,
 } from "../designSystem/command";
 import { Button } from "../designSystem/button";
+import { Input } from "../designSystem/input";
 import { cn } from "../designSystem/cn";
 import { PreviewLoading, PreviewNull } from "../../components/Preview";
 import { useNavigation } from "../../components/ValRouter";
-import { Link, Check, ChevronsUpDown } from "lucide-react";
+import { Link, Check, ChevronsUpDown, Plus } from "lucide-react";
 import { DropdownPreviewRow } from "../DropdownPreviewRow";
 import { ReadonlyGuard } from "./ReadonlyGuard";
 import { AnyField } from "../AnyField";
+import { emptyOf, RoutePattern } from "@valbuild/shared/internal";
+import { JSONValue } from "@valbuild/core/patch";
+import { RouteForm } from "../RouteForm";
+import {
+  isExternalRouter,
+  routePatternOfRouterModule,
+} from "../creatableRouters";
 
 export type KeyPreview = {
   title: string;
@@ -49,6 +58,25 @@ export interface KeySelectorProps {
   className?: string;
   portalContainer?: HTMLElement | null;
   isLoading?: boolean;
+  /**
+   * Add an entry to the referenced record from here, and reference it - the
+   * reference counterpart of "New page" in `RouteSelector`.
+   *
+   * The caller owns the WHOLE outcome - the entry, the selection, and where the
+   * editor ends up afterwards - so this does not report back through
+   * `onChange`: a new entry is empty, and following it is part of creating it.
+   *
+   * Only a record can take a new key (an object's keys ARE its schema), so
+   * `KeyOfField` passes this only then. Omitted: no create option is shown.
+   */
+  onCreate?: (key: string) => void;
+  /** The referenced record's key description, shown above the key input. */
+  keyDescription?: string;
+  /**
+   * Set when the referenced record is a router: its keys are routes, so the new
+   * key is asked for per segment rather than as a free string.
+   */
+  createRoutePattern?: RoutePattern[] | null;
 }
 
 export function KeySelector({
@@ -60,87 +88,270 @@ export function KeySelector({
   className,
   portalContainer,
   isLoading = false,
+  onCreate,
+  keyDescription,
+  createRoutePattern,
 }: KeySelectorProps) {
   const [open, setOpen] = React.useState(false);
-  const selectedPreview = value ? previews?.[value] : undefined;
+  const [creating, setCreating] = React.useState(false);
+  // Held rather than left to cmdk so that the create form can start from it: an
+  // editor types the key they were looking for, find it is not there, and the
+  // key they typed is what they want the new entry to be called.
+  const [search, setSearch] = React.useState("");
+  /**
+   * The preview for a key, unless it has nothing to show.
+   *
+   * A preview built from the entry's own fields (`title: val.name`) is EMPTY
+   * for an entry that was just created here, and a preview row with an empty
+   * title draws a blank where the reference should be. The key is what the
+   * reference is, so it is the honest fallback.
+   */
+  const previewOf = (key: string): KeyPreview | undefined => {
+    const preview = previews?.[key];
+    return preview && preview.title ? preview : undefined;
+  };
+  const selectedPreview = value !== null ? previewOf(value) : undefined;
+  // Closing discards a half-filled form: reopening into someone else's
+  // abandoned input is worse than starting clean. Same rule as `RouteSelector`.
+  const closeAndReset = () => {
+    setOpen(false);
+    setCreating(false);
+    setSearch("");
+  };
+  const createLabel = createRoutePattern ? "New page" : "New entry";
+  const onCreateSubmit = (key: string) => {
+    onCreate?.(key);
+    closeAndReset();
+  };
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="ghost"
-          role="combobox"
-          aria-expanded={open}
-          className={cn(
-            "w-full justify-start text-left border border-border-primary bg-bg-primary hover:bg-bg-primary-hover h-auto py-1.5",
-            className,
-          )}
-        >
-          {value ? (
-            selectedPreview ? (
-              <DropdownPreviewRow
-                title={selectedPreview.title}
-                subtitle={selectedPreview.subtitle ?? null}
-                image={selectedPreview.image ?? null}
-              />
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        if (next) {
+          setOpen(true);
+        } else {
+          closeAndReset();
+        }
+      }}
+    >
+      <div className="flex items-center w-full min-w-0">
+        <PopoverTrigger asChild>
+          <Button
+            variant="ghost"
+            role="combobox"
+            aria-expanded={open}
+            className={cn(
+              "w-full justify-start text-left border border-border-primary bg-bg-primary hover:bg-bg-primary-hover h-auto py-1.5",
+              className,
+            )}
+          >
+            {value ? (
+              selectedPreview ? (
+                <DropdownPreviewRow
+                  title={selectedPreview.title}
+                  subtitle={selectedPreview.subtitle ?? null}
+                  image={selectedPreview.image ?? null}
+                />
+              ) : (
+                <span className="truncate flex-1">{value}</span>
+              )
             ) : (
-              <span className="truncate flex-1">{value}</span>
-            )
-          ) : (
-            <span className="truncate flex-1">{placeholder}</span>
-          )}
-          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-        </Button>
-      </PopoverTrigger>
+              <span className="truncate flex-1">{placeholder}</span>
+            )}
+            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        {/* The same create form, reachable without opening the menu first -
+            the "+" beside a reference select that Django's admin, Sanity's
+            reference input and Contentful all have. It is deliberately the
+            SAME popover: a second one anchored to this button would be a
+            second copy of the form to keep in step. Outside the trigger, so a
+            click on it opens straight into the form rather than toggling the
+            list. */}
+        {onCreate !== undefined && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="ml-1 shrink-0"
+            title={createLabel}
+            aria-label={createLabel}
+            onClick={() => {
+              setCreating(true);
+              setOpen(true);
+            }}
+          >
+            <Plus className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
       <PopoverContent
         className="w-[var(--radix-popover-trigger-width)] p-0"
         container={portalContainer}
       >
-        <Command>
-          <CommandInput placeholder="Search key..." />
-          <CommandList>
-            {isLoading ? (
-              <div className="py-6 text-center text-sm">Loading...</div>
-            ) : keys.length === 0 ? (
-              <CommandEmpty>No keys found.</CommandEmpty>
-            ) : (
-              <CommandGroup>
-                {keys.map((key) => {
-                  const preview = previews?.[key];
-                  const filterValue = preview ? `${key} ${preview.title}` : key;
-                  return (
+        {creating && onCreate !== undefined ? (
+          createRoutePattern ? (
+            <div className="p-3">
+              <RouteForm
+                routePattern={createRoutePattern}
+                existingKeys={keys}
+                submitText="Create"
+                keyDescription={keyDescription}
+                onSubmit={onCreateSubmit}
+                onCancel={() => setCreating(false)}
+              />
+            </div>
+          ) : (
+            <NewKeyForm
+              defaultKey={search}
+              existingKeys={keys}
+              keyDescription={keyDescription}
+              onSubmit={onCreateSubmit}
+              onCancel={() => setCreating(false)}
+            />
+          )
+        ) : (
+          <Command>
+            <CommandInput
+              placeholder="Search key..."
+              value={search}
+              onValueChange={setSearch}
+            />
+            <CommandList>
+              {isLoading ? (
+                <div className="py-6 text-center text-sm">Loading...</div>
+              ) : keys.length === 0 ? (
+                <CommandEmpty>No keys found.</CommandEmpty>
+              ) : (
+                <CommandGroup>
+                  {keys.map((key) => {
+                    const preview = previewOf(key);
+                    const filterValue = preview
+                      ? `${key} ${preview.title}`
+                      : key;
+                    return (
+                      <CommandItem
+                        key={key}
+                        value={filterValue}
+                        onSelect={() => {
+                          onChange(key);
+                          setOpen(false);
+                        }}
+                        className="flex items-center gap-2"
+                      >
+                        <Check
+                          className={cn(
+                            "h-4 w-4 shrink-0",
+                            value === key ? "opacity-100" : "opacity-0",
+                          )}
+                        />
+                        {preview ? (
+                          <DropdownPreviewRow
+                            title={preview.title}
+                            subtitle={preview.subtitle ?? null}
+                            image={preview.image ?? null}
+                          />
+                        ) : (
+                          <span className="truncate">{key}</span>
+                        )}
+                      </CommandItem>
+                    );
+                  })}
+                </CommandGroup>
+              )}
+              {onCreate !== undefined && !isLoading && (
+                <>
+                  {/* Both of these are told to stay: cmdk hides a separator
+                      while there is a search, and hides a GROUP whose items do
+                      not match it - and a force-mounted item inside a hidden
+                      group is still invisible. Which is exactly backwards here,
+                      because a search that matches nothing is how the editor
+                      establishes that the key does not exist yet, and the
+                      moment they need this option most. The group's
+                      `forceMount` reaches its items through cmdk's context. */}
+                  <CommandSeparator alwaysRender />
+                  <CommandGroup forceMount>
                     <CommandItem
-                      key={key}
-                      value={filterValue}
-                      onSelect={() => {
-                        onChange(key);
-                        setOpen(false);
-                      }}
+                      value="__val_new_key__"
+                      onSelect={() => setCreating(true)}
                       className="flex items-center gap-2"
                     >
-                      <Check
-                        className={cn(
-                          "h-4 w-4 shrink-0",
-                          value === key ? "opacity-100" : "opacity-0",
-                        )}
-                      />
-                      {preview ? (
-                        <DropdownPreviewRow
-                          title={preview.title}
-                          subtitle={preview.subtitle ?? null}
-                          image={preview.image ?? null}
-                        />
-                      ) : (
-                        <span className="truncate">{key}</span>
-                      )}
+                      <Plus className="h-4 w-4 shrink-0" />
+                      <span>{createLabel}</span>
                     </CommandItem>
-                  );
-                })}
-              </CommandGroup>
-            )}
-          </CommandList>
-        </Command>
+                  </CommandGroup>
+                </>
+              )}
+            </CommandList>
+          </Command>
+        )}
       </PopoverContent>
     </Popover>
+  );
+}
+
+/**
+ * Asking for the key of a new entry in the referenced record.
+ *
+ * The key is what the reference is stored as, so it is worth refusing an empty
+ * or duplicate one here: adding at an existing key would silently overwrite
+ * that entry - which is not "add an author", it is "replace an author".
+ */
+function NewKeyForm({
+  defaultKey,
+  existingKeys,
+  keyDescription,
+  onSubmit,
+  onCancel,
+}: {
+  defaultKey?: string;
+  existingKeys: string[];
+  keyDescription?: string;
+  onSubmit: (key: string) => void;
+  onCancel: () => void;
+}) {
+  const [key, setKey] = React.useState(defaultKey ?? "");
+  const trimmed = key.trim();
+  const error = !trimmed
+    ? null
+    : existingKeys.includes(trimmed)
+      ? "This key already exists"
+      : null;
+  const disabled = !trimmed || error !== null;
+  return (
+    <form
+      className="p-3 space-y-3"
+      onSubmit={(ev) => {
+        ev.preventDefault();
+        if (disabled) {
+          return;
+        }
+        onSubmit(trimmed);
+      }}
+    >
+      <div className="text-sm font-medium text-fg-primary">New entry</div>
+      {keyDescription && (
+        <div className="text-xs text-pretty text-fg-tertiary">
+          {keyDescription}
+        </div>
+      )}
+      <div className="space-y-1">
+        <Input
+          autoFocus
+          value={key}
+          placeholder="Key"
+          onChange={(ev) => setKey(ev.target.value)}
+        />
+        {error && <p className="text-xs text-fg-error">{error}</p>}
+      </div>
+      <div className="flex gap-2 justify-end pt-1">
+        <Button size="sm" variant="ghost" type="button" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button size="sm" type="submit" disabled={disabled}>
+          Create
+        </Button>
+      </div>
+    </form>
   );
 }
 
@@ -180,7 +391,7 @@ export function KeyOfField({
     schemaAtPath.data.render?.as === "inline";
   const referencedSchemaAtPath = useSchemaAtPath(keyOf?.path ?? path);
   const sourceAtPath = useShallowSourceAtPath(path, type);
-  const { patchPath, addPatch } = useAddPatch(path);
+  const { patchPath, addPatch, addModuleFilePatch } = useAddPatch(path);
   const portalContainer = useValPortal();
   if (schemaAtPath.status === "error") {
     return (
@@ -276,6 +487,81 @@ export function KeyOfField({
     keyOf === undefined ||
     keys === undefined;
 
+  const referencedSchema =
+    "data" in referencedSchemaAtPath ? referencedSchemaAtPath.data : undefined;
+  // Adding an entry to the referenced module, so that an editor can reference
+  // something that does not exist yet - an author who has not been added to the
+  // authors record - without leaving the field, adding it, and coming back to
+  // link it.
+  //
+  // A RECORD only: an object's keys are its schema, so there is no key to add.
+  // A media record (`s.images()` / `s.files()`) is keyed by file path and needs
+  // bytes rather than a key, so it is left to the gallery.
+  const creatableRecordSchema =
+    !readonly &&
+    keyOf?.path !== undefined &&
+    referencedSchema?.type === "record" &&
+    !referencedSchema.readonly &&
+    referencedSchema.mediaType === undefined
+      ? referencedSchema
+      : undefined;
+  const [referencedModuleFilePath, referencedModulePath] =
+    keyOf?.path !== undefined
+      ? Internal.splitModuleFilePathAndModulePath(keyOf.path)
+      : [undefined, undefined];
+  // A key of a router record IS a route, so it is asked for per segment - the
+  // same form the sitemap's "Add page" uses. The external router is the
+  // exception: its keys are plain URLs.
+  const createRoutePattern =
+    creatableRecordSchema?.router !== undefined &&
+    referencedModuleFilePath !== undefined &&
+    !isExternalRouter(creatableRecordSchema.router)
+      ? routePatternOfRouterModule(referencedModuleFilePath)
+      : null;
+  // What to write in the key box. The record's own key schema describes the key
+  // itself ("Unique identifier for the author"), so it is the better answer
+  // when there is one; the field's description is what is left when there is
+  // not, and it is still about what this reference is.
+  const keyDescription =
+    creatableRecordSchema?.key?.description ??
+    ("data" in schemaAtPath && schemaAtPath.data?.type === "keyOf"
+      ? schemaAtPath.data.description
+      : undefined);
+  const createKey = (key: string) => {
+    if (
+      creatableRecordSchema === undefined ||
+      keyOf?.path === undefined ||
+      referencedModuleFilePath === undefined ||
+      referencedModulePath === undefined
+    ) {
+      return;
+    }
+    // The entry, in the module the key belongs to.
+    addModuleFilePatch(
+      referencedModuleFilePath,
+      [
+        {
+          op: "add",
+          path: Internal.createPatchPath(referencedModulePath).concat(key),
+          value: emptyOf(creatableRecordSchema.item) as JSONValue,
+        },
+      ],
+      "record",
+    );
+    // The reference, in this one. Immediately, rather than waiting for the new
+    // key to come back through the referenced source: referencing it is what
+    // the editor opened this for.
+    addPatch([{ op: "replace", path: patchPath, value: key }], type);
+    // And then to the entry itself, because it is EMPTY - what was created is
+    // a key and a shape, and the editor still has to say who this author is.
+    // Not when the entry renders inline under the selector: it is already on
+    // screen, and navigating away from it is the one thing inline render
+    // exists to avoid. Same rule `AddRecordPopover` follows.
+    if (!inlineRender) {
+      navigate(Internal.createValPathOfItem(keyOf.path, key) as SourcePath);
+    }
+  };
+
   // The schema of the entry the key points at: a record's item schema, or the
   // selected key's field schema when the reference is to an object.
   const referencedItemSchema =
@@ -315,6 +601,9 @@ export function KeyOfField({
           }}
           portalContainer={portalContainer}
           isLoading={isLoading}
+          onCreate={creatableRecordSchema !== undefined ? createKey : undefined}
+          keyDescription={keyDescription}
+          createRoutePattern={createRoutePattern}
         />
         {source && keyOf?.path && (
           <button

--- a/packages/ui/spa/components/fields/KeySelector.stories.tsx
+++ b/packages/ui/spa/components/fields/KeySelector.stories.tsx
@@ -128,3 +128,34 @@ function InteractiveStory() {
 export const Interactive: Story = {
   render: () => <InteractiveStory />,
 };
+
+/**
+ * Referencing something that does not exist yet: the dropdown can add the entry
+ * to the referenced record, which only a record can take - an object's keys are
+ * its schema. Search for a key that is not there, and the create option is
+ * still offered, with what was searched for as the new key.
+ */
+function CreatableStory() {
+  const [keys, setKeys] = useState(recordKeys);
+  const [value, setValue] = useState<string | null>(null);
+  return (
+    <KeySelector
+      keys={keys}
+      previews={recordPreviews}
+      value={value}
+      onChange={(key) => setValue(key)}
+      keyDescription="A short, unique id for the page"
+      // In the Studio this also writes the entry to the referenced module and
+      // navigates to it - `onCreate` owns the whole outcome, so a story that
+      // only has a list to add to does both of the parts it has.
+      onCreate={(key) => {
+        setKeys((prev) => [...prev, key]);
+        setValue(key);
+      }}
+    />
+  );
+}
+
+export const Creatable: Story = {
+  render: () => <CreatableStory />,
+};


### PR DESCRIPTION
A `keyOf` dropdown could only point at entries that already existed, so referencing an author who is not in the authors record yet meant leaving the post, adding the author, and coming back to link them.

It can now create the entry it is about to point at: name the key, and the entry is added to the **referenced** module, the field points at it, and the editor is taken to the new entry — which is empty, and is the rest of the job.

## What an editor sees

Two ways in, which is how reference fields normally do this: **New entry** at the foot of the dropdown (react-select's `Creatable`, `RouteSelector`'s "New page") and a **+** beside it (Django's admin, Sanity's reference input) for the editor who has not opened the dropdown. Both open the *same* popover, so there is one form rather than two to keep in step.

- The key box starts from what was searched for, so typing `sindre`, finding nothing and creating gives an entry called `sindre`.
- It says what a key is here, from the record's `key` description (`"Unique identifier for the author"`) or the field's own.
- A key that already exists is refused rather than overwriting that entry.
- Where the field renders the entry inline, it stays put: the new entry's fields are already on screen. Same rule `AddRecordPopover` follows.

## Where it does not apply

Only a record can take a new key — an object's keys are its schema — and a media record needs bytes rather than a key, so both are left out, as is a readonly field or record. A router record asks for the key per route segment via `RouteForm`, so a key of a router is still a valid route.

## Popover placement

The `keyOf` menu now opens `side="top"`: a reference is usually set from inside a form, so opening downwards puts the list over the fields the editor has not filled in yet, and over this row's own "+" and go-to-reference link. Radix keeps collision detection on, so it still flips below when there is no room above.

While pinning that, `PopoverContent` turned out to read `container` off `props` and then spread the rest of `props` — `container` included — onto the content div, handing the portal node to the DOM as an attribute value. React drops it with an "Invalid value for prop `container`" warning, which is why nothing looked broken. Every other primitive in the design system (`tooltip`, `dropdown-menu`, `hover-card`) destructures it; now this one does too.

## Two things only a browser saw

- cmdk hides the **group** a force-mounted item sits in when the search matches nothing — exactly when the create option is needed. jsdom does not compute visibility, so jest clicked the hidden item quite happily; the e2e caught it. Written down in `architecture/quirks.md`.
- An entry created here has an empty preview title (`title: val.name` on a blank author), which drew a blank trigger until the key became the fallback.

## Tests

- `packages/ui/spa/components/fields/KeyOfField.test.tsx` — which module each write lands in, at the hook. Writing the entry to the *referring* module type-checks and looks identical until the source comes back, so this is the claim worth pinning: plus the inline case not navigating, the duplicate key, the object reference offering nothing, and the readonly field.
- `e2e/keyof-create.spec.ts` — both patches read back off the server in their own modules, where the editor ends up, the "+" opening the same form, and the panel being in the Studio's portal above the combobox.
- Storybook: `Fields/KeySelector` → **Creatable**.

Green on lint, `prettier --check`, `pnpm run -r typecheck`, and `pnpm test` (253 suites / 3165 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015eqxb3LnX6eCD7XUwTnyv7

---
_Generated by [Claude Code](https://claude.ai/code/session_015eqxb3LnX6eCD7XUwTnyv7)_