### PR TITLE
Stop shipping zod to every visitor of a Val site

### DIFF
--- a/.changeset/lazy-val-client-zod.md
+++ b/.changeset/lazy-val-client-zod.md
@@ -1,0 +1,29 @@
+---
+"@valbuild/shared": patch
+"@valbuild/next": patch
+---
+
+Stop shipping zod to every visitor of a Val site (~113 KB)
+
+`@valbuild/next`'s client code needed five things from
+`@valbuild/shared/internal`, three of which are string constants like
+`VAL_THEME_SESSION_STORAGE_KEY`. But preconstruct publishes each entrypoint as
+a single bundled module, so importing a string constant pulled in the whole
+entrypoint — including `ApiRoutes.ts` and its zod schemas. Measured on
+val.build, that was 113 KB of zod in the initial JS of every page, for
+visitors who never open the Studio.
+
+Two changes:
+
+- New `@valbuild/shared/client` entrypoint carrying the parts that are safe in
+  a browser bundle: the session-storage keys, the canvas protocol, and the
+  route-pattern helpers. Nothing reachable from it may import zod, and
+  `noZodInClientEntrypoint.test.ts` walks the source graph to enforce that —
+  one careless re-export would silently put the 113 KB back.
+- `ValNextProvider` now imports `createValClient` on first use rather than at
+  module scope. It genuinely needs zod (it `safeParse`s every request and
+  response), but its only caller is the draft-mode poll, which returns early
+  unless the overlay is mounted. A visitor without the Val Enable cookie never
+  triggers the import.
+
+No API change. `@valbuild/shared/internal` still exports everything it did.

