### PR TITLE
Studio: put the combobox focus ring on the search row, not the input inside it

### DIFF
--- a/.changeset/combobox-search-ring-full-width.md
+++ b/.changeset/combobox-search-ring-full-width.md
@@ -1,0 +1,7 @@
+---
+"@valbuild/ui": patch
+---
+
+Studio: the focus ring on a dropdown's search field now runs the full width of the box.
+
+A ring is a `box-shadow`, so it is drawn around whatever element carries it — and the search input is not the search field you see. It starts after the magnifier icon and stops short of the row's padding, so the ring was a rectangle floating inside the popover with a gap down each side. It is on the row now, edge to edge, with its top corners following the box's own radius.

--- a/e2e/combobox-focus-ring.spec.ts
+++ b/e2e/combobox-focus-ring.spec.ts
@@ -1,0 +1,94 @@
+import { expect } from "@playwright/test";
+import { openStudio, test } from "./studio";
+
+/**
+ * The focus ring on a combobox's search field.
+ *
+ * A ring is a `box-shadow` spread, so it is only ever drawn around the element
+ * that carries it - and the search INPUT is not the search field the user sees.
+ * It starts after the magnifier icon and stops short of the row's padding, so a
+ * ring on it is a rectangle floating inside the popover with a gap down each
+ * side. The ring belongs on the row, which is the box.
+ *
+ * Only a browser can answer this: the ring is a computed `box-shadow` behind a
+ * `:has(:focus-visible)` selector, and jsdom has neither. So the test reads the
+ * painted shadow and the two boxes rather than the class list - a class name
+ * assertion would pass just as happily with the ring on the wrong element.
+ */
+const POST = "/val/~/app/blogs/[blog]/page.val.ts?p=%22%2Fblogs%2Fblog1%22";
+
+/** The green in `--border-focus`, as Chromium reports it. */
+const FOCUS_RING = "rgb(71, 205, 137) 0px 0px 0px 2px inset";
+
+test.describe("the combobox search field's focus ring", () => {
+  test("is drawn on the row, edge to edge, and not on the input inside it", async ({
+    page,
+  }) => {
+    await openStudio(page, POST);
+    const studio = page.locator("#val-shadow-root");
+    const combo = studio
+      .locator(`[data-val-studio-path*='"author"']`)
+      .getByRole("combobox");
+    await expect(combo, "the author field never rendered").toHaveCount(1, {
+      timeout: 30000,
+    });
+    await combo.scrollIntoViewIfNeeded();
+    await combo.click();
+
+    const search = studio.getByPlaceholder("Search key...");
+    await expect(search).toHaveCount(1, { timeout: 15000 });
+    await search.click();
+    // A text field matches `:focus-visible` whenever it is focused, but only
+    // once the page has seen a keypress at all - so type one.
+    await page.keyboard.press("a");
+
+    const measured = await page.evaluate(() => {
+      const sr = document.getElementById("val-shadow-root")?.shadowRoot;
+      const row = sr?.querySelector("[cmdk-input-wrapper]");
+      if (!(row instanceof HTMLElement)) return null;
+      const input = row.querySelector("input");
+      const box = row.parentElement?.parentElement;
+      if (!(input instanceof HTMLElement) || !(box instanceof HTMLElement)) {
+        return null;
+      }
+      const edges = (el: HTMLElement) => {
+        const r = el.getBoundingClientRect();
+        return { left: r.left, right: r.right };
+      };
+      return {
+        box: edges(box),
+        row: edges(row),
+        input: edges(input),
+        rowShadow: getComputedStyle(row).boxShadow,
+        inputShadow: getComputedStyle(input).boxShadow,
+        // The top corners follow the box's own radius, so the ring does not cut
+        // across a rounded corner.
+        rowRadius: getComputedStyle(row).borderTopLeftRadius,
+      };
+    });
+    expect(measured, "the search row never rendered").not.toBeNull();
+    if (measured === null) return;
+
+    expect(
+      measured.rowShadow,
+      "the ring is not painted on the search row",
+    ).toContain(FOCUS_RING);
+    expect(
+      measured.inputShadow,
+      "the ring is still on the input, which is narrower than the box",
+    ).toBe("none");
+
+    // The row reaches both edges of the box, give or take its 1px border. The
+    // input does not, which is the whole point - so assert the gap it leaves is
+    // real, or this test would pass on a layout where the two coincide and
+    // prove nothing.
+    expect(measured.row.left - measured.box.left).toBeLessThanOrEqual(1);
+    expect(measured.box.right - measured.row.right).toBeLessThanOrEqual(1);
+    expect(
+      measured.input.left - measured.box.left,
+      "the input is expected to be inset from the box - if it is not, this test no longer proves anything",
+    ).toBeGreaterThan(8);
+
+    expect(measured.rowRadius).not.toBe("0px");
+  });
+});

