### PR TITLE
Parse the settings schema on its way to the Studio

### DIFF
--- a/packages/shared/src/internal/zod/SerializedSchema.test.ts
+++ b/packages/shared/src/internal/zod/SerializedSchema.test.ts
@@ -45,4 +45,25 @@ describe("SerializedSchema round-trips", () => {
       options: { a: { type: "route" }, img: { type: "image" } },
     });
   });
+
+  // Not a strip but an outright rejection: `settings` was in the TypeScript
+  // union and absent from this one, so /schema answered 500 for every project
+  // with a settings module rather than dropping a field.
+  test("settings parses, nested sections and all", () => {
+    const parsed = SerializedSchema.safeParse(serialize(s.settings()));
+    expect(parsed.success).toBe(true);
+    expect(parsed.success && parsed.data).toMatchObject({
+      type: "settings",
+      items: {
+        assistant: {
+          type: "settings",
+          items: {
+            enabled: { type: "boolean" },
+            context: { type: "string" },
+            tone: { type: "string" },
+          },
+        },
+      },
+    });
+  });
 });

--- a/packages/shared/src/internal/zod/SerializedSchema.ts
+++ b/packages/shared/src/internal/zod/SerializedSchema.ts
@@ -19,6 +19,7 @@ import {
   type SerializedColorSchema as SerializedColorSchemaT,
   type SerializedCodeSchema as SerializedCodeSchemaT,
   type SerializedImageSchema as SerializedImageSchemaT,
+  type SerializedSettingsSchema as SerializedSettingsSchemaT,
   CODE_LANGUAGES,
 } from "@valbuild/core";
 import { SourcePath } from "./SourcePath";
@@ -368,6 +369,26 @@ export const SerializedRouteSchema: z.ZodType<SerializedRouteSchemaT> =
     hidden: z.boolean().optional(),
   });
 
+// A settings module, and each section inside one, serialize as this - the
+// shape is recursive because `items` holds sections which are themselves
+// settings schemas. `s.settings()` never writes render/preview/customValidate
+// (see core/src/schema/settings.ts), but they are accepted here because they
+// are part of the declared type.
+export const SerializedSettingsSchema: z.ZodType<SerializedSettingsSchemaT> =
+  z.lazy(() => {
+    return z.object({
+      type: z.literal("settings"),
+      render: FieldRender,
+      preview: z.literal(true).optional(),
+      items: z.record(z.string(), SerializedSchema),
+      opt: z.boolean(),
+      customValidate: z.boolean().optional(),
+      readonly: z.boolean().optional(),
+      hidden: z.boolean().optional(),
+      description: z.string().optional(),
+    });
+  });
+
 export const SerializedSchema: z.ZodType<SerializedSchemaT> = z.union([
   SerializedStringSchema,
   SerializedLiteralSchema,
@@ -385,5 +406,6 @@ export const SerializedSchema: z.ZodType<SerializedSchemaT> = z.union([
   SerializedDateTimeSchema,
   SerializedColorSchema,
   SerializedCodeSchema,
+  SerializedSettingsSchema,
   SerializedImageSchema,
 ]);


### PR DESCRIPTION
## What

`s.settings()` serializes as `type: "settings"`. That variant is in core's `SerializedSchema` TypeScript union (`packages/core/src/schema/index.ts`) but was missing from the zod union in `packages/shared/src/internal/zod/SerializedSchema.ts`.

`ValRouter` validates every response unconditionally (`packages/server/src/ValRouter.ts:428`), so `GET /api/val/schema` answered **500 for any project with a settings module** — `examples/next` included, which means the Studio could not load against it at all.

This is not dev-only; the same validation runs in production.

## Why it is a bit different from the usual gap here

The round-trip tests already in this file guard against *strips*: these `z.object`s drop undeclared keys, so a forgotten field goes missing silently for that one field. This was an outright rejection instead — one unparseable module took the entire schema response down with it.

## Notes

- Placed next to `SerializedRouteSchema` in the union to mirror the order core declares the type union in.
- `render` / `preview` / `customValidate` are accepted even though `s.settings()` never writes them, because they are part of the declared type (see the comment in `core/src/schema/settings.ts` explaining why they exist).
- Added a round-trip test covering the nested-section shape.

Found while setting this branch up to run locally. Based on `claude/full-restore-history-xjhjpt`, but the bug is pre-existing on `main` — retarget if you would rather it land there directly.

## Separate bug this turned up

While writing the test I found that `description` is stripped for most schema types: every core schema declares `description?: string`, but only `date`, `dateTime`, `color` and `code` declare it in the zod validators. So `.describe(...)` never reaches the Studio for `string`, `boolean`, `number`, `object`, `array`, `union`, `richtext`, `record`, `keyOf`, `route`, `file`, `image` or `literal` — including the descriptions `s.settings()` puts on its own fields. Left out of this PR to keep it focused; happy to follow up.

## Test plan

- `npx jest packages/shared` — 119 passed
- `npx tsc --noEmit -p packages/shared/tsconfig.json` — clean
- Verified against a local content server: `GET /api/val/schema` went from 500 to 200 and the Studio loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)