--- a/docs/plans/client-bundle-weight.md
+++ b/docs/plans/client-bundle-weight.md
@@ -1,0 +1,164 @@
+# Slimming what Val ships to the browser
+
+A production site that uses Val puts **~288 KB of Val JavaScript** in the
+initial bundle of every page, for visitors who will never open the Studio.
+This is what that is made of, why tree-shaking does not touch it, and which
+cut is worth making.
+
+Measured on `valbuild/web` (val.build), Next 16.3.3, webpack, production
+build, landing page. Chunks were attributed by building with
+`productionBrowserSourceMaps: true` and reading each chunk's source map.
+
+## What is actually shipped
+
+The landing page's critical JS is 915 KB. Val's share:
+
+| Bytes (minified) | Chunk maps to                               | Why it is reachable                               |
+| ---------------- | ------------------------------------------- | ------------------------------------------------- |
+| 155 KB           | `@valbuild/core/dist/index-5fe6fb98.esm.js` | any import from `@valbuild/core`                  |
+| 113 KB           | `zod`                                       | `@valbuild/shared/internal`, via `@valbuild/next` |
+| ~20 KB           | `@valbuild/next`                            | `ValProvider`, `ValRichText`, `useVal`            |
+
+For comparison, the framework costs 236 KB (Next router) + 196 KB (React DOM).
+Val is the third-largest thing on the page and the largest thing that is not a
+framework.
+
+The 155 KB is not richtext rendering. It is the whole of core: the `Schema`
+class hierarchy with `executeValidate`, `executeCustomValidateFunctions`,
+`executeAssert` and `executeSerialize`, plus the MIME-type tables that
+`s.file()`'s `accept` is checked against — 535 occurrences of `application/…`,
+including `opendocument` and `macroEnabled` variants. None of it runs for a
+visitor without the Val Enable cookie.
+
+## Three things that are NOT the cause
+
+Each of these was measured, not reasoned about, and each was wrong:
+
+1. **"Lazy-load `ValProvider`."** Removing `ValProvider` and
+   `ValModulesClient` from the app's root layout entirely — not deferring
+   them, deleting them — moved the landing page from 1,370,543 to 1,368,918
+   bytes. **1.6 KB.** The provider is not what pulls core in; `ValRichText` is,
+   and it renders actual page content, so it cannot be deferred.
+
+2. **"The overlay ships even though it never mounts."** True but nearly free.
+   `ValNextProvider` gates the overlay on `mountOverlay`, and the Studio SPA
+   itself is served separately from `/api/val/static/…`, so it is not in the
+   app bundle.
+
+3. **"Set `sideEffects: false`."** `@valbuild/next` declares
+   `"sideEffects": true` and core and shared leave it unset, which does look
+   like the bug. Patching all three to `false` in `node_modules` and
+   rebuilding changed the landing page by **177 bytes**. It cannot work — see
+   below.
+
+## Why tree-shaking cannot help
+
+`@valbuild/core`'s published `dist` is not a module graph. Preconstruct
+bundles the entire package into one file:
+
+```
+dist/valbuild-core.esm.js        1 KB   ← re-export shim
+dist/index-5fe6fb98.esm.js     407 KB   ← everything
+```
+
+The shim is `export { A as ArraySchema, B as BooleanSchema, … }` pointing at
+the one big module. Webpack sees a single module with no internal boundaries,
+so there is nothing to shake along: importing `Internal` — which
+`stegaEncode`, `attrs`, `cssUtils` and `valEnableCookie` all genuinely need —
+takes the validation engine and the MIME tables with it. `sideEffects` only
+lets a bundler drop _modules_ it can prove are unused, and here there is only
+one.
+
+`Internal` compounds it. It is a single object literal holding ~40 functions
+(`mediaUrl`, `resolvePath`, `nextAppRouter`, `remote.getValidationHash`,
+`validate`, …). Even with a real module graph, a bundler cannot drop
+properties off an object that is exported whole.
+
+The same shape produces the zod cost. Client code in `@valbuild/next` reaches
+into `@valbuild/shared/internal` for `VAL_SESSION_COOKIE`,
+`VAL_CONFIG_SESSION_STORAGE_KEY`, `VAL_THEME_SESSION_STORAGE_KEY`,
+`isValCanvasFrame` and `createValClient`. Three of those are **string
+constants**. That entrypoint also contains `ApiRoutes.ts`, which builds zod
+schemas for the entire API surface — so importing a string constant costs
+113 KB of zod.
+
+## The two candidate cuts
+
+### A. Split validation off `Schema` in `@valbuild/core`
+
+Reclaims the most (up to 155 KB) and fixes it for every consumer, not just
+Next. It also asks for surgery on core's most load-bearing types: every schema
+class would have to keep its shape and serialization while its `executeValidate`
+/ `executeCustomValidateFunctions` / `executeAssert` moved behind a separate
+entrypoint that the CLI, the server and the Studio import and the browser does
+not.
+
+The risk is that the split is not clean. `Internal.validate` calls
+`getSchema(val)["executeValidate"]`, `stegaEncode` switches on
+`Serialized*Schema` variants, and the remote-file helpers compute validation
+hashes from schemas. Each of those has to land on one side of the line.
+
+### B. A render-only client entrypoint in `@valbuild/next`
+
+Ship `@valbuild/next/render` (or similar) exporting only `ValRichText`,
+`ValImage` and the stega readers, importing nothing that reaches the Schema
+classes. Much smaller blast radius, no core churn, additive and non-breaking.
+
+But it cannot work on its own, and this is the point: as long as core is one
+bundled module, a render-only entry that touches `Internal` for `mediaUrl` or
+`resolvePath` still drags in all 407 KB. **B is downstream of A.**
+
+## Recommendation
+
+Do them in this order, and stop after whichever one pays.
+
+1. **Give `@valbuild/core` real module boundaries first.** Add preconstruct
+   entrypoints — the package already does this for `./fp` and `./patch`, so
+   the mechanism is in place and the release plumbing already understands it.
+   The first cut worth trying is `@valbuild/core/schema` (classes, shapes,
+   serialization) versus the validation machinery, with `Internal` broken into
+   the handful of namespaces that consumers actually use rather than one
+   object.
+
+   Even before splitting validation, simply _having_ boundaries lets
+   `sideEffects: false` start working, which is currently a no-op.
+
+2. **Then fix `@valbuild/shared/internal`.** Move the string constants and
+   `isValCanvasFrame` out of the entrypoint that contains `ApiRoutes.ts`. This
+   is much easier than (1), independent of it, and worth 113 KB — the best
+   ratio of the three. Consider doing it first for that reason.
+
+3. **Then add the render-only `@valbuild/next` entry**, once (1) means it can
+   actually be narrow.
+
+Set `sideEffects` correctly across core, next and shared as part of (1) — not
+before, where it measures as noise and reads as a fix that did not work.
+
+## How to verify a change
+
+Do not trust the route table or a byte count from `next build`; measure what a
+browser downloads.
+
+```bash
+# in the consuming app
+# next.config.js: productionBrowserSourceMaps: true
+pnpm run build && pnpm run start
+```
+
+Then load the page and attribute every chunk in the critical path back to its
+sources through its `.js.map` — `sources` plus `sourcesContent` lengths gives a
+per-file breakdown. Split "before the load event" from "after" so route
+prefetches are not counted as critical.
+
+The number to move is **critical JS attributed to `@valbuild/*` and its
+dependencies**, currently ~288 KB. Total blocking time on a 4x-throttled CPU is
+the user-visible consequence and the better headline, but it is noisier; use
+bytes to know whether a cut landed and TBT to know whether it mattered.
+
+## What this is not
+
+Prerendering. A separate finding on the same site: one `cookies()` call in the
+root layout opted every route out of static generation. That is an application
+bug, not a Val one — `fetchVal` does no network call unless draft mode is on,
+and `draftMode()` does not itself force dynamic rendering in Next 16. Fixed in
+`valbuild/web#23`; noted here only because the two get confused.

