### PR TITLE
Republish @valbuild/mcp: 0.123.0 cannot be installed

### DIFF
--- a/.agent/rules.md
+++ b/.agent/rules.md
@@ -679,6 +679,71 @@ until someone bumps it. So, once the new version is on npm:
    shows up here first, and this is the last place to catch it before it is what
    every new project starts from.
 
+### Publishing a package for the FIRST time
+
+A new package cannot be published by CI, and the failure looks like nothing to do
+with that:
+
+```
+@valbuild/mcp@0.123.0
+└ E404: Not Found - PUT https://registry.npmjs.org/@valbuild%2fmcp - Not found
+  The requested resource '@valbuild/mcp@0.123.0' could not be found or you do not
+  have permission to access it.
+```
+
+The Release workflow publishes with npm trusted publishing (OIDC), and a trusted
+publisher configuration is **per package** — so a package that has never been
+published has none, and the OIDC token has no permission to create it. npm answers
+a PUT it will not authorize with 404 rather than 403, which is why this reads as
+"missing" rather than "forbidden". There is no way to pre-register the name:
+npm has no reserve-a-name flow, and the org's Teams → Add package screen only
+enumerates packages the org already owns. Nothing is staged, so — unlike the
+E401 below — there is nothing to approve and the version number is not burned.
+
+`changeset publish` goes in dependency order and stops at the failure, so every
+package that depends on the new one is never attempted. Expect a half-published
+release: fix the new package, then re-run the job, and `changeset publish` picks
+up exactly what is missing.
+
+**Bootstrap it by hand, and use `pnpm publish`:**
+
+```bash
+pnpm install && pnpm run build     # `files` ships only dist/, so build first
+cd packages/<new-package>
+pnpm publish --access public --no-git-checks
+pnpm preconstruct dev              # back in the repo root, restore dev entries
+```
+
+`--access public` because a scoped package's first publish defaults to
+_restricted_, and a restricted package 404s for everyone else — indistinguishable
+from not existing. A brand-new package also takes up to a couple of minutes to
+become publicly readable, so a 404 right after a successful publish is usually
+just the read path catching up.
+
+**`pnpm publish`, never `npm publish`.** This is the one that cost a release.
+Every package here declares its siblings as `"@valbuild/x": "workspace:*"`, and
+that protocol is rewritten to a real version **at pack time by pnpm**. `npm
+publish` uploads the manifest verbatim, so the published package asks consumers
+to resolve `workspace:*` and cannot be installed by anything:
+
+```
+npm  → EUNSUPPORTEDPROTOCOL  Unsupported URL Type "workspace:": workspace:*
+pnpm → ERR_PNPM_WORKSPACE_PKG_NOT_FOUND
+```
+
+It is unfixable in place: npm versions are immutable, and unpublishing burns the
+number permanently rather than freeing it. Everything pinning that exact version
+— `@valbuild/next` pins its siblings exactly — is broken with it, so the recovery
+is a patch release of the bad package (changesets bumps the dependents for you),
+`npm deprecate` on both bad versions, and `npm dist-tag add <pkg>@<last good>
+latest` in the meantime so installs stop failing.
+
+Once the package exists, add its trusted publisher — the package page →
+Settings → Trusted publishing, organization `valbuild`, repository `val`,
+workflow `release.yml`, no environment, **`npm publish` ticked** — and CI handles
+it from then on, provenance included. The hand-published version is the only one
+without an attestation.
+
 ### The Release job fails with `E401 … Failed to generate Web Auth URLs`
 
 Symptom: `changeset publish` publishes some packages and then fails on one:

--- a/.changeset/republish-mcp-workspace-protocol.md
+++ b/.changeset/republish-mcp-workspace-protocol.md
@@ -1,0 +1,20 @@
+---
+"@valbuild/mcp": patch
+---
+
+Republish `@valbuild/mcp` with resolvable dependency versions.
+
+`@valbuild/mcp@0.123.0` shipped its manifest with the workspace protocol intact —
+`"@valbuild/core": "workspace:*"` and the same for `server` and `shared` — so it
+cannot be installed. npm refuses it with
+`EUNSUPPORTEDPROTOCOL: Unsupported URL Type "workspace:"`, and pnpm with
+`ERR_PNPM_WORKSPACE_PKG_NOT_FOUND`. `@valbuild/next@0.123.0` depends on that exact
+version, so it could not be installed either.
+
+Both of those versions are deprecated. Use this one.
+
+Nothing in the source was wrong: every package in the repository declares its
+siblings as `workspace:*` and the publish step rewrites them to real versions.
+That version was published by hand with `npm publish`, which uploads the manifest
+verbatim — the rewrite is pnpm's, and only `pnpm publish` (which is what
+`changeset publish` runs here) performs it.