--- a/e2e/combobox-focus-ring.spec.ts
+++ b/e2e/combobox-focus-ring.spec.ts
@@ -17,9 +17,6 @@ import { openStudio, test } from "./studio";
  */
 const POST = "/val/~/app/blogs/[blog]/page.val.ts?p=%22%2Fblogs%2Fblog1%22";
 
-/** The green in `--border-focus`, as Chromium reports it. */
-const FOCUS_RING = "rgb(71, 205, 137) 0px 0px 0px 2px inset";
-
 test.describe("the combobox search field's focus ring", () => {
   test("is drawn on the row, edge to edge, and not on the input inside it", async ({
     page,
@@ -55,7 +52,19 @@ test.describe("the combobox search field's focus ring", () => {
         const r = el.getBoundingClientRect();
         return { left: r.left, right: r.right };
       };
+      // `--border-focus` is a different green in light mode and in dark, so the
+      // colour is read from the token rather than written down here - a literal
+      // would pin one theme and fail on the other for a reason that has nothing
+      // to do with where the ring is. Painted onto a probe because a computed
+      // `color` is always normalised to `rgb(...)`, which is the form
+      // `box-shadow` reports.
+      const probe = document.createElement("span");
+      probe.style.color = "var(--border-focus)";
+      row.appendChild(probe);
+      const focusColor = getComputedStyle(probe).color;
+      probe.remove();
       return {
+        focusColor,
         box: edges(box),
         row: edges(row),
         input: edges(input),
@@ -70,9 +79,13 @@ test.describe("the combobox search field's focus ring", () => {
     if (measured === null) return;
 
     expect(
+      measured.focusColor,
+      "`--border-focus` did not resolve to a colour",
+    ).toMatch(/^rgba?\(/);
+    expect(
       measured.rowShadow,
       "the ring is not painted on the search row",
-    ).toContain(FOCUS_RING);
+    ).toContain(`${measured.focusColor} 0px 0px 0px 2px inset`);
     expect(
       measured.inputShadow,
       "the ring is still on the input, which is narrower than the box",

--- a/packages/ui/spa/components/designSystem/command.tsx
+++ b/packages/ui/spa/components/designSystem/command.tsx
@@ -52,7 +52,26 @@ const CommandInput = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Input>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 >(({ className, ...props }, ref) => (
-  <div className="flex items-center px-3" cmdk-input-wrapper="">
+  // The ring goes on the ROW, not on the input. The input starts after the
+  // search icon and stops short of the row's padding - measured in the router
+  // dropdown, a 890px popover with the input running 194..1034 - so a ring on
+  // it is a rectangle floating inside the box with a gap down each side, which
+  // is not what a focused text field looks like. On the row it runs the full
+  // width of the box, which is where the eye expects the edge to be.
+  //
+  // `ring-inset` because there is nothing outside the row either: a popover
+  // (`p-0` + `overflow-hidden`) clips an outset ring away against its top edge,
+  // and the inline search box (`overflow-visible`) draws it on top of its own
+  // border. `rounded-t-[inherit]` so the two top corners follow whatever radius
+  // the box has - `rounded-md` in a popover, `rounded-lg` in the search box.
+  //
+  // `has-[:focus-visible]` and not `focus-within`: the row must light up for
+  // the keyboard, and stay dark when the input is focused by a click or
+  // programmatically - which is the same rule the input itself had.
+  <div
+    className="flex items-center px-3 rounded-t-[inherit] has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-inset has-[:focus-visible]:ring-border-focus"
+    cmdk-input-wrapper=""
+  >
     <Search className="w-4 h-4 mr-2 opacity-50 shrink-0" />
     <CommandPrimitive.Input
       ref={ref}
@@ -60,12 +79,6 @@ const CommandInput = React.forwardRef<
         "flex h-11 w-full rounded-sm py-3 text-sm",
         "placeholder:text-fg-secondary",
         "bg-transparent focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
-        // `ring-inset`: the input fills its row edge to edge, so an outset ring
-        // has nowhere to go. In a popover (`p-0` + `overflow-hidden`) it was
-        // clipped away against the top edge, and in the inline search box
-        // (`overflow-visible`) it was drawn on top of the box's own border - the
-        // "outline beyond the box". Inset, the halo lands inside the input.
-        "focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-border-focus",
         className,
       )}
       {...props}


### PR DESCRIPTION
Follow-up to #604, which fixed the *clipping* on this ring but left it on the wrong element. The ask this time was that the ring be "the entire box left and right sides".

## What was wrong

A ring is a `box-shadow` spread, so it is only ever drawn around the element that carries it — and the search **input** is not the search field anyone sees. It starts after the magnifier icon and stops short of the row's padding, so the ring was a rectangle floating inside the popover with a gap down each side.

Measured in the author dropdown rather than eyeballed:

| | left | right |
| --- | --- | --- |
| popover box | 157 | 1047 |
| search **row** (`[cmdk-input-wrapper]`) | 158 | 1046 |
| search **input** (had the ring) | 194 | 1034 |

36px short on the left, 12px on the right.

## The fix

The ring moves to the row, which *is* the box — `158..1046`, both edges flush against the popover's 1px border.

- `rounded-t-[inherit]` so the two top corners follow whatever radius the container has (`rounded-md` in a popover, `rounded-lg` in the inline search box) instead of cutting a square across a rounded corner. Chromium reports `6px` on the row after the change.
- `ring-inset` stays, for the reason #604 established: a popover (`p-0` + `overflow-hidden`) clips an outset ring away against its top edge, and the inline search box (`overflow-visible`) draws it on top of its own border.
- `has-[:focus-visible]` rather than `focus-within`, keeping the rule the input already had — the row lights up for the keyboard and stays dark when the field is focused by a click or programmatically.

This is `CommandInput` in the shared design system, so it covers every combobox that uses it: the router field, `keyOf`, the media picker, the rich-text link picker, the references list, and the inline content search.

## Before / after

Shot from the running Studio with the same field focused and one character typed. The computed `box-shadow` either side:

```
before  row:   none
        input: rgb(71, 205, 137) 0px 0px 0px 2px inset
after   row:   rgb(71, 205, 137) 0px 0px 0px 2px inset
        input: none
```

Read together with the table above: before, the green ran `194..1034` inside a box spanning `157..1047`; after, it runs `158..1046`.

## Checks

`pnpm run lint`, `pnpm -w run format`, `pnpm run -r typecheck` and `pnpm test` (**3231 passing, 262 suites**) all green.

New: `e2e/combobox-focus-ring.spec.ts`. It reads the painted `box-shadow` and the two boxes rather than the class list — a class-name assertion would pass just as happily with the ring on the wrong element — and asserts the input really is inset from the box, so the test cannot quietly go vacuous if the layout changes. Verified it fails on the previous behaviour (`Error: the ring is not painted on the search row`) and passes on this one.

Also re-ran the specs that drive these dropdowns: `keyof-create`, `inline-render`, `screens` — 9 passed.

Changeset: `.changeset/combobox-search-ring-full-width.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YeuYZonAAmGASG4wEVCqf