--- a/docs/plans/client-bundle-weight.md
+++ b/docs/plans/client-bundle-weight.md
@@ -110,29 +110,34 @@ bundled module, a render-only entry that touches `Internal` for `mediaUrl` or
 
 ## Recommendation
 
-Do them in this order, and stop after whichever one pays.
+**Start with `@valbuild/shared/internal` (2). It is the one to do first.**
 
-1. **Give `@valbuild/core` real module boundaries first.** Add preconstruct
+It is worth 113 KB, it is independent of everything else here, and it is a
+file move rather than a redesign: pull the string constants and
+`isValCanvasFrame` out of the entrypoint that carries `ApiRoutes.ts`, so
+client code can import `VAL_SESSION_COOKIE` without importing zod. Of the
+three cuts it has by far the best ratio of bytes reclaimed to risk taken, and
+nothing else has to land first.
+
+Then, if the remaining 155 KB justifies it:
+
+1. **Give `@valbuild/core` real module boundaries.** Add preconstruct
    entrypoints — the package already does this for `./fp` and `./patch`, so
    the mechanism is in place and the release plumbing already understands it.
    The first cut worth trying is `@valbuild/core/schema` (classes, shapes,
    serialization) versus the validation machinery, with `Internal` broken into
-   the handful of namespaces that consumers actually use rather than one
-   object.
+   the handful of namespaces consumers actually use rather than one object.
 
-   Even before splitting validation, simply _having_ boundaries lets
-   `sideEffects: false` start working, which is currently a no-op.
+   Even before validation is split out, simply _having_ boundaries lets
+   `sideEffects: false` start working, which is currently a no-op. Set
+   `sideEffects` correctly across core, next and shared as part of this step —
+   not before, where it measures as noise and reads as a fix that did not work.
 
-2. **Then fix `@valbuild/shared/internal`.** Move the string constants and
-   `isValCanvasFrame` out of the entrypoint that contains `ApiRoutes.ts`. This
-   is much easier than (1), independent of it, and worth 113 KB — the best
-   ratio of the three. Consider doing it first for that reason.
+2. **Then add the render-only `@valbuild/next` entry**, which can only be
+   narrow once core has boundaries.
 
-3. **Then add the render-only `@valbuild/next` entry**, once (1) means it can
-   actually be narrow.
-
-Set `sideEffects` correctly across core, next and shared as part of (1) — not
-before, where it measures as noise and reads as a fix that did not work.
+Cut (A) is the big one but it is surgery on core's most load-bearing types, and
+(B) cannot pay off before it. Neither should block shipping the shared fix.
 
 ## How to verify a change
 