### PR DESCRIPTION
`@valbuild/mcp@0.123.0` and `@valbuild/next@0.123.0` cannot be installed by anyone. `next` is on the `latest` tag, so **every new `npm install @valbuild/next` is currently failing.**

## What happened

`@valbuild/mcp@0.123.0`'s published manifest still carries the workspace protocol:

```json
"dependencies": {
  "@valbuild/core": "workspace:*",
  "@valbuild/server": "workspace:*",
  "@valbuild/shared": "workspace:*"
}
```

Verified against the registry with both package managers:

```
$ npm install @valbuild/mcp@0.123.0
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:*

$ pnpm add @valbuild/next@0.123.0
ERR_PNPM_WORKSPACE_PKG_NOT_FOUND  "@valbuild/core@workspace:*" is in the dependencies
  but no package named "@valbuild/core" is present in the workspace
This error happened while installing the dependencies of @valbuild/next@0.123.0
 at @valbuild/mcp@0.123.0
```

`@valbuild/next` pins its siblings exactly (`"@valbuild/mcp": "0.123.0"`), so it went down with it. `@valbuild/next@0.122.0` installs cleanly, and nothing else in the release is affected — `cli`, `ui`, `shared`, `server`, `react`, `language-server` and `create` don't depend on `mcp`, and their manifests carry real versions.

**Nothing in the source was wrong.** Every package here declares its siblings as `workspace:*` and relies on the publish step to rewrite them. That rewrite is pnpm's, done at pack time. `@valbuild/mcp@0.123.0` was published by hand with `npm publish`, which uploads the manifest verbatim — this would have happened to any package in the repo published that way.

## The fix

A single patch changeset. `changeset status` confirms it bumps `@valbuild/next` along with it, because changesets treats it as a dependent:

```
Packages to be bumped:
- patch
  - @valbuild/mcp
  - @valbuild/next
```

It cannot be repaired in place: npm versions are immutable, and unpublishing burns the number permanently rather than freeing it, so `0.123.0` stays broken forever for both packages.

## Before merging this

`@valbuild/mcp` now exists on npm, so it can finally have a trusted publisher — **add it before this merges**, or CI hits the same `E404` and we're back here: the package page → Settings → Trusted publishing, organization `valbuild`, repository `val`, workflow `release.yml`, no environment, **`npm publish` ticked under Allowed actions**.

## Alongside this, out-of-band

```sh
# Stop installs failing right now
npm dist-tag add @valbuild/next@0.122.0 latest

# Once 0.123.1 is out
npm deprecate @valbuild/mcp@0.123.0  "Unresolvable workspace: protocol in the manifest — use 0.123.1 or later"
npm deprecate @valbuild/next@0.123.0 "Requires the broken @valbuild/mcp@0.123.0 — use 0.123.1 or later"
```

Publishing `0.123.1` moves `latest` forward on its own, so the dist-tag change doesn't need undoing.

## Documentation

`CLAUDE.md`'s release section gains the two traps that produced this, both of which read as something else when you hit them:

1. **A package that has never been published cannot be published by CI.** Trusted publishing is configured per package, so a new one has no configuration and the OIDC token cannot create it. npm answers an unauthorized PUT with `404`, so it reads as "missing" rather than "forbidden". There's no reserve-a-name flow, and nothing gets staged — unlike the `E401` case already documented, there's nothing to approve.
2. **The hand bootstrap that therefore has to happen must use `pnpm publish`**, with `--access public`, because of the substitution above. The existing docs said nothing about it, which is exactly why this went out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GJADGAANbSxr2bgNLVu9d

---
_Generated by [Claude Code](https://claude.ai/code/session_019GJADGAANbSxr2bgNLVu9d)_