### PR TITLE
Clear the overlay's selection box when the pointer leaves Val content

### DIFF
--- a/.changeset/tidy-pans-tap.md
+++ b/.changeset/tidy-pans-tap.md
@@ -1,0 +1,7 @@
+---
+"@valbuild/ui": patch
+---
+
+Fix the page going unclickable behind a stale selection box in the overlay's select mode.
+
+In select mode the overlay draws a box over whatever Val content the pointer is on, and that box is what turns a click into "edit this" — it sits above the page and stops the event. The box was only ever written when the pointer found tagged content, never cleared when it left, so it stayed parked over the last thing the pointer crossed. Everything under that rectangle stopped responding for as long as select mode was on: most visibly, a link there could not be followed.

--- a/e2e/overlay-select.spec.ts
+++ b/e2e/overlay-select.spec.ts
@@ -1,0 +1,128 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * The overlay's select mode, on the customer's own page.
+ *
+ * Not the canvas: this is Val mounted in the host app, where the page is the
+ * real page and the only thing between a click and it is the overlay. Select
+ * mode works by drawing a box over whatever Val content the pointer is on and
+ * catching the click on that box — so the box is not decoration, it is the
+ * intercept. Anywhere it is, the page underneath has stopped responding.
+ *
+ * Which is why where it *is not* has to be asserted. The box used to be written
+ * only when the pointer found tagged content, so it stayed over the last thing
+ * the pointer crossed and quietly ate every click in that rectangle — a link
+ * there could not be followed, with a green outline as the only clue.
+ *
+ * There is no unit test for this. jsdom has no layout and no
+ * `elementsFromPoint`, and the whole behaviour is "what is on top at these
+ * coordinates".
+ */
+
+/**
+ * The host app's home page, which has Val content and a link in it.
+ *
+ * Absolute, because `redirect_to` is handed to a `Location` header rather than
+ * resolved against the request — the same reason `uncommitted-routes.spec.ts`
+ * spells the origin out.
+ */
+const HOME = "http://localhost:3456/";
+
+/**
+ * Turn preview mode on and land on the page, in one navigation.
+ *
+ * `/api/val/enable` sets the Val Enable cookie *and* draft mode, then redirects
+ * — and both are needed before the page mounts any of Val's client code.
+ */
+async function openInPreviewMode(
+  page: import("@playwright/test").Page,
+): Promise<void> {
+  await page.goto(`/api/val/enable?redirect_to=${encodeURIComponent(HOME)}`);
+  // Next's dev-tools badge floats over the page and intercepts pointer events.
+  await page.addStyleTag({
+    content: "nextjs-portal { display: none !important; }",
+  });
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          const host = document.querySelector("#val-shadow-root");
+          return !!host?.shadowRoot?.querySelector("#val-overlay-container");
+        }),
+      { timeout: 60_000, message: "the overlay never mounted on the page" },
+    )
+    .toBe(true);
+}
+
+/**
+ * Whether the Val overlay is what a click at this point would hit.
+ *
+ * Read from the host document, which is the only place it can be read from: the
+ * box lives in a shadow root, so `elementsFromPoint` reports its host element
+ * rather than the box itself. The host being on top *is* the intercept.
+ */
+async function overlayCovers(
+  page: import("@playwright/test").Page,
+  point: { x: number; y: number },
+): Promise<boolean> {
+  return page.evaluate(
+    ({ x, y }) => document.elementsFromPoint(x, y)[0]?.id === "val-shadow-root",
+    point,
+  );
+}
+
+test.describe("the overlay's select mode", () => {
+  test("stops covering the page once the pointer leaves Val content", async ({
+    page,
+  }) => {
+    await openInPreviewMode(page);
+
+    // The select-mode toggle, by its icon: the menu buttons carry tooltips
+    // rather than labels, and the tooltip is in a hover card that is not open.
+    const armed = await page.evaluate(() => {
+      const root = (
+        document.querySelector("#val-shadow-root") as HTMLElement | null
+      )?.shadowRoot;
+      const button = root
+        ? [...root.querySelectorAll("button")].find((candidate) =>
+            candidate.querySelector("svg.lucide-square-dashed-mouse-pointer"),
+          )
+        : undefined;
+      if (!button) return false;
+      button.click();
+      return true;
+    });
+    expect(armed, "the select-mode toggle was not on the menu").toBe(true);
+
+    const tagged = page.locator("main a[data-val-path]").first();
+    await expect(
+      tagged,
+      "the page rendered no tagged content to select",
+    ).toBeVisible();
+    const box = await tagged.boundingBox();
+    expect(box, "the tagged element has no box to point at").toBeTruthy();
+    const centre = {
+      x: box!.x + box!.width / 2,
+      y: box!.y + box!.height / 2,
+    };
+
+    // On the content: the overlay takes the click, which is the point of the
+    // mode. Asserted so this test cannot pass by select mode never arming.
+    await page.mouse.move(centre.x, centre.y);
+    await expect
+      .poll(() => overlayCovers(page, centre), {
+        message: "select mode did not put the overlay over Val content",
+      })
+      .toBe(true);
+
+    // Off it, onto page background with nothing tagged under it: the overlay
+    // has to let go. This is the assertion the bug failed.
+    await page.mouse.move(4, 4);
+    await expect
+      .poll(() => overlayCovers(page, centre), {
+        message:
+          "the selection box stayed over the content the pointer had left, so clicks there still could not reach the page",
+      })
+      .toBe(false);
+  });
+});

