### PR TITLE
Offer the extract-entry quick fix in the editor

### DIFF
--- a/.changeset/jsonvalues-extract-entry-quickfix.md
+++ b/.changeset/jsonvalues-extract-entry-quickfix.md
@@ -1,0 +1,12 @@
+---
+"@valbuild/server": patch
+"@valbuild/language-server": patch
+---
+
+Add the editor quick fix for a `.jsonValues()` entry written inline: **Val: move entry into its own .val.json**.
+
+The language server already reported the problem — "Entry '…' is written inline … Run 'val validate --fix' to move it" — but offered no way to act on it, so the only remedy was to leave the editor and run the CLI. It now offers a quick fix that creates the `*.val.json` with the entry's content and rewrites the `.val.ts` to `c.json(() => import("./…"))`, in one undoable step.
+
+The fix is computed from the same code `val validate --fix` runs, so the two write the same files, and it is computed against the buffer you are looking at rather than what is on disk — an unsaved module can be fixed without saving first. It refuses, rather than overwriting, when a file or an unsaved buffer already occupies the target path.
+
+Requires an editor that honours file creation inside a workspace edit; VS Code does. In an editor that does not announce it, no action is offered rather than one that would rewrite the module to import a file that never got created.

--- a/packages/language-server/src/__testHelpers__/lspClient.ts
+++ b/packages/language-server/src/__testHelpers__/lspClient.ts
@@ -55,10 +55,22 @@ export type LspCompletionItem = {
   data?: unknown;
 };
 
