### PR TITLE
Check .jsonValues() records structurally, not by constructor identity

### DIFF
--- a/.changeset/jsonvalues-npx-realm.md
+++ b/.changeset/jsonvalues-npx-realm.md
@@ -1,0 +1,9 @@
+---
+"@valbuild/server": patch
+---
+
+Fix `.jsonValues()` validation being silently skipped when the CLI is run through `npx` / `pnpm dlx`.
+
+`npx @valbuild/cli validate` reported a `.jsonValues()` module whose entries were still written inline in the `.val.ts` as **valid**, and `--fix` moved nothing into `*.val.json`. Running the CLI installed in the project (`./node_modules/.bin/val validate --fix`) worked, which made this look like a schema or path problem rather than a tooling one.
+
+The cause: the project's `*.val.ts` are evaluated with a `require` rooted at the project, so their schemas come from the project's `@valbuild/core`, while `npx`/`dlx` runs the CLI's own second copy. The entry check guarded on `schema instanceof RecordSchema`, which is false across those two copies, and it failed open — the whole check returned "no errors". The guard is now structural, so it holds whichever copy built the schema. If you gate CI on `npx @valbuild/cli validate`, that gate was green for the wrong reason.

--- a/packages/server/src/validateJsonValues.test.ts
+++ b/packages/server/src/validateJsonValues.test.ts
@@ -1,8 +1,39 @@
-import { initVal, ModuleFilePath } from "@valbuild/core";
+import { initVal, ModuleFilePath, RecordSchema } from "@valbuild/core";
 import { validateJsonValuesEntries } from "./validateJsonValues";
 
 const { s, c } = initVal();
 const modulePath = "/blogs.val.ts" as ModuleFilePath;