--- a/packages/next/src/ValCanvasBridge.tsx
+++ b/packages/next/src/ValCanvasBridge.tsx
@@ -7,7 +7,7 @@ import {
   VAL_CANVAS_MESSAGE,
   ValCanvasElement,
   ValCanvasPageMessage,
-} from "@valbuild/shared/internal";
+} from "@valbuild/shared/client";
 
 /**
  * The colours Val outlines its content in.

--- a/packages/next/src/ValNextProvider.tsx
+++ b/packages/next/src/ValNextProvider.tsx
@@ -15,13 +15,13 @@ import Script from "next/script";
 import React, { useEffect } from "react";
 import { ValExternalStore, ValOverlayProvider } from "./ValOverlayContext";
 import { SET_AUTO_TAG_JSX_ENABLED } from "@valbuild/react/stega";
-import { createValClient } from "@valbuild/shared/internal";
+import type { ValClient } from "@valbuild/shared/internal";
 import { useConfigStorageSave } from "./useConfigStorageSave";
 import { initSessionTheme } from "./initSessionTheme";
 import { cn, prefixStyles, valPrefixedClass } from "./cssUtils";
 import { hasValEnableCookie } from "./valEnableCookie";
 import { floatDarkBg, floatLightBg } from "./fallbackColors";
-import { isValCanvasFrame } from "@valbuild/shared/internal";
+import { isValCanvasFrame } from "@valbuild/shared/client";
 import { ValCanvasBridge } from "./ValCanvasBridge";
 import { shouldSafetyRefresh } from "./safetyRefresh";
 
@@ -141,14 +141,30 @@ export const ValNextProvider = (props: {
 }) => {
   // TODO: use config:
   const route = "/api/val";
-  const client = React.useMemo(
-    () =>
-      createValClient(route, {
-        ...props.config,
+  /**
+   * Loaded on first use, never at import time.
+   *
+   * `createValClient` validates every request and response against the zod
+   * schemas in `@valbuild/shared/internal`'s `ApiRoutes`, and preconstruct
+   * publishes that entrypoint as one module - so importing it statically put
+   * ~113 KB of zod in the bundle of every page of every Val site. The only
+   * caller is the draft-mode poll below, which returns early unless
+   * `mountOverlay` is set, so a visitor without the Val Enable cookie never
+   * triggers this import and never downloads that chunk.
+   */
+  const clientRef = React.useRef<ValClient | null>(null);
+  const configRef = React.useRef(props.config);
+  configRef.current = props.config;
+  const getClient = React.useCallback(async (): Promise<ValClient> => {
+    if (!clientRef.current) {
+      const { createValClient } = await import("@valbuild/shared/internal");
+      clientRef.current = createValClient(route, {
+        ...configRef.current,
         contentHostUrl: DEFAULT_CONTENT_HOST,
-      }),
-    [route, props.config],
-  );
+      });
+    }
+    return clientRef.current;
+  }, [route]);
 
   // TODO: move below into react package
   const valStore = React.useMemo(() => new ValExternalStore(), []);
@@ -448,7 +464,8 @@ export const ValNextProvider = (props: {
         }),
       );
       const pollDraftStatId = ++pollDraftStatIdRef.current;
