### PR TITLE
Fix the drag overlay landing 132px below the finger on a phone

### DIFF
--- a/.changeset/mobile-drag-overlay-offset.md
+++ b/.changeset/mobile-drag-overlay-offset.md
@@ -1,0 +1,22 @@
+---
+"@valbuild/ui": patch
+---
+
+Fix dragging a list row on a phone, which picked the row up well below the
+finger and dropped it about three rows too far down.
+
+The card that follows your finger is positioned against the viewport, and on a
+phone the editor and the page ride on a track that was transformed even while it
+was standing still. A transformed box becomes the reference point for everything
+positioned that way inside it, so with the preview open the card was placed
+against a box already pushed down by the strip of switches — 132px of it. The
+same offset decided where the row landed, which is why the drop missed by
+roughly three positions.
+
+The track is now only transformed while it is actually moving between the
+editor and the page.
+
+Drag handles also declare `touch-action: none`, as dnd-kit asks them to. Without
+it a phone can decide mid-drag that your finger meant to scroll, and from that
+moment the drag and the list move at the same time. The rule had been written as
+an HTML attribute rather than as CSS, so it had never taken effect.

--- a/architecture/quirks.md
+++ b/architecture/quirks.md
@@ -30,6 +30,25 @@ paths; it moves _content between fixed paths_. Two consequences:
   permutation plus the patch's permutation cancel out, and the drag silently does
   nothing. Measured. `SortableList.tsx` carries the note.
 
