### PR TITLE
Make `.remote()` the only way to enable remote on media collections

### DIFF
--- a/.changeset/images-files-remote-method.md
+++ b/.changeset/images-files-remote-method.md
@@ -1,0 +1,25 @@
+---
+"@valbuild/core": minor
+---
+
+**Breaking:** `s.images()` and `s.files()` no longer take a `remote` option. Use
+`.remote()`, the same way `s.image()` and `s.file()` already did.
+
+```ts
+// before
+s.images({ directory: "/public/val/images", remote: true });
+s.files({
+  directory: "/public/val/docs",
+  accept: "application/pdf",
+  remote: true,
+});
+
+// after
+s.images({ directory: "/public/val/images" }).remote();
+s.files({ directory: "/public/val/docs", accept: "application/pdf" }).remote();
+```
+
+Behaviour is unchanged — remote is still off unless asked for. This only makes
+remote one thing spelled one way across all four media schemas, instead of an
+option on the two collections and a method on the two fields. `remote: false`
+has no replacement because it was the default; drop it.

--- a/architecture/media.md
+++ b/architecture/media.md
@@ -5,10 +5,16 @@
 `s.images()` / `s.files()` are **whole-module collections**. `s.image()` /
 `s.file()` are **fields**. They are not variants of each other.
 
-|       | collection (is the module)                        | field (lives at a path)                                      |
-| ----- | ------------------------------------------------- | ------------------------------------------------------------ |
-| image | `s.images({ directory, accept?, alt?, remote? })` | `s.image({ directory, accept })` or `s.image(galleryModule)` |
-| file  | `s.files({ directory, accept, remote? })`         | `s.file({ accept })`                                         |
+|       | collection (is the module)               | field (lives at a path)                                      |
+| ----- | ---------------------------------------- | ------------------------------------------------------------ |
+| image | `s.images({ directory, accept?, alt? })` | `s.image({ directory, accept })` or `s.image(galleryModule)` |
+| file  | `s.files({ directory, accept })`         | `s.file({ accept })`                                         |
+
+Remote is a **method, not an option**, everywhere: `s.images({...}).remote()`,
+`s.files({...}).remote()`, `s.image().remote()`, `s.file().remote()`. It used to
+be `{ remote: true }` on the two collections and a `.remote()` on the two fields,
+which meant the same fact was spelled two ways depending on which of the four you
+were looking at.
 
 A collection's `directory` is **required**. It used to default to `/public/val`,
 which meant a gallery that had simply not said where it wanted its files shared a

--- a/architecture/media.md
+++ b/architecture/media.md
@@ -8,7 +8,7 @@
 |       | collection (is the module)               | field (lives at a path)                                      |
 | ----- | ---------------------------------------- | ------------------------------------------------------------ |
 | image | `s.images({ directory, accept?, alt? })` | `s.image({ directory, accept })` or `s.image(galleryModule)` |
-| file  | `s.files({ directory, accept })`         | `s.file({ accept })`                                         |
+| file  | `s.files({ directory, accept })`         | `s.file({ accept })` or `s.file(collectionModule)`           |
 
 Remote is a **method, not an option**, everywhere: `s.images({...}).remote()`,
 `s.files({...}).remote()`, `s.image().remote()`, `s.file().remote()`. It used to
@@ -59,9 +59,9 @@ only a path outside `/public`** — `isRemoteMediaPath` is the whole test.
 writes the derived ones **one property at a time** rather than replacing the
 object.
 
-A **gallery-backed** field (`s.image(galleryModule)`) carries neither: the
-gallery has them, keyed by path, and repeating them is how two copies of one
-fact get to disagree. `s.image(galleryVal)` refuses them at author time, and
+A **gallery-backed** field (`s.image(galleryModule)`, and `s.file(collectionModule)`
+for the file pair) carries neither: the gallery has them, keyed by path, and
+repeating them is how two copies of one fact get to disagree. `s.image(galleryVal)` refuses them at author time, and
 validation refuses a path the gallery does not track. `fillFromGallery` supplies
 them at resolve time — including `alt`, but only when the field has none, so a
 per-image override wins. A gallery whose `alt` is a locale record holds an object

--- a/architecture/quirks.md
+++ b/architecture/quirks.md
@@ -222,7 +222,7 @@ hidden item quite happily; `e2e/keyof-create.spec.ts` is what caught it.
 `@valbuild/core`, and only that.** There used to be two — the server's, gating
 whether `/save` demands remote credentials, and the Studio's
 `findRequiredRemoteFiles`, gating the `/remote/settings` fetch — and they
-disagreed about `s.images({ remote: true })`. A media collection serializes as a
+disagreed about `s.images({ ... }).remote()`. A media collection serializes as a
 `record` of metadata with the file named by the KEY, so a walk that only recurses
 into `item` finds no image schema and says no; that was the server's answer. If
 you add a schema type, teach that one function about it: the `never` assignment in