+/** A `documentChanges` entry: either a resource operation or a document's edits. */
+export type LspDocumentChange =
+  | { kind: "create" | "delete"; uri: string }
+  | { kind: "rename"; oldUri: string; newUri: string }
+  | {
+      textDocument: { uri: string; version: number | null };
+      edits: LspTextEdit[];
+    };
+
 export type LspCodeAction = {
   title: string;
   kind?: string;
-  edit?: { changes?: Record<string, LspTextEdit[]> };
+  edit?: {
+    changes?: Record<string, LspTextEdit[]>;
+    documentChanges?: LspDocumentChange[];
+  };
 };
 
 export type LspSession = {
@@ -95,7 +107,16 @@ const SHUTDOWN_DEADLINE_MS = 2_000;
 
 export async function startLspSession({
   valRoot = EXAMPLE_APP,
-}: { valRoot?: string } = {}): Promise<LspSession> {
+  capabilities = {},
+}: {
+  valRoot?: string;
+  /**
+   * `InitializeParams.capabilities`. Defaults to `{}` — the bare client a
+   * hand-written LSP config sends. Pass something here to exercise a fix that
+   * is gated on a capability, e.g. `workspace.workspaceEdit.resourceOperations`.
+   */
+  capabilities?: Record<string, unknown>;
+} = {}): Promise<LspSession> {
   let child: ChildProcessWithoutNullStreams | undefined = spawn(
     process.execPath,
     [BIN, "--stdio"],
@@ -137,7 +158,7 @@ export async function startLspSession({
   }>("initialize", {
     processId: process.pid,
     rootUri: `file://${valRoot}`,
-    capabilities: {},
+    capabilities,
     initializationOptions: {
       client: { name: "lsp-test-client", version: "0.0.0" },
       supportedProtocolVersions: { min: 1, max: PROTOCOL_VERSION },

--- a/packages/language-server/src/clientCapabilities.ts
+++ b/packages/language-server/src/clientCapabilities.ts
@@ -1,0 +1,30 @@
+/**
+ * What the client announced it will do with a `WorkspaceEdit`.
+ *
+ * A resource operation — a file created, renamed or deleted as part of an edit —
+ * is silently DROPPED by a client that did not announce it. The rest of the edit
+ * still applies, so a fix that needs one and is offered anyway leaves the
+ * project in a state that is worse than the one it set out to fix: a `.val.ts`
+ * rewritten to import a file that was never created, a path rewritten to a file
+ * that never moved. Hence: probe first, and do not offer the action at all.
+ *
+ * Read defensively. These come from `InitializeParams.capabilities`, which is
+ * whatever the client sent — this is the one place that has to cope with the
+ * field being absent or the wrong shape.
+ */
+export function supportsResourceOperation(
+  capabilities: unknown,
+  operation: "create" | "rename" | "delete",
+): boolean {
+  const workspace = (
+    capabilities as
+      | {
+          workspace?: {
+            workspaceEdit?: { resourceOperations?: unknown };
+          };
+        }
+      | undefined
+  )?.workspace;
+  const operations = workspace?.workspaceEdit?.resourceOperations;
+  return Array.isArray(operations) && operations.includes(operation);
+}

--- a/packages/language-server/src/codeActions.ts
+++ b/packages/language-server/src/codeActions.ts
@@ -1,5 +1,7 @@
 import {
   DEFAULT_VAL_REMOTE_HOST,
+  Internal,
+  type Json,
   type ModuleFilePath,
   type SourcePath,
   type ValidationError,
@@ -9,6 +11,7 @@ import { result } from "@valbuild/core/fp";
 import {
   createFixPatch,
   patchSourceFile,
+  planJsonValuesEntryExtraction,
   type FixHandlerResult,
 } from "@valbuild/server";
 import {
@@ -33,6 +36,7 @@ import {
 } from "./valModulesRegistry";
 import type { ValModuleContent } from "./ValProject";
 import { jsonEntryEditFor, type JsonEntryEdit } from "./jsonEntryEdit";
+import { supportsResourceOperation } from "./clientCapabilities";
 import { minimalTextEdit } from "./textEdit";
 
 // Re-exported: it lives in its own module so that `commands.ts` can use it
@@ -41,7 +45,7 @@ export { minimalTextEdit };
 import fs from "fs";
 import path from "path";
 import ts from "typescript";
-import { pathToUri } from "./uri";
+import { pathToUri, uriToPath } from "./uri";
 
 /**
  * Quick fixes, built by running Val's own fix machinery.
@@ -72,6 +76,20 @@ const LOCAL_FIXES: readonly ValidationFix[] = [
   "files:check-all-files",
 ];
 
+/**
+ * Fixes that are local, but are NOT a patch against the document they are
+ * reported on, so they never reach `computeFixEdit`.
+ *
+ * `jsonValues:extract-entry` creates a file and rewrites another — see
+ * {@link createExtractEntryAction}. `createFixPatch` has no branch for it at all
+ * (the fix lives in the server's own `extractJsonValuesEntry`), so routing it
+ * through the patch pipeline would silently produce an empty patch and no
+ * action, which is exactly what it did before this existed.
+ */
+const WORKSPACE_EDIT_FIXES: readonly ValidationFix[] = [
+  "jsonValues:extract-entry",
+];
+
 /** Human-readable titles; falls back to the fix name for anything unknown. */
 const FIX_TITLES: Partial<Record<ValidationFix, string>> = {
   "image:add-metadata": "Val: add image metadata",
@@ -80,10 +98,20 @@ const FIX_TITLES: Partial<Record<ValidationFix, string>> = {
   "file:check-metadata": "Val: update file metadata",
   "images:check-all-files": "Val: update gallery image metadata",
   "files:check-all-files": "Val: update gallery file metadata",
+  "jsonValues:extract-entry": "Val: move entry into its own .val.json",
 };
 
 export function isLocalFix(fix: string): fix is ValidationFix {
   return (LOCAL_FIXES as readonly string[]).includes(fix);
+}
+
+export function isWorkspaceEditFix(fix: string): fix is ValidationFix {
+  return (WORKSPACE_EDIT_FIXES as readonly string[]).includes(fix);
+}
+
+/** Whether the client will honour a file CREATE inside a `WorkspaceEdit`. */
+export function canCreateFiles(capabilities: unknown): boolean {
+  return supportsResourceOperation(capabilities, "create");
 }
 
 /**
@@ -110,6 +138,7 @@ export async function createValCodeActions({
   moduleFilePath,
   read,
   remoteHost = process.env.VAL_REMOTE_HOST || DEFAULT_VAL_REMOTE_HOST,
+  allowCreateFiles = false,
 }: {
   document: TextDocument;
   diagnostics: Diagnostic[];
@@ -128,6 +157,11 @@ export async function createValCodeActions({
    */
   read?: (fsPath: string) => string | undefined;
   remoteHost?: string;
+  /**
+   * Whether the client honours a file CREATE in a `WorkspaceEdit`. Without it
+   * the extract-entry fix is not offered at all — see {@link canCreateFiles}.
+   */
+  allowCreateFiles?: boolean;
 }): Promise<CodeAction[]> {
   const actions: CodeAction[] = [];
   /**
@@ -175,6 +209,26 @@ export async function createValCodeActions({
         });
         continue;
       }
+      if (isWorkspaceEditFix(fix)) {
+        if (offered.has(`${data.sourcePath}|${fix}`)) {
+          continue;
+        }
+        const action = createExtractEntryAction({
+          document,
+          sourcePath: data.sourcePath as SourcePath,
+          content,
+          valRoot,
+          moduleFilePath,
+          read,
+          allowCreateFiles,
+        });
+        if (!action) {
+          continue;
+        }
+        offered.add(`${data.sourcePath}|${fix}`);
+        actions.push(action);
+        continue;
+      }
       if (!isLocalFix(fix)) {
         continue;
       }
@@ -218,6 +272,139 @@ export async function createValCodeActions({
   }
 
   return actions;
+}
+
+/**
+ * The quick fix for `jsonValues:extract-entry`: move an entry that was written
+ * inline in the `.val.ts` into its own `*.val.json`.
+ *
+ * Not a patch, and so not `computeFixEdit`. Two files change at once — a
+ * `*.val.json` is created with the entry's content, and the `.val.ts` has the
+ * inline value replaced by `c.json(() => import("./..."))` — and a `Patch` can
+ * only edit one `.val.ts` and cannot create anything. That is why the fix is
+ * `extractJsonValuesEntry` in the server rather than a `createFixPatch` branch,
+ * and why the editor had no fix to offer for it at all until now: the patch
+ * pipeline produced nothing and the action was dropped.
+ *
+ * The plan comes from the same `planJsonValuesEntryExtraction` that
+ * `val validate --fix` runs, so the two cannot write different files; only the
+ * last step differs. Here it is a `WorkspaceEdit`, so the change goes through
+ * the editor's undo stack, and — crucially — is computed against the buffer the
+ * user is looking at rather than what is on disk.
+ */
+function createExtractEntryAction({
+  document,
+  sourcePath,
+  content,
+  valRoot,
+  moduleFilePath,
+  read,
+  allowCreateFiles,
+}: {
+  document: TextDocument;
+  sourcePath: SourcePath;
+  content: ValModuleContent;
+  valRoot: string;
+  moduleFilePath?: ModuleFilePath;
+  read?: (fsPath: string) => string | undefined;
+  allowCreateFiles: boolean;
+}): CodeAction | undefined {
+  if (!moduleFilePath || !allowCreateFiles) {
+    return undefined;
+  }
+  const [, modulePath] = Internal.splitModuleFilePathAndModulePath(sourcePath);
+  const parts = Internal.splitModulePath(modulePath);
+  // Root-only by contract, exactly as the server's fix handler asserts: the
+  // entry is a direct child of the module's root record/router.
+  if (parts.length !== 1) {
+    return undefined;
+  }
+  const entryKey = parts[0];
+  const entryContent = entryContentOf(content.source, entryKey);
+  if (entryContent === undefined) {
+    return undefined;
+  }
+  const planned = planJsonValuesEntryExtraction({
+    moduleFilePath,
+    entryKey,
+    content: entryContent,
+    valTsPath: uriToPath(document.uri),
+    // The editor's text, not the file's: an edit computed against stale text
+    // has ranges that land in the wrong place.
+    valTsText: document.getText(),
+  });
+  if (result.isErr(planned)) {
+    return undefined;
+  }
+  const absoluteJsonPath = path.join(valRoot, planned.value.jsonPath);
+  // Same refusal as the CLI's, widened by one case: an unsaved buffer counts as
+  // occupied too. Creating over either would destroy content that a `--fix` run
+  // refuses to touch.
+  if (
+    read?.(absoluteJsonPath) !== undefined ||
+    fs.existsSync(absoluteJsonPath)
+  ) {
+    return undefined;
+  }
+  const valTsEdit = minimalTextEdit(
+    document.getText(),
+    planned.value.valTsContent,
+    document,
+  );
+  if (!valTsEdit) {
+    return undefined;
+  }
+  const jsonUri = pathToUri(absoluteJsonPath);
+  return {
+    title:
+      FIX_TITLES["jsonValues:extract-entry"] ??
+      "Val: move entry into its own .val.json",
+    kind: CodeActionKind.QuickFix,
+    edit: {
+      // `documentChanges`, not `changes`: a plain edit map cannot create a file,
+      // and an edit addressed to a file that does not exist is an error rather
+      // than a creation.
+      documentChanges: [
+        { kind: "create", uri: jsonUri },
+        {
+          textDocument: { uri: jsonUri, version: null },
+          edits: [
+            {
+              range: {
+                start: { line: 0, character: 0 },
+                end: { line: 0, character: 0 },
+              },
+              newText: planned.value.jsonContent,
+            },
+          ],
+        },
+        {
+          textDocument: { uri: document.uri, version: null },
+          edits: [valTsEdit],
+        },
+      ],
+    },
+  };
+}
+
+/**
+ * One entry's value out of a module's source.
+ *
+ * `Object.entries` rather than an index: the source is a `Source`, which has no
+ * index signature, and reading a dynamic key off it is the one thing this needs
+ * to do. Mirrors what the server's fix handler reads, so the editor extracts the
+ * same bytes `val validate --fix` would.
+ */
+function entryContentOf(source: unknown, entryKey: string): Json | undefined {
+  if (source === null || typeof source !== "object" || Array.isArray(source)) {
+    return undefined;
+  }
+  for (const [key, value] of Object.entries(source)) {
+    if (key === entryKey) {
+      return value;
+    }
+  }
+  return undefined;
 }
 
 async function computeFixEdit({

--- a/packages/language-server/src/extractEntryFix.test.ts
+++ b/packages/language-server/src/extractEntryFix.test.ts
@@ -1,0 +1,231 @@
+import fs from "fs";
+import path from "path";
+import { canCreateFiles } from "./codeActions";
+import {
+  startLspSession,
+  EXAMPLE_APP,
+  type LspCodeAction,
+  type LspDocumentChange,
+  type LspSession,
+  type LspTextEdit,
+  type PublishedDiagnostic,
+} from "./__testHelpers__/lspClient";
+
+jest.setTimeout(90000);
+
+/**
+ * The quick fix for an entry written inline in a `.jsonValues()` module.
+ *
+ * The language server has always PUBLISHED this diagnostic correctly — the
+ * `jsonValues:extract-entry` fix rode along in `data.fixes` — but offered no
+ * action for it, so the editor showed a warning telling the reader to go and run
+ * a CLI command. Two reasons, one behind the other: the fix was not in
+ * `LOCAL_FIXES`, and `createFixPatch` has no branch for it either, so adding it
+ * there would only have produced an empty patch and no action.
+ *
+ * What makes it different from every other quick fix is that it is not a patch
+ * at all: it CREATES the `*.val.json` and rewrites the `.val.ts` to import it.
+ */
+
+const MODULE_FILE = path.join(EXAMPLE_APP, "content", "jsonEntryMedia.val.ts");
+const MODULE_URI = `file://${MODULE_FILE}`;
+const ON_DISK = fs.readFileSync(MODULE_FILE, "utf8");
+
+/** The fixture, plus a second entry hand-authored inline. Buffer only, never written. */
+const INLINE_ENTRY_TEXT = ON_DISK.replace(
+  `    hero: c.json(() => import("./jsonEntryMedia/hero.val.json")),`,
+  `    hero: c.json(() => import("./jsonEntryMedia/hero.val.json")),\n` +
+    `    inlined: {\n` +
+    `      image: {\n` +
+    `        path: "/public/val/image.png",\n` +
+    `        width: 944,\n` +
+    `        height: 944,\n` +
+    `        mimeType: "image/png",\n` +
+    `      },\n` +
+    `    },`,
+);
+
+/** What the fixed `.val.ts` should say, and where the content should land. */
+const EXPECTED_IMPORT =
+  'c.json(() => import("./jsonEntryMedia/inlined.val.json"))';
+const EXPECTED_JSON_PATH = path.join(
+  EXAMPLE_APP,
+  "content",
+  "jsonEntryMedia",
+  "inlined.val.json",
+);
+
+/** A client that announces it will honour a file create inside a WorkspaceEdit. */
+const CAN_CREATE = {
+  workspace: { workspaceEdit: { resourceOperations: ["create", "rename"] } },
+};
+
+function isExtractAction(action: LspCodeAction): boolean {
+  return action.title.includes("move entry into its own");
+}
+
+function applyEdit(text: string, edit: LspTextEdit): string {
+  const lines = text.split("\n");
+  const offsetOf = (position: { line: number; character: number }) => {
+    let offset = 0;
+    for (let i = 0; i < position.line; i++) {
+      offset += lines[i].length + 1;
+    }
+    return offset + position.character;
+  };
+  return (
+    text.slice(0, offsetOf(edit.range.start)) +
+    edit.newText +
+    text.slice(offsetOf(edit.range.end))
+  );
+}
+
+function editsFor(
+  changes: LspDocumentChange[] | undefined,
+  uri: string,
+): LspTextEdit[] {
+  for (const change of changes ?? []) {
+    if ("textDocument" in change && change.textDocument.uri === uri) {
+      return change.edits;
+    }
+  }
+  return [];
+}
+
+describe("canCreateFiles", () => {
+  test("only true when the client announced the create operation", () => {
+    expect(canCreateFiles(CAN_CREATE)).toBe(true);
+    expect(
+      canCreateFiles({
+        workspace: { workspaceEdit: { resourceOperations: ["rename"] } },
+      }),
+    ).toBe(false);
+    expect(canCreateFiles({ workspace: { workspaceEdit: {} } })).toBe(false);
+    expect(canCreateFiles({})).toBe(false);
+    expect(canCreateFiles(undefined)).toBe(false);
+  });
+});
+
+describe("jsonValues:extract-entry quick fix", () => {
+  test("the fixture really is a jsonValues module with an inline entry", () => {
+    expect(INLINE_ENTRY_TEXT).not.toBe(ON_DISK);
+    expect(ON_DISK).toContain("jsonValues()");
+    // Nothing may exist at the target path, or the fix must refuse — the
+    // "refuses to overwrite" test below depends on this being true first.
+    expect(fs.existsSync(EXPECTED_JSON_PATH)).toBe(false);
+  });
+
+  describe("a client that can create files", () => {
+    let session: LspSession;
+    let diagnostics: PublishedDiagnostic[];
+    let actions: LspCodeAction[];
+
+    beforeAll(async () => {
+      session = await startLspSession({ capabilities: CAN_CREATE });
+      session.openDocument(MODULE_URI, INLINE_ENTRY_TEXT);
+      const published = await session.nextDiagnostics(MODULE_URI, (d) =>
+        d.diagnostics.some((x) =>
+          x.data?.fixes?.some((f) => f === "jsonValues:extract-entry"),
+        ),
+      );
+      diagnostics = published.diagnostics.filter((d) =>
+        d.data?.fixes?.some((f) => f === "jsonValues:extract-entry"),
+      );
+      actions = await session.requestCodeActions(MODULE_URI, diagnostics);
+    });
+
+    afterAll(async () => {
+      await session?.dispose();
+    });
+
+    test("the diagnostic carries the fix", () => {
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0].message).toContain("written inline");
+    });
+
+    test("offers exactly one extract action", () => {
+      expect(actions.filter(isExtractAction)).toHaveLength(1);
+    });
+
+    test("creates the *.val.json and fills it with the entry's content", () => {
+      const changes = actions.find(isExtractAction)?.edit?.documentChanges;
+      const jsonUri = `file://${EXPECTED_JSON_PATH}`;
+      // The create must come FIRST: an edit addressed to a file that does not
+      // exist yet is an error, not a creation.
+      expect(changes?.[0]).toEqual({ kind: "create", uri: jsonUri });
+
+      const [jsonEdit] = editsFor(changes, jsonUri);
+      expect(jsonEdit).toBeDefined();
+      expect(JSON.parse(jsonEdit.newText)).toEqual({
+        image: {
+          path: "/public/val/image.png",
+          width: 944,
+          height: 944,
+          mimeType: "image/png",
+        },
+      });
+    });
+
+    test("rewrites the .val.ts to import it, and nothing is written to disk", () => {
+      const changes = actions.find(isExtractAction)?.edit?.documentChanges;
+      const [valTsEdit] = editsFor(changes, MODULE_URI);
+      expect(valTsEdit).toBeDefined();
+
+      const fixed = applyEdit(INLINE_ENTRY_TEXT, valTsEdit);
+      expect(fixed).toContain(EXPECTED_IMPORT);
+      // The inline value is gone, and the entry that was already extracted is
+      // untouched.
+      expect(fixed).not.toContain('path: "/public/val/image.png"');
+      expect(fixed).toContain(
+        'hero: c.json(() => import("./jsonEntryMedia/hero.val.json"))',
+      );
+
+      // A quick fix is an edit, not a write: the buffer is unsaved, so the file
+      // on disk must still say what it said.
+      expect(fs.readFileSync(MODULE_FILE, "utf8")).toBe(ON_DISK);
+      expect(fs.existsSync(EXPECTED_JSON_PATH)).toBe(false);
+    });
+
+    test("refuses when something already lives at the target path", async () => {
+      // Not a hypothetical: the CLI's fix throws in this case rather than
+      // overwriting, and an editor that silently clobbered a file the CLI
+      // refuses to touch would be the more dangerous of the two.
+      fs.mkdirSync(path.dirname(EXPECTED_JSON_PATH), { recursive: true });
+      fs.writeFileSync(EXPECTED_JSON_PATH, '{ "image": { "path": "x" } }\n');
+      try {
+        const again = await session.requestCodeActions(MODULE_URI, diagnostics);
+        expect(again.filter(isExtractAction)).toHaveLength(0);
+      } finally {
+        fs.rmSync(EXPECTED_JSON_PATH);
+      }
+    });
+  });
+
+  describe("a client that cannot create files", () => {
+    let session: LspSession;
+
+    beforeAll(async () => {
+      session = await startLspSession();
+    });
+
+    afterAll(async () => {
+      await session?.dispose();
+    });
+
+    test("is offered nothing, rather than an edit that half-applies", async () => {
+      // A create the client drops leaves the `.val.ts` importing a file that
+      // does not exist — a module that no longer loads. Worse than the warning.
+      session.openDocument(MODULE_URI, INLINE_ENTRY_TEXT);
+      const published = await session.nextDiagnostics(MODULE_URI, (d) =>
+        d.diagnostics.some((x) =>
+          x.data?.fixes?.some((f) => f === "jsonValues:extract-entry"),
+        ),
+      );
+      const actions = await session.requestCodeActions(
+        MODULE_URI,
+        published.diagnostics,
+      );
+      expect(actions.filter(isExtractAction)).toHaveLength(0);
+    });
+  });
+});

--- a/packages/language-server/src/galleryFixes.ts
+++ b/packages/language-server/src/galleryFixes.ts
@@ -27,6 +27,7 @@ import {
 import type { TextDocument } from "vscode-languageserver-textdocument";
 import { extractFileMetadata, extractImageMetadata } from "@valbuild/server";
 import type { GalleryMembership } from "./diagnostics";
+import { supportsResourceOperation } from "./clientCapabilities";
 import { pathToUri } from "./uri";
 
 /**
@@ -37,17 +38,7 @@ import { pathToUri } from "./uri";
  * was — worse than not offering the fix.
  */
 export function canRenameFiles(capabilities: unknown): boolean {
-  const workspace = (
-    capabilities as
-      | {
-          workspace?: {
-            workspaceEdit?: { resourceOperations?: unknown };
-          };
-        }
-      | undefined
-  )?.workspace;
-  const operations = workspace?.workspaceEdit?.resourceOperations;
-  return Array.isArray(operations) && operations.includes("rename");
+  return supportsResourceOperation(capabilities, "rename");
 }
 
 export async function createGalleryMembershipActions({

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -45,6 +45,7 @@ import {
   createValCodeActions,
   createMissingModuleCodeAction,
   adjudicateGalleryCheck,
+  canCreateFiles as clientCanCreateFiles,
 } from "./codeActions";
 import { createValCompletions, resolveValCompletion } from "./completions";
 import { createValCommands, valCommandNames } from "./commands";
@@ -253,6 +254,7 @@ export function createValLanguageServer(connection: Connection): {
   const documents = new TextDocuments(TextDocument);
   let canRegisterWatchers = false;
   let canRenameFiles = false;
+  let canCreateFiles = false;
 
   /**
    * The editor's view of a file, by absolute path, or `undefined` when the file
@@ -434,6 +436,10 @@ export function createValLanguageServer(connection: Connection): {
     // A RenameFile sent to a client that did not announce resourceOperations is
     // silently dropped, which would rewrite the path and leave the file behind.
     canRenameFiles = clientCanRenameFiles(params.capabilities);
+    // Same reasoning for the extract-entry fix: it CREATES the `*.val.json` the
+    // rewritten `.val.ts` imports, so a client that drops the create would be
+    // left importing a file that is not there.
+    canCreateFiles = clientCanCreateFiles(params.capabilities);
 
     const clientCapabilities: ValClientCapabilities =
       (
@@ -695,6 +701,7 @@ export function createValLanguageServer(connection: Connection): {
           valRoot: project.valRoot,
           moduleFilePath,
           read: readOpenDocument,
+          allowCreateFiles: canCreateFiles,
         })),
       );
       return actions;

--- a/packages/server/src/extractJsonValuesEntry.test.ts
+++ b/packages/server/src/extractJsonValuesEntry.test.ts
@@ -1,0 +1,106 @@
+import type { Json, ModuleFilePath } from "@valbuild/core";
+import { result } from "@valbuild/core/fp";
+import { planJsonValuesEntryExtraction } from "./extractJsonValuesEntry";
+
+const MODULE_FILE_PATH = "/content/blogs.val.ts" as ModuleFilePath;
+const VAL_TS_PATH = "/project/content/blogs.val.ts";
+
+const valTs = (entries: string) => `import { c, s } from "../val.config";
+
+export default c.define(
+  "/content/blogs.val.ts",
+  s.record(s.object({ title: s.string() })).jsonValues(),
+  {
+${entries}
+  },
+);
+`;
+
+function plan(entries: string, entryKey: string, content: Json) {
+  return planJsonValuesEntryExtraction({
+    moduleFilePath: MODULE_FILE_PATH,
+    entryKey,
+    content,
+    valTsPath: VAL_TS_PATH,
+    valTsText: valTs(entries),
+  });
+}
+
+describe("planJsonValuesEntryExtraction", () => {
+  const ENTRIES = [
+    `    "/kept": c.json(() => import("./blogs/kept.val.json")),`,
+    `    "/inline": { title: "Written inline" },`,
+  ].join("\n");
+
+  test("derives the canonical file path and the import that reaches it", () => {
+    const planned = plan(ENTRIES, "/inline", { title: "Written inline" });
+    if (result.isErr(planned)) {
+      throw Error(planned.error);
+    }
+    expect(planned.value.jsonPath).toBe("/content/blogs/inline.val.json");
+    expect(planned.value.valTsContent).toContain(
+      'c.json(() => import("./blogs/inline.val.json"))',
+    );
+    expect(planned.value.valTsPath).toBe(VAL_TS_PATH);
+  });
+
+  test("moves the value out of the .val.ts and into the JSON, unchanged", () => {
+    const content = { title: "Written inline" };
+    const planned = plan(ENTRIES, "/inline", content);
+    if (result.isErr(planned)) {
+      throw Error(planned.error);
+    }
+    expect(JSON.parse(planned.value.jsonContent)).toEqual(content);
+    // Trailing newline: the file is written to a repo, and `--fix` output that
+    // every formatter immediately rewrites is noise in the next diff.
+    expect(planned.value.jsonContent.endsWith("\n")).toBe(true);
+    expect(planned.value.valTsContent).not.toContain("Written inline");
+    // The entry that was already extracted is left exactly as it was.
+    expect(planned.value.valTsContent).toContain(
+      'c.json(() => import("./blogs/kept.val.json"))',
+    );
+  });
+
+  test("leaves non-ASCII text elsewhere in the module alone", () => {
+    // The fix must touch one entry and nothing else. The ops splice printed text
+    // into the existing source rather than reprinting the file, so today this
+    // holds for free — pinned because `neverAsciiEscape` is off in the printer,
+    // and a change to how the ops produce text would otherwise turn every æøå in
+    // a Norwegian module into a `\uXXXX` escape, silently, in an unrelated diff.
+    const entries = [
+      `    "/nb": { title: "Så høyt på en gren" },`,
+      `    "/inline": { title: "Written inline" },`,
+    ].join("\n");
+    const planned = plan(entries, "/inline", { title: "Written inline" });
+    if (result.isErr(planned)) {
+      throw Error(planned.error);
+    }
+    expect(planned.value.valTsContent).toContain("Så høyt på en gren");
+    expect(planned.value.valTsContent).not.toContain("\\u");
+  });
+
+  test("refuses an entry key that would escape the module's own directory", () => {
+    const entries = `    "/../../etc/passwd": { title: "nope" },`;
+    const planned = plan(entries, "/../../etc/passwd", { title: "nope" });
+    expect(result.isErr(planned)).toBe(true);
+    if (result.isErr(planned)) {
+      expect(planned.error).toContain("resolves outside");
+    }
+  });
+
+  test("reports a key that is not in the record instead of inventing one", () => {
+    const planned = plan(ENTRIES, "/missing", { title: "nope" });
+    expect(result.isErr(planned)).toBe(true);
+    if (result.isErr(planned)) {
+      expect(planned.error).toContain(VAL_TS_PATH);
+    }
+  });
+
+  test("says nothing about whether the target exists — that is the caller's", () => {
+    // Deliberate: the CLI asks the filesystem, the editor also has to count an
+    // unsaved buffer as occupied. A check in here would answer only one of them,
+    // and the planner would need a filesystem it has no other use for.
+    const planned = plan(ENTRIES, "/inline", { title: "Written inline" });
+    expect(result.isOk(planned)).toBe(true);
+  });
+});

--- a/packages/server/src/extractJsonValuesEntry.ts
+++ b/packages/server/src/extractJsonValuesEntry.ts
@@ -15,18 +15,103 @@ import {
 } from "./patch/ts/syntax";
 
 /**
+ * The two files an extraction touches, as text — nothing written yet.
+ *
+ * Both paths are project-relative in the `ModuleFilePath` style (a leading
+ * slash), because that is what the callers already hold and what
+ * {@link getNewJsonEntryPaths} derives. Join them onto the project root to get
+ * somewhere to write.
+ */
+export type JsonValuesEntryExtraction = {
+  /** The `*.val.json` to CREATE. It must not already exist — see the note below. */
+  jsonPath: string;
+  jsonContent: string;
+  /** The `.val.ts` to rewrite, and its complete new text. */
+  valTsPath: string;
+  valTsContent: string;
+};
+
+/**
+ * Works out what moving ONE inline `.jsonValues()` entry into its own
+ * `*.val.json` would change, without changing anything.
+ *
+ * This is the whole fix for `jsonValues:extract-entry`, minus the writing. It
+ * is split out because the two callers cannot share a way of applying it: the
+ * CLI writes both files ({@link extractJsonValuesEntry}), while the editor has
+ * to hand the same two changes back as a `WorkspaceEdit` so they go through the
+ * undo stack and respect an unsaved buffer. Anything that lived in only one of
+ * those would be a fix that behaves differently depending on where it was
+ * invoked from, which is exactly the drift `codeActions.ts` exists to prevent.
+ *
+ * It does NOT check whether `jsonPath` already exists: that needs a filesystem,
+ * and the editor's answer ("is there a buffer or a file here?") is not the
+ * CLI's. Every caller must check before writing — overwriting an unrelated file
+ * is not a fix.
+ *
+ * Root-only, like the rest of the `.jsonValues()` machinery: the entry is looked
+ * up in the module's root record/router object literal.
+ */
+export function planJsonValuesEntryExtraction({
+  moduleFilePath,
+  entryKey,
+  content,
+  valTsPath,
+  valTsText,
+}: {
+  moduleFilePath: ModuleFilePath;
+  entryKey: string;
+  /** The entry's value, as it is written inline in the `.val.ts`. */
+  content: Json;
+  /** Where the `.val.ts` lives, for error messages. */
+  valTsPath: string;
+  /** Its text — the editor's version of it, where there is an editor. */
+  valTsText: string;
+}): result.Result<JsonValuesEntryExtraction, string> {
+  const pathsRes = getNewJsonEntryPaths(moduleFilePath, entryKey);
+  if (result.isErr(pathsRes)) {
+    return result.err(formatPatchSourceError(pathsRes.error));
+  }
+  const { jsonPath, importPath } = pathsRes.value;
+  const sourceFile = ts.createSourceFile(
+    valTsPath,
+    valTsText,
+    ts.ScriptTarget.ES2020,
+  );
+
+  // Remove the inline property, then add the `c.json(...)` reference back. The
+  // entry moves to the end of the record: entry ORDER in a jsonValues record is
+  // not meaningful (the Studio and the runtime key entries by name), and
+  // insert-in-place would mean reimplementing insertValJsonEntry.
+  const removed = removeValJsonEntry(sourceFile, [], entryKey);
+  if (result.isErr(removed)) {
+    return result.err(
+      `${valTsPath}\n${formatOpsError(removed.error, sourceFile)}`,
+    );
+  }
+  const inserted = insertValJsonEntry(removed.value, [], entryKey, importPath);
+  if (result.isErr(inserted)) {
+    return result.err(
+      `${valTsPath}\n${formatOpsError(inserted.error, removed.value)}`,
+    );
+  }
+  return result.ok({
+    jsonPath,
+    jsonContent: JSON.stringify(content, null, 2) + "\n",
+    valTsPath,
+    valTsContent: printSourceFile(inserted.value),
+  });
+}
+
+/**
  * Moves ONE `.jsonValues()` entry that was written inline in the `.val.ts` into
  * its own `*.val.json`, replacing the inline value with
  * `c.json(() => import("./<key>.val.json"))`.
  *
- * This is the fix for the `jsonValues:extract-entry` validation error. It is not
- * expressible as a patch (a patch edits one `.val.ts` and cannot create the
+ * The `val validate --fix` half of {@link planJsonValuesEntryExtraction}. It is
+ * not expressible as a patch (a patch edits one `.val.ts` and cannot create the
  * backing JSON file), so it writes both files directly — JSON first, so a
  * failure part-way through never leaves the module pointing at a file that does
  * not exist.
- *
- * Root-only, like the rest of the `.jsonValues()` machinery: the entry is looked
- * up in the module's root record/router object literal.
  */
 export function extractJsonValuesEntry(
   moduleFilePath: ModuleFilePath,
@@ -43,43 +128,50 @@ export function extractJsonValuesEntry(
       .replace(".val.jsx", ".val")
       .replace(".val.tsx", ".val")}`,
   );
-  const sourceFile = sourceFileHandler.getSourceFile(valTsPath);
-  if (!sourceFile) {
+  const valTsText = sourceFileHandler.host.readFile(valTsPath);
+  if (valTsText === undefined) {
     throw Error(`Source file ${valTsPath} not found`);
   }
-  const pathsRes = getNewJsonEntryPaths(moduleFilePath, entryKey);
-  if (result.isErr(pathsRes)) {
-    throw Error(formatPatchSourceError(pathsRes.error));
+  const planned = planJsonValuesEntryExtraction({
+    moduleFilePath,
+    entryKey,
+    content,
+    valTsPath,
+    valTsText,
+  });
+  if (result.isErr(planned)) {
+    throw Error(planned.error);
   }
-  const { jsonPath, importPath } = pathsRes.value;
-  const absoluteJsonPath = path.join(rootDir, jsonPath);
+  const absoluteJsonPath = path.join(rootDir, planned.value.jsonPath);
   if (sourceFileHandler.host.fileExists(absoluteJsonPath)) {
     throw Error(
-      `Cannot extract .jsonValues() entry '${entryKey}' of ${moduleFilePath}: '${jsonPath}' already exists`,
-    );
-  }
-
-  // Remove the inline property, then add the `c.json(...)` reference back. The
-  // entry moves to the end of the record: entry ORDER in a jsonValues record is
-  // not meaningful (the Studio and the runtime key entries by name), and
-  // insert-in-place would mean reimplementing insertValJsonEntry.
-  const removed = removeValJsonEntry(sourceFile, [], entryKey);
-  if (result.isErr(removed)) {
-    throw Error(`${valTsPath}\n${formatOpsError(removed.error, sourceFile)}`);
-  }
-  const inserted = insertValJsonEntry(removed.value, [], entryKey, importPath);
-  if (result.isErr(inserted)) {
-    throw Error(
-      `${valTsPath}\n${formatOpsError(inserted.error, removed.value)}`,
+      `Cannot extract .jsonValues() entry '${entryKey}' of ${moduleFilePath}: '${planned.value.jsonPath}' already exists`,
     );
   }
 
   sourceFileHandler.writeFile(
     absoluteJsonPath,
-    JSON.stringify(content, null, 2) + "\n",
+    planned.value.jsonContent,
     "utf8",
   );
-  sourceFileHandler.writeSourceFile(inserted.value);
+  sourceFileHandler.writeFile(valTsPath, planned.value.valTsContent, "utf8");
+}
+
+/**
+ * The text of a source file the TS ops produced, exactly as
+ * `ValSourceFileHandler.writeSourceFile` would have written it.
+ *
+ * The unescape undoes the printer's `\uXXXX` output for non-ASCII. Today the
+ * ops splice printed text into `document.text` and this fix only ever prints an
+ * ASCII `c.json(() => import("./..."))`, so nothing here is escaped and the
+ * unescape is a no-op — but `neverAsciiEscape` is off in the printer, so that is
+ * a property of what this fix happens to print, not a guarantee. Kept because
+ * this replaced a `writeSourceFile` call and the text written must not change.
+ *
+ * https://github.com/microsoft/TypeScript/issues/36174
+ */
+function printSourceFile(sourceFile: ts.SourceFile): string {
+  return unescape(sourceFile.text.replace(/\\u/g, "%u"));
 }
 
 function formatOpsError(

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -156,7 +156,15 @@ export { findJsonEntryFilePath } from "./jsonEntryLocation";
 // which file an edit belongs in.
 export { classifyJsonValuesOp, rebaseContentOp } from "./patch/jsonValuesPatch";
 export type { JsonValuesOpClass } from "./patch/jsonValuesPatch";
-export { extractJsonValuesEntry } from "./extractJsonValuesEntry";
+// `extractJsonValuesEntry` writes both files; `planJsonValuesEntryExtraction`
+// works out the same two changes as text so the editor can hand them back as a
+// `WorkspaceEdit` instead. Same reasoning as the pair above: one implementation,
+// two ways of applying it.
+export {
+  extractJsonValuesEntry,
+  planJsonValuesEntryExtraction,
+} from "./extractJsonValuesEntry";
+export type { JsonValuesEntryExtraction } from "./extractJsonValuesEntry";
 export type { ModulePathMap } from "./modulePathMap";
 // Exposed for the CLI's `debug` command and the snapshot replay harness, which
 // need to drive the same ops the app's api routes drive.


### PR DESCRIPTION
## The bug

An entry hand-written inline in a `.jsonValues()` module gets a warning in VS Code and nothing else — the message tells the reader to go and run a CLI command, and there is no quick fix on the lightbulb.

The language server has always *published* the diagnostic correctly. Driving a real LSP session against `main`:

```json
"message": "Entry 'inlined' is written inline in ... Run 'val validate --fix' to move it.",
"data": { "fixes": ["jsonValues:extract-entry"], ... }
```

```
CODE ACTIONS: []
```

Two reasons, one behind the other:

1. `codeActions.ts` filters through `LOCAL_FIXES`, which lists only the six image/file/gallery metadata fixes. `git log -S` says `jsonValues:extract-entry` was never in it.
2. Adding it there alone would not have helped. Quick fixes are built as `createFixPatch → Patch → patchSourceFile → TextEdit`, and `createFixPatch` has no branch for this fix at all — the implementation is `extractJsonValuesEntry` in `packages/server`. The pipeline would have produced an empty patch and dropped the action.

## Why it needed more than a list entry

This fix is not a patch. It **creates** a `*.val.json` with the entry's content and **rewrites** the `.val.ts` to `c.json(() => import("./…"))`. A `Patch` edits one `.val.ts` and cannot create anything, and `computeFixEdit` returns a single `{uri, edit}`. `extractJsonValuesEntry` also writes to disk directly, which a code action must never do — the LS deliberately calls fix handlers with `fix: false` so nothing is written behind the editor's back.

So `extractJsonValuesEntry` splits in two:

- `planJsonValuesEntryExtraction` — pure, text in and text out: the JSON file's path and content, the `.val.ts` path and its new text. It deliberately does not ask whether the target exists; that needs a filesystem, and the editor's answer is not the CLI's.
- `extractJsonValuesEntry` — unchanged behaviour, now `plan` + the two writes.

The editor then turns the same plan into a `WorkspaceEdit`: a `create`, an edit filling the new file, and an edit on the `.val.ts`. One implementation, two ways of applying it — the same split as `classifyJsonValuesOp`/`rebaseContentOp` already use, and the reason `codeActions.ts` routes through Val's own fix machinery in the first place.

## Editor-specific behaviour, deliberately

- **Plans against the buffer, not the file.** An unsaved module can be fixed without saving first, and the edit's ranges are computed against the text the user is actually looking at.
- **Refuses on an occupied target — one case wider than the CLI.** `--fix` throws rather than overwrite an existing file; the editor counts an unsaved buffer as occupied too. Silently clobbering what the CLI will not touch would be the more dangerous of the two.
- **Gated on the client announcing the `create` resource operation.** A create that the client drops leaves the `.val.ts` importing a file that was never created — a module that no longer loads, which is worse than the warning it replaced. So no action is offered there at all. `vscode-languageclient` announces `resourceOperations: [Create, Rename, Delete]` unconditionally (verified in 10.1.1, which the extension uses without overriding), and the existing gallery-move fix already depends on the same mechanism, so **no change is needed in `valbuild/vscode-val-build`.**

The `canRenameFiles` probe from `galleryFixes.ts` moved into a shared `clientCapabilities.ts` alongside the new `canCreateFiles`; `canRenameFiles` keeps its export and its behaviour.

## Verification

- `extractEntryFix.test.ts` drives a real LSP session end to end: the diagnostic arrives, exactly one action is offered, the `create` comes first, the JSON carries the entry's content, applying the `.val.ts` edit yields the `c.json(() => import(...))` form with the already-extracted sibling untouched, and **nothing is written to disk**. Plus the two refusals — target occupied, and a client that cannot create files. Three of these fail if the fix is unregistered.
- `extractJsonValuesEntry.test.ts` covers the planner: derived path and import, content moved verbatim, an entry key that would escape the module's directory refused, a missing key reported.
- The CLI path is unchanged: `val validate --root examples/next` is byte-identical to `main` (`2 errors (1 fixable) across 2 files · 20 valid · 1 skipped`) from `src/` and via `bin.js`, and `--fix` on the fixture produces the same `.val.ts` and `*.val.json` as before.
- Full CI locally: lint, `prettier --check`, `-r typecheck`, `pnpm test` (3537 passed), root `build`, `examples/next` build.

Second of two. The first, [#621](https://github.com/valbuild/val/pull/621), fixes the unrelated bug with the same symptom on the CLI side (`npx @valbuild/cli validate` skipping the check entirely).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jzwhh37RHxQSuCjkgRdXN

---
_Generated by [Claude Code](https://claude.ai/code/session_013jzwhh37RHxQSuCjkgRdXN)_