### PR TITLE
Check which project an access token was approved for

### DIFF
--- a/.changeset/mcp-verify-project-claim.md
+++ b/.changeset/mcp-verify-project-claim.md
@@ -1,0 +1,29 @@
+---
+"@valbuild/next": patch
+---
+
+MCP: an access token now has to say which Val project it was approved for, and
+the endpoint checks it.
+
+Val's authorization server stamps a `val_project` claim (`org/name`) on every
+access token, and `@valbuild/next` refuses a token whose claim is not the
+project this app is configured for. The project comes from `val.config.ts` (or
+`VAL_PROJECT`), not from the `oauth` block, so there is nothing extra to
+configure and nothing to get wrong.
+
+**Why, when `aud` already binds the token to this address.** It binds it to the
+_address_; what binds the address to a project is a registration at the
+authorization server, which this app cannot see. If that binding is ever wrong —
+a mistaken entry, a domain that changed hands, an origin registered by the wrong
+project — a token approved by a member of another organization would arrive here
+with a matching `aud` and a signature that verifies, and would be honoured under
+this app's own API key against this project's content. With the claim checked,
+the worst such a mistake can produce is a refusal.
+
+A token carrying no `val_project` at all is refused rather than accepted for
+compatibility: "accept it if absent" is a downgrade, since anything able to strip
+the claim would turn the check off. In practice this means MCP clients holding an
+access token minted before this release re-authorize once — access tokens live an
+hour, and a refresh mints one with the claim. Local filesystem mode is unaffected:
+`project` is optional there, and with nothing to compare against there is no other
+tenant for the check to protect.

--- a/docs/plans/mcp.md
+++ b/docs/plans/mcp.md
@@ -686,6 +686,13 @@ The properties that the code in this repository depends on:
   request, and becomes the token's `aud`. It resolves to a project by the
   **exact origin** of that project's production URL, so a token is bound to one
   deployment rather than to anything that merely starts with the same string.
+- **The project is on the token too**, as `val_project` (`org/name`), and
+  `@valbuild/next` refuses a token whose claim is not the project it serves.
+  `aud` binds the token to an address; the address is bound to a project by a
+  registration at the issuer that a resource server cannot see, and this is what
+  keeps a wrong binding from becoming a member of one organization writing to
+  another's content. A token carrying no such claim is refused rather than
+  accepted.
 - **Access tokens are ES256 JWTs**, one hour, verifiable against the JWKS with no
   round trip to the issuer — per-request introspection would be the wrong shape
   for a serverless route.
@@ -736,6 +743,16 @@ grant and withdraw one, and rotation of the signing keys on a schedule. The
 resource-server half of rotation is done — an unknown `kid` refetches rather than
 refusing, from 0.120.1 — so what is missing there is the schedule, not the
 ability to survive it.