+**A transformed ancestor moves the drag overlay, and moves the drop with it.**
+dnd-kit's `DragOverlay` — the card that follows the cursor — is `position:
+fixed` at the dragged row's client rect, and it renders inside the list rather
+than in a portal. A transformed ancestor is the containing block for every fixed
+descendant, so anything between the row and the viewport that carries a
+`transform` re-bases it. `translateX(0%)` counts: it moves nothing and still
+creates the containing block. The phone's preview put the two panes on such a
+track, and with the preview open the overlay's `top` was resolved against a box
+already pushed down by the strip of switches — the row floated 132px below the
+finger.
+
+The visible offset is the smaller half. dnd-kit collides the OVERLAY's measured
+rect against the rows to pick the drop, so the same 132px landed the row about
+three positions past where it was being aimed, which is how it was reported. If a
+drag is off by a constant, look for a `transform` above the list before looking
+at the sensors. `e2e/mobile-canvas.spec.ts` measures the gap between the finger
+and the overlay; use `isolation: isolate` where a stacking context is what the
+transform was really there for.
+
 ## Media
 
 The `/public` URL rule and the `appliedAt` gate — see [media.md](./media.md). The

--- a/e2e/mobile-canvas.spec.ts
+++ b/e2e/mobile-canvas.spec.ts
@@ -340,3 +340,121 @@ test.describe("the preview modes on a phone", () => {
     expect(await wholeOnScreen()).toBe(true);
   });
 });
+
+/**
+ * Dragging a list row with the preview open, on a phone.
+ *
+ * dnd-kit's `DragOverlay` — the card that follows the finger — is
+ * `position: fixed`, placed at the dragged row's client rect. Fixed positioning
+ * resolves against the viewport only while no ancestor is transformed, and the
+ * phone's two panes ride on a track that was transformed even when it was
+ * standing still (`translateX(0%)` moves nothing and still creates a containing
+ * block). So with the preview open the overlay's `top` was measured against a
+ * box already pushed down by `PHONE_STRIP_CLEARANCE`: the card floated 132px
+ * below the finger.
+ *
+ * That number is not only cosmetic. dnd-kit collides the OVERLAY's rect against
+ * the rows to decide where the drop lands, so the same 132px moved the drop
+ * about three rows past where the row was being aimed — which is how this was
+ * reported. Measuring the gap between the finger and the overlay therefore pins
+ * both halves at once, and it is the half a screenshot cannot show.
+ */
+test.describe("dragging a list row on a phone", () => {
+  test.use({ hasTouch: true, isMobile: true });
+
+  /** How far the finger moves between samples, in px. */
+  const STEP = 12;
+
+  /** The drag overlay: the only `position: fixed` box holding a grip. */
+  async function overlayCenterY(page: Page): Promise<number | null> {
+    return page.evaluate(() => {
+      const root = document.getElementById("val-shadow-root")?.shadowRoot;
+      if (!root) return null;
+      const overlay = Array.from(root.querySelectorAll("div")).find(
+        (el) =>
+          getComputedStyle(el).position === "fixed" &&
+          el.querySelector("svg.lucide-grip-vertical") !== null,
+      );
+      if (!overlay) return null;
+      const rect = overlay.getBoundingClientRect();
+      return rect.top + rect.height / 2;
+    });
+  }
+
+  test("keeps the dragged row under the finger", async ({ page }) => {
+    await openPreview(page);
+    await mode(page, "Normal").click();
+
+    const grip = page
+      .locator("#val-shadow-root")
+      .locator("button:has(svg.lucide-grip-vertical)")
+      .first();
+    await expect(grip).toBeEnabled();
+    // The first list on this page is below the fold on a phone, and a drag has
+    // to start from somewhere the finger can reach.
+    await grip.scrollIntoViewIfNeeded();
+    await expect
+      .poll(async () => (await grip.boundingBox())?.y ?? -1)
+      .toBeGreaterThan(0);
+    const box = (await grip.boundingBox())!;
+
+    /*
+     * Real touch events, over CDP.
+     *
+     * Playwright's `touchscreen` taps and does not drag, and `mouse` never
+     * reaches dnd-kit's touch sensor — which is the one that matters here,
+     * since the mouse sensor is not what a phone uses.
+     */
+    const cdp = await page.context().newCDPSession(page);
+    const x = box.x + box.width / 2;
+    const startY = box.y + box.height / 2;
+    const touch = (type: "touchStart" | "touchMove" | "touchEnd", y: number) =>
+      cdp.send("Input.dispatchTouchEvent", {
+        type,
+        touchPoints: type === "touchEnd" ? [] : [{ x, y }],
+      });
+
+    await touch("touchStart", startY);
+    try {
+      /*
+       * The first move STARTS the drag rather than being part of it.
+       *
+       * dnd-kit's touch sensor activates on the first `touchmove`, and that is
+       * the event that mounts the overlay — at the row's own position, with
+       * nothing translated yet. So it is one step behind by construction and
+       * for that one event only: from the next move on the overlay is exactly
+       * where the finger is, and holding still does not change either number.
+       */
+      await touch("touchMove", startY + STEP);
+      for (let step = 2; step <= 8; step++) {
+        const y = startY + step * STEP;
+        await touch("touchMove", y);
+        /*
+         * Polled rather than read straight back: the overlay's position is a
+         * render, and the event was dispatched, not awaited to paint. A gap
+         * that is there because the overlay is anchored to the wrong box never
+         * closes, so the poll runs out and says so.
+         *
+         * One pixel of rounding, and nothing more. The bug was 132 of them, so
+         * a loose bound would catch it too — but any drift at all means the
+         * overlay is positioned against something other than the viewport,
+         * which is the mistake rather than its size.
+         */
+        await expect
+          .poll(
+            async () => {
+              const center = await overlayCenterY(page);
+              return center === null ? null : Math.abs(center - y);
+            },
+            {
+              message:
+                "the dragged row did not follow the finger — a transformed ancestor is the usual reason",
+            },
+          )
+          .toBeLessThanOrEqual(1);
+      }
+    } finally {
+      await touch("touchEnd", startY);
+    }
+  });
+});

--- a/packages/ui/spa/components/BlockList.tsx
+++ b/packages/ui/spa/components/BlockList.tsx
@@ -55,6 +55,7 @@ import {
   PopoverTrigger,
 } from "./designSystem/popover";
 import { cn } from "./designSystem/cn";
+import { DRAG_HANDLE_TOUCH, SORTABLE_ROW_TOUCH } from "./dragHandle";
 import { emptyOf } from "@valbuild/shared/internal";
 import { sourcePathOfItem } from "../utils/sourcePathOfItem";
 import { FieldValidationError } from "./FieldValidationError";
@@ -337,9 +338,12 @@ function BlockRow({
     <button
       {...attributes}
       {...listeners}
-      className={cn("cursor-grab text-fg-quaternary hover:text-fg-primary", {
-        "opacity-30": readonly,
-      })}
+      className={cn(
+        "cursor-grab text-fg-quaternary hover:text-fg-primary",
+        // See `DRAG_HANDLE_TOUCH`.
+        DRAG_HANDLE_TOUCH,
+        { "opacity-30": readonly },
+      )}
       disabled={readonly}
     >
       <GripVertical size={14} />
@@ -354,7 +358,6 @@ function BlockRow({
 
   return (
     <div
-      touch-action="manipulation"
       /* The row is the anchor for its own path: nothing inside an inline row
          goes through `Field`, so without this a navigation to a path in this
          list has nothing to scroll to (see `scrollToStudioPath`). */
@@ -363,6 +366,8 @@ function BlockRow({
       style={style}
       className={cn(
         "border bg-bg-primary",
+        // See `SORTABLE_ROW_TOUCH`.
+        SORTABLE_ROW_TOUCH,
         // A nested row shares its parent row's LEFT border instead of drawing
         // its own: the parent's body has no left padding, so the child sits
         // flush against that edge — one border line, and the horizontal room

--- a/packages/ui/spa/components/InlineSortableItem.tsx
+++ b/packages/ui/spa/components/InlineSortableItem.tsx
@@ -2,6 +2,7 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { GripVertical } from "lucide-react";
 import { cn } from "./designSystem/cn";
+import { DRAG_HANDLE_TOUCH } from "./dragHandle";
 
 export function InlineSortableItem({
   id,
@@ -23,7 +24,8 @@ export function InlineSortableItem({
       <button
         {...attributes}
         {...listeners}
-        className={cn("pt-4 pr-1", { invisible: disabled })}
+        /* See `DRAG_HANDLE_TOUCH`. */
+        className={cn("pt-4 pr-1", DRAG_HANDLE_TOUCH, { invisible: disabled })}
         disabled={disabled}
       >
         <GripVertical size={16} />

--- a/packages/ui/spa/components/SortableList.tsx
+++ b/packages/ui/spa/components/SortableList.tsx
@@ -31,6 +31,7 @@ import {
   PopoverTrigger,
 } from "./designSystem/popover";
 import { cn } from "./designSystem/cn";
+import { DRAG_HANDLE_TOUCH, SORTABLE_ROW_TOUCH } from "./dragHandle";
 
 export function SortableContainer({
   source,
@@ -253,13 +254,17 @@ export function SortableItemRow({
   const centerGripAndDeleteIcons = !(validationErrors[path]?.length > 0);
   return (
     <div
-      touch-action="manipulation"
       ref={setNodeRef}
       style={style}
-      className={cn("relative flex disabled:opacity-55 flex-1", {
-        "items-start": !centerGripAndDeleteIcons,
-        "items-center": centerGripAndDeleteIcons,
-      })}
+      className={cn(
+        "relative flex disabled:opacity-55 flex-1",
+        // See `SORTABLE_ROW_TOUCH`.
+        SORTABLE_ROW_TOUCH,
+        {
+          "items-start": !centerGripAndDeleteIcons,
+          "items-center": centerGripAndDeleteIcons,
+        },
+      )}
     >
       <button
         {...attributes}
@@ -270,6 +275,8 @@ export function SortableItemRow({
           // `tabIndex=0` — so it needs the same focus ring as every other
           // control, not the browser default.
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus",
+          // See `DRAG_HANDLE_TOUCH`.
+          DRAG_HANDLE_TOUCH,
           {
             "opacity-30": disabled,
             "mt-2.5": !centerGripAndDeleteIcons,

--- a/packages/ui/spa/components/dragHandle.ts
+++ b/packages/ui/spa/components/dragHandle.ts
@@ -1,0 +1,30 @@
+/**
+ * What a drag handle has to say about touch, for the browser to leave it alone.
+ *
+ * dnd-kit's touch sensor works by calling `preventDefault()` on `touchmove`.
+ * That only works while the event is still cancelable, and it stops being
+ * cancelable the moment the compositor has decided the gesture is a scroll —
+ * which, on a real phone, it can decide before the main thread has run a single
+ * listener. From then on the finger drags the LIST and the row at the same
+ * time, and dnd-kit is left tracking a pointer whose coordinates no longer mean
+ * what the measured rects mean.
+ *
+ * `touch-action: none` is how you tell the browser there is no gesture here to
+ * take, so the decision never happens. It costs a scroll started exactly on the
+ * grip, which is the trade dnd-kit's own docs make.
+ *
+ * NB: this has to be real CSS. It was `touch-action="manipulation"` written as
+ * an HTML attribute on the row — React passes unknown attributes straight
+ * through, so it rendered, and it did nothing at all.
+ */
+export const DRAG_HANDLE_TOUCH = "touch-none";
+
+/**
+ * The rest of a sortable row.
+ *
+ * `manipulation` keeps panning and pinching — the row is not a handle, and a
+ * list you cannot scroll by dragging its rows is worse than a slow double tap —
+ * while dropping the double-tap-to-zoom delay that otherwise sits in front of
+ * every tap on it.
+ */
+export const SORTABLE_ROW_TOUCH = "touch-manipulation";

--- a/packages/ui/spa/components/shell/canvas/PageWorkspace.tsx
+++ b/packages/ui/spa/components/shell/canvas/PageWorkspace.tsx
@@ -942,10 +942,31 @@ export function PageWorkspace({
           className="h-full overflow-clip"
           style={open ? { paddingTop: PHONE_STRIP_CLEARANCE } : undefined}
         >
+          {/*
+           * The transform is dropped while the track is at rest, and that is
+           * not a micro-optimisation.
+           *
+           * A transformed element is the containing block for every
+           * `position: fixed` descendant, so `translateX(0%)` — a transform
+           * that moves nothing — silently re-bases the whole editor pane's
+           * fixed positioning onto this box. dnd-kit's `DragOverlay` is
+           * `position: fixed` at the dragged row's CLIENT rect, and it is
+           * rendered inside the list, so with the preview open its `top` was
+           * resolved against a box already pushed down by
+           * `PHONE_STRIP_CLEARANCE`: the card floated 132px below the finger,
+           * and — because the same rect is what dnd-kit collides against —
+           * dropping it landed the row about three positions too far down.
+           *
+           * `isolation` keeps the stacking context the transform used to
+           * create, which the strip above depends on (see the `z-window` note
+           * below); unlike a transform it does not touch fixed positioning.
+           */}
           <div
-            className="flex h-full w-full"
+            className="flex h-full w-full isolate"
             style={{
-              transform: `translateX(${open && pane === "canvas" ? "-100%" : "0%"})`,
+              ...(open && pane === "canvas"
+                ? { transform: "translateX(-100%)" }
+                : {}),
               transition: ease(["transform"]),
             }}
           >


### PR DESCRIPTION
Dragging a list row in the Studio on a phone picked the row up well below the touch point, and releasing it moved the row about three positions further down than where it was aimed.

## What it was

dnd-kit's `DragOverlay` — the card that follows the finger — is `position: fixed` at the dragged row's client rect, and it renders inside the list rather than in a portal. A transformed ancestor is the containing block for every `position: fixed` descendant, and the phone's two panes ride on a track that carried `translateX(0%)` even while standing still. A transform that moves nothing still creates that containing block, so with the preview open the overlay's `top` was resolved against a box already pushed down by `PHONE_STRIP_CLEARANCE` — 132px, measured.

The visible offset is the smaller half of it. dnd-kit collides the *overlay's* measured rect against the rows to decide where the drop lands, so the same 132px landed the row roughly three positions too far down, which is how this was reported.

## What changed

- `PageWorkspace` transforms the phone track only while it is actually moving between the editor and the page. `isolation: isolate` keeps the stacking context the strip of switches depends on; unlike a transform it does not touch fixed positioning.
- The drag handles in `SortableList`, `BlockList` and `InlineSortableItem` declare `touch-action: none`, as dnd-kit asks them to. Without it the compositor can decide mid-gesture that the finger meant to scroll, after which `preventDefault` is refused and the list and the row move together. The rule was already there in spirit — as `touch-action="manipulation"` written as an HTML attribute rather than as CSS, which React passed straight through and the browser ignored. The rows themselves keep `manipulation` (now as real CSS), so a list is still scrollable by dragging a row.
- `architecture/quirks.md` records the transformed-ancestor trap, since "the drag is off by a constant" points at the sensors and the answer is above the list.

## How it was verified

`e2e/mobile-canvas.spec.ts` drives a real touch drag over CDP on a 390×844 viewport with the preview open, and measures the gap between the finger and the overlay on every step. It reports `132` without the `PageWorkspace` change and passes with it.

Full check run, all green: `lint`, `format`, `typecheck` (every package), `typecheck:e2e`, `jest` (3158 tests), the whole `chromium` Playwright project (93 passed, 6 pre-existing skips), the root `build`, and `examples/next build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SV59HQX5vCyzeTfr9WqpGd

---
_Generated by [Claude Code](https://claude.ai/code/session_01SV59HQX5vCyzeTfr9WqpGd)_