### PR TITLE
Reach every destination on a tablet, and put Review before Preview

### DIFF
--- a/.changeset/tablet-destinations-and-review-first.md
+++ b/.changeset/tablet-destinations-and-review-first.md
@@ -1,0 +1,17 @@
+---
+"@valbuild/ui": patch
+---
+
+Two fixes to the Studio's chrome
+
+**Data, Media and Settings are reachable again on a tablet.** The left rail is
+drawn from 1200px up, and the top bar's menu button opens the first destination
+a project has and nothing else — so between 768px and 1200px, which is an iPad
+in either orientation and any half screen, whichever panel happened to be open
+was the only panel you could reach. The destination switcher that stands in for
+the rail was shown below 768px only, and the tablet width fell through the gap
+between the two. It is now shown at every width where the rail is not.
+
+**Review moved to the left of Preview.** The three actions read left to right
+in the order they are done in — Review, Preview, Publish — instead of putting
+the first step between the other two.

--- a/e2e/canvas.spec.ts
+++ b/e2e/canvas.spec.ts
@@ -492,8 +492,8 @@ test.describe("the canvas", () => {
       { timeout: 30000 },
     );
 
-    // Review is in the top bar at this viewport, beside Publish; the Quick
-    // actions panel carries it on mobile only, where the top bar does not.
+    // Review is in the top bar at this viewport, to the left of Preview; the
+    // Quick actions panel carries it on mobile only, where the top bar does not.
     await studio.getByRole("button", { name: /Review \d+ change/ }).click();
 
     await expect(

--- a/e2e/screens.spec.ts
+++ b/e2e/screens.spec.ts
@@ -231,6 +231,34 @@ test("light mode", async ({ page }) => {
   await shot(page, "16-light-shell");
 });
 
+/**
+ * The tablet, which is the width with no left rail and no bottom bar.
+ *
+ * Worth its own pictures because it is the layout that is neither of the two
+ * that get looked at: the destinations move into a switcher at the top of each
+ * panel, and that switcher is the only way across between 768px and 1200px.
+ */
+test("tablet", async ({ page }) => {
+  await page.setViewportSize({ width: 1024, height: 768 });
+  await openStudio(page);
+  const studio = page.locator("#val-shadow-root");
+  await page.waitForTimeout(3000);
+  await shot(page, "21-tablet-resting");
+
+  // Pages, which is what the menu button opens, with the switcher above it.
+  await studio.getByRole("button", { name: "Open navigation" }).click();
+  await page.waitForTimeout(1500);
+  await shot(page, "22-tablet-pages");
+
+  // Data, reached the only way there is at this width.
+  await studio
+    .getByRole("tablist", { name: "Destinations" })
+    .getByRole("tab", { name: "Data" })
+    .click();
+  await page.waitForTimeout(1500);
+  await shot(page, "23-tablet-data");
+});
+
 test("mobile", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await openStudio(page);

--- a/e2e/tablet-nav.spec.ts
+++ b/e2e/tablet-nav.spec.ts
@@ -1,0 +1,97 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+import { openStudio, test } from "./studio";
+
+/**
+ * Getting from one destination to another on a tablet.
+ *
+ * The left rail is desktop-only (1200px and up), and the top bar's menu button
+ * opens the FIRST destination a project has and nothing else. Between 768px
+ * and 1200px — an iPad in either orientation, or a half screen — that left
+ * whichever panel happened to be open as the only panel reachable: Data, Media
+ * and Settings had no route at all. The switcher that stands in for the rail
+ * was gated on the mobile breakpoint, and the tablet width fell through the
+ * gap between the two.
+ *
+ * Driven at a real viewport rather than unit-tested because the bug WAS the
+ * viewport: every panel rendered correctly, and each one was fine to look at.
+ */
+test.use({ viewport: { width: 1024, height: 768 } });
+
+function switcher(studio: Locator): Locator {
+  return studio.getByRole("tablist", { name: "Destinations" });
+}
+
+function destination(studio: Locator, name: string): Locator {
+  return switcher(studio).getByRole("tab", { name });
+}
+
+/** Open the studio with one panel already up, and hand back the shadow root. */
+async function studioWithPanel(page: Page, panel: string): Promise<Locator> {
+  await openStudio(page, `/val?panel=${panel}`);
+  return page.locator("#val-shadow-root");
+}
+
+test.describe("the destinations on a tablet", () => {
+  test("has no rail at this width - that is the premise", async ({ page }) => {
+    const studio = await studioWithPanel(page, "pages");
+    await expect(studio.getByRole("navigation", { name: "Main" })).toHaveCount(
+      0,
+    );
+  });
+
+  test("reaches Data from the panel the menu button opens", async ({
+    page,
+  }) => {
+    await openStudio(page);
+    const studio = page.locator("#val-shadow-root");
+    // What the menu button does: the first destination, which is Pages.
+    await studio.getByRole("button", { name: "Open navigation" }).click();
+    await expect(studio.getByRole("dialog", { name: "Pages" })).toBeVisible();
+
+    await destination(studio, "Data").click();
+    await expect(studio.getByRole("dialog", { name: "Data" })).toBeVisible();
+    // And back, so this is a switcher rather than a one-way door.
+    await destination(studio, "Pages").click();
+    await expect(studio.getByRole("dialog", { name: "Pages" })).toBeVisible();
+  });
+
+  test("reaches Media and Settings too", async ({ page }) => {
+    const studio = await studioWithPanel(page, "data");
+    await expect(studio.getByRole("dialog", { name: "Data" })).toBeVisible();
+
+    await destination(studio, "Media").click();
+    await expect(studio.getByRole("dialog", { name: "Media" })).toBeVisible();
+
+    await destination(studio, "Settings").click();
+    await expect(
+      studio.getByRole("dialog", { name: "Settings" }),
+    ).toBeVisible();
+  });
+
+  test("marks the panel that is open, so the rest read as somewhere to go", async ({
+    page,
+  }) => {
+    const studio = await studioWithPanel(page, "data");
+    await expect(destination(studio, "Data")).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    await expect(destination(studio, "Pages")).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+  });
+});
+
+test.describe("the same panels on desktop", () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test("carry no switcher - the rail is the one there", async ({ page }) => {
+    const studio = await studioWithPanel(page, "data");
+    await expect(
+      studio.getByRole("navigation", { name: "Main" }),
+    ).toBeVisible();
+    await expect(studio.getByRole("dialog", { name: "Data" })).toBeVisible();
+    await expect(switcher(studio)).toHaveCount(0);
+  });
+});

--- a/packages/ui/spa/components/shell/FloatingPanel.tsx
+++ b/packages/ui/spa/components/shell/FloatingPanel.tsx
@@ -20,8 +20,9 @@ export type FloatingPanelProps = {
   /** Rendered to the right of the title, e.g. a "New" button. */
   headerAction?: ReactNode;
   /**
-   * Rendered directly below the header, above `sticky`. Used on mobile to
-   * carry the destination switcher, since there is no left rail there.
+   * Rendered directly below the header, above `sticky`. Used below the desktop
+   * breakpoint to carry the destination switcher, since there is no left rail
+   * there — see `NavSwitcher`.
    */
   subheader?: ReactNode;
   /** Pinned below the header, outside the scroll area, e.g. a search field. */

--- a/packages/ui/spa/components/shell/MobileChrome.tsx
+++ b/packages/ui/spa/components/shell/MobileChrome.tsx
@@ -1,57 +1,6 @@
 import { Info, PanelRight } from "lucide-react";
 import { ReactNode } from "react";
-import { cn } from "../designSystem/cn";
 import { PreviewButton, PublishButton } from "./TopBar";
-import { visibleRailItems } from "./LeftRail";
-import { ShellDestination, ShellPanel } from "./types";
-
-/**
- * The destination switcher shown at the top of every navigation sheet on
- * mobile, standing in for the left rail.
- */
-export function MobileNavSwitcher({
-  openPanel,
-  onSelect,
-  destinations,
-}: {
-  openPanel: ShellPanel | null;
-  onSelect: (panel: ShellPanel) => void;
-  /** The destinations this project has content for. See `LeftRailProps`. */
-  destinations?: readonly ShellDestination[];
-}) {
-  const items = visibleRailItems(destinations);
-  if (items.length < 2) {
-    // One destination is not a choice, and a tab strip with a single tab in it
-    // just takes a row off the top of every sheet.
-    return null;
-  }
-  return (
-    <div
-      role="tablist"
-      aria-label="Destinations"
-      className="flex gap-0.5 p-0.5 rounded-md bg-bg-float-raised"
-    >
-      {items.map(({ panel, label, icon: Icon }) => (
-        <button
-          key={panel}
-          type="button"
-          role="tab"
-          aria-selected={openPanel === panel}
-          onClick={() => onSelect(panel)}
-          className={cn(
-            "flex-1 inline-flex items-center justify-center gap-1.5 h-7 rounded text-[0.6875rem]",
-            openPanel === panel
-              ? "bg-bg-float text-fg-primary shadow-sm font-medium"
-              : "text-fg-secondary",
-          )}
-        >
-          <Icon size={13} />
-          {label}
-        </button>
-      ))}
-    </div>
-  );
-}
 
 /**
  * The sticky mobile bottom bar. Preview and Publish are always reachable

--- a/packages/ui/spa/components/shell/NavSwitcher.tsx
+++ b/packages/ui/spa/components/shell/NavSwitcher.tsx
@@ -3,23 +3,43 @@ import { visibleRailItems } from "./LeftRail";
 import { ShellBreakpoint, ShellDestination, ShellPanel } from "./types";
 
 /**
- * Whether the navigation panels have to carry a destination switcher.
+ * Whether the destinations amount to a choice.
  *
- * Anywhere the left rail is not drawn, which is everything below desktop. The
- * rail being desktop-only means that between 768px and 1200px — an iPad, a
- * half screen — the switcher is the ONLY way to get from one destination to
+ * One is not: a tab strip with a single tab in it just takes a row off the top
+ * of every panel. Shared by `needsNavSwitcher` and `NavSwitcher` so that "must
+ * a panel carry a switcher" and "does the switcher render anything" cannot
+ * disagree — where they disagree, the panel gets an empty bordered band under
+ * its header, which is what `FloatingPanel` makes of a `subheader` that renders
+ * `null`.
+ */
+function offersChoice(destinations?: readonly ShellDestination[]): boolean {
+  return visibleRailItems(destinations).length > 1;
+}
+
+/**
+ * Whether a navigation panel has to carry a destination switcher.
+ *
+ * Anywhere the left rail is not drawn, which is everything below desktop, and
+ * only where there is more than one destination to switch between. The rail
+ * being desktop-only means that between 768px and 1200px — an iPad, a half
+ * screen — the switcher is the ONLY way to get from one destination to
  * another: the top bar's menu button opens the first destination a project has
  * and nothing else, so Data, Media and Settings were unreachable at those
  * widths once Pages was open. Mobile had the switcher from the start; the
  * tablet breakpoint fell through the gap between the two.
  *
  * A predicate rather than a `breakpoint` prop on `NavSwitcher` itself, because
- * the caller has to be able to pass `undefined` for the panel's subheader: a
- * switcher that renders `null` still leaves `FloatingPanel` an empty bordered
- * band under the header.
+ * the caller has to be able to pass `undefined` for the panel's subheader —
+ * see `offersChoice` for what a rendered `null` costs.
+ *
+ * `destinations` omitted means all of them, which is what `visibleRailItems`
+ * means by it.
  */
-export function needsNavSwitcher(breakpoint: ShellBreakpoint): boolean {
-  return breakpoint !== "desktop";
+export function needsNavSwitcher(
+  breakpoint: ShellBreakpoint,
+  destinations?: readonly ShellDestination[],
+): boolean {
+  return breakpoint !== "desktop" && offersChoice(destinations);
 }
 
 /**
@@ -37,9 +57,10 @@ export function NavSwitcher({
   destinations?: readonly ShellDestination[];
 }) {
   const items = visibleRailItems(destinations);
-  if (items.length < 2) {
-    // One destination is not a choice, and a tab strip with a single tab in it
-    // just takes a row off the top of every panel.
+  if (!offersChoice(destinations)) {
+    // Nothing to choose between. `needsNavSwitcher` says the same thing, so a
+    // caller that asked first has already passed `undefined` instead; this is
+    // for one that renders the switcher directly.
     return null;
   }
   return (

--- a/packages/ui/spa/components/shell/NavSwitcher.tsx
+++ b/packages/ui/spa/components/shell/NavSwitcher.tsx
@@ -1,0 +1,71 @@
+import { cn } from "../designSystem/cn";
+import { visibleRailItems } from "./LeftRail";
+import { ShellBreakpoint, ShellDestination, ShellPanel } from "./types";
+
+/**
+ * Whether the navigation panels have to carry a destination switcher.
+ *
+ * Anywhere the left rail is not drawn, which is everything below desktop. The
+ * rail being desktop-only means that between 768px and 1200px — an iPad, a
+ * half screen — the switcher is the ONLY way to get from one destination to
+ * another: the top bar's menu button opens the first destination a project has
+ * and nothing else, so Data, Media and Settings were unreachable at those
+ * widths once Pages was open. Mobile had the switcher from the start; the
+ * tablet breakpoint fell through the gap between the two.
+ *
+ * A predicate rather than a `breakpoint` prop on `NavSwitcher` itself, because
+ * the caller has to be able to pass `undefined` for the panel's subheader: a
+ * switcher that renders `null` still leaves `FloatingPanel` an empty bordered
+ * band under the header.
+ */
+export function needsNavSwitcher(breakpoint: ShellBreakpoint): boolean {
+  return breakpoint !== "desktop";
+}
+
+/**
+ * The destination switcher shown at the top of every navigation panel wherever
+ * the left rail is not drawn, standing in for it. See `needsNavSwitcher`.
+ */
+export function NavSwitcher({
+  openPanel,
+  onSelect,
+  destinations,
+}: {
+  openPanel: ShellPanel | null;
+  onSelect: (panel: ShellPanel) => void;
+  /** The destinations this project has content for. See `LeftRailProps`. */
+  destinations?: readonly ShellDestination[];
+}) {
+  const items = visibleRailItems(destinations);
+  if (items.length < 2) {
+    // One destination is not a choice, and a tab strip with a single tab in it
+    // just takes a row off the top of every panel.
+    return null;
+  }
+  return (
+    <div
+      role="tablist"
+      aria-label="Destinations"
+      className="flex gap-0.5 p-0.5 rounded-md bg-bg-float-raised"
+    >
+      {items.map(({ panel, label, icon: Icon }) => (
+        <button
+          key={panel}
+          type="button"
+          role="tab"
+          aria-selected={openPanel === panel}
+          onClick={() => onSelect(panel)}
+          className={cn(
+            "flex-1 inline-flex items-center justify-center gap-1.5 h-7 rounded text-[0.6875rem]",
+            openPanel === panel
+              ? "bg-bg-float text-fg-primary shadow-sm font-medium"
+              : "text-fg-secondary",
+          )}
+        >
+          <Icon size={13} />
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/packages/ui/spa/components/shell/Shell.tsx
+++ b/packages/ui/spa/components/shell/Shell.tsx
@@ -31,7 +31,8 @@ import {
 } from "./GlobalSearch";
 import { LeftRail } from "./LeftRail";
 import { MediaPanel } from "./MediaPanel";
-import { MobileBottomBar, MobileNavSwitcher } from "./MobileChrome";
+import { MobileBottomBar } from "./MobileChrome";
+import { NavSwitcher, needsNavSwitcher } from "./NavSwitcher";
 import { PendingChangesGate } from "./PendingChangesGate";
 import type { ChainProgress } from "../../utils/describePendingChangesStall";
 
@@ -770,14 +771,20 @@ export function Shell({
     [data, select, onOpenSearchResult],
   );
 
-  const navSwitcher =
-    breakpoint === "mobile" ? (
-      <MobileNavSwitcher
-        openPanel={openPanel}
-        onSelect={setOpenPanel}
-        destinations={destinations}
-      />
-    ) : undefined;
+  /**
+   * The destination switcher every navigation panel carries as its subheader.
+   *
+   * `undefined` on desktop, where the rail is the switcher and a second copy of
+   * it inside the panel would be two controls for one choice — see
+   * `needsNavSwitcher`.
+   */
+  const navSwitcher = needsNavSwitcher(breakpoint) ? (
+    <NavSwitcher
+      openPanel={openPanel}
+      onSelect={setOpenPanel}
+      destinations={destinations}
+    />
+  ) : undefined;
 
   /**
    * The editor column: whatever the main pane is showing right now.

--- a/packages/ui/spa/components/shell/Shell.tsx
+++ b/packages/ui/spa/components/shell/Shell.tsx
@@ -775,10 +775,13 @@ export function Shell({
    * The destination switcher every navigation panel carries as its subheader.
    *
    * `undefined` on desktop, where the rail is the switcher and a second copy of
-   * it inside the panel would be two controls for one choice — see
-   * `needsNavSwitcher`.
+   * it inside the panel would be two controls for one choice, and `undefined`
+   * for a project with only one destination, where there is nothing to switch
+   * between — see `needsNavSwitcher`. It has to be `undefined` rather than a
+   * switcher that renders nothing: `FloatingPanel` gives any subheader it is
+   * handed its own bordered band.
    */
-  const navSwitcher = needsNavSwitcher(breakpoint) ? (
+  const navSwitcher = needsNavSwitcher(breakpoint, destinations) ? (
     <NavSwitcher
       openPanel={openPanel}
       onSelect={setOpenPanel}

--- a/packages/ui/spa/components/shell/TopBar.tsx
+++ b/packages/ui/spa/components/shell/TopBar.tsx
@@ -68,10 +68,12 @@ export type TopBarProps = {
   /**
    * Opens the review view. Absent in layouts that have none.
    *
-   * Review sits beside Publish because it is the step before it: a reader who
-   * is about to ship wants to see what they are shipping, and the action lived
-   * only in the Quick actions panel — two clicks away, behind an icon that does
-   * not say "review".
+   * Review is the first of the three actions — Review, Preview, Publish — read
+   * left to right in the order someone shipping a change does them: see what
+   * changed, look at it on the page, send it. It used to sit between Preview
+   * and Publish, which put the step you do FIRST in the middle; before that it
+   * lived only in the Quick actions panel, two clicks away behind an icon that
+   * does not say "review".
    */
   onCompare?: () => void;
   /**
@@ -114,9 +116,10 @@ export type PublishState = "idle" | "publishing" | "error" | "blocked";
 /**
  * The floating top bar.
  *
- * Preview and Publish stay visible at every breakpoint above mobile; on
- * mobile they move to the sticky bottom bar and the top bar keeps only
- * navigation, notifications, AI and account.
+ * Review, Preview and Publish stay visible at every breakpoint above mobile —
+ * in that order, which is the order they are done in; on mobile Preview and
+ * Publish move to the sticky bottom bar, Review moves to the Quick actions
+ * panel, and the top bar keeps only navigation, notifications, AI and account.
  */
 export function TopBar({
   breakpoint,
@@ -173,16 +176,16 @@ export function TopBar({
       <div className="ml-auto flex items-center gap-1.5 shrink-0">
         {!isMobile && (
           <>
+            <ReviewButton
+              onCompare={onCompare}
+              pendingChanges={pendingChanges}
+              reviewCount={reviewCount}
+            />
             <PreviewButton
               onPreview={onPreview}
               previewHref={previewHref}
               onToggleCanvas={onToggleCanvas}
               isCanvasOpen={isCanvasOpen}
-            />
-            <ReviewButton
-              onCompare={onCompare}
-              pendingChanges={pendingChanges}
-              reviewCount={reviewCount}
             />
             {publishSlot ?? (
               <PublishButton
@@ -520,16 +523,20 @@ function BarDivider() {
 }
 
 /**
- * Review, beside Publish.
+ * Review, first of the three actions and to the left of Preview.
  *
  * Present whenever the shell can review at all, and merely INVISIBLE until
  * there is something to review. Not `null`, which is what it was: this group is
  * `ml-auto`, so its right edge is pinned and its left edge grows — a button
- * appearing in the middle of it slides Preview and everything left of it across
- * by its own width. That happens exactly when the first change lands, which is
- * exactly when someone is working in there, and it moved the Preview button out
- * from under a click that had already started. `canvas.spec.ts` caught it as a
- * click that hit nothing; a person gets the same miss and no error.
+ * mounting inside it moves the group's left edge, and everything left of that
+ * edge, by its own width. That happens exactly when the first change lands,
+ * which is exactly when someone is working in there, and while Review sat
+ * BETWEEN Preview and Publish it also moved Preview out from under a click that
+ * had already started. `canvas.spec.ts` caught it as a click that hit nothing;
+ * a person gets the same miss and no error. Being leftmost now spares Preview
+ * and Publish specifically, but the space still has to be held: the search
+ * field and the project name are to the left of it, and they would take the
+ * jump instead.
  *
  * `visibility: hidden` rather than opacity: it holds the space, takes no
  * clicks, takes no tab stop, and is not announced — so nothing is offered that

--- a/packages/ui/spa/components/shell/index.ts
+++ b/packages/ui/spa/components/shell/index.ts
@@ -42,7 +42,8 @@ export { UtilityPanel } from "./UtilityPanel";
 export { AIChatPanel } from "./AIChatPanel";
 export { NotificationsPanel } from "./NotificationsPanel";
 export { EditorCanvas, PageEditor, CANVAS_MAX_WIDTH } from "./EditorCanvas";
-export { MobileBottomBar, MobileNavSwitcher } from "./MobileChrome";
+export { MobileBottomBar } from "./MobileChrome";
+export { NavSwitcher, needsNavSwitcher } from "./NavSwitcher";
 export {
   useShellBreakpoint,
   SHELL_MOBILE_BREAKPOINT,

--- a/packages/ui/spa/components/shell/tabletDestinations.test.tsx
+++ b/packages/ui/spa/components/shell/tabletDestinations.test.tsx
@@ -1,0 +1,122 @@
+/** @jest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { ModuleFilePath } from "@valbuild/core";
+import { NavSwitcher, needsNavSwitcher } from "./NavSwitcher";
+import { DataPanel } from "./DataPanel";
+import { ShellBreakpoint, ShellDataModule, ShellDestination } from "./types";
+
+/**
+ * Getting from one destination to another between 768px and 1200px.
+ *
+ * The left rail is desktop-only and the top bar's menu button opens the FIRST
+ * destination a project has and nothing else, so at an iPad's width — or a
+ * half screen — Data, Media and Settings had no route at all once Pages was
+ * open: whichever panel was showing was the only panel reachable. The switcher
+ * that stands in for the rail was gated on `breakpoint === "mobile"`, and the
+ * tablet breakpoint fell through the gap between the two.
+ *
+ * `Shell` itself is not renderable here — it pulls in the whole editor tree —
+ * so what is pinned is the rule it asks (`needsNavSwitcher`) and that a panel
+ * handed the switcher at tablet width actually shows it.
+ */
+const destinations: ShellDestination[] = ["pages", "media", "data", "settings"];
+
+const dataModule: ShellDataModule = {
+  id: "/content/settings.val.ts" as ModuleFilePath,
+  name: "settings",
+  moduleFilePath: "/content/settings.val.ts" as ModuleFilePath,
+};
+
+function switcher(props: Partial<Parameters<typeof NavSwitcher>[0]> = {}) {
+  return (
+    <NavSwitcher
+      openPanel="data"
+      onSelect={() => undefined}
+      destinations={destinations}
+      {...props}
+    />
+  );
+}
+
+/** The Data panel as the shell renders it, switcher and all. */
+function dataPanel(breakpoint: ShellBreakpoint) {
+  return (
+    <DataPanel
+      breakpoint={breakpoint}
+      data={[dataModule]}
+      selectedId={null}
+      onSelect={() => undefined}
+      onClose={() => undefined}
+      navSwitcher={
+        needsNavSwitcher(breakpoint)
+          ? switcher({ openPanel: "data" })
+          : undefined
+      }
+    />
+  );
+}
+
+describe("which breakpoints need the switcher", () => {
+  test("tablet does - it has no rail and no other way across", () => {
+    expect(needsNavSwitcher("tablet")).toBe(true);
+  });
+
+  test("mobile does, as it always did", () => {
+    expect(needsNavSwitcher("mobile")).toBe(true);
+  });
+
+  test("desktop does not - the rail is the switcher there", () => {
+    expect(needsNavSwitcher("desktop")).toBe(false);
+  });
+});
+
+describe("the switcher itself", () => {
+  test("offers every destination the project has", () => {
+    render(switcher());
+    for (const name of ["Pages", "Media", "Data", "Settings"]) {
+      expect(screen.queryByRole("tab", { name })).not.toBeNull();
+    }
+  });
+
+  test("marks the open panel, so the others read as somewhere to go", () => {
+    render(switcher());
+    expect(
+      screen.getByRole("tab", { name: "Data" }).getAttribute("aria-selected"),
+    ).toBe("true");
+    expect(
+      screen.getByRole("tab", { name: "Pages" }).getAttribute("aria-selected"),
+    ).toBe("false");
+  });
+
+  test("selects the destination it is asked for", () => {
+    const selected: string[] = [];
+    render(switcher({ onSelect: (panel) => selected.push(panel) }));
+    screen.getByRole("tab", { name: "Pages" }).click();
+    expect(selected).toEqual(["pages"]);
+  });
+
+  test("offers only what the project has - no icon for an empty panel", () => {
+    render(switcher({ destinations: ["pages", "data"] }));
+    expect(screen.queryByRole("tab", { name: "Media" })).toBeNull();
+    expect(screen.queryByRole("tab", { name: "Data" })).not.toBeNull();
+  });
+
+  test("is nothing at all when there is only one destination", () => {
+    render(switcher({ destinations: ["data"] }));
+    expect(screen.queryByRole("tablist")).toBeNull();
+  });
+});
+
+describe("a navigation panel at tablet width", () => {
+  test("carries the switcher, so Pages is one click away from Data", () => {
+    render(dataPanel("tablet"));
+    expect(screen.queryByRole("dialog", { name: "Data" })).not.toBeNull();
+    expect(screen.queryByRole("tab", { name: "Pages" })).not.toBeNull();
+  });
+
+  test("carries none of it on desktop", () => {
+    render(dataPanel("desktop"));
+    expect(screen.queryByRole("dialog", { name: "Data" })).not.toBeNull();
+    expect(screen.queryByRole("tablist")).toBeNull();
+  });
+});

--- a/packages/ui/spa/components/shell/tabletDestinations.test.tsx
+++ b/packages/ui/spa/components/shell/tabletDestinations.test.tsx
@@ -38,8 +38,18 @@ function switcher(props: Partial<Parameters<typeof NavSwitcher>[0]> = {}) {
   );
 }
 
-/** The Data panel as the shell renders it, switcher and all. */
-function dataPanel(breakpoint: ShellBreakpoint) {
+/**
+ * The Data panel as the shell renders it, switcher and all.
+ *
+ * The `navSwitcher` expression is `Shell`'s, copied rather than imported
+ * because `Shell` pulls in the whole editor tree — so the thing that has to
+ * stay true is that this is the same expression. It is the whole of the bug
+ * the empty-band tests below are about.
+ */
+function dataPanel(
+  breakpoint: ShellBreakpoint,
+  available: ShellDestination[] = destinations,
+) {
   return (
     <DataPanel
       breakpoint={breakpoint}
@@ -48,8 +58,8 @@ function dataPanel(breakpoint: ShellBreakpoint) {
       onSelect={() => undefined}
       onClose={() => undefined}
       navSwitcher={
-        needsNavSwitcher(breakpoint)
-          ? switcher({ openPanel: "data" })
+        needsNavSwitcher(breakpoint, available)
+          ? switcher({ openPanel: "data", destinations: available })
           : undefined
       }
     />
@@ -67,6 +77,42 @@ describe("which breakpoints need the switcher", () => {
 
   test("desktop does not - the rail is the switcher there", () => {
     expect(needsNavSwitcher("desktop")).toBe(false);
+  });
+
+  /**
+   * The predicate has to agree with what the switcher will actually render.
+   *
+   * `FloatingPanel` gives any subheader it is handed its own bordered band, so
+   * a `true` here for a project the switcher renders `null` for is an empty
+   * band under the panel header — a hairline and a row of padding around
+   * nothing.
+   */
+  test("a project with one destination does not - there is no choice", () => {
+    expect(needsNavSwitcher("tablet", ["data"])).toBe(false);
+    expect(needsNavSwitcher("mobile", ["data"])).toBe(false);
+  });
+
+  test("a project with no destinations at all does not either", () => {
+    expect(needsNavSwitcher("tablet", [])).toBe(false);
+  });
+
+  test("two is a choice, and gets one", () => {
+    expect(needsNavSwitcher("tablet", ["pages", "data"])).toBe(true);
+  });
+
+  test("agrees with the switcher on every project shape", () => {
+    const shapes: ShellDestination[][] = [
+      [],
+      ["data"],
+      ["pages", "data"],
+      ["pages", "media", "data", "settings"],
+    ];
+    for (const available of shapes) {
+      const { unmount } = render(switcher({ destinations: available }));
+      const rendersSomething = screen.queryByRole("tablist") !== null;
+      expect(needsNavSwitcher("tablet", available)).toBe(rendersSomething);
+      unmount();
+    }
   });
 });
 
@@ -118,5 +164,37 @@ describe("a navigation panel at tablet width", () => {
     render(dataPanel("desktop"));
     expect(screen.queryByRole("dialog", { name: "Data" })).not.toBeNull();
     expect(screen.queryByRole("tablist")).toBeNull();
+  });
+
+  /**
+   * No band where there is no switcher.
+   *
+   * A single-destination project has nothing to switch between, so the panel
+   * must be handed `undefined` rather than a switcher that renders `null`:
+   * `FloatingPanel` wraps whatever it is given in a bordered row, and that row
+   * around nothing is a hairline and some padding under the header.
+   */
+  test("leaves no empty band when there is only one destination", () => {
+    // Counted rather than named: the panel has hairlines of its own (its
+    // header, its filter), and the claim is that the switcher's band is not
+    // among them — so the number is the one the same panel has on desktop,
+    // where there is no subheader at all.
+    const bands = (view: HTMLElement) =>
+      view.querySelectorAll(".border-b.border-border-float").length;
+
+    const desktop = render(dataPanel("desktop"));
+    const withoutSubheader = bands(desktop.container);
+    desktop.unmount();
+
+    const single = render(dataPanel("tablet", ["data"]));
+    expect(screen.queryByRole("tablist")).toBeNull();
+    expect(bands(single.container)).toBe(withoutSubheader);
+    single.unmount();
+
+    // And the band IS there when the switcher is, so the count above is
+    // measuring the thing it claims to.
+    const many = render(dataPanel("tablet"));
+    expect(screen.queryByRole("tablist")).not.toBeNull();
+    expect(bands(many.container)).toBe(withoutSubheader + 1);
   });
 });

--- a/packages/ui/spa/components/shell/topBarActionOrder.test.tsx
+++ b/packages/ui/spa/components/shell/topBarActionOrder.test.tsx
@@ -67,6 +67,17 @@ describe("Review, Preview, Publish", () => {
     // Nothing pending: the button is invisible but still in the layout, so the
     // bar must not reflow when the first change lands. See `ReviewButton`.
     render(topBar({ pendingChanges: 0, reviewCount: 0 }));
+    /*
+     * By label, not by role, and this is the one query that works.
+     *
+     * With nothing pending the button carries `aria-hidden`, and the
+     * accessible NAME of an element hidden from the accessibility tree
+     * computes as the empty string — so
+     * `getByRole("button", { name: "Review changes", hidden: true })` matches
+     * nothing, `hidden: true` included: that option widens which elements are
+     * considered, not how their names are computed. `getByLabelText` reads the
+     * `aria-label` attribute itself, which is unaffected.
+     */
     const review = screen.getByLabelText("Review changes");
     expect(
       precedes(review, screen.getByRole("button", { name: "Preview" })),

--- a/packages/ui/spa/components/shell/topBarActionOrder.test.tsx
+++ b/packages/ui/spa/components/shell/topBarActionOrder.test.tsx
@@ -1,0 +1,75 @@
+/** @jest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { TopBar } from "./TopBar";
+
+/**
+ * The order of the three actions in the top bar.
+ *
+ * Review, Preview, Publish — left to right in the order someone shipping a
+ * change does them: see what changed, look at it on the page, send it. Review
+ * used to sit between Preview and Publish, which put the step you do FIRST in
+ * the middle of the other two.
+ *
+ * Pinned as DOM order rather than as a class name because that is what decides
+ * both the reading order and the tab order, and it is the thing a later edit to
+ * this group can break without touching anything that looks like layout.
+ */
+function topBar(props: Partial<Parameters<typeof TopBar>[0]> = {}) {
+  return (
+    <TopBar
+      breakpoint="desktop"
+      projectName="acme/marketing-site"
+      openPanel={null}
+      onTogglePanel={() => undefined}
+      onOpenMenu={() => undefined}
+      onOpenSearch={() => undefined}
+      onPreview={() => undefined}
+      onCompare={() => undefined}
+      onPublish={() => undefined}
+      pendingChanges={3}
+      reviewCount={3}
+      {...props}
+    />
+  );
+}
+
+/** True when `first` comes before `second` in the document. */
+function precedes(first: Element, second: Element): boolean {
+  return (
+    (first.compareDocumentPosition(second) &
+      Node.DOCUMENT_POSITION_FOLLOWING) !==
+    0
+  );
+}
+
+describe("Review, Preview, Publish", () => {
+  test("Review comes before Preview", () => {
+    render(topBar());
+    expect(
+      precedes(
+        screen.getByRole("button", { name: "Review 3 changes" }),
+        screen.getByRole("button", { name: "Preview" }),
+      ),
+    ).toBe(true);
+  });
+
+  test("Preview comes before Publish", () => {
+    render(topBar());
+    expect(
+      precedes(
+        screen.getByRole("button", { name: "Preview" }),
+        screen.getByRole("button", { name: /^Publish/ }),
+      ),
+    ).toBe(true);
+  });
+
+  test("the space Review holds is to the left of Preview too", () => {
+    // Nothing pending: the button is invisible but still in the layout, so the
+    // bar must not reflow when the first change lands. See `ReviewButton`.
+    render(topBar({ pendingChanges: 0, reviewCount: 0 }));
+    const review = screen.getByLabelText("Review changes");
+    expect(
+      precedes(review, screen.getByRole("button", { name: "Preview" })),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Two visual fixes to the Studio's chrome.

## The Data panel disappears between 768px and 1200px

The left rail is drawn from 1200px up, and the top bar's menu button opens the first destination a project has and nothing else — so at an iPad's width, or on any half screen, whichever panel happened to be open was the only panel reachable: **Data, Media and Settings had no route at all**. The destination switcher that stands in for the rail was gated on `breakpoint === "mobile"`, and the tablet breakpoint fell through the gap between the two.

At 1024px before this change, the Pages panel is a header, a filter and a list, and nothing in the shell offers another destination. After it, the panel carries a `Pages | Media | Data | Settings` strip between its header and its filter — the same one a phone has always had — and Data is one click away. `e2e/screens.spec.ts` grows a `tablet` case that photographs exactly those two panels, for the next person who wants to look at this width.

The gate is now `needsNavSwitcher`, which is "anywhere the rail is not" — a named predicate rather than an inline comparison because it has to agree with `LeftRail`'s own breakpoint, and because the caller has to be able to pass `undefined` for the panel's subheader: a switcher that renders `null` still leaves `FloatingPanel` an empty bordered band under the header. `MobileNavSwitcher` is renamed `NavSwitcher` and moved out of `MobileChrome.tsx`, which is no longer where it belongs.

## Review moved to the left of Preview

The three actions now read left to right in the order they are done in — Review, Preview, Publish — instead of putting the first step between the other two.

Review stays `invisible` rather than unmounted with nothing pending. It is leftmost now, so it no longer displaces Preview when the first change lands (which is what `canvas.spec.ts` caught as a click that hit nothing), but the search field and the project name are still to its left and would take the jump instead.

## Testing

- `tabletDestinations.test.tsx` — the breakpoint rule and the switcher's own behaviour.
- `topBarActionOrder.test.tsx` — the DOM order of the three actions, which is what decides the reading order and the tab order.
- `e2e/tablet-nav.spec.ts` — driven at 1024px, because the bug WAS the viewport: every panel rendered correctly and each one was fine to look at.

Both new layers were confirmed to fail against the old gate before the fix. Also run: `pnpm run lint`, `pnpm run format`, `pnpm run -r typecheck`, `pnpm test` (3719 passing), and `e2e/canvas.spec.ts` + `e2e/compare.spec.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019So83VVd74JoKuB1kpH9Zr