-      client("/draft/stat", "GET", {})
+      getClient()
+        .then((client) => client("/draft/stat", "GET", {}))
         .then((res) => {
           if (pollDraftStatIdRef.current !== pollDraftStatId) {
             return;

--- a/packages/next/src/initSessionTheme.ts
+++ b/packages/next/src/initSessionTheme.ts
@@ -1,5 +1,5 @@
 import { ValConfig } from "@valbuild/core";
-import { VAL_THEME_SESSION_STORAGE_KEY } from "@valbuild/shared/internal";
+import { VAL_THEME_SESSION_STORAGE_KEY } from "@valbuild/shared/client";
 
 export function initSessionTheme(config: ValConfig) {
   if (typeof window === "undefined") {

--- a/packages/next/src/routeFromVal.ts
+++ b/packages/next/src/routeFromVal.ts
@@ -4,7 +4,7 @@ import {
   getPatternFromModuleFilePath,
   parseRoutePattern,
   RoutePattern,
-} from "@valbuild/shared/internal";
+} from "@valbuild/shared/client";
 
 /**
  * True when the module's schema is a `.jsonValues()` record/router — i.e. each

--- a/packages/next/src/useConfigStorageSave.ts
+++ b/packages/next/src/useConfigStorageSave.ts
@@ -1,5 +1,5 @@
 import { ValConfig } from "@valbuild/core";
-import { VAL_CONFIG_SESSION_STORAGE_KEY } from "@valbuild/shared/internal";
+import { VAL_CONFIG_SESSION_STORAGE_KEY } from "@valbuild/shared/client";
 import React from "react";
 
 /*

--- a/packages/shared/client/package.json
+++ b/packages/shared/client/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/valbuild-shared-client.cjs.js",
+  "module": "dist/valbuild-shared-client.esm.js"
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -18,6 +18,10 @@
       "module": "./dist/valbuild-shared.esm.js",
       "default": "./dist/valbuild-shared.cjs.js"
     },
+    "./client": {
+      "module": "./client/dist/valbuild-shared-client.esm.js",
+      "default": "./client/dist/valbuild-shared-client.cjs.js"
+    },
     "./internal": {
       "module": "./internal/dist/valbuild-shared-internal.esm.js",
       "default": "./internal/dist/valbuild-shared-internal.cjs.js"
@@ -28,6 +32,7 @@
   "preconstruct": {
     "entrypoints": [
       "./index.ts",
+      "./client/index.ts",
       "./internal/index.ts"
     ],
     "exports": true
@@ -41,10 +46,13 @@
   "files": [
     "CHANGELOG.md",
     "dist",
+    "client/dist",
+    "client/package.json",
     "internal/dist",
     "internal/package.json"
   ],
   "devDependencies": {
     "typescript": "^6.0.3"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/shared/src/client/index.ts
+++ b/packages/shared/src/client/index.ts
@@ -1,0 +1,21 @@
+/**
+ * The part of `@valbuild/shared/internal` that is safe to put in a browser
+ * bundle.
+ *
+ * `@valbuild/shared/internal` is a single preconstruct entrypoint, so
+ * preconstruct publishes it as ONE module: importing a string constant from it
+ * pulls in everything else, and everything else includes `ApiRoutes.ts`, whose
+ * zod schemas cost ~113 KB minified. `@valbuild/next`'s client code needs five
+ * things from that entrypoint, three of which are string constants, so every
+ * production visitor to a Val site was paying for zod to read
+ * `VAL_THEME_SESSION_STORAGE_KEY`.
+ *
+ * Nothing re-exported here may import zod, directly or transitively. The
+ * `noZodInClientEntrypoint.test.ts` beside this file is what enforces that -
+ * a single new re-export can silently put 113 KB back.
+ */
+export * from "../internal/sessionStorage";
+export * from "../internal/valCanvasProtocol";
+export * from "../internal/parseRoutePattern";
+export * from "../internal/getNextAppRouterSourceFolder";
+export * from "../internal/getSitemapTree";

--- a/packages/shared/src/client/noZodInClientEntrypoint.test.ts
+++ b/packages/shared/src/client/noZodInClientEntrypoint.test.ts
@@ -1,0 +1,80 @@
+import fs from "fs";
+import path from "path";
+
+/**
+ * `@valbuild/shared/client` exists so that `@valbuild/next`'s client code can
+ * read a string constant without a browser downloading zod.
+ *
+ * Preconstruct publishes each entrypoint as ONE bundled module, so this is not
+ * a preference that a bundler can partially honour: the moment anything
+ * reachable from `client/index.ts` imports zod, every visitor to every Val site
+ * pays ~113 KB for it again, and nothing else in CI would notice.
+ *
+ * The walk is over the source graph rather than the built `dist`, so this fails
+ * on the commit that introduces the import rather than at release time.
+ */
+const SRC = path.resolve(__dirname, "..");
+const ENTRY = path.join(SRC, "client", "index.ts");
+
+const FORBIDDEN = ["zod", "zod-validation-error"];
+
+function resolveImport(fromFile: string, spec: string): string | null {
+  if (!spec.startsWith(".")) {
+    return null;
+  }
+  const base = path.resolve(path.dirname(fromFile), spec);
+  const candidates = [
+    base,
+    `${base}.ts`,
+    `${base}.tsx`,
+    path.join(base, "index.ts"),
+    path.join(base, "index.tsx"),
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+/** Every `from "..."` specifier in a file, type-only imports included. */
+function importSpecifiers(source: string): string[] {
+  const specs: string[] = [];
+  const re = /(?:^|\n)\s*(?:import|export)[\s\S]*?from\s*["']([^"']+)["']/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(source)) !== null) {
+    specs.push(m[1]);
+  }
+  return specs;
+}
+
+describe("@valbuild/shared/client", () => {
+  test("reaches no zod, directly or transitively", () => {
+    const seen = new Set<string>();
+    const offenders: string[] = [];
+    const walk = (file: string, trail: string[]) => {
+      if (seen.has(file)) {
+        return;
+      }
+      seen.add(file);
+      const source = fs.readFileSync(file, "utf-8");
+      for (const spec of importSpecifiers(source)) {
+        if (FORBIDDEN.includes(spec) || spec.startsWith("zod/")) {
+          offenders.push(
+            [...trail, path.relative(SRC, file), `→ ${spec}`].join(" → "),
+          );
+          continue;
+        }
+        const resolved = resolveImport(file, spec);
+        if (resolved) {
+          walk(resolved, [...trail, path.relative(SRC, file)]);
+        }
+      }
+    };
+    walk(ENTRY, []);
+
+    expect(seen.size).toBeGreaterThan(1); // the walk actually traversed
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Found while investigating why val.build felt slow. A production Val site put **~288 KB of Val JavaScript** in the initial bundle of every page, for visitors who never open the Studio. This removes 113 KB of it.

## The problem

`@valbuild/next`'s client code needs five things from `@valbuild/shared/internal` — `VAL_SESSION_COOKIE`, `VAL_CONFIG_SESSION_STORAGE_KEY`, `VAL_THEME_SESSION_STORAGE_KEY`, `isValCanvasFrame`, `createValClient`. Three of those are string constants.

But preconstruct publishes each entrypoint as **one bundled module**, and that entrypoint also carries `ApiRoutes.ts` and its zod schemas. So importing a string constant cost 113 KB of zod, in the initial JS of every page of every Val site.

Three explanations that sound right and measure as wrong, all tested on val.build before landing on this one:

- **Lazy-load `ValProvider`** — deleting `ValProvider` and `ValModulesClient` from the app's root layout entirely moved the page by **1.6 KB**. The provider is not what pulls Val in.
- **The overlay ships though it never mounts** — true but nearly free; the Studio SPA is served separately from `/api/val/static/…`.
- **`sideEffects: false`** — patching it across core, next and shared changed the page by **177 bytes**. It cannot work: with one bundled module per entrypoint there are no modules to shake along.

## The change

Neither half is sufficient alone.

**`@valbuild/shared/client`**, a new entrypoint carrying what belongs in a browser: the session-storage keys, the canvas protocol, the route-pattern helpers. Preconstruct emits a **13 KB** chunk for it against the **195 KB** one `internal` resolves to, with no zod anywhere in it:

```
client/dist/…client.esm.js        475 B  → dist/getSitemapTree-….esm.js  13,177 B  zod=0
internal/dist/…internal.esm.js                                          195,395 B  zod=6
```

**`createValClient` loads on first use** rather than at module scope in `ValNextProvider`. It genuinely needs zod — it `safeParse`s every request and response — so it cannot move to the client entrypoint. But its only caller is the draft-mode poll, which returns early unless `mountOverlay` is set, so a visitor without the Val Enable cookie never triggers the import.

## The guard

`noZodInClientEntrypoint.test.ts` walks the source import graph from `client/index.ts` and fails if it reaches zod. This matters more than usual: one careless re-export puts the 113 KB back and **nothing else in CI would notice**. The test asserts the walk actually traversed something, so it can't pass vacuously, and it reports the full trail:

```
client/index.ts → internal/ApiRoutes.ts → → zod
client/index.ts → internal/ApiRoutes.ts → internal/zod/Patch.ts → → zod
```

I verified it fails by temporarily re-exporting `ApiRoutes` from the client entrypoint.

## Verification

`pnpm test` (309 suites, 3706 tests), `pnpm run -r typecheck` (all 13 packages incl. `examples/next`), `pnpm run lint`, `prettier --check`, and `pnpm run build` all green. Dev entrypoints restored with `preconstruct dev` afterwards.

**No API change** — `@valbuild/shared/internal` still exports everything it did.

## Not in this PR

The other 155 KB is `@valbuild/core`, which preconstruct publishes as a single 407 KB module behind a re-export shim, so importing anything takes all of it — validation engine and a 535-entry MIME table included. Giving it real entrypoints is a bigger change against its most load-bearing types; written up in `docs/plans/client-bundle-weight.md`, also in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014aCVyFESMmxUSQ61X6fBpM

---
_Generated by [Claude Code](https://claude.ai/code/session_014aCVyFESMmxUSQ61X6fBpM)_