### PR TITLE
Allow readonly() and hidden() to take boolean flag arguments

### DIFF
--- a/.changeset/schema-flag-arguments.md
+++ b/.changeset/schema-flag-arguments.md
@@ -1,0 +1,18 @@
+---
+"@valbuild/core": patch
+"@valbuild/next": patch
+---
+
+`.readonly()` and `.hidden()` now take the flag as an argument, so a schema can
+decide these from a variable instead of only from whether the call was written at
+all:
+
+```ts
+s.string().readonly(!canEdit);
+s.image().hidden(hideMedia);
+```
+
+The argument defaults to `true`, so `.readonly()` and `.readonly(true)` are the
+same thing and nothing about existing schemas changes. Passing `false` leaves the
+field editable or visible, which is also what a schema is without the call - it
+is there so the flag can come from a variable.

--- a/packages/core/src/schema/array.ts
+++ b/packages/core/src/schema/array.ts
@@ -172,12 +172,12 @@ export class ArraySchema<
     );
   }
 
-  readonly(): ArraySchema<T, Src> {
+  readonly(isReadonly: boolean = true): ArraySchema<T, Src> {
     return new ArraySchema(
       this.item,
       this.opt,
       this.customValidateFunctions,
-      true,
+      isReadonly,
       this.isHidden,
       this.description,
       this.previewInput,
@@ -185,13 +185,13 @@ export class ArraySchema<
     );
   }
 
-  hidden(): ArraySchema<T, Src> {
+  hidden(isHidden: boolean = true): ArraySchema<T, Src> {
     return new ArraySchema(
       this.item,
       this.opt,
       this.customValidateFunctions,
       this.isReadonly,
-      true,
+      isHidden,
       this.description,
       this.previewInput,
       this.renderInput,

--- a/packages/core/src/schema/boolean.ts
+++ b/packages/core/src/schema/boolean.ts
@@ -133,11 +133,11 @@ export class BooleanSchema<Src extends boolean | null> extends Schema<Src> {
     );
   }
 
-  readonly(): BooleanSchema<Src> {
+  readonly(isReadonly: boolean = true): BooleanSchema<Src> {
     return new BooleanSchema<Src>(
       this.opt,
       this.customValidateFunctions,
-      true,
+      isReadonly,
       this.isHidden,
       this.description,
       this.renderInput,
@@ -145,12 +145,12 @@ export class BooleanSchema<Src extends boolean | null> extends Schema<Src> {
     );
   }
 
-  hidden(): BooleanSchema<Src> {
+  hidden(isHidden: boolean = true): BooleanSchema<Src> {
     return new BooleanSchema<Src>(
       this.opt,
       this.customValidateFunctions,
       this.isReadonly,
-      true,
+      isHidden,
       this.description,
       this.renderInput,
       this.previewInput,

--- a/packages/core/src/schema/code.ts
+++ b/packages/core/src/schema/code.ts
@@ -192,12 +192,12 @@ export class CodeSchema<Src extends string | null> extends Schema<Src> {
     );
   }
 
-  readonly(): CodeSchema<Src> {
+  readonly(isReadonly: boolean = true): CodeSchema<Src> {
     return new CodeSchema<Src>(
       this.options,
       this.opt,
       this.customValidateFunctions,
-      true,
+      isReadonly,
       this.isHidden,
       this.description,
       this.renderInput,
@@ -205,13 +205,13 @@ export class CodeSchema<Src extends string | null> extends Schema<Src> {
     );
   }
 
-  hidden(): CodeSchema<Src> {
+  hidden(isHidden: boolean = true): CodeSchema<Src> {
     return new CodeSchema<Src>(
       this.options,
       this.opt,
       this.customValidateFunctions,
       this.isReadonly,
-      true,
+      isHidden,
       this.description,
       this.renderInput,
       this.previewInput,

--- a/packages/core/src/schema/color.ts
+++ b/packages/core/src/schema/color.ts
@@ -228,12 +228,12 @@ export class ColorSchema<Src extends string | null> extends Schema<Src> {
     );
   }
 
-  readonly(): ColorSchema<Src> {
+  readonly(isReadonly: boolean = true): ColorSchema<Src> {
     return new ColorSchema<Src>(
       this.options,
       this.opt,
       this.customValidateFunctions,
-      true,
+      isReadonly,
       this.isHidden,
       this.description,
       this.renderInput,
@@ -241,13 +241,13 @@ export class ColorSchema<Src extends string | null> extends Schema<Src> {
     );
   }
 
-  hidden(): ColorSchema<Src> {
+  hidden(isHidden: boolean = true): ColorSchema<Src> {
     return new ColorSchema<Src>(
       this.options,
       this.opt,
       this.customValidateFunctions,
       this.isReadonly,
-      true,
+      isHidden,
       this.description,
       this.renderInput,
       this.previewInput,

--- a/packages/core/src/schema/date.ts
+++ b/packages/core/src/schema/date.ts
@@ -216,12 +216,12 @@ export class DateSchema<Src extends string | null> extends Schema<Src> {
     );
   }
 
-  readonly(): DateSchema<Src> {
+  readonly(isReadonly: boolean = true): DateSchema<Src> {
     return new DateSchema<Src>(
       this.options,
       this.opt,
       this.customValidateFunctions,
-      true,
+      isReadonly,
       this.isHidden,
       this.description,
       this.renderInput,
@@ -229,13 +229,13 @@ export class DateSchema<Src extends string | null> extends Schema<Src> {
     );
   }
 
-  hidden(): DateSchema<Src> {
+  hidden(isHidden: boolean = true): DateSchema<Src> {
     return new DateSchema<Src>(
       this.options,
       this.opt,
       this.customValidateFunctions,
       this.isReadonly,
-      true,
+      isHidden,
       this.description,
       this.renderInput,
       this.previewInput,

--- a/packages/core/src/schema/datetime.ts
+++ b/packages/core/src/schema/datetime.ts
@@ -252,12 +252,12 @@ export class DateTimeSchema<Src extends string | null> extends Schema<Src> {
     );
   }
 
-  readonly(): DateTimeSchema<Src> {
+  readonly(isReadonly: boolean = true): DateTimeSchema<Src> {
     return new DateTimeSchema<Src>(
       this.options,
       this.opt,
       this.customValidateFunctions,
-      true,
+      isReadonly,
       this.isHidden,
       this.description,
       this.renderInput,
@@ -265,13 +265,13 @@ export class DateTimeSchema<Src extends string | null> extends Schema<Src> {
     );
   }
 
-  hidden(): DateTimeSchema<Src> {
+  hidden(isHidden: boolean = true): DateTimeSchema<Src> {
     return new DateTimeSchema<Src>(
       this.options,
       this.opt,
       this.customValidateFunctions,
       this.isReadonly,
-      true,
+      isHidden,
       this.description,
       this.renderInput,
       this.previewInput,

--- a/packages/core/src/schema/file.ts
+++ b/packages/core/src/schema/file.ts
@@ -375,14 +375,14 @@ export class FileSchema<Src extends FileSource | null> extends Schema<Src> {
     );
   }
 
-  readonly(): FileSchema<Src> {
+  readonly(isReadonly: boolean = true): FileSchema<Src> {
     return new FileSchema<Src>(
       this.options,
       this.opt,
       this.isRemote,
       this.customValidateFunctions,
       this.moduleMetadata,
-      true,
+      isReadonly,
       this.isHidden,
       this.description,
       this.renderInput,
@@ -390,7 +390,7 @@ export class FileSchema<Src extends FileSource | null> extends Schema<Src> {
     );
   }
 
-  hidden(): FileSchema<Src> {
+  hidden(isHidden: boolean = true): FileSchema<Src> {
     return new FileSchema<Src>(
       this.options,
       this.opt,
@@ -398,7 +398,7 @@ export class FileSchema<Src extends FileSource | null> extends Schema<Src> {
       this.customValidateFunctions,
       this.moduleMetadata,
       this.isReadonly,
-      true,
+      isHidden,
       this.description,
       this.renderInput,
       this.previewInput,

--- a/packages/core/src/schema/hidden.test.ts
+++ b/packages/core/src/schema/hidden.test.ts
@@ -89,4 +89,44 @@ describe("Schema.hidden()", () => {
       plain["executeValidate"](path, "x"),
     );
   });
+
+  test("hidden(true) is the same as hidden()", () => {
+    expect(s.string().hidden(true)["executeSerialize"]().hidden).toBe(true);
+  });
+
+  test("hidden(false) leaves the field un-hidden", () => {
+    expect(s.string().hidden(false)["executeSerialize"]().hidden).toBe(false);
+  });
+
+  test("hidden(false) undoes a previous hidden()", () => {
+    expect(s.string().hidden().hidden(false)["executeSerialize"]().hidden).toBe(
+      false,
+    );
+  });
+
+  test("hidden takes the flag from a variable", () => {
+    const fields: { secret: boolean; visible: boolean } = {
+      secret: true,
+      visible: false,
+    };
+    expect(s.string().hidden(fields.secret)["executeSerialize"]().hidden).toBe(
+      true,
+    );
+    expect(s.string().hidden(fields.visible)["executeSerialize"]().hidden).toBe(
+      false,
+    );
+  });
+
+  test("hidden(false) serializes across schema types", () => {
+    expect(s.number().hidden(false)["executeSerialize"]().hidden).toBe(false);
+    expect(s.array(s.string()).hidden(false)["executeSerialize"]().hidden).toBe(
+      false,
+    );
+    expect(
+      s.object({ a: s.string() }).hidden(false)["executeSerialize"]().hidden,
+    ).toBe(false);
+    expect(
+      s.record(s.string()).hidden(false)["executeSerialize"]().hidden,
+    ).toBe(false);
+  });
 });

--- a/packages/core/src/schema/hidden.test.ts
+++ b/packages/core/src/schema/hidden.test.ts
@@ -118,15 +118,18 @@ describe("Schema.hidden()", () => {
   });
 
   test("hidden(false) serializes across schema types", () => {
-    expect(s.number().hidden(false)["executeSerialize"]().hidden).toBe(false);
-    expect(s.array(s.string()).hidden(false)["executeSerialize"]().hidden).toBe(
+    expect(s.number().hidden().hidden(false)["executeSerialize"]().hidden).toBe(
       false,
     );
     expect(
-      s.object({ a: s.string() }).hidden(false)["executeSerialize"]().hidden,
+      s.array(s.string()).hidden().hidden(false)["executeSerialize"]().hidden,
     ).toBe(false);
     expect(
-      s.record(s.string()).hidden(false)["executeSerialize"]().hidden,
+      s.object({ a: s.string() }).hidden().hidden(false)["executeSerialize"]()
+        .hidden,
+    ).toBe(false);
+    expect(
+      s.record(s.string()).hidden().hidden(false)["executeSerialize"]().hidden,
     ).toBe(false);
   });
 });

--- a/packages/core/src/schema/image.ts
+++ b/packages/core/src/schema/image.ts
@@ -448,14 +448,14 @@ export class ImageSchema<Src extends ImageSource | null> extends Schema<Src> {
     );
   }
 
-  readonly(): ImageSchema<Src> {
+  readonly(isReadonly: boolean = true): ImageSchema<Src> {
     return new ImageSchema<Src>(
       this.options,
       this.opt,
       this.isRemote,
       this.customValidateFunctions,
       this.moduleMetadata,
-      true,
+      isReadonly,
       this.isHidden,
       this.description,
       this.renderInput,
@@ -463,7 +463,7 @@ export class ImageSchema<Src extends ImageSource | null> extends Schema<Src> {
     );
   }
 
-  hidden(): ImageSchema<Src> {
+  hidden(isHidden: boolean = true): ImageSchema<Src> {
     return new ImageSchema<Src>(
       this.options,
       this.opt,
@@ -471,7 +471,7 @@ export class ImageSchema<Src extends ImageSource | null> extends Schema<Src> {
       this.customValidateFunctions,
       this.moduleMetadata,
       this.isReadonly,
-      true,
+      isHidden,
       this.description,
       this.renderInput,
       this.previewInput,

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -164,15 +164,23 @@ export abstract class Schema<Src extends SelectorSource> {
    *
    * This is a UI-only flag: the field is rendered disabled in the editor, but
    * the value is not otherwise validated or enforced differently.
+   *
+   * The flag defaults to `true`, so `.readonly()` and `.readonly(true)` are the
+   * same thing. `.readonly(false)` leaves the field editable, which is what a
+   * schema is anyway - pass it when the decision comes from a variable.
    */
-  abstract readonly(): Schema<Src>;
+  abstract readonly(isReadonly?: boolean): Schema<Src>;
   /**
    * Hide this field from the Val editor.
    *
    * This is a UI-only flag: the field is not rendered in the editor, but the
    * value is still stored, validated and serialized as normal.
+   *
+   * The flag defaults to `true`, so `.hidden()` and `.hidden(true)` are the
+   * same thing. `.hidden(false)` leaves the field visible, which is what a
+   * schema is anyway - pass it when the decision comes from a variable.
    */
-  abstract hidden(): Schema<Src>;
+  abstract hidden(isHidden?: boolean): Schema<Src>;
   protected abstract executeSerialize(): SerializedSchema;
   /**
    * @param scope Which paths the caller needs a preview for. Absent means the

--- a/packages/core/src/schema/keyOf.ts
+++ b/packages/core/src/schema/keyOf.ts
@@ -315,13 +315,13 @@ export class KeyOfSchema<
     );
   }
 
-  readonly(): KeyOfSchema<Sel, Src> {
+  readonly(isReadonly: boolean = true): KeyOfSchema<Sel, Src> {
     return new KeyOfSchema(
       this.schema,
       this.sourcePath,
       this.opt,
       this.customValidateFunctions,
-      true,
+      isReadonly,
       this.isHidden,
       this.description,
       this.renderInput,
@@ -329,14 +329,14 @@ export class KeyOfSchema<
     );
   }
 
-  hidden(): KeyOfSchema<Sel, Src> {
+  hidden(isHidden: boolean = true): KeyOfSchema<Sel, Src> {
     return new KeyOfSchema(
       this.schema,
       this.sourcePath,
       this.opt,
       this.customValidateFunctions,
       this.isReadonly,
-      true,
+      isHidden,
       this.description,
       this.renderInput,
       this.previewInput,

--- a/packages/core/src/schema/literal.ts
+++ b/packages/core/src/schema/literal.ts
@@ -160,12 +160,12 @@ export class LiteralSchema<Src extends string | null> extends Schema<Src> {
     );
   }
 
-  readonly(): LiteralSchema<Src> {
+  readonly(isReadonly: boolean = true): LiteralSchema<Src> {
     return new LiteralSchema<Src>(
       this.value,
       this.opt,
       this.customValidateFunctions,
-      true,
+      isReadonly,
       this.isHidden,
       this.description,
       this.renderInput,
@@ -173,13 +173,13 @@ export class LiteralSchema<Src extends string | null> extends Schema<Src> {
     );
   }
 
-  hidden(): LiteralSchema<Src> {
+  hidden(isHidden: boolean = true): LiteralSchema<Src> {
     return new LiteralSchema<Src>(
       this.value,
       this.opt,
       this.customValidateFunctions,
       this.isReadonly,
-      true,
+      isHidden,
       this.description,
       this.renderInput,
       this.previewInput,

--- a/packages/core/src/schema/number.ts
+++ b/packages/core/src/schema/number.ts
@@ -176,12 +176,12 @@ export class NumberSchema<Src extends number | null> extends Schema<Src> {
     );
   }
 
-  readonly(): NumberSchema<Src> {
+  readonly(isReadonly: boolean = true): NumberSchema<Src> {
     return new NumberSchema<Src>(
       this.options,
       this.opt,
       this.customValidateFunctions,
-      true,
+      isReadonly,
       this.isHidden,
       this.description,
       this.renderInput,
@@ -189,13 +189,13 @@ export class NumberSchema<Src extends number | null> extends Schema<Src> {
     );
   }
 
-  hidden(): NumberSchema<Src> {
+  hidden(isHidden: boolean = true): NumberSchema<Src> {
     return new NumberSchema<Src>(
       this.options,
       this.opt,
       this.customValidateFunctions,
       this.isReadonly,
-      true,
+      isHidden,
       this.description,
       this.renderInput,
       this.previewInput,

--- a/packages/core/src/schema/object.ts
+++ b/packages/core/src/schema/object.ts
@@ -252,12 +252,12 @@ export class ObjectSchema<
     );
   }
 
-  readonly(): ObjectSchema<Props, Src> {
+  readonly(isReadonly: boolean = true): ObjectSchema<Props, Src> {
     return new ObjectSchema(
       this.items,
       this.opt,
       this.customValidateFunctions,
-      true,
+      isReadonly,
       this.isHidden,
       this.description,
       this.renderInput,
@@ -265,13 +265,13 @@ export class ObjectSchema<
     );
   }
 
-  hidden(): ObjectSchema<Props, Src> {
+  hidden(isHidden: boolean = true): ObjectSchema<Props, Src> {
     return new ObjectSchema(
       this.items,
       this.opt,
       this.customValidateFunctions,
       this.isReadonly,
-      true,
+      isHidden,
       this.description,
       this.renderInput,
       this.previewInput,

--- a/packages/core/src/schema/readonly.test.ts
+++ b/packages/core/src/schema/readonly.test.ts
@@ -113,18 +113,23 @@ describe("Schema.readonly()", () => {
   });
 
   test("readonly(false) serializes across schema types", () => {
-    expect(s.number().readonly(false)["executeSerialize"]().readonly).toBe(
-      false,
-    );
     expect(
-      s.array(s.string()).readonly(false)["executeSerialize"]().readonly,
+      s.number().readonly().readonly(false)["executeSerialize"]().readonly,
     ).toBe(false);
     expect(
-      s.object({ a: s.string() }).readonly(false)["executeSerialize"]()
+      s.array(s.string()).readonly().readonly(false)["executeSerialize"]()
         .readonly,
     ).toBe(false);
     expect(
-      s.record(s.string()).readonly(false)["executeSerialize"]().readonly,
+      s
+        .object({ a: s.string() })
+        .readonly()
+        .readonly(false)
+        ["executeSerialize"]().readonly,
+    ).toBe(false);
+    expect(
+      s.record(s.string()).readonly().readonly(false)["executeSerialize"]()
+        .readonly,
     ).toBe(false);
   });
 });

--- a/packages/core/src/schema/readonly.test.ts
+++ b/packages/core/src/schema/readonly.test.ts
@@ -82,4 +82,49 @@ describe("Schema.readonly()", () => {
       plain["executeValidate"](path, "x"),
     );
   });
+
+  test("readonly(true) is the same as readonly()", () => {
+    expect(s.string().readonly(true)["executeSerialize"]().readonly).toBe(true);
+  });
+
+  test("readonly(false) leaves the field un-readonly", () => {
+    expect(s.string().readonly(false)["executeSerialize"]().readonly).toBe(
+      false,
+    );
+  });
+
+  test("readonly(false) undoes a previous readonly()", () => {
+    expect(
+      s.string().readonly().readonly(false)["executeSerialize"]().readonly,
+    ).toBe(false);
+  });
+
+  test("readonly takes the flag from a variable", () => {
+    const fields: { locked: boolean; editable: boolean } = {
+      locked: true,
+      editable: false,
+    };
+    expect(
+      s.string().readonly(fields.locked)["executeSerialize"]().readonly,
+    ).toBe(true);
+    expect(
+      s.string().readonly(fields.editable)["executeSerialize"]().readonly,
+    ).toBe(false);
+  });
+
+  test("readonly(false) serializes across schema types", () => {
+    expect(s.number().readonly(false)["executeSerialize"]().readonly).toBe(
+      false,
+    );
+    expect(
+      s.array(s.string()).readonly(false)["executeSerialize"]().readonly,
+    ).toBe(false);
+    expect(
+      s.object({ a: s.string() }).readonly(false)["executeSerialize"]()
+        .readonly,
+    ).toBe(false);
+    expect(
+      s.record(s.string()).readonly(false)["executeSerialize"]().readonly,
+    ).toBe(false);
+  });
 });

--- a/packages/core/src/schema/record.ts
+++ b/packages/core/src/schema/record.ts
@@ -584,7 +584,7 @@ export class RecordSchema<
     ) as RecordSchema<T, K, Src | null>;
   }
 
-  readonly(): RecordSchema<T, K, Src> {
+  readonly(isReadonly: boolean = true): RecordSchema<T, K, Src> {
     return new RecordSchema(
       this.item,
       this.opt,
@@ -592,7 +592,7 @@ export class RecordSchema<
       this.currentRouter,
       this.keySchema,
       this.mediaOptions,
-      true,
+      isReadonly,
       this.isHidden,
       this.description,
       this.isJsonValues,
@@ -601,7 +601,7 @@ export class RecordSchema<
     );
   }
 
-  hidden(): RecordSchema<T, K, Src> {
+  hidden(isHidden: boolean = true): RecordSchema<T, K, Src> {
     return new RecordSchema(
       this.item,
       this.opt,
@@ -610,7 +610,7 @@ export class RecordSchema<
       this.keySchema,
       this.mediaOptions,
       this.isReadonly,
-      true,
+      isHidden,
       this.description,
       this.isJsonValues,
       this.previewInput,

--- a/packages/core/src/schema/richtext.ts
+++ b/packages/core/src/schema/richtext.ts
@@ -669,12 +669,12 @@ export class RichTextSchema<
     );
   }
 
-  readonly(): RichTextSchema<O, Src> {
+  readonly(isReadonly: boolean = true): RichTextSchema<O, Src> {
     return new RichTextSchema(
       this.options,
       this.opt,
       this.customValidateFunctions,
-      true,
+      isReadonly,
       this.isHidden,
       this.description,
       this.renderInput,
@@ -682,13 +682,13 @@ export class RichTextSchema<
     );
   }
 
-  hidden(): RichTextSchema<O, Src> {
+  hidden(isHidden: boolean = true): RichTextSchema<O, Src> {
     return new RichTextSchema(
       this.options,
       this.opt,
       this.customValidateFunctions,
       this.isReadonly,
-      true,
+      isHidden,
       this.description,
       this.renderInput,
       this.previewInput,

--- a/packages/core/src/schema/route.ts
+++ b/packages/core/src/schema/route.ts
@@ -205,12 +205,12 @@ export class RouteSchema<Src extends string | null> extends Schema<Src> {
     ) as unknown as RouteSchema<Src | null>;
   }
 
-  readonly(): RouteSchema<Src> {
+  readonly(isReadonly: boolean = true): RouteSchema<Src> {
     return new RouteSchema<Src>(
       this.options,
       this.opt,
       this.customValidateFunctions,
-      true,
+      isReadonly,
       this.isHidden,
       this.description,
       this.renderInput,
@@ -218,13 +218,13 @@ export class RouteSchema<Src extends string | null> extends Schema<Src> {
     );
   }
 
-  hidden(): RouteSchema<Src> {
+  hidden(isHidden: boolean = true): RouteSchema<Src> {
     return new RouteSchema<Src>(
       this.options,
       this.opt,
       this.customValidateFunctions,
       this.isReadonly,
-      true,
+      isHidden,
       this.description,
       this.renderInput,
       this.previewInput,

--- a/packages/core/src/schema/string.ts
+++ b/packages/core/src/schema/string.ts
@@ -266,14 +266,14 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
     ) as unknown as StringSchema<Src | null>;
   }
 
-  readonly(): StringSchema<Src> {
+  readonly(isReadonly: boolean = true): StringSchema<Src> {
     return new StringSchema<Src>(
       this.options,
       this.opt,
       this.isRaw,
       this.customValidateFunctions,
       this.renderInput,
-      true,
+      isReadonly,
       this.isHidden,
       this.description,
       this.previewInput,
@@ -281,7 +281,7 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
     );
   }
 
-  hidden(): StringSchema<Src> {
+  hidden(isHidden: boolean = true): StringSchema<Src> {
     return new StringSchema<Src>(
       this.options,
       this.opt,
@@ -289,7 +289,7 @@ export class StringSchema<Src extends string | null> extends Schema<Src> {
       this.customValidateFunctions,
       this.renderInput,
       this.isReadonly,
-      true,
+      isHidden,
       this.description,
       this.previewInput,
       this.isMultiline,

--- a/packages/core/src/schema/union.ts
+++ b/packages/core/src/schema/union.ts
@@ -521,13 +521,13 @@ export class UnionSchema<
     );
   }
 
-  readonly(): UnionSchema<Key, T, Src> {
+  readonly(isReadonly: boolean = true): UnionSchema<Key, T, Src> {
     return new UnionSchema(
       this.key,
       this.items,
       this.opt,
       this.customValidateFunctions,
-      true,
+      isReadonly,
       this.isHidden,
       this.description,
       this.renderInput,
@@ -535,14 +535,14 @@ export class UnionSchema<
     );
   }
 
-  hidden(): UnionSchema<Key, T, Src> {
+  hidden(isHidden: boolean = true): UnionSchema<Key, T, Src> {
     return new UnionSchema(
       this.key,
       this.items,
       this.opt,
       this.customValidateFunctions,
       this.isReadonly,
-      true,
+      isHidden,
       this.description,
       this.renderInput,
       this.previewInput,

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -48,6 +48,7 @@
   - [Number](#number)
   - [Boolean](#boolean)
   - [Nullable](#nullable)
+  - [Read-only and hidden fields](#read-only-and-hidden-fields)
   - [Array](#array)
   - [Record](#record)
   - [Router](#router)
@@ -382,6 +383,24 @@ All schema types can be nullable (optional). A nullable schema creates a union o
 import { s } from "./val.config";
 
 s.string().nullable(); // <- Schema<string | null>
+```
+
+## Read-only and hidden fields
+
+`.readonly()` renders a field disabled in the Val editor, and `.hidden()` leaves
+it out of the editor entirely. Both are UI-only: the value is still stored,
+validated and serialized as normal.
+
+Both take an optional flag which defaults to `true`, so `.readonly()` and
+`.readonly(true)` are the same thing. Pass it when the decision comes from a
+variable rather than being written out:
+
+```ts
+import { s } from "./val.config";
+
+s.string().readonly(); // same as .readonly(true)
+s.string().readonly(!canEdit);
+s.image().hidden(hideMedia);
 ```
 
 ## Description


### PR DESCRIPTION
## Summary

`.readonly()` and `.hidden()` schema methods now accept an optional boolean argument that defaults to `true`, enabling these UI flags to be set dynamically from variables instead of only through whether the method call is written.

## Changes

- **Schema API updates**: Modified abstract method signatures in `Schema` base class to accept optional `isReadonly?: boolean` and `isHidden?: boolean` parameters with JSDoc updates explaining the new behavior
- **Implementation across all schema types**: Updated 16 schema classes (Array, Boolean, Code, Color, Date, DateTime, File, Image, KeyOf, Literal, Number, Object, Record, RichText, Route, String, Union) to:
  - Accept the boolean parameter with default value `true`
  - Pass the parameter value instead of hardcoded `true` to constructor calls
- **Documentation**: Added new "Read-only and hidden fields" section to the Next.js README with usage examples
- **Test coverage**: Added comprehensive test suites for both `readonly()` and `hidden()` covering:
  - `readonly(true)` / `hidden(true)` equivalence with parameterless calls
  - `readonly(false)` / `hidden(false)` leaving fields editable/visible
  - Undoing previous calls with `false`
  - Dynamic flag values from variables
  - Cross-schema-type consistency
- **Changelog**: Added changeset documenting the feature

## Implementation Details

The change is backward compatible—existing code using `.readonly()` and `.hidden()` without arguments continues to work identically since the parameter defaults to `true`. The `false` case is particularly useful for conditional logic where the decision comes from a variable:

```typescript
s.string().readonly(!canEdit);
s.image().hidden(hideMedia);
```

All schema types follow the same pattern, ensuring consistent behavior across the API.

https://claude.ai/code/session_01WDfm1hDCDJ1Uwtc8h4Pi3c