--- a/examples/next/content/remoteImages.val.ts
+++ b/examples/next/content/remoteImages.val.ts
@@ -17,6 +17,6 @@ import { s, c } from "../val.config";
  */
 export default c.define(
   "/content/remoteImages.val.ts",
-  s.images({ remote: true, directory: "/public/remote-images" }),
+  s.images({ directory: "/public/remote-images" }).remote(),
   {},
 );

--- a/packages/cli/src/__fixtures__/basic/content/basic-gallery-remote-existing.val.ts
+++ b/packages/cli/src/__fixtures__/basic/content/basic-gallery-remote-existing.val.ts
@@ -2,11 +2,12 @@ import { c, s } from "../val.config";
 
 export default c.define(
   "/content/basic-gallery-remote-existing.val.ts",
-  s.images({
-    directory: "/public/val/images-remote2",
-    accept: "image/*",
-    remote: true,
-  }),
+  s
+    .images({
+      directory: "/public/val/images-remote2",
+      accept: "image/*",
+    })
+    .remote(),
 
   {
     "https://remote.val.build/file/p/proj123/b/01/v/1.0.0/h/abc1/f/def4/p/public/val/images-remote2/image.png":

--- a/packages/cli/src/__fixtures__/basic/content/basic-gallery-remote.val.ts
+++ b/packages/cli/src/__fixtures__/basic/content/basic-gallery-remote.val.ts
@@ -2,11 +2,12 @@ import { c, s } from "../val.config";
 
 export default c.define(
   "/content/basic-gallery-remote.val.ts",
-  s.images({
-    directory: "/public/val/images-remote",
-    accept: "image/*",
-    remote: true,
-  }),
+  s
+    .images({
+      directory: "/public/val/images-remote",
+      accept: "image/*",
+    })
+    .remote(),
 
   {
     "/public/val/images-remote/image.png": {

--- a/packages/core/src/schema/files.ts
+++ b/packages/core/src/schema/files.ts
@@ -22,11 +22,6 @@ export type FilesOptions = {
    * a directory with every other one.
    */
   directory: "/public" | `/public/${string}`;
-  /**
-   * Whether remote files are allowed
-   * @default false
-   */
-  remote?: boolean;
 };
 
 /**
@@ -43,6 +38,8 @@ type FilesItemSrc = { mimeType: string };
 
 /**
  * Define a collection of files.
+ *
+ * Remote is off by default: call `.remote()` on the result to allow remote files.
  *
  * @example
  * ```typescript
@@ -73,6 +70,6 @@ export const files = (
     type: "files",
     accept: options.accept,
     directory,
-    remote: options.remote ?? false,
+    remote: false,
   });
 };

--- a/packages/core/src/schema/hasRemoteFileSchema.test.ts
+++ b/packages/core/src/schema/hasRemoteFileSchema.test.ts
@@ -280,10 +280,10 @@ describe("hasRemoteFileSchema", () => {
    * and the commit lands a remote ref with no bytes behind it.
    */
   describe("media collections", () => {
-    it("should return true for s.images({ remote: true })", () => {
+    it("should return true for a remote s.images()", () => {
       expect(
         hasRemoteFileSchema(
-          serialize(s.images({ directory: "/public/val", remote: true })),
+          serialize(s.images({ directory: "/public/val" }).remote()),
         ),
       ).toBe(true);
     });
@@ -294,11 +294,12 @@ describe("hasRemoteFileSchema", () => {
       expect(
         hasRemoteFileSchema(
           serialize(
-            s.files({
-              directory: "/public/val",
-              accept: "application/pdf",
-              remote: true,
-            }),
+            s
+              .files({
+                directory: "/public/val",
+                accept: "application/pdf",
+              })
+              .remote(),
           ),
         ),
       ).toBe(true);
@@ -320,21 +321,13 @@ describe("hasRemoteFileSchema", () => {
       ).toBe(false);
     });
 
-    it("should return false for s.images({ remote: false })", () => {
-      expect(
-        hasRemoteFileSchema(
-          serialize(s.images({ directory: "/public/val", remote: false })),
-        ),
-      ).toBe(false);
-    });
-
     it("should find a remote gallery nested in an object", () => {
       expect(
         hasRemoteFileSchema(
           serialize(
             s.object({
               title: s.string(),
-              gallery: s.images({ directory: "/public/val", remote: true }),
+              gallery: s.images({ directory: "/public/val" }).remote(),
             }),
           ),
         ),
@@ -353,7 +346,7 @@ describe("hasRemoteFileSchema", () => {
               }),
               s.object({
                 type: s.literal("images"),
-                images: s.images({ directory: "/public/val", remote: true }),
+                images: s.images({ directory: "/public/val" }).remote(),
               }),
             ),
           ),

--- a/packages/core/src/schema/hasRemoteFileSchema.ts
+++ b/packages/core/src/schema/hasRemoteFileSchema.ts
@@ -10,7 +10,7 @@ import type { SerializedSchema } from "./index";
  * The one answer to that question. There used to be two — `hasRemoteFileSchema`
  * in the server, gating whether `/save` demands remote credentials, and
  * `findRequiredRemoteFiles` in the Studio, gating the `/remote/settings` fetch —
- * and they disagreed about `s.images({ remote: true })`: the Studio's counted a
+ * and they disagreed about `s.images({ ... }).remote()`: the Studio's counted a
  * remote media record, the server's did not, because a media collection
  * serializes as a `record` of metadata rather than as an image schema.
  *

--- a/packages/core/src/schema/hasRemoteFileSchema.ts
+++ b/packages/core/src/schema/hasRemoteFileSchema.ts
@@ -10,9 +10,10 @@ import type { SerializedSchema } from "./index";
  * The one answer to that question. There used to be two — `hasRemoteFileSchema`
  * in the server, gating whether `/save` demands remote credentials, and
  * `findRequiredRemoteFiles` in the Studio, gating the `/remote/settings` fetch —
- * and they disagreed about `s.images({ ... }).remote()`: the Studio's counted a
- * remote media record, the server's did not, because a media collection
- * serializes as a `record` of metadata rather than as an image schema.
+ * and they disagreed about `s.images({ ... }).remote()`: the Studio's version
+ * counted a remote media record, the server's did not, because a media
+ * collection serializes as a `record` of metadata rather than as an image
+ * schema.
  *
  * The server's answer was the wrong one, and silently so. With it false,
  * `/save` runs `saveOrUploadFiles` in `skip-remote` mode, and that mode does not

--- a/packages/core/src/schema/images.ts
+++ b/packages/core/src/schema/images.ts
@@ -41,11 +41,6 @@ export type ImagesOptions<Accept extends `image/${string}`> = {
    */
   alt?: AltSchema;
   /**
-   * Whether remote images are allowed
-   * @default false
-   */
-  remote?: boolean;
-  /**
    * Re-encode uploads in the browser before they are uploaded.
    *
    * Off unless set. A field backed by this gallery (`s.image(galleryVal)`)
@@ -89,7 +84,7 @@ type ImagesItemSrc = {
  *
  * `directory` is required — it decides where uploads land, so it is not something
  * to be inferred. The rest defaults: any image type (`"image/*"`), nullable alt
- * text, remote disabled.
+ * text, remote disabled. Call `.remote()` on the result to allow remote images.
  *
  * @example
  * ```typescript
@@ -130,7 +125,7 @@ export const images = <Accept extends `image/${string}`>(
     type: "images",
     accept: options.accept ?? "image/*",
     directory,
-    remote: options.remote ?? false,
+    remote: false,
     altSchema,
     encode: options.encode,
   });

--- a/packages/server/src/fixHandlers.ts
+++ b/packages/server/src/fixHandlers.ts
@@ -464,7 +464,7 @@ export async function handleRemoteFileUpload(
   );
 }
 
-// Gallery (s.images({ remote: true }) / s.files({ remote: true })) upload.
+// Gallery (s.images({ ... }).remote() / s.files({ ... }).remote()) upload.
 // Unlike a single image/file field, a gallery entry is keyed by its local file
 // path and the value is bare metadata (no FileSource), so we derive the file
 // ref from the key and synthesize the image/file schema from the record's


### PR DESCRIPTION
## Summary

Removes the `remote` option from `s.images()` and `s.files()` schema factories, making `.remote()` the only way to enable remote file support across all four media schemas. This unifies the API: previously `s.image()` and `s.file()` used `.remote()` while `s.images()` and `s.files()` used a `remote` option.

## Changes

- **Breaking change**: `s.images({ remote: true })` → `s.images({...}).remote()`
- **Breaking change**: `s.files({ remote: true })` → `s.files({...}).remote()`
- Removed `remote?: boolean` option from `ImagesOptions` and `FilesOptions` types
- Updated all test cases to use the new `.remote()` method syntax
- Updated fixture files and examples to reflect the new API
- Updated architecture documentation to reflect the unified method-based approach
- Updated comments in `hasRemoteFileSchema.ts` and `fixHandlers.ts` to reference the new syntax
- Added changeset documenting the breaking change and migration path

## Implementation Details

- Remote defaults to `false` in both `images()` and `files()` factories (unchanged behavior)
- The `.remote()` method is already implemented on the schema objects returned by these factories
- This change makes the media schema API consistent: all four schemas (`s.image()`, `s.file()`, `s.images()`, `s.files()`) now use `.remote()` as a method rather than mixing methods and options
- `remote: false` has no replacement since it was the default; users should simply omit the `.remote()` call

https://claude.ai/code/session_0144L5wjVw6u8vmqq4GT8Cyh