+
+/**
+ * The same schema as a SECOND copy of `@valbuild/core` would hand it over: same
+ * own fields, same methods, a prototype chain rebuilt from fresh objects so no
+ * constructor identity survives.
+ *
+ * This is what `npx @valbuild/cli` / `pnpm dlx` actually produce. The project's
+ * `*.val.ts` are evaluated by `loadValModules` with a `require` rooted at the
+ * project, so the schemas come from the project's `@valbuild/core`, while the
+ * tool runs its own copy from the temporary install.
+ */
+function fromAnotherRealm<T extends object>(value: T): T {
+  const chain: object[] = [];
+  for (
+    let proto = Object.getPrototypeOf(value);
+    proto && proto !== Object.prototype;
+    proto = Object.getPrototypeOf(proto)
+  ) {
+    chain.push(proto);
+  }
+  let rebuilt: object = Object.prototype;
+  for (const proto of chain.reverse()) {
+    rebuilt = Object.create(rebuilt, Object.getOwnPropertyDescriptors(proto));
+  }
+  // `Object.create` is typed `any`, so this needs no assertion.
+  const copy: T = Object.create(
+    rebuilt,
+    Object.getOwnPropertyDescriptors(value),
+  );
+  return copy;
+}
 
 describe("validateJsonValuesEntries", () => {
   const schema = s.record(s.object({ title: s.string() })).jsonValues();
@@ -69,6 +100,74 @@ describe("validateJsonValuesEntries", () => {
     const [error] = errors[keys[0] as keyof typeof errors];
     expect(error.fixes).toEqual(["jsonValues:extract-entry"]);
     expect(error.message).toContain("written inline");
+  });
+
+  // A record from a second copy of `@valbuild/core`. `instanceof RecordSchema`
+  // is false for it, and the guard that used to ask that question failed OPEN —
+  // `npx @valbuild/cli validate` reported a module with entries written inline
+  // as VALID, applied no fix, and a CI gate on it went green.
+  describe("a record built by another copy of @valbuild/core", () => {
+    const foreign = fromAnotherRealm(schema);
+
+    test("the fixture really is foreign", () => {
+      expect(schema instanceof RecordSchema).toBe(true);
+      expect(foreign instanceof RecordSchema).toBe(false);
+      // ...and identical in every way the check actually depends on.
+      expect(foreign.constructor.name).toBe("RecordSchema");
+      expect(foreign["executeSerialize"]()).toEqual(
+        schema["executeSerialize"](),
+      );
+    });
+
+    test("still reports an entry written inline as fixable", async () => {
+      const source = {
+        "/a": c.json(() => Promise.resolve({ default: { title: "ok" } })),
+        "/inline": { title: "legal shape, wrong place" },
+      };
+      const { errors } = await validateJsonValuesEntries(
+        foreign,
+        source,
+        modulePath,
+      );
+      const keys = Object.keys(errors);
+      expect(keys).toHaveLength(1);
+      expect(keys[0]).toContain("/inline");
+      expect(errors[keys[0] as keyof typeof errors][0].fixes).toEqual([
+        "jsonValues:extract-entry",
+      ]);
+    });
+
+    test("still validates loaded entry content", async () => {
+      const source = {
+        "/bad": c.json(() => Promise.resolve({ default: { title: 123 } })),
+      };
+      const { errors } = await validateJsonValuesEntries(
+        foreign,
+        source,
+        modulePath,
+      );
+      expect(Object.keys(errors).some((k) => k.includes("/bad"))).toBe(true);
+    });
+
+    test("a foreign NON-jsonValues record is still skipped", async () => {
+      const foreignPlain = fromAnotherRealm(
+        s.record(s.object({ title: s.string() })),
+      );
+      let loaded = false;
+      const source = {
+        "/a": c.json(() => {
+          loaded = true;
+          return Promise.resolve({ default: { title: "ok" } });
+        }),
+      };
+      const { errors } = await validateJsonValuesEntries(
+        foreignPlain,
+        source,
+        modulePath,
+      );
+      expect(errors).toEqual({});
+      expect(loaded).toBe(false);
+    });
   });
 
   test("skips non-jsonValues records (no content loading)", async () => {

--- a/packages/server/src/validateJsonValues.ts
+++ b/packages/server/src/validateJsonValues.ts
@@ -2,12 +2,11 @@ import {
   Internal,
   type Json,
   ModuleFilePath,
-  RecordSchema,
   Schema,
   SelectorSource,
   SourcePath,
 } from "@valbuild/core";
-import { ValidationError } from "@valbuild/core";
+import { ValidationError, ValidationErrors } from "@valbuild/core";
 
 /**
  * The outcome of {@link validateJsonValuesEntries}: the errors found inside the
@@ -25,6 +24,54 @@ export type JsonValuesEntriesValidation = {
   errors: Record<SourcePath, ValidationError[]>;
   loadedEntries: Record<string, Json>;
 };
+
+/**
+ * The part of a `.jsonValues()` record this file calls. Named structurally
+ * because the value may not be an instance of *this* copy of `RecordSchema` —
+ * see {@link isJsonValuesRecord}.
+ */
+type JsonValuesRecord = {
+  validateJsonEntryContent(
+    path: SourcePath,
+    content: SelectorSource,
+  ): ValidationErrors;
+};
+
+/**
+ * Is this a `.jsonValues()` record?
+ *
+ * NOT `schema instanceof RecordSchema`, and the distinction is the whole point.
+ * `loadValModules` evaluates the project's `*.val.ts` with a `require` rooted at
+ * the PROJECT, deliberately, so the schemas are built by whatever
+ * `@valbuild/core` the project resolves. When the CLI is itself installed in
+ * that project, that is this very module and `instanceof` holds. When it is run
+ * through `npx` / `pnpm dlx`, the tool gets its own copy of `@valbuild/core`
+ * beside the project's, and `instanceof` is false for a record that is a record
+ * in every way that matters — same class name, same serialized schema, same
+ * methods, different realm.
+ *
+ * That failed OPEN: the whole check returned "no errors", so
+ * `npx @valbuild/cli validate` called a module with un-extracted entries VALID
+ * and a CI gate on it was green for the wrong reason. `loadValModules` avoids
+ * constructor checks for exactly this reason and says so; this one was the
+ * exception.
+ *
+ * `validateJsonEntryContent` is declared by `RecordSchema` and by nothing else,
+ * so it is the brand — and checking it first keeps the cheap short-circuit
+ * `instanceof` gave us, rather than serializing every non-record schema.
+ */
+function isJsonValuesRecord(
+  schema: Schema<SelectorSource>,
+): schema is Schema<SelectorSource> & JsonValuesRecord {
+  if (
+    !("validateJsonEntryContent" in schema) ||
+    typeof schema.validateJsonEntryContent !== "function"
+  ) {
+    return false;
+  }
+  const serialized = schema["executeSerialize"]();
+  return serialized.type === "record" && serialized.jsonValues === true;
+}
 
 /**
  * Validates the content of every `.jsonValues()` entry in a module by loading
@@ -84,10 +131,7 @@ export async function validateJsonValuesEntries(
   const out: Record<SourcePath, ValidationError[]> = {};
   const loadedEntries: Record<string, Json> = {};
   const res: JsonValuesEntriesValidation = { errors: out, loadedEntries };
-  if (!(schema instanceof RecordSchema)) {
-    return res;
-  }
-  if (!schema["executeSerialize"]().jsonValues) {
+  if (!isJsonValuesRecord(schema)) {
     return res;
   }
   if (source === null || typeof source !== "object" || Array.isArray(source)) {


### PR DESCRIPTION
## The bug

`npx @valbuild/cli validate` (or `pnpx`) reports a `.jsonValues()` module whose entries are still written inline in the `.val.ts` as **valid**, and `--fix` moves nothing into `*.val.json`. The same CLI installed in the project gets it right, which is what makes this look like a schema or a path problem rather than a tooling one.

Reproduced on `valbuild/web` with a router-backed `.jsonValues()` record:

```
$ pnpx @valbuild/cli validate --fix
✔ app/(main)/blogs/[id]/page.val.ts  valid (5ms)
✔ No validation errors found · 21 valid

$ ./node_modules/.bin/val validate --fix          # same version, same file
⚠ Applied fix for /app/(main)/blogs/[id]/page.val.ts?p="/blogs/scalable-front-end-architecture"
⚠ Applied fix for /app/(main)/blogs/[id]/page.val.ts?p="/blogs/why-content-as-code"
```

## Why

`loadValModules` evaluates the project's `*.val.ts` with a `require` rooted at the **project** — deliberately, so "user modules share the exact same `@valbuild/core` instance". Run through `npx` / `pnpm dlx`, the tool brings its own second copy of `@valbuild/core` beside the project's, and that premise no longer holds.

`validateJsonValuesEntries` guarded on `schema instanceof RecordSchema`. Instrumenting the published build under `dlx`:

```
[DBG] modulePath= /app/(main)/blogs/[id]/page.val.ts  ctor= RecordSchema
      instanceof RecordSchema= false   serialized.jsonValues= true
```

Right class name, right serialized schema, wrong realm — and the guard **failed open**, returning "no errors" for the whole module. So an un-extracted module passed, and anyone gating CI on `npx @valbuild/cli validate` had a check that was green for the wrong reason.

`loadValModules` already avoids constructor checks for exactly this reason and says so in a comment; this guard was the one exception. It was also the only `instanceof` in `packages/server` applied to a user-supplied schema — the `ValOpsFS`/`ValOpsHttp` checks are on values the server constructs itself, so they are unaffected.

## The change

Ask the serialized schema (`type === "record"` + `jsonValues`) and duck-type the one method the file calls. `validateJsonEntryContent` is declared by `RecordSchema` and nothing else, so it is the brand — and checking it first keeps the cheap short-circuit `instanceof` gave us, so a non-record schema is still rejected without being serialized.

## Verification

- New unit tests build the schema through a rebuilt prototype chain — same own fields, same methods, no constructor identity — which is what a second copy of core actually hands over. They **fail on `main`** (2 failed) and pass here, and cover the inline-entry report, the loaded-content validation, and that a foreign *non*-`jsonValues` record is still skipped without loading anything.
- Patched the new guard into the published build inside the `pnpm dlx` cache and re-ran the original failing command against `valbuild/web`: it now applies both fixes and writes the `*.val.json` files.
- `val validate --root examples/next` is byte-identical to `main` (`2 errors (1 fixable) across 2 files · 20 valid · 1 skipped`), from `src/` and via the packaged `bin.js` — no change to the same-realm path.
- Full CI locally: lint, `prettier --check`, `-r typecheck`, `pnpm test` (3527 passed), root `build`, and `examples/next` build.

The VS Code extension has a *separate* bug with the same symptom — the language server publishes the `jsonValues:extract-entry` diagnostic correctly but offers no quick fix. That needs a real feature (a two-file `WorkspaceEdit`) and is coming as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jzwhh37RHxQSuCjkgRdXN

---
_Generated by [Claude Code](https://claude.ai/code/session_013jzwhh37RHxQSuCjkgRdXN)_