### PR TITLE
Give Source one name, and say what it is not

### DIFF
--- a/.agent/rules.md
+++ b/.agent/rules.md
@@ -57,6 +57,12 @@ expensive to re-derive from the code:
 
 Val has a dual type system: **Source** types define data shape, **Selector** types is the user facing types.
 
+**Source is the data of a module** - JSON, the thing patches apply to. It is not
+the `.val.ts` file and not a description of it; a variable holding `.val.ts`
+text is text, not Source. See
+[`architecture/terminology.md`](../architecture/terminology.md) for that
+distinction and the path vocabulary that goes with it.
+
 ```
 Source (data)          →  Selector (access)
 ─────────────────────────────────────────────

--- a/architecture/README.md
+++ b/architecture/README.md
@@ -5,6 +5,7 @@ don't. Written for a human reading it once, not as a reference to be exhaustive.
 
 | file                                             | what it covers                                                                                                           |
 | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| [terminology.md](./terminology.md)               | Source, module file, schema, selector, paths — one meaning each, and the synonyms that cause trouble                     |
 | [media.md](./media.md)                           | `s.images()`, `s.files()`, `s.image()`, `s.file()` — collections vs fields, where bytes land, how a URL is chosen        |
 | [stores.md](./stores.md)                         | The Studio's client state: ten stores, two realms, and the one rule the whole design turns on                            |
 | [quirks.md](./quirks.md)                         | Things that are true, surprising, and cost someone an afternoon                                                          |

--- a/architecture/terminology.md
+++ b/architecture/terminology.md
@@ -1,0 +1,59 @@
+# Terminology
+
+The words below have one meaning each in this codebase. Using a synonym for one
+of them is how a design conversation quietly ends up describing two different
+systems.
+
+## Source
+
+**The data of a module.** JSON: objects, arrays, strings, numbers, media
+objects, richtext. `Source` in `packages/core/src/source/index.ts` is the type.
+
+This is the thing patches apply to, the thing the Studio edits, the thing a
+schema validates. It is what `s.object({...})` describes and what
+`c.define(path, schema, ...)` is given.
+
+It is **not** the `.val.ts` file, and it is not a description of that file.
+Do not call it "the extracted JSON", "the module data", "the resolved value" or
+"the parsed module" — it is the Source, and every one of those synonyms invites
+someone to believe there is a fifth concept.
+
+## Module file
+
+The `.val.ts` (or `.val.js`) file on disk. It is **code**: an import list and a
+`c.define` call. Its Source is the literal that `c.define` was given.
+
+Getting from a module file to its Source is a static extraction —
+`analyzeValModule` + `evaluateExpression` — and it is best-effort. A module
+whose value is not a literal has no Source that can be read this way, which is
+why `.jsonValues()` modules (`c.json(() => import(...))`) cannot be read from
+their module file at all: their Source lives in the `.val.json` beside it.
+
+**Text is not Source.** A variable holding `.val.ts` text is not a "source
+file" in this sense however plausible that reads — name it `text`, or
+`moduleFileText`. (`previousSourceFiles` on `POST /commit` is exactly this
+trap: the name says Source, the value is text.)
+
+## Schema
+
+What a module's Source is allowed to be, built with `s.*`. `SerializedSchema`
+is its wire form — the shape the Studio receives and renders fields from.
+
+## Selector
+
+The user-facing type consumers hold: `ObjectSelector`, `ArraySelector`,
+`GenericSelector`. Selectors are how content is _read_ in an app; Source is what
+is _stored_. See the table in `.claude/CLAUDE.md`.
+
+## Paths
+
+| term             | example                                 | is                                        |
+| ---------------- | --------------------------------------- | ----------------------------------------- |
+| `ModuleFilePath` | `/content/page.val.ts`                  | which module                              |
+| `ModulePath`     | `"hero"."title"`                        | where inside its Source                   |
+| `SourcePath`     | `/content/page.val.ts?p="hero"."title"` | the two joined — a specific value         |
+| patch path       | `["hero", "title"]`                     | the same location, as JSON Patch wants it |
+
+`Internal.splitModuleFilePathAndModulePath` and `Internal.createPatchPath`
+convert between them. A `SourcePath` names a place in a Source; it never names a
+place in a module file.


### PR DESCRIPTION
Adds `architecture/terminology.md`, links it from the architecture index and from the type-hierarchy section of the agent rules.

## Why

"Source" already means one thing in Val — the data of a module, the JSON that patches apply to and a schema validates — but nothing wrote that down. So design discussions keep inventing synonyms for it. "The extracted JSON" is the one that prompted this; "the module data" and "the resolved value" are the same mistake. Every synonym invites a reader to believe there is another concept.

## What it covers

- **Source vs module file.** A `.val.ts` is *code*; its Source is the literal inside it. Getting from one to the other is a best-effort static extraction (`analyzeValModule` + `evaluateExpression`) that can fail — which is precisely why `.jsonValues()` modules cannot be read from their module file at all.
- **Text is not Source.** A variable holding `.val.ts` text is text, however plausibly "source file" reads as a name for it. `previousSourceFiles` on `POST /commit` is that trap already in the codebase, so it is cited rather than quietly left.
- **The path vocabulary** — `ModuleFilePath`, `ModulePath`, `SourcePath`, patch path — in one table, since which of the four a function wants is not obvious from its signature.

Docs only; no code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1XGRuPC6BTaMcxizVttCb)_