--- a/e2e/overlay-select.spec.ts
+++ b/e2e/overlay-select.spec.ts
@@ -80,9 +80,7 @@ test.describe("the overlay's select mode", () => {
     // The select-mode toggle, by its icon: the menu buttons carry tooltips
     // rather than labels, and the tooltip is in a hover card that is not open.
     const armed = await page.evaluate(() => {
-      const root = (
-        document.querySelector("#val-shadow-root") as HTMLElement | null
-      )?.shadowRoot;
+      const root = document.getElementById("val-shadow-root")?.shadowRoot;
       const button = root
         ? [...root.querySelectorAll("button")].find((candidate) =>
             candidate.querySelector("svg.lucide-square-dashed-mouse-pointer"),
@@ -99,11 +97,16 @@ test.describe("the overlay's select mode", () => {
       tagged,
       "the page rendered no tagged content to select",
     ).toBeVisible();
+    // A throw rather than an `expect`, because everything below needs the box
+    // itself: a matcher fails the test but does not narrow the type, so the
+    // reads after it would each have to assert the null away again.
     const box = await tagged.boundingBox();
-    expect(box, "the tagged element has no box to point at").toBeTruthy();
+    if (box === null) {
+      throw new Error("the tagged element has no box to point at");
+    }
     const centre = {
-      x: box!.x + box!.width / 2,
-      y: box!.y + box!.height / 2,
+      x: box.x + box.width / 2,
+      y: box.y + box.height / 2,
     };
 
     // On the content: the overlay takes the click, which is the point of the

--- a/packages/ui/spa/components/ValOverlay.tsx
+++ b/packages/ui/spa/components/ValOverlay.tsx
@@ -251,9 +251,20 @@ export function ValOverlay(props: ValOverlayProps) {
             }
           }
         }
-        if (boundingBox) {
-          setBoundingBox(boundingBox);
-        }
+        /**
+         * Set unconditionally, `null` included.
+         *
+         * `null` is the answer whenever the pointer is over nothing Val
+         * tracks, and it has to be written: this used to set only when it
+         * found something, so the box stayed parked over the last piece of
+         * content the pointer crossed for as long as select mode was on. That
+         * box is the thing that turns a click into "edit this" — it sits above
+         * the page and stops the event — so whatever the page had at those
+         * coordinates stopped responding, and a link under it could not be
+         * followed. The stale outline looked like a rendering quirk; the dead
+         * link underneath was the real cost.
+         */
+        setBoundingBox(boundingBox);
       };
       const touchListener = (ev: TouchEvent) => {
         listener(ev.touches[0].clientX, ev.touches[0].clientY);


### PR DESCRIPTION
In the overlay's select mode, the box drawn over the hovered element is not decoration — it **is** the intercept. It sits above the page in the shadow root and takes the click, which is how a click becomes "edit this" instead of whatever the page would have done with it.

The mousemove listener only ever wrote the box when it found tagged content under the pointer, and never wrote `null` when it did not:

```tsx
if (boundingBox) {
  setBoundingBox(boundingBox);
}
```

So it never cleared. The box stayed parked over the last thing the pointer crossed for as long as select mode was on, and everything inside that rectangle stopped responding — most visibly, a link there could not be followed. The stale green outline read as a rendering quirk; the dead link underneath was the real cost.

The fix is to write the computed value unconditionally, `null` included.

## How this was found

Investigating a report that clicking a link in the host app in preview mode did not open the link. The behaviour splits three ways, all checked in a real browser against `examples/next`:

| State | Click on a link | |
| --- | --- | --- |
| Preview off | navigates | ✅ |
| Preview on, select **off** | navigates | ✅ |
| Preview on, select **on**, over Val content | opens the field, does not navigate | by design |

So preview mode on its own never swallowed a click. Select mode does, deliberately — but the box outstaying the pointer meant it kept doing so over content the pointer had left, which is the bug fixed here.

**The canvas was checked too and is correct**, so this is not the place to look if something similar turns up there. It intercepts differently: `ValCanvasBridge` installs a capture-phase `click` listener on `document` and calls `preventDefault()` / `stopPropagation()` when `target.closest("[data-val-path]")` hits — an event handler, not an element, so it has nothing to leave behind. Verified that a tagged link in the canvas opens the field and does not navigate the frame, and that it holds under ctrl/cmd+click, `Enter` on the focused link, and a click issued in the same tick as arming select mode.

One known gap, left alone as out of scope: a link with **no** tagged ancestor still navigates while picking is on (`if (!attribute) return;`). That is intentional for the Normal view — "Clicking the page follows links, as a visitor would" — and arguably wrong in select mode, but it is a separate decision.

## Testing

- `e2e/overlay-select.spec.ts` (new) asserts the overlay is on top while the pointer is on Val content, and **not** on top once it leaves. Reverted the fix and re-ran to confirm the test actually fails without it.
- No unit test: jsdom has neither layout nor `elementsFromPoint`, and the whole behaviour is "what is on top at these coordinates".
- Locally green: `lint`, `format`, `pnpm run -r typecheck`, `typecheck:e2e`, `pnpm test` (3158 passed), and `canvas.spec.ts` + the new spec.

The second commit drops two type assertions from the new test, per Copilot's review — `getElementById` in place of `querySelector` + `as HTMLElement | null`, and a narrowing `throw` in place of `expect(...).toBeTruthy()` followed by `!` on every read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiPzdZCjUWbk9AVvmAzmRn