+
+**Where one address per project goes next:** removing the PAT relay (#597) turned
+"a PAT works anywhere" into "OAuth or nothing", and OAuth reaches exactly one
+address per project, from a browser — so preview deployments, an app running
+locally in proxy mode, and headless clients have no way to authenticate at all.
+The follow-up is planned in the authorization server's own repository, at
+`docs/plans/multi-address-oauth.md` in `valbuild/home`: registered resource
+origins, loopback by explicit project selection, preview wildcards limited to a
+suffix the project already holds, and an RFC 8628 device grant. The `val_project`
+claim above is that plan's first step, and the only part of it that lands here.
 
 ### D.8 Prerequisite fix in `packages/server`, separate PR (done)
 

--- a/packages/next/src/server/initValMcp.test.ts
+++ b/packages/next/src/server/initValMcp.test.ts
@@ -411,6 +411,9 @@ function oauthHarness(): {
           sub: "profile-123",
           exp: nowSeconds + 600,
           scope: "val:read val:write",
+          // The project the harness's env (`VAL_PROJECT`) configures, since
+          // `initValMcp` checks the claim against Val's own config.
+          val_project: "test/project",
           ...claims,
         }),
       )}`;
@@ -480,6 +483,46 @@ describe("oauth mode", () => {
       profileId: "profile-123",
       scopes: ["val:read", "val:write"],
     });
+  });
+
+  test("a token approved for another project is refused, even at this address", async () => {
+    const harness = oauthHarness();
+    const res = await withEnv(httpModeEnv(), () =>
+      initValMcp({ config, modules: [] }, config, {
+        oauth: harness,
+      }).valMcpAuthorize(
+        request({
+          authorization: `Bearer ${harness.signToken({
+            val_project: "someone-else/site",
+          })}`,
+        }),
+      ),
+    );
+
+    // Signed by the right issuer, minted for this exact address, unexpired —
+    // and for somebody else's content. `aud` cannot see the difference, because
+    // the address is the audience.
+    expect(res.status).toBe("refused");
+    if (res.status !== "refused") {
+      return;
+    }
+    expect(res.response.status).toBe(401);
+  });
+
+  test("the project checked is Val's own config, not what the app passed", async () => {
+    const harness = oauthHarness();
+    const res = await withEnv(httpModeEnv(), () =>
+      initValMcp({ config, modules: [] }, config, {
+        // An app naming a project in its `oauth` block does not get to decide
+        // which project this server serves: `val.config.ts` (here, VAL_PROJECT)
+        // is the authority, and it says `test/project`.
+        oauth: { ...harness, project: "someone-else/site" },
+      }).valMcpAuthorize(
+        request({ authorization: `Bearer ${harness.signToken()}` }),
+      ),
+    );
+
+    expect(res.status).toBe("ok");
   });
 
   test("a forged token is refused with invalid_token", async () => {

--- a/packages/next/src/server/initValMcp.test.ts
+++ b/packages/next/src/server/initValMcp.test.ts
@@ -525,6 +525,38 @@ describe("oauth mode", () => {
     expect(res.status).toBe("ok");
   });
 
+  test("an app cannot turn the project check on where Val has no project", async () => {
+    const harness = oauthHarness();
+    /**
+     * The hole the test above could not see.
+     *
+     * It runs in http mode, where Val always has a project, so the override
+     * always happened and the assertion passed for the right reason by
+     * accident. In local filesystem mode `project` is optional — and while the
+     * override was a conditional spread, an app-supplied `oauth.project` passed
+     * straight through and enabled a check against a value the app chose,
+     * which is the opposite of what the comment beside it claimed.
+     *
+     * The token here carries `test/project` and the app asks for
+     * `someone-else/site`. Val has no project, so there is nothing to compare
+     * against and the claim is not checked at all.
+     */
+    const res = await withNodeEnv("development", () =>
+      withEnv({ VAL_PROJECT: undefined }, () =>
+        initValMcp({ config, modules: [] }, config, {
+          oauth: { ...harness, project: "someone-else/site" },
+        }).valMcpAuthorize(
+          request({
+            host: "localhost:3000",
+            authorization: `Bearer ${harness.signToken()}`,
+          }),
+        ),
+      ),
+    );
+
+    expect(res.status).toBe("ok");
+  });
+
   test("a forged token is refused with invalid_token", async () => {
     const harness = oauthHarness();
     const other = oauthHarness();

--- a/packages/next/src/server/initValMcp.ts
+++ b/packages/next/src/server/initValMcp.ts
@@ -105,6 +105,11 @@ export function initValMcp(
     );
     return {
       mode: options.mode,
+      // The project Val is configured for, which is what a token's
+      // `val_project` claim is checked against. Read from Val's own config
+      // rather than from the `oauth` block, so an app cannot state it twice and
+      // get it wrong the second time.
+      project: options.project,
       tools: createValTools(valModules, {
         ...options,
         formatter: opts?.formatter,
@@ -207,7 +212,19 @@ export function initValMcp(
         };
       }
 
-      const verified = await verifyValAccessToken(request, oauth);
+      /**
+       * The audience the app was configured with, plus the project Val is
+       * configured for.
+       *
+       * Built here rather than at `initValMcp` time because the project comes
+       * out of `initHandlerOptions`, which is resolved asynchronously. The
+       * app's own `oauth.project`, if it set one, is deliberately overridden:
+       * `val.config.ts` is the authority on which project this is.
+       */
+      const verified = await verifyValAccessToken(request, {
+        ...oauth,
+        ...(setup.project === undefined ? {} : { project: setup.project }),
+      });
       if (verified.status === "refused") {
         // 401 for a missing or bad token, 403 once the token is good but does
         // not carry the scope: RFC 6750 section 3.1, and the distinction is

--- a/packages/next/src/server/initValMcp.ts
+++ b/packages/next/src/server/initValMcp.ts
@@ -217,13 +217,21 @@ export function initValMcp(
        * configured for.
        *
        * Built here rather than at `initValMcp` time because the project comes
-       * out of `initHandlerOptions`, which is resolved asynchronously. The
-       * app's own `oauth.project`, if it set one, is deliberately overridden:
-       * `val.config.ts` is the authority on which project this is.
+       * out of `initHandlerOptions`, which is resolved asynchronously.
+       *
+       * `project` is assigned **unconditionally**, so `val.config.ts` is the
+       * authority on which project this is and an app's own `oauth.project`
+       * can never survive. It was a conditional spread, which meant the
+       * override only happened when Val had a project — so in local filesystem
+       * mode, where `project` is optional, an app-supplied `oauth.project`
+       * passed straight through and turned on a check against a value the app
+       * chose. Writing `undefined` here is the point rather than an oversight:
+       * it is what explicitly disables the claim check when Val has no project
+       * to compare against.
        */
       const verified = await verifyValAccessToken(request, {
         ...oauth,
-        ...(setup.project === undefined ? {} : { project: setup.project }),
+        project: setup.project,
       });
       if (verified.status === "refused") {
         // 401 for a missing or bad token, 403 once the token is good but does

--- a/packages/next/src/server/valAccessToken.test.ts
+++ b/packages/next/src/server/valAccessToken.test.ts
@@ -133,8 +133,18 @@ function serveJwks(keys: Record<string, unknown>[]): {
   };
 }
 
+const PROJECT = "acme/site";
+
 function oauth(fetchImpl: typeof fetch): ValOAuthConfig {
   return { issuer: ISSUER, resource: RESOURCE, fetchImpl };
+}
+
+/** The same config as an app that knows which project it serves. */
+function oauthForProject(
+  fetchImpl: typeof fetch,
+  project: string = PROJECT,
+): ValOAuthConfig {
+  return { issuer: ISSUER, resource: RESOURCE, project, fetchImpl };
 }
 
 function request(token?: string): Request {
@@ -256,6 +266,87 @@ describe("verifyValAccessToken", () => {
     if (res.status === "refused") {
       expect(res.description).toContain("aud");
     }
+  });
+
+  test("refuses a token approved for another project at this address", async () => {
+    const keys = makeKeys();
+    const jwks = serveJwks([keys.publicJwk]);
+    // Everything an audience check looks at is correct: this is the address the
+    // token was minted for, signed by a key the issuer publishes, unexpired.
+    const token = signToken(keys, {
+      scope: "val:read",
+      val_project: "someone-else/site",
+    });
+
+    const res = await verifyValAccessToken(
+      request(token),
+      oauthForProject(jwks.fetchImpl),
+    );
+
+    /**
+     * The case `aud` cannot catch, because the address *is* the audience.
+     *
+     * The address is bound to a project by a registration at the authorization
+     * server, which this server cannot see. If that binding is ever wrong, a
+     * member of another organization approving a token for this address would
+     * produce exactly the token above — and without this check it would be
+     * honoured, under this app's own API key, against this project's content.
+     */
+    expect(res).toMatchObject({ status: "refused", error: "invalid_token" });
+    if (res.status === "refused") {
+      expect(res.description).toContain("val_project");
+    }
+  });
+
+  test("refuses a token that does not say which project it is for", async () => {
+    const keys = makeKeys();
+    const jwks = serveJwks([keys.publicJwk]);
+    const token = signToken(keys, { scope: "val:read" });
+
+    const res = await verifyValAccessToken(
+      request(token),
+      oauthForProject(jwks.fetchImpl),
+    );
+
+    // Refused rather than accepted for compatibility: "accept it if absent" is
+    // a downgrade, and anything that could strip the claim would turn the check
+    // off.
+    expect(res).toMatchObject({ status: "refused", error: "invalid_token" });
+  });
+
+  test("accepts a token approved for the project this server serves", async () => {
+    const keys = makeKeys();
+    const jwks = serveJwks([keys.publicJwk]);
+    const token = signToken(keys, {
+      scope: "val:read",
+      val_project: PROJECT,
+    });
+
+    const res = await verifyValAccessToken(
+      request(token),
+      oauthForProject(jwks.fetchImpl),
+    );
+
+    expect(res).toMatchObject({ status: "ok" });
+  });
+
+  test("skips the project check where there is no project to check against", async () => {
+    const keys = makeKeys();
+    const jwks = serveJwks([keys.publicJwk]);
+    const token = signToken(keys, {
+      scope: "val:read",
+      val_project: "someone-else/site",
+    });
+
+    // Local filesystem mode, where `project` is optional: there is no backend
+    // and no other tenant, so there is nothing for the claim to protect and
+    // nothing to compare it against.
+    const res = await verifyValAccessToken(
+      request(token),
+      oauth(jwks.fetchImpl),
+    );
+
+    expect(res).toMatchObject({ status: "ok" });
   });
 
   test("accepts an audience array that includes this resource", async () => {

--- a/packages/next/src/server/valAccessToken.ts
+++ b/packages/next/src/server/valAccessToken.ts
@@ -65,6 +65,28 @@ export type ValOAuthConfig = {
    */
   resource: string;
   /**
+   * The project this app serves, as `org/name`, and therefore the expected
+   * `val_project`.
+   *
+   * Filled in by {@link initValMcp} from Val's own config rather than by the
+   * app, because it is the thing the check exists to establish and an app that
+   * could state it separately could state it wrongly.
+   *
+   * This is a second binding, not a redundant one. `aud` binds a token to an
+   * *address*; the address is bound to a project by a registration at the
+   * authorization server, and that registration is the one thing in the chain
+   * this app cannot see. If it is ever wrong — a mistaken entry, a domain that
+   * changed hands — a token approved by a member of another organization would
+   * arrive here with a matching `aud` and a signature that verifies, and
+   * without this check it would be honoured. With it, the worst such a mistake
+   * can produce is a refusal.
+   *
+   * Absent only where there is nothing to compare against: local filesystem
+   * mode, where `project` is optional and there is no backend and no other
+   * tenant to be confused with.
+   */
+  project?: string;
+  /**
    * Clock skew allowance, in seconds.
    *
    * Servers disagree about the time by more than you would like, and a token
@@ -473,6 +495,27 @@ export async function verifyValAccessToken(
     return invalidToken(
       "The access token is not valid for this server (aud claim).",
     );
+  }
+  if (config.project !== undefined) {
+    /**
+     * A missing claim is refused rather than accepted for compatibility.
+     *
+     * "Accept it if it is absent" is a downgrade: anything able to obtain a
+     * token from an issuer that does not set the claim — or to strip it — would
+     * turn the check off. Val's authorization server sets it unconditionally,
+     * so the only tokens this refuses are ones minted before it did, and those
+     * expire within the hour.
+     */
+    if (typeof payload.val_project !== "string") {
+      return invalidToken(
+        "The access token does not say which Val project it was approved for (val_project claim). Authorize again.",
+      );
+    }
+    if (payload.val_project !== config.project) {
+      return invalidToken(
+        "The access token was approved for a different Val project than this server serves (val_project claim).",
+      );
+    }
   }
   const subject = payload.sub;
   if (typeof subject !== "string" || subject.length === 0) {


### PR DESCRIPTION
**Parked — not proceeding for now.** Closing rather than merging; the branch is retained.

## What this was

`@valbuild/next` would check a `val_project` claim on an access token, alongside `aud`, so that a token approved for one project could not be honoured by an app serving another. It was the resource-server half of a wider piece of work on Val's authorization server.

## Why it is parked

It cannot ship on its own: the claim is set by the authorization server, and that half is not merged, so releasing this alone would make `@valbuild/next` refuse every access token in proxy mode. It would need a coordinated release, issuer first.

And the case it guards does not currently arise. A project resolves to exactly one address today, and where two projects could ever claim one address the authorization server already refuses as ambiguous — it fails closed. The claim's value was as insurance for letting a project have several addresses, which is not shipping.

The two cases that matter are both already covered: editors reach MCP at a project's production URL, and developers run it locally in filesystem mode, which needs no credential at all.

## Worth keeping if this is revisited

One finding from review here is independent of all of the above and applies to shipped code: `val login`'s IP resolution takes the first `x-forwarded-for` entry without validating it is an address, and that value reaches an `INET` column. Worth pulling out on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015B9ViTYQVGMCjq8HgowE1d