### PR TITLE
Stop the serialized-schema parser dropping schema metadata

### DIFF
--- a/.changeset/serialized-schema-parser-strip.md
+++ b/.changeset/serialized-schema-parser-strip.md
@@ -1,0 +1,32 @@
+---
+"@valbuild/shared": patch
+---
+
+Stop the serialized-schema parser dropping `customValidate`, `description`, `remote` and `referencedModule`
+
+`SerializedSchema` in `@valbuild/shared` is a zod mirror of the serialized
+schema type, and its `z.object`s strip keys they do not declare. Four fields
+were declared on some schemas and forgotten on others:
+
+- `customValidate` — missing on twelve of the eighteen schemas. This is the flag
+  that says a schema declares a `.validate()`; the function itself cannot
+  serialize, so the flag is the only thing that tells the Studio to run the
+  custom validators against the real instance.
+- `description` — missing on thirteen, so a `.describe()` went unseen.
+- `remote` and `referencedModule` — missing on `s.image()` and `s.file()`, so a
+  remote field read as local and a gallery-backed field lost the gallery it
+  reads its dimensions and mime type from.
+
+Because it strips rather than rejects, nothing failed and nothing said so. The
+live `/schema` route was unaffected — `ValClient` validates the response and
+then returns the raw JSON — but the history path consumes the parsed output, so
+in a commit or historical patch-set view (`getModuleAtCommit`,
+`getHistoricalPatchSet`) a schema's custom validators, description, remoteness
+and backing gallery all quietly disappeared.
+
+The fields every serialized schema shares are now spread from one
+`commonSchemaFields` object instead of being retyped eighteen times, which is
+how they drifted apart in the first place. A round-trip test walks each schema's
+serialized output against the parsed result and fails with the path of any key
+that did not survive, so a field added to a serialized schema and forgotten in
+the parser is caught without anyone having to remember to assert it.

--- a/.changeset/serialized-schema-parser-strip.md
+++ b/.changeset/serialized-schema-parser-strip.md
@@ -2,10 +2,10 @@
 "@valbuild/shared": patch
 ---
 
-Stop the serialized-schema parser dropping `customValidate`, `description`, `remote` and `referencedModule`
+Stop the serialized-schema parser dropping schema metadata
 
 `SerializedSchema` in `@valbuild/shared` is a zod mirror of the serialized
-schema type, and its `z.object`s strip keys they do not declare. Four fields
+schema type, and its `z.object`s strip keys they do not declare. Five fields
 were declared on some schemas and forgotten on others:
 
 - `customValidate` — missing on twelve of the eighteen schemas. This is the flag
@@ -16,6 +16,9 @@ were declared on some schemas and forgotten on others:
 - `remote` and `referencedModule` — missing on `s.image()` and `s.file()`, so a
   remote field read as local and a gallery-backed field lost the gallery it
   reads its dimensions and mime type from.
+- the `message` on a `.regexp(pattern, message)` — so a field with a custom
+  pattern message fell back to the generic "Expected string to match reg
+  exp: …".
 
 Because it strips rather than rejects, nothing failed and nothing said so. The
 live `/schema` route was unaffected — `ValClient` validates the response and

--- a/packages/shared/src/internal/zod/SerializedSchema.test.ts
+++ b/packages/shared/src/internal/zod/SerializedSchema.test.ts
@@ -157,12 +157,17 @@ describe("SerializedSchema keeps every field the schema wrote", () => {
     {},
   );
   const cases: [string, Schema<SelectorSource>][] = [
+    // `render` and `preview` are the two fields that moved into
+    // `commonSchemaFields`, so one case has to actually SERIALIZE them or
+    // deleting either line from that object leaves this whole suite green.
     [
       "string",
       s
         .string()
         .validate(() => false)
-        .describe("d"),
+        .describe("d")
+        .render({ as: "inline" })
+        .preview(({ val }) => ({ title: val })),
     ],
     // The regexp MESSAGE is a separate branch of the parser from the pattern,
     // and the case above does not reach it — which is exactly how it stayed

--- a/packages/shared/src/internal/zod/SerializedSchema.test.ts
+++ b/packages/shared/src/internal/zod/SerializedSchema.test.ts
@@ -69,6 +69,17 @@ describe("SerializedSchema round-trips", () => {
 });
 
 /**
+ * Narrowing instead of asserting: the repo avoids type assertions, and one here
+ * would claim an arbitrary `unknown` is indexable rather than checking it.
+ * `droppedKeys` tests `Array.isArray` before calling this, which is what keeps
+ * an array - an object too, as far as `typeof` is concerned - out of the record
+ * branch.
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+/**
  * Every key the serialized schema carried, or the paths of the ones that did
  * not survive.
  *
@@ -80,15 +91,6 @@ describe("SerializedSchema round-trips", () => {
  * Only checks that keys SURVIVE. A key the parser declares and the schema never
  * writes is not a bug, so extra keys on the parsed side are ignored.
  */
-/**
- * Narrowing instead of asserting: the repo avoids type assertions, and here one
- * would claim an arbitrary `unknown` is indexable rather than checking it. The
- * array branch below runs FIRST, so an array never reaches this.
- */
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object";
-}
-
 function droppedKeys(before: unknown, after: unknown, path = ""): string[] {
   if (Array.isArray(before)) {
     if (!Array.isArray(after)) {
@@ -128,13 +130,20 @@ function expectNothingDropped(schema: Schema<SelectorSource>) {
 
 /**
  * The parser used to declare `customValidate` and `description` on six of the
- * eighteen schemas and drop them on the other twelve, and to drop `remote` and
- * `referencedModule` on both media schemas. It is a strip rather than a
- * rejection, so nothing failed and nothing said so: on the history path - the
- * one place a parsed schema is consumed rather than merely validated
+ * eighteen schemas and drop them on the other twelve, to drop `remote` and
+ * `referencedModule` on both media schemas, and to drop the `message` on a
+ * `.regexp(pattern, message)`. It is a strip rather than a rejection, so
+ * nothing failed and nothing said so: on the history path - the one place a
+ * parsed schema is consumed rather than merely validated
  * (`getModuleAtCommit`, `getHistoricalPatchSet`) - a historical `.validate()`
- * stopped existing, a remote image read as local, and a gallery-backed field
- * lost the gallery it reads its metadata from.
+ * stopped existing, a remote image read as local, a gallery-backed field lost
+ * the gallery it reads its metadata from, and a custom pattern message fell
+ * back to the generic one.
+ *
+ * Each of those five was missed the same way: no case in this suite reached
+ * the branch. That is the failure mode to keep in mind when adding a field -
+ * the recursion is exhaustive over what a case SERIALIZES, not over the schema
+ * types that exist.
  */
 describe("SerializedSchema keeps every field the schema wrote", () => {
   const gallery = c.define(

--- a/packages/shared/src/internal/zod/SerializedSchema.test.ts
+++ b/packages/shared/src/internal/zod/SerializedSchema.test.ts
@@ -80,6 +80,15 @@ describe("SerializedSchema round-trips", () => {
  * Only checks that keys SURVIVE. A key the parser declares and the schema never
  * writes is not a bug, so extra keys on the parsed side are ignored.
  */
+/**
+ * Narrowing instead of asserting: the repo avoids type assertions, and here one
+ * would claim an arbitrary `unknown` is indexable rather than checking it. The
+ * array branch below runs FIRST, so an array never reaches this.
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
 function droppedKeys(before: unknown, after: unknown, path = ""): string[] {
   if (Array.isArray(before)) {
     if (!Array.isArray(after)) {
@@ -89,24 +98,21 @@ function droppedKeys(before: unknown, after: unknown, path = ""): string[] {
       droppedKeys(item, after[i], `${path}[${i}]`),
     );
   }
-  if (before !== null && typeof before === "object") {
-    if (after === null || typeof after !== "object") {
+  if (isRecord(before)) {
+    if (!isRecord(after)) {
       return [`${path}: object became ${String(after)}`];
     }
-    const parsed = after as Record<string, unknown>;
-    return Object.entries(before as Record<string, unknown>).flatMap(
-      ([key, value]) => {
-        // `executeSerialize` writes `undefined` for absent optional fields, and
-        // JSON drops those in transit anyway - not something to hold the parser to.
-        if (value === undefined) {
-          return [];
-        }
-        if (!(key in parsed)) {
-          return [`${path}.${key} (was ${JSON.stringify(value)})`];
-        }
-        return droppedKeys(value, parsed[key], `${path}.${key}`);
-      },
-    );
+    return Object.entries(before).flatMap(([key, value]) => {
+      // `executeSerialize` writes `undefined` for absent optional fields, and
+      // JSON drops those in transit anyway - not something to hold the parser to.
+      if (value === undefined) {
+        return [];
+      }
+      if (!(key in after)) {
+        return [`${path}.${key} (was ${JSON.stringify(value)})`];
+      }
+      return droppedKeys(value, after[key], `${path}.${key}`);
+    });
   }
   return [];
 }
@@ -136,6 +142,11 @@ describe("SerializedSchema keeps every field the schema wrote", () => {
     s.images({ directory: "/public/val" }),
     {},
   );
+  const filesGallery = c.define(
+    "/test/files-gallery.val.ts",
+    s.files({ accept: "application/pdf", directory: "/public/val/files" }),
+    {},
+  );
   const cases: [string, Schema<SelectorSource>][] = [
     [
       "string",
@@ -144,6 +155,14 @@ describe("SerializedSchema keeps every field the schema wrote", () => {
         .validate(() => false)
         .describe("d"),
     ],
+    // The regexp MESSAGE is a separate branch of the parser from the pattern,
+    // and the case above does not reach it — which is exactly how it stayed
+    // stripped through the first round of this fix.
+    [
+      "string with a regexp message",
+      s.string().regexp(/^a/, "Must start with a"),
+    ],
+    ["string with a bare regexp", s.string().regexp(/^a/)],
     [
       "literal",
       s
@@ -237,6 +256,10 @@ describe("SerializedSchema keeps every field the schema wrote", () => {
         .validate(() => false)
         .describe("d"),
     ],
+    // `referencedModule` on FILE is its own parser line; without this case
+    // deleting that line would still typecheck and every other case would
+    // still pass.
+    ["gallery-backed file", s.file(filesGallery).describe("d")],
     [
       "remote file",
       s
@@ -314,6 +337,29 @@ describe("SerializedSchema keeps every field the schema wrote", () => {
     expect(parsed.success && parsed.data).toMatchObject({
       type: "image",
       remote: true,
+    });
+  });
+
+  test("a regexp keeps the author's own message", () => {
+    const parsed = SerializedSchema.safeParse(
+      serialize(s.string().regexp(/^\d+$/, "Digits only, please")),
+    );
+    expect(parsed.success && parsed.data).toMatchObject({
+      type: "string",
+      options: { regexp: { message: "Digits only, please" } },
+    });
+  });
+
+  test("a gallery-backed file keeps its gallery", () => {
+    const files = c.define(
+      "/test/backing-files.val.ts",
+      s.files({ accept: "application/pdf", directory: "/public/val/files" }),
+      {},
+    );
+    const parsed = SerializedSchema.safeParse(serialize(s.file(files)));
+    expect(parsed.success && parsed.data).toMatchObject({
+      type: "file",
+      referencedModule: "/test/backing-files.val.ts",
     });
   });
 

--- a/packages/shared/src/internal/zod/SerializedSchema.test.ts
+++ b/packages/shared/src/internal/zod/SerializedSchema.test.ts
@@ -1,7 +1,7 @@
 import { initVal, Schema, SelectorSource } from "@valbuild/core";
 import { SerializedSchema } from "./SerializedSchema";
 
-const { s } = initVal();
+const { s, c } = initVal();
 
 /**
  * These z.objects STRIP unknown keys, so anything the serialized schema carries
@@ -64,6 +64,269 @@ describe("SerializedSchema round-trips", () => {
           },
         },
       },
+    });
+  });
+});
+
+/**
+ * Every key the serialized schema carried, or the paths of the ones that did
+ * not survive.
+ *
+ * Recursive, and driven by what `executeSerialize` actually produced rather
+ * than by a list kept here - which is the point. A field added to a serialized
+ * schema and forgotten in the parser fails this without anyone remembering to
+ * come back and assert it, and the failure names the path it was dropped from.
+ *
+ * Only checks that keys SURVIVE. A key the parser declares and the schema never
+ * writes is not a bug, so extra keys on the parsed side are ignored.
+ */
+function droppedKeys(before: unknown, after: unknown, path = ""): string[] {
+  if (Array.isArray(before)) {
+    if (!Array.isArray(after)) {
+      return [`${path}: array became ${typeof after}`];
+    }
+    return before.flatMap((item, i) =>
+      droppedKeys(item, after[i], `${path}[${i}]`),
+    );
+  }
+  if (before !== null && typeof before === "object") {
+    if (after === null || typeof after !== "object") {
+      return [`${path}: object became ${String(after)}`];
+    }
+    const parsed = after as Record<string, unknown>;
+    return Object.entries(before as Record<string, unknown>).flatMap(
+      ([key, value]) => {
+        // `executeSerialize` writes `undefined` for absent optional fields, and
+        // JSON drops those in transit anyway - not something to hold the parser to.
+        if (value === undefined) {
+          return [];
+        }
+        if (!(key in parsed)) {
+          return [`${path}.${key} (was ${JSON.stringify(value)})`];
+        }
+        return droppedKeys(value, parsed[key], `${path}.${key}`);
+      },
+    );
+  }
+  return [];
+}
+
+function expectNothingDropped(schema: Schema<SelectorSource>) {
+  const serialized = serialize(schema);
+  const parsed = SerializedSchema.safeParse(serialized);
+  if (!parsed.success) {
+    throw new Error(`did not parse at all: ${parsed.error.message}`);
+  }
+  expect(droppedKeys(serialized, parsed.data)).toEqual([]);
+}
+
+/**
+ * The parser used to declare `customValidate` and `description` on six of the
+ * eighteen schemas and drop them on the other twelve, and to drop `remote` and
+ * `referencedModule` on both media schemas. It is a strip rather than a
+ * rejection, so nothing failed and nothing said so: on the history path - the
+ * one place a parsed schema is consumed rather than merely validated
+ * (`getModuleAtCommit`, `getHistoricalPatchSet`) - a historical `.validate()`
+ * stopped existing, a remote image read as local, and a gallery-backed field
+ * lost the gallery it reads its metadata from.
+ */
+describe("SerializedSchema keeps every field the schema wrote", () => {
+  const gallery = c.define(
+    "/test/gallery.val.ts",
+    s.images({ directory: "/public/val" }),
+    {},
+  );
+  const cases: [string, Schema<SelectorSource>][] = [
+    [
+      "string",
+      s
+        .string()
+        .validate(() => false)
+        .describe("d"),
+    ],
+    [
+      "literal",
+      s
+        .literal("a")
+        .validate(() => false)
+        .describe("d"),
+    ],
+    [
+      "boolean",
+      s
+        .boolean()
+        .validate(() => false)
+        .describe("d"),
+    ],
+    [
+      "number",
+      s
+        .number()
+        .validate(() => false)
+        .describe("d"),
+    ],
+    [
+      "object",
+      s
+        .object({ a: s.string() })
+        .validate(() => false)
+        .describe("d"),
+    ],
+    [
+      "array",
+      s
+        .array(s.string())
+        .validate(() => false)
+        .describe("d"),
+    ],
+    [
+      "union of literals",
+      s
+        .union(s.literal("a"), s.literal("b"))
+        .validate(() => false)
+        .describe("d"),
+    ],
+    [
+      "union of objects",
+      s
+        .union("k", s.object({ k: s.literal("a") }))
+        .validate(() => false)
+        .describe("d"),
+    ],
+    [
+      "richtext",
+      s
+        .richtext({})
+        .validate(() => false)
+        .describe("d"),
+    ],
+    [
+      "record",
+      s
+        .record(s.string())
+        .validate(() => false)
+        .describe("d"),
+    ],
+    [
+      "keyOf",
+      s
+        .keyOf(gallery)
+        .validate(() => false)
+        .describe("d"),
+    ],
+    [
+      "image",
+      s
+        .image()
+        .validate(() => false)
+        .describe("d"),
+    ],
+    [
+      "remote image",
+      s
+        .image()
+        .remote()
+        .validate(() => false)
+        .describe("d"),
+    ],
+    ["gallery-backed image", s.image(gallery).describe("d")],
+    [
+      "file",
+      s
+        .file()
+        .validate(() => false)
+        .describe("d"),
+    ],
+    [
+      "remote file",
+      s
+        .file()
+        .remote()
+        .validate(() => false)
+        .describe("d"),
+    ],
+    [
+      "date",
+      s
+        .date()
+        .validate(() => false)
+        .describe("d"),
+    ],
+    [
+      "datetime",
+      s
+        .datetime()
+        .validate(() => false)
+        .describe("d"),
+    ],
+    [
+      "color",
+      s
+        .color()
+        .validate(() => false)
+        .describe("d"),
+    ],
+    [
+      "code",
+      s
+        .code()
+        .validate(() => false)
+        .describe("d"),
+    ],
+    [
+      "route",
+      s
+        .route()
+        .validate(() => false)
+        .describe("d"),
+    ],
+    ["settings", s.settings()],
+  ];
+
+  test.each(cases)("%s", (_name, schema) => {
+    expectNothingDropped(schema);
+  });
+
+  // The four fields the strip actually cost, named so a regression says which
+  // one rather than only where.
+  test("a `.validate()` is still visible to the Studio", () => {
+    const parsed = SerializedSchema.safeParse(
+      serialize(s.string().validate(() => false)),
+    );
+    expect(parsed.success && parsed.data).toMatchObject({
+      type: "string",
+      customValidate: true,
+    });
+  });
+
+  test("a `.describe()` survives", () => {
+    const parsed = SerializedSchema.safeParse(
+      serialize(s.string().describe("What this field is for")),
+    );
+    expect(parsed.success && parsed.data).toMatchObject({
+      type: "string",
+      description: "What this field is for",
+    });
+  });
+
+  test("a remote image is still remote", () => {
+    const parsed = SerializedSchema.safeParse(serialize(s.image().remote()));
+    expect(parsed.success && parsed.data).toMatchObject({
+      type: "image",
+      remote: true,
+    });
+  });
+
+  test("a gallery-backed image keeps its gallery", () => {
+    const gallery = c.define(
+      "/test/backing-gallery.val.ts",
+      s.images({ directory: "/public/val" }),
+      {},
+    );
+    const parsed = SerializedSchema.safeParse(serialize(s.image(gallery)));
+    expect(parsed.success && parsed.data).toMatchObject({
+      type: "image",
+      referencedModule: "/test/backing-gallery.val.ts",
     });
   });
 });

--- a/packages/shared/src/internal/zod/SerializedSchema.ts
+++ b/packages/shared/src/internal/zod/SerializedSchema.ts
@@ -33,14 +33,38 @@ import { SourcePath } from "./SourcePath";
 const InlineRender = z.object({ as: z.literal("inline") });
 const FieldRender = InlineRender.optional();
 
+/**
+ * The fields EVERY serialized schema carries, in one place.
+ *
+ * Spread into each schema below rather than retyped, because retyping them is
+ * exactly how they went missing: `customValidate` and `description` were
+ * declared on six of the eighteen schemas and silently dropped by the other
+ * twelve. A field added to the base of `SerializedSchema` needs adding here and
+ * nowhere else.
+ *
+ * `type`, `opt` and whatever is particular to the schema stay at the call site
+ * - those differ per schema, so there is nothing to share.
+ */
+const commonSchemaFields = {
+  render: FieldRender,
+  preview: z.literal(true).optional(),
+  // Whether the schema declares a `.validate()`. The function cannot serialize,
+  // so this flag is what tells the Studio to run the custom validators on the
+  // main thread against the real instance - dropped, and they never run at all.
+  // See `hasCustomValidate` in `ui/spa/validation/customValidate.ts`.
+  customValidate: z.boolean().optional(),
+  readonly: z.boolean().optional(),
+  hidden: z.boolean().optional(),
+  description: z.string().optional(),
+};
+
 export const SerializedStringSchema: z.ZodType<SerializedStringSchemaT> =
   z.object({
+    ...commonSchemaFields,
     type: z.literal("string"),
-    render: FieldRender,
     // `.multiline()`. Stripped like any undeclared key if it goes missing here,
     // which is a single-line input where the author asked for a text box.
     multiline: z.boolean().optional(),
-    preview: z.literal(true).optional(),
     options: z
       .object({
         maxLength: z.number().optional(),
@@ -51,40 +75,32 @@ export const SerializedStringSchema: z.ZodType<SerializedStringSchemaT> =
             flags: z.string(),
           })
           .optional(),
+        customValidate: z.boolean().optional(),
       })
       .optional(),
     opt: z.boolean(),
     raw: z.boolean(),
-    readonly: z.boolean().optional(),
-    hidden: z.boolean().optional(),
   });
 
 export const SerializedLiteralSchema: z.ZodType<SerializedLiteralSchemaT> =
   z.object({
+    ...commonSchemaFields,
     type: z.literal("literal"),
-    render: FieldRender,
-    preview: z.literal(true).optional(),
     value: z.string(),
     opt: z.boolean(),
-    readonly: z.boolean().optional(),
-    hidden: z.boolean().optional(),
   });
 
 export const SerializedBooleanSchema: z.ZodType<SerializedBooleanSchemaT> =
   z.object({
+    ...commonSchemaFields,
     type: z.literal("boolean"),
-    render: FieldRender,
-    preview: z.literal(true).optional(),
     opt: z.boolean(),
-    readonly: z.boolean().optional(),
-    hidden: z.boolean().optional(),
   });
 
 export const SerializedNumberSchema: z.ZodType<SerializedNumberSchemaT> =
   z.object({
+    ...commonSchemaFields,
     type: z.literal("number"),
-    render: FieldRender,
-    preview: z.literal(true).optional(),
     options: z
       .object({
         max: z.number().optional(),
@@ -92,33 +108,25 @@ export const SerializedNumberSchema: z.ZodType<SerializedNumberSchemaT> =
       })
       .optional(),
     opt: z.boolean(),
-    readonly: z.boolean().optional(),
-    hidden: z.boolean().optional(),
   });
 
 export const SerializedObjectSchema: z.ZodType<SerializedObjectSchemaT> =
   z.lazy(() => {
     return z.object({
+      ...commonSchemaFields,
       type: z.literal("object"),
-      render: FieldRender,
-      preview: z.literal(true).optional(),
       items: z.record(z.string(), SerializedSchema),
       opt: z.boolean(),
-      readonly: z.boolean().optional(),
-      hidden: z.boolean().optional(),
     });
   });
 
 export const SerializedArraySchema: z.ZodType<SerializedArraySchemaT> = z.lazy(
   () => {
     return z.object({
+      ...commonSchemaFields,
       type: z.literal("array"),
-      render: FieldRender,
-      preview: z.literal(true).optional(),
       item: SerializedSchema,
       opt: z.boolean(),
-      readonly: z.boolean().optional(),
-      hidden: z.boolean().optional(),
     });
   },
 );
@@ -127,24 +135,18 @@ export const SerializedUnionSchema: z.ZodType<SerializedUnionSchemaT> = z.lazy(
   () => {
     return z.union([
       z.object({
+        ...commonSchemaFields,
         type: z.literal("union"),
-        render: FieldRender,
-        preview: z.literal(true).optional(),
         key: SerializedLiteralSchema,
         items: z.array(SerializedLiteralSchema),
         opt: z.boolean(),
-        readonly: z.boolean().optional(),
-        hidden: z.boolean().optional(),
       }),
       z.object({
+        ...commonSchemaFields,
         type: z.literal("union"),
-        render: FieldRender,
-        preview: z.literal(true).optional(),
         key: z.string(),
         items: z.array(SerializedObjectSchema),
         opt: z.boolean(),
-        readonly: z.boolean().optional(),
-        hidden: z.boolean().optional(),
       }),
     ]);
   },
@@ -166,13 +168,15 @@ export const ImageOptions = z.object({
 });
 export const SerializedImageSchema: z.ZodType<SerializedImageSchemaT> =
   z.object({
+    ...commonSchemaFields,
     type: z.literal("image"),
-    render: FieldRender,
-    preview: z.literal(true).optional(),
     options: ImageOptions.optional(),
     opt: z.boolean(),
-    readonly: z.boolean().optional(),
-    hidden: z.boolean().optional(),
+    // `.remote()`, and the gallery a gallery-backed field reads its metadata
+    // from. Neither is cosmetic: dropped, a remote field looks local and a
+    // gallery-backed one looks like it holds its own dimensions.
+    remote: z.boolean().optional(),
+    referencedModule: z.string().optional(),
   });
 
 export const RichTextOptions: z.ZodType<SerializedRichTextOptionsT> = z.lazy(
@@ -202,22 +206,18 @@ export const RichTextOptions: z.ZodType<SerializedRichTextOptionsT> = z.lazy(
 );
 export const SerializedRichTextSchema: z.ZodType<SerializedRichTextSchemaT> =
   z.object({
+    ...commonSchemaFields,
     type: z.literal("richtext"),
-    render: FieldRender,
-    preview: z.literal(true).optional(),
     options: RichTextOptions.optional(),
     opt: z.boolean(),
-    readonly: z.boolean().optional(),
-    hidden: z.boolean().optional(),
   });
 
 export const SerializedRecordSchema: z.ZodType<SerializedRecordSchemaT> =
   z.lazy(() => {
     return z
       .object({
+        ...commonSchemaFields,
         type: z.literal("record"),
-        render: FieldRender,
-        preview: z.literal(true).optional(),
         item: SerializedSchema,
         opt: z.boolean(),
         // Optional gallery marker for files/images
@@ -233,8 +233,6 @@ export const SerializedRecordSchema: z.ZodType<SerializedRecordSchemaT> =
         moduleMetadata: z
           .record(z.string(), z.record(z.string(), z.any()))
           .optional(),
-        readonly: z.boolean().optional(),
-        hidden: z.boolean().optional(),
       })
       .passthrough();
   });
@@ -242,9 +240,8 @@ export const SerializedRecordSchema: z.ZodType<SerializedRecordSchemaT> =
 export const SerializedKeyOfSchema: z.ZodType<SerializedKeyOfSchemaT> = z.lazy(
   () => {
     return z.object({
+      ...commonSchemaFields,
       type: z.literal("keyOf"),
-      render: FieldRender,
-      preview: z.literal(true).optional(),
       path: SourcePath,
       schema: z
         .union([
@@ -258,8 +255,6 @@ export const SerializedKeyOfSchema: z.ZodType<SerializedKeyOfSchemaT> = z.lazy(
         .optional(),
       values: z.union([z.literal("string"), z.array(z.string())]),
       opt: z.boolean(),
-      readonly: z.boolean().optional(),
-      hidden: z.boolean().optional(),
     });
   },
 );
@@ -268,13 +263,14 @@ export const FileOptions = z.object({
   accept: z.string().optional(),
 });
 export const SerializedFileSchema: z.ZodType<SerializedFileSchemaT> = z.object({
+  ...commonSchemaFields,
   type: z.literal("file"),
-  render: FieldRender,
-  preview: z.literal(true).optional(),
   options: FileOptions.optional(),
   opt: z.boolean(),
-  readonly: z.boolean().optional(),
-  hidden: z.boolean().optional(),
+  // See `SerializedImageSchema` above: `.remote()` and the gallery a
+  // gallery-backed field reads from.
+  remote: z.boolean().optional(),
+  referencedModule: z.string().optional(),
 });
 
 export const DateOptions = z.object({
@@ -283,28 +279,18 @@ export const DateOptions = z.object({
 });
 
 export const SerializedDateSchema: z.ZodType<SerializedDateSchemaT> = z.object({
+  ...commonSchemaFields,
   type: z.literal("date"),
-  render: FieldRender,
-  preview: z.literal(true).optional(),
   options: DateOptions.optional(),
   opt: z.boolean(),
-  customValidate: z.boolean().optional(),
-  readonly: z.boolean().optional(),
-  hidden: z.boolean().optional(),
-  description: z.string().optional(),
 });
 
 export const SerializedDateTimeSchema: z.ZodType<SerializedDateTimeSchemaT> =
   z.object({
+    ...commonSchemaFields,
     type: z.literal("dateTime"),
-    render: FieldRender,
-    preview: z.literal(true).optional(),
     options: DateOptions.optional(),
     opt: z.boolean(),
-    customValidate: z.boolean().optional(),
-    readonly: z.boolean().optional(),
-    hidden: z.boolean().optional(),
-    description: z.string().optional(),
   });
 
 export const ColorOptions = z.object({
@@ -314,15 +300,10 @@ export const ColorOptions = z.object({
 
 export const SerializedColorSchema: z.ZodType<SerializedColorSchemaT> =
   z.object({
+    ...commonSchemaFields,
     type: z.literal("color"),
-    render: FieldRender,
-    preview: z.literal(true).optional(),
     options: ColorOptions.optional(),
     opt: z.boolean(),
-    customValidate: z.boolean().optional(),
-    readonly: z.boolean().optional(),
-    hidden: z.boolean().optional(),
-    description: z.string().optional(),
   });
 
 export const CodeOptions = z.object({
@@ -330,22 +311,16 @@ export const CodeOptions = z.object({
 });
 
 export const SerializedCodeSchema: z.ZodType<SerializedCodeSchemaT> = z.object({
+  ...commonSchemaFields,
   type: z.literal("code"),
-  render: FieldRender,
-  preview: z.literal(true).optional(),
   options: CodeOptions.optional(),
   opt: z.boolean(),
-  customValidate: z.boolean().optional(),
-  readonly: z.boolean().optional(),
-  hidden: z.boolean().optional(),
-  description: z.string().optional(),
 });
 
 export const SerializedRouteSchema: z.ZodType<SerializedRouteSchemaT> =
   z.object({
+    ...commonSchemaFields,
     type: z.literal("route"),
-    render: FieldRender,
-    preview: z.literal(true).optional(),
     options: z
       .object({
         include: z
@@ -364,9 +339,6 @@ export const SerializedRouteSchema: z.ZodType<SerializedRouteSchemaT> =
       })
       .optional(),
     opt: z.boolean(),
-    customValidate: z.boolean().optional(),
-    readonly: z.boolean().optional(),
-    hidden: z.boolean().optional(),
   });
 
 // A settings module, and each section inside one, serialize as this - the
@@ -377,15 +349,10 @@ export const SerializedRouteSchema: z.ZodType<SerializedRouteSchemaT> =
 export const SerializedSettingsSchema: z.ZodType<SerializedSettingsSchemaT> =
   z.lazy(() => {
     return z.object({
+      ...commonSchemaFields,
       type: z.literal("settings"),
-      render: FieldRender,
-      preview: z.literal(true).optional(),
       items: z.record(z.string(), SerializedSchema),
       opt: z.boolean(),
-      customValidate: z.boolean().optional(),
-      readonly: z.boolean().optional(),
-      hidden: z.boolean().optional(),
-      description: z.string().optional(),
     });
   });
 

--- a/packages/shared/src/internal/zod/SerializedSchema.ts
+++ b/packages/shared/src/internal/zod/SerializedSchema.ts
@@ -71,6 +71,11 @@ export const SerializedStringSchema: z.ZodType<SerializedStringSchemaT> =
         minLength: z.number().optional(),
         regexp: z
           .object({
+            // `.regexp(re, message)`'s message. Written by
+            // `StringSchema.executeSerialize`, so omitting it here strips the
+            // author's own wording and leaves the generic "Expected string to
+            // match reg exp: …" in its place.
+            message: z.string().optional(),
             source: z.string(),
             flags: z.string(),
           })


### PR DESCRIPTION
Found while planning validation warnings (#631) — the zod mirror of `SerializedSchema` is the file that plan has to edit, and it turned out to already be dropping five fields.

## The bug

`SerializedSchema` in `@valbuild/shared` mirrors the serialized schema type in zod, and `z.object` **strips keys it does not declare** — that is its default, and the file says so in its own comment. Five fields were declared on some schemas and forgotten on others:

| Field | Declared on | Dropped by |
| --- | --- | --- |
| `customValidate` | date, datetime, color, code, route, settings | the other **12** |
| `description` | date, datetime, color, code, settings | the other **13** |
| `remote` | — | image, file |
| `referencedModule` | — | image, file |
| `regexp.message` | — | string |

`customValidate` is the one that costs the most behaviour. A `.validate()` closure cannot serialize, so the flag is the only thing that tells the Studio to run the custom validators on the main thread against the real instance (`hasCustomValidate` in `ui/spa/validation/customValidate.ts` reads exactly this key). The others are not cosmetic either: without `remote` a remote field reads as local, without `referencedModule` a gallery-backed field looks like it holds its own dimensions and mime type, and without `regexp.message` a custom pattern message falls back to the generic "Expected string to match reg exp: …".

`record` was unaffected — it is `.passthrough()`.

## Blast radius: the history path, not `/schema`

Because the strip is silent, nothing failed and nothing said so.

The live `/schema` and `/sources/~` routes are **unaffected**, and the reason is worth stating precisely because it is easy to get wrong: it is not that zod is lenient. Both response hops validate and then discard the parsed value — `ValRouter` returns `res`, `ValClient` returns the raw `json`, never `result.data`. The stripped copy is computed and thrown away.

The history path is where the strip is real, because it is the one place that **consumes** the parsed output: `schemaRes.data` in both [`getModuleAtCommit`](https://github.com/valbuild/val/blob/main/packages/server/src/history/getModuleAtCommit.ts) and [`getHistoricalPatchSet`](https://github.com/valbuild/val/blob/main/packages/server/src/history/getHistoricalPatchSet.ts). So in a commit or historical patch-set view, a schema's custom validators, description, remoteness, backing gallery and pattern message all quietly disappeared.

## The fix

The fields every serialized schema shares now come from one `commonSchemaFields` object, spread into each schema, instead of being retyped eighteen times — which is how they drifted apart in the first place. A field added to the base of `SerializedSchema` now needs adding in one place.

## The guard, and what it taught

The round-trip test is the part worth reviewing. It walks each schema's `executeSerialize()` output against the parsed result recursively and fails with the **path** of any key that did not survive, driven by what the schema actually wrote rather than by a list kept in the test.

**Its limit is the lesson.** Copilot's review found two of the five fields *after* the guard existed — the `regexp.message` and the coverage hole on `referencedModule` for `s.file()` — because the guard is exhaustive over what a case **serializes**, not over the schema types that exist. A field is only protected if some case actually sets it. A third round found the same hole for `render` and `preview`.

So the shared object is now checked line by line, by deleting each one and running the suite:

| line in `commonSchemaFields` | tests failing when removed |
| --- | --- |
| `render` | 1 |
| `preview` | 1 |
| `customValidate` | 26 |
| `readonly` | 25 |
| `hidden` | 25 |
| `description` | 23 |

`readonly` and `hidden` were already covered, because `executeSerialize` writes them as `false` rather than `undefined` and the helper skips only `undefined`.

That limitation is now written into the suite's own comment and into #631's plan, where the next batch of fields (`severity`) gets added.

## Verification

Full CI set from the repo root: `pnpm run lint`, `pnpm -w run format`, `pnpm run -r typecheck` (13 packages), `pnpm test` (308 suites, 3736 tests), `cd examples/next && pnpm run build` — all green. Root `pnpm run build` not run: nothing here needs the built output and it would swap the workspace onto `dist/` entries.

Each fix was checked by reverting it and watching the suite fail, rather than by assuming: removing `regexp.message` fails 2 tests, removing file `referencedModule` fails 2, and each `commonSchemaFields` line as tabled above.

A throwaway probe over 23 richer cases — every option branch I could construct, including richtext `a`/`img` as both booleans and as schemas, `encode` variants, both gallery kinds, `router`, `jsonValues`, `keyOf` and `settings` — found nothing else dropped. It is not committed.

Since `packages/server` consumes this: `pnpm exec tsx src/cli.ts validate --root ../../examples/next` loads and validates 20 modules, with only the two documented pre-existing content errors (stale image metadata in the example app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYBFcEEbwMAuaCma59YUgN