### PR TITLE
Stop @valbuild/shared replacing a consumer's own flexsearch types

### DIFF
--- a/.changeset/no-flexsearch-in-shared-types.md
+++ b/.changeset/no-flexsearch-in-shared-types.md
@@ -1,0 +1,30 @@
+---
+"@valbuild/shared": patch
+---
+
+Stop `@valbuild/shared` replacing a consumer's own flexsearch types
+
+`@valbuild/shared` gained a flexsearch dependency in 0.123.0, for
+`search_content`, and typed its exported `SearchIndex.index` as flexsearch's
+own `Index`. That put `import { Index } from "flexsearch"` into the published
+`searchIndex.d.ts` — and flexsearch's type entry opens with
+`declare module "flexsearch"`, which is an AMBIENT module declaration and so
+global to a whole TypeScript program.
+
+The effect on a project that uses flexsearch itself, at a different version:
+its own calls are checked against the copy Val dragged in. valbuild/web pins
+flexsearch 0.7 and builds an index with
+`new flexsearch.Document({ language: "en", … })`; on `@valbuild/shared@0.123.2`
+that stopped compiling, because 0.8's `DocumentOptions` has no `language`. Its
+resolved copy was still 0.7 — only the types had been swapped underneath it.
+
+`SearchIndex.index` is now a structural type covering the three methods this
+package calls, so nothing in the published declarations names flexsearch. The
+library is still used to build the index; that is a value import, which never
+reaches a `.d.ts`.
+
+No API change: `SearchIndex` is still assignable from a real flexsearch
+`Index`, and `noFlexsearchInPublishedTypes.test.ts` asserts both halves of that
+— that no source file names flexsearch in a type position, and that a real
+`Index` still satisfies the stand-in, so it cannot drift from the library
+unnoticed.

--- a/packages/shared/src/internal/search/noFlexsearchInPublishedTypes.test.ts
+++ b/packages/shared/src/internal/search/noFlexsearchInPublishedTypes.test.ts
@@ -1,0 +1,108 @@
+import fs from "fs";
+import path from "path";
+import FlexSearch from "flexsearch";
+import { SearchIndex, createSearchIndex } from "./searchIndex";
+
+/**
+ * flexsearch must not appear in this package's published type declarations.
+ *
+ * `declare module "flexsearch"` is what flexsearch's own `index.d.ts` opens
+ * with, and an ambient module declaration is global to a TypeScript program.
+ * So a `.d.ts` of ours that merely NAMES flexsearch pulls that declaration into
+ * every consumer's program — and a consumer with its own flexsearch at another
+ * version then type-checks its OWN calls against whichever of the two copies
+ * wins.
+ *
+ * The incident: `@valbuild/shared` gained flexsearch in 0.123.0 for
+ * `search_content`, and `SearchIndex.index` was typed as flexsearch's `Index`,
+ * so `searchIndex.d.ts` shipped `import { Index } from "flexsearch"`. On
+ * 0.123.2 valbuild/web stopped building — it pins flexsearch 0.7 and calls
+ * `new flexsearch.Document({ language: "en", … })`, and 0.8's `DocumentOptions`
+ * has no `language`. Its own resolved copy was still 0.7; only the types had
+ * been swapped underneath it. Same shape as the `@types/react` duplication in
+ * CLAUDE.md, and the same lesson as the zod leak that
+ * `noZodInClientEntrypoint.test.ts` guards.
+ *
+ * Two things are checked, because either alone would miss the regression:
+ * that no source file names flexsearch in a type position, and that the
+ * structural type standing in for `Index` still describes the real library.
+ */
+const SRC = path.resolve(__dirname, "..", "..");
+
+/** Every `.ts`/`.tsx` file under `packages/shared/src`. */
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...sourceFiles(full));
+    } else if (/\.tsx?$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe("flexsearch in @valbuild/shared's types", () => {
+  /**
+   * A default VALUE import is fine — it is erased from the declarations, since
+   * it is only ever called inside a function body. A named or type-only import
+   * is how the type reaches the `.d.ts`, and `Index` arrived exactly that way.
+   */
+  test("is imported only as a default value binding", () => {
+    const files = sourceFiles(SRC).filter(
+      (file) => !file.endsWith("noFlexsearchInPublishedTypes.test.ts"),
+    );
+    expect(files.length).toBeGreaterThan(20); // the walk found the package
+
+    const offenders: string[] = [];
+    for (const file of files) {
+      const source = fs.readFileSync(file, "utf-8");
+      // The clause may not itself contain `from`, or the match runs back
+      // through every earlier import in the file to reach this one.
+      const re =
+        /import\s+((?:(?!\bfrom\b)[\s\S])*?)\s+from\s*["']flexsearch["']/g;
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(source)) !== null) {
+        const clause = m[1].trim();
+        // `FlexSearch` — a bare default binding — and nothing else.
+        if (!/^[A-Za-z_$][\w$]*$/.test(clause)) {
+          offenders.push(`${path.relative(SRC, file)}: import ${clause}`);
+        }
+      }
+      if (
+        /import\s+type\s+((?:(?!\bfrom\b)[\s\S])*?)\s+from\s*["']flexsearch["']/.test(
+          source,
+        )
+      ) {
+        offenders.push(`${path.relative(SRC, file)}: import type`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  /**
+   * And the stand-in has to keep describing the real thing.
+   *
+   * Structural types go stale silently: flexsearch could rename `remove` and
+   * nothing else here would fail, because no call site is checked against the
+   * library any more. Assigning a real `Index` to the exported field is what
+   * catches that — the same trick `sharpImageProcessor.test.ts` uses to stop
+   * `SharpLike` drifting from sharp.
+   */
+  test("stands in for a real flexsearch Index", () => {
+    const real = new FlexSearch.Index({ tokenize: "forward" });
+    // Fails to compile if `SearchableIndex` asks for anything `Index` lacks.
+    const index: SearchIndex["index"] = real;
+
+    // And is the same shape the module actually builds for itself.
+    expect(typeof createSearchIndex().index.add).toBe("function");
+
+    // Exercised, not just assigned: a signature can be satisfied by a type and
+    // still be the wrong call.
+    index.add("a/path", "hello world");
+    expect(index.search("hello", { limit: 10 })).toEqual(["a/path"]);
+    index.remove("a/path");
+    expect(index.search("hello", { limit: 10 })).toEqual([]);
+  });
+});

--- a/packages/shared/src/internal/search/noFlexsearchInPublishedTypes.test.ts
+++ b/packages/shared/src/internal/search/noFlexsearchInPublishedTypes.test.ts
@@ -45,40 +45,75 @@ function sourceFiles(dir: string): string[] {
 
 describe("flexsearch in @valbuild/shared's types", () => {
   /**
-   * A default VALUE import is fine — it is erased from the declarations, since
-   * it is only ever called inside a function body. A named or type-only import
-   * is how the type reaches the `.d.ts`, and `Index` arrived exactly that way.
+   * One reviewed way to name flexsearch: a default VALUE import.
+   *
+   * That form is erased from the declarations, because the binding is only ever
+   * called inside a function body. Every other way of naming the module reaches
+   * the `.d.ts` — a named or type-only import (how `Index` arrived), a
+   * re-export (`export { Index } from`, `export * from`), or a type query
+   * (`import("flexsearch")`).
+   *
+   * So rather than enumerate the bad forms, the allowed one is stripped and
+   * anything still naming the module is an offender. Enumerating was the first
+   * attempt and it missed the re-exports and the type query.
    */
-  test("is imported only as a default value binding", () => {
+  test("is named only by a default value import", () => {
     const files = sourceFiles(SRC).filter(
       (file) => !file.endsWith("noFlexsearchInPublishedTypes.test.ts"),
     );
     expect(files.length).toBeGreaterThan(20); // the walk found the package
 
+    /** `import FlexSearch from "flexsearch"` — a bare default binding. */
+    const ALLOWED = /import\s+[A-Za-z_$][\w$]*\s+from\s*["']flexsearch["']/g;
+    /**
+     * flexsearch in a MODULE SPECIFIER position.
+     *
+     * Anchored on `from` / `import(` / `require(` rather than on the bare word,
+     * so prose may still discuss it: `searchIndex.ts` explains this very rule
+     * in a comment that quotes `declare module "flexsearch"`, and that is
+     * preceded by `module`, not by any of these.
+     */
+    const SPECIFIER =
+      /(?:\bfrom\b|\bimport\s*\(|\brequire\s*\()\s*["']flexsearch["']/g;
+
     const offenders: string[] = [];
     for (const file of files) {
       const source = fs.readFileSync(file, "utf-8");
-      // The clause may not itself contain `from`, or the match runs back
-      // through every earlier import in the file to reach this one.
-      const re =
-        /import\s+((?:(?!\bfrom\b)[\s\S])*?)\s+from\s*["']flexsearch["']/g;
-      let m: RegExpExecArray | null;
-      while ((m = re.exec(source)) !== null) {
-        const clause = m[1].trim();
-        // `FlexSearch` — a bare default binding — and nothing else.
-        if (!/^[A-Za-z_$][\w$]*$/.test(clause)) {
-          offenders.push(`${path.relative(SRC, file)}: import ${clause}`);
-        }
-      }
-      if (
-        /import\s+type\s+((?:(?!\bfrom\b)[\s\S])*?)\s+from\s*["']flexsearch["']/.test(
-          source,
-        )
-      ) {
-        offenders.push(`${path.relative(SRC, file)}: import type`);
+      const stripped = source.replace(ALLOWED, "");
+      for (const m of stripped.matchAll(SPECIFIER)) {
+        offenders.push(`${path.relative(SRC, file)}: ${m[0].trim()}`);
       }
     }
     expect(offenders).toEqual([]);
+  });
+
+  /**
+   * The stripping has to actually be load bearing.
+   *
+   * A typo in `ALLOWED` that made it match nothing would leave the real default
+   * import as an offender and fail the test above; a typo that made it match
+   * everything would pass it no matter what. This pins the middle: the allowed
+   * form is accepted, and each of the four leaking forms is caught.
+   */
+  test("catches every form that reaches a .d.ts", () => {
+    // Built per call: `test` on a /g/ regex carries `lastIndex` between calls,
+    // so a shared one would answer differently depending on call order.
+    const leaks = (source: string): boolean => {
+      const allowed = /import\s+[A-Za-z_$][\w$]*\s+from\s*["']flexsearch["']/g;
+      const specifier =
+        /(?:\bfrom\b|\bimport\s*\(|\brequire\s*\()\s*["']flexsearch["']/g;
+      return specifier.test(source.replace(allowed, ""));
+    };
+
+    expect(leaks('import FlexSearch from "flexsearch";')).toBe(false);
+    expect(leaks('// see declare module "flexsearch" for why')).toBe(false);
+
+    expect(leaks('import { Index } from "flexsearch";')).toBe(true);
+    expect(leaks('import type { Index } from "flexsearch";')).toBe(true);
+    expect(leaks('export { Index } from "flexsearch";')).toBe(true);
+    expect(leaks('export * from "flexsearch";')).toBe(true);
+    expect(leaks('type I = import("flexsearch").Index;')).toBe(true);
+    expect(leaks('const f = require("flexsearch");')).toBe(true);
   });
 
   /**

--- a/packages/shared/src/internal/search/searchIndex.ts
+++ b/packages/shared/src/internal/search/searchIndex.ts
@@ -5,7 +5,7 @@ import {
   SerializedSchema,
   SourcePath,
 } from "@valbuild/core";
-import FlexSearch, { Index } from "flexsearch";
+import FlexSearch from "flexsearch";
 import { traverseSchemaSource, flattenRichText } from "./traverseSchemaSource";
 import { getRefParts } from "./getFilenameFromRef";
 
@@ -24,8 +24,36 @@ import { getRefParts } from "./getFilenameFromRef";
  * them — an agent and an editor searching the same project should find the same
  * things.
  */
+/**
+ * The parts of FlexSearch's `Index` this module uses.
+ *
+ * Structural, rather than importing flexsearch's own `Index`, because
+ * {@link SearchIndex} is EXPORTED — and a `.d.ts` that names `flexsearch` pulls
+ * that package's `declare module "flexsearch"` into every consumer's TypeScript
+ * program. Ambient module declarations are global to a program, so a consumer
+ * with its own flexsearch at another version then checks its OWN calls against
+ * the copy we dragged in, whichever of the two wins.
+ *
+ * That is not hypothetical: `@valbuild/shared` gained a flexsearch dependency
+ * in 0.123.0 for `search_content`, and valbuild/web — which pins flexsearch
+ * 0.7 and calls `new flexsearch.Document({ language: "en", … })` — stopped
+ * building on 0.123.2, because 0.8's `DocumentOptions` has no `language`. Its
+ * own resolved copy was still 0.7; only the types had been replaced.
+ *
+ * Three methods is all this module calls, and none of their signatures here is
+ * a guess: `add` and `remove` are used in `indexModule`/`removeModule`, and
+ * `search`'s result is only ever `.length`-ed, `.slice`-d and mapped over as
+ * ids. `FlexSearch.Index` is still constructed with the real library in
+ * {@link createSearchIndex} — a value import, which does not reach the `.d.ts`.
+ */
+type SearchableIndex = {
+  add(id: string, content: string): void;
+  remove(id: string): void;
+  search(query: string, options: { limit: number }): (string | number)[];
+};
+
 export type SearchIndex = {
-  index: Index;
+  index: SearchableIndex;
   pathToLabel: Map<string, string>;
   /**
    * Which document ids belong to which module, so one module can be re-indexed


### PR DESCRIPTION
Found while bumping [valbuild/web](https://github.com/valbuild/web) to `@valbuild/*@0.123.2`: the bump does not build.

```
components/search/DocSearchDialog.tsx(47,7): error TS2345: Argument of type
'{ language: string; tokenize: "full"; document: { id: string; index: string[]; }; }'
is not assignable to parameter of type 'DocumentOptions<DocumentData, false, false>'.
  'language' does not exist in type 'DocumentOptions<DocumentData, false, false>'.
```

Three type parameters and no `language` — that is flexsearch **0.8**'s signature. web pins flexsearch `^0.7.43`, and `node_modules/flexsearch` still resolves to 0.7.43. Only the types had been swapped underneath it.

## Why

`@valbuild/shared` gained a flexsearch dependency in 0.123.0, for `search_content`, and typed its exported `SearchIndex.index` as flexsearch's own `Index`. So the published `searchIndex.d.ts` shipped, on line 2:

```ts
import { Index } from "flexsearch";
```

flexsearch's type entry opens with `declare module "flexsearch"`. An ambient module declaration is **global to a TypeScript program**, so naming the package in one of our `.d.ts` files puts it into every consumer's program — and a consumer with its own flexsearch at another version then type-checks its own calls against whichever copy wins.

Same shape as the `@types/react` duplication documented in CLAUDE.md, and the same lesson as the zod leak in #629: a dependency escaping into consumers through the published surface.

## The fix

`SearchIndex.index` becomes `SearchableIndex`, a structural type covering the three methods this package actually calls (`add`, `remove`, `search`). The library still builds the index in `createSearchIndex` — a value import, and one used only inside a function body never reaches a `.d.ts`.

Verified against a real `pnpm run build`: `from "flexsearch"` now appears in **no** declaration file in the repo, where 0.123.2's shipped it on line 2. And with the same edit applied to web's installed copy, web builds again.

No API change — `SearchIndex` is still assignable from a real flexsearch `Index`.

## Guards

`noFlexsearchInPublishedTypes.test.ts` pins both halves, because either alone would miss the regression:

- **No source file imports flexsearch with a named or type-only binding** — the form `Index` arrived by. A default value binding stays allowed, since that is what builds the index and it is erased from the declarations. I re-introduced `import FlexSearch, { Index }` and confirmed this test fails on it.
- **A real `FlexSearch.Index` is still assignable to the stand-in, and is exercised through it.** A structural type goes stale silently once no call site is checked against the library any more — flexsearch could rename `remove` and nothing else here would notice. This is the trick `sharpImageProcessor.test.ts` already uses to keep `SharpLike` honest against sharp.

Run locally: `pnpm run lint`, `pnpm run format`, `pnpm run -r typecheck`, the search suite (37 passing), and `pnpm run build` (then `pnpm preconstruct dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019So83VVd74JoKuB1kpH9Zr

---
_Generated by [Claude Code](https://claude.ai/code/session_019So83VVd74JoKuB1kpH9Zr)_