### PR TITLE
Commit the AI summary that landed during the publish wait

### DIFF
--- a/.changeset/publish-commits-the-ai-summary.md
+++ b/.changeset/publish-commits-the-ai-summary.md
@@ -1,0 +1,22 @@
+---
+"@valbuild/ui": patch
+---
+
+Publish the AI summary that arrived while you were waiting for it
+
+Pressing Publish while the AI was still writing the commit message starts a
+short countdown, so the summary gets a chance to land before the commit goes
+out. It landed — the box on screen filled with it — and then the commit said
+"Update Home" anyway.
+
+The text was read back out of the summary state by the publish button, from
+that button's own render. The countdown fires a callback created when Publish
+was pressed, and applying the summary and ending the wait happen in the same
+flush, so the callback always ran with the text the box held _before_ the
+summary arrived. No amount of waiting could have fixed it.
+
+The popover now hands the text to publish along with the request, and works it
+out from the values as they are at that moment. The rule is unchanged and is
+still the one thing this flow guarantees: an AI summary takes over only a box
+nobody has typed in, so anyone who wrote their own summary publishes exactly
+what they wrote, whenever the AI happens to answer.

--- a/packages/ui/spa/components/PublishButton.tsx
+++ b/packages/ui/spa/components/PublishButton.tsx
@@ -80,8 +80,7 @@ export function PublishButton({
   compact?: boolean;
 }) {
   const [summaryOpen, setSummaryOpen] = useState(false);
-  const { publish, publishDisabled, isPublishing, summary } =
-    usePublishSummary();
+  const { publish, publishDisabled, isPublishing } = usePublishSummary();
   const allValidationErrors = useAllValidationErrors();
   const validationErrorPaths = Object.keys(allValidationErrors ?? {});
   const { patchErrors } = useAllPatchErrors();
@@ -270,12 +269,17 @@ export function PublishButton({
             onClose={() => {
               setSummaryOpen(false);
             }}
-            onPublish={() => {
+            onPublish={(summary) => {
               setSummaryOpen(false);
-              if (summary.type === "not-asked") {
+              // The text comes from the popover rather than from the summary
+              // state read here: publishing can be fired by the grace period,
+              // after an AI summary landed but before this component has
+              // re-rendered with it, and this render's copy would commit the
+              // text the user was no longer looking at.
+              const summaryText = summary.trim();
+              if (summaryText === "") {
                 return;
               }
-              const summaryText = summary.text.trim();
               publish(summaryText);
             }}
           />

--- a/packages/ui/spa/components/PublishSummary.test.tsx
+++ b/packages/ui/spa/components/PublishSummary.test.tsx
@@ -1,0 +1,240 @@
+/** @jest-environment jsdom */
+import { useState } from "react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { PublishSummary } from "./PublishSummary";
+import { TooltipProvider } from "./designSystem/tooltip";
+import type { AiSummaryState } from "./PublishSummaryView";
+
+/**
+ * What actually gets committed when Publish is pressed.
+ *
+ * The rule the popover is built around is that the AI never blocks anyone: the
+ * box is filled with a summary that needed no network call, and the AI's
+ * version takes over only if the user has not written their own. Pressing
+ * Publish while the AI is still writing buys it a few seconds — and this is
+ * the seam that broke.
+ *
+ * The text used to be read back out of the summary STATE by the publish button,
+ * from that button's own render. Publishing during the grace period is fired by
+ * a callback created when Publish was pressed, and the summary lands after
+ * that: the box on screen said the AI's sentence and the commit said "Update
+ * Home". Both effects run in the same flush, so no amount of waiting fixed it.
+ * Hence the tests below assert on the text handed to `onPublish`, not on the
+ * textarea.
+ */
+
+const mockPatchSets = {
+  status: "success",
+  data: [
+    {
+      moduleFilePath: "/content/home.val.ts",
+      patchPath: ["hero", "title"],
+      schemaTypes: ["string"],
+    },
+  ],
+};
+
+const mockValSystem = {
+  system: {
+    sourceStore: {
+      peek: () => ({ status: "ready", data: "New heading" }),
+      peekBase: () => ({ status: "ready", data: "Old heading" }),
+    },
+  },
+};
+
+/** Set by the harness on every render; read by the mocked hooks below. */
+let mockPublishSummaryHook: {
+  summary: { type: "not-asked" } | { type: "manual" | "ai"; text: string };
+  setSummary: (
+    summary: { type: "manual" | "ai"; text: string } | { type: "not-asked" },
+  ) => void;
+};
+let mockAiState: AiSummaryState = { status: "loading" };
+
+const mockAiHook = {
+  get state() {
+    return mockAiState;
+  },
+  start: jest.fn(),
+  cancel: jest.fn(),
+  reveal: jest.fn(),
+};
+
+jest.mock("./ValProvider", () => ({
+  usePublishSummary: () => ({
+    ...mockPublishSummaryHook,
+    publishDisabled: false,
+    isPublishing: false,
+    aiEnabled: true,
+  }),
+  usePatchSets: () => mockPatchSets,
+  useAvailableAIModel: () => ({ id: "test-model", provider: "test" }),
+}));
+jest.mock("../stores/react/SystemContext", () => ({
+  useValSystem: () => mockValSystem,
+}));
+jest.mock("../hooks/useCommitSummary", () => ({
+  useCommitSummary: () => mockAiHook,
+}));
+jest.mock("./ValRouter", () => ({
+  useSessionParam: () => ({ setSessionParam: jest.fn() }),
+}));
+jest.mock("./AIChatActionsContext", () => ({
+  useAIChatActions: () => ({ openAIChat: jest.fn() }),
+}));
+jest.mock("./ValPortalProvider", () => ({
+  useValPortal: () => null,
+}));
+
+const AI_TEXT = "The hero now leads with the product name";
+const DEFAULT_TEXT = "Update Home";
+
+function Harness({ onPublish }: { onPublish: (summary: string) => void }) {
+  // The real summary lives in a provider and is persisted; all this flow needs
+  // of it is that reads see the last write.
+  const [summary, setSummaryState] = useState<
+    { type: "not-asked" } | { type: "manual" | "ai"; text: string }
+  >({ type: "not-asked" });
+  mockPublishSummaryHook = { summary, setSummary: setSummaryState };
+  return (
+    <TooltipProvider>
+      <PublishSummary onPublish={onPublish} onClose={() => {}} />
+    </TooltipProvider>
+  );
+}
+
+function setAiState(next: AiSummaryState, rerender: () => void) {
+  mockAiState = next;
+  act(() => {
+    rerender();
+  });
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  mockAiState = { status: "loading" };
+  mockAiHook.start.mockClear();
+  mockAiHook.cancel.mockClear();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+function summaryBox(): HTMLTextAreaElement {
+  return screen.getByPlaceholderText(
+    "Write a summary of your changes",
+  ) as HTMLTextAreaElement;
+}
+
+describe("PublishSummary", () => {
+  test("fills the box with a summary that needed no network call", () => {
+    const onPublish = jest.fn();
+    render(<Harness onPublish={onPublish} />);
+    expect(summaryBox().value).toBe(DEFAULT_TEXT);
+  });
+
+  test("the AI summary takes over a box nobody has typed in", () => {
+    const onPublish = jest.fn();
+    const { rerender } = render(<Harness onPublish={onPublish} />);
+    setAiState({ status: "ready", text: AI_TEXT, sessionId: null }, () =>
+      rerender(<Harness onPublish={onPublish} />),
+    );
+    expect(summaryBox().value).toBe(AI_TEXT);
+  });
+
+  test("a summary that lands during the grace period is what gets committed", () => {
+    const onPublish = jest.fn();
+    const { rerender } = render(<Harness onPublish={onPublish} />);
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /publish/i }));
+    });
+    // Publishing waits rather than going ahead with the default.
+    expect(onPublish).not.toHaveBeenCalled();
+    expect(screen.getByText(/Waiting for the AI summary/)).toBeTruthy();
+
+    setAiState({ status: "ready", text: AI_TEXT, sessionId: null }, () =>
+      rerender(<Harness onPublish={onPublish} />),
+    );
+
+    // The regression: this used to be called with DEFAULT_TEXT, because the
+    // callback the countdown fired predated the summary arriving.
+    expect(onPublish).toHaveBeenCalledWith(AI_TEXT);
+    expect(summaryBox().value).toBe(AI_TEXT);
+  });
+
+  test("the wait ends on its own, with the box as it stands", () => {
+    const onPublish = jest.fn();
+    render(<Harness onPublish={onPublish} />);
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /publish/i }));
+    });
+    // A second apart, one act each: the next tick is only scheduled by the
+    // re-render the previous one caused, so a single long advance runs one.
+    for (let second = 0; second <= 10; second++) {
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+    }
+    expect(onPublish).toHaveBeenCalledWith(DEFAULT_TEXT);
+  });
+
+  test("a second press skips the rest of the wait", () => {
+    const onPublish = jest.fn();
+    render(<Harness onPublish={onPublish} />);
+    const publish = () =>
+      act(() => {
+        fireEvent.click(screen.getByRole("button", { name: /publish/i }));
+      });
+    publish();
+    expect(onPublish).not.toHaveBeenCalled();
+    publish();
+    expect(onPublish).toHaveBeenCalledWith(DEFAULT_TEXT);
+  });
+
+  test("what the user wrote is committed, and never waits on the AI", () => {
+    const onPublish = jest.fn();
+    const { rerender } = render(<Harness onPublish={onPublish} />);
+    act(() => {
+      fireEvent.change(summaryBox(), {
+        target: { value: "Fix the typo in the footer" },
+      });
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /publish/i }));
+    });
+    expect(onPublish).toHaveBeenCalledWith("Fix the typo in the footer");
+
+    // And an arrival afterwards does not rewrite it either.
+    setAiState({ status: "ready", text: AI_TEXT, sessionId: null }, () =>
+      rerender(<Harness onPublish={onPublish} />),
+    );
+    expect(summaryBox().value).toBe("Fix the typo in the footer");
+  });
+
+  test("an AI summary already in the box is committed as it stands", () => {
+    const onPublish = jest.fn();
+    const { rerender } = render(<Harness onPublish={onPublish} />);
+    setAiState({ status: "ready", text: AI_TEXT, sessionId: null }, () =>
+      rerender(<Harness onPublish={onPublish} />),
+    );
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /publish/i }));
+    });
+    expect(onPublish).toHaveBeenCalledWith(AI_TEXT);
+  });
+
+  test("a failed summary is not waited for", () => {
+    const onPublish = jest.fn();
+    const { rerender } = render(<Harness onPublish={onPublish} />);
+    setAiState({ status: "failed", message: "No key configured" }, () =>
+      rerender(<Harness onPublish={onPublish} />),
+    );
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /publish/i }));
+    });
+    expect(onPublish).toHaveBeenCalledWith(DEFAULT_TEXT);
+  });
+});

--- a/packages/ui/spa/components/PublishSummary.tsx
+++ b/packages/ui/spa/components/PublishSummary.tsx
@@ -6,6 +6,7 @@ import { useValSystem } from "../stores/react/SystemContext";
 import { PublishSummaryView, usePublishGrace } from "./PublishSummaryView";
 import {
   buildDefaultCommitSummary,
+  resolvePublishText,
   shouldAutoApplyAiSummary,
 } from "./publish/defaultCommitSummary";
 import {
@@ -61,7 +62,13 @@ export function PublishSummary({
   onPublish,
   onClose,
 }: {
-  onPublish?: () => void;
+  /**
+   * Publish, committing exactly this text. Passed rather than read back out of
+   * the summary state: publishing can be fired by the grace period after the
+   * AI summary landed, and a caller reading its own render's copy of the state
+   * would commit the text the box no longer shows.
+   */
+  onPublish?: (summary: string) => void;
   onClose: () => void;
 }) {
   const { summary, setSummary, publishDisabled, isPublishing, aiEnabled } =
@@ -188,10 +195,37 @@ export function PublishSummary({
     }
   }, [ai.state.status, isWaiting, skip]);
 
+  // Written on every render, read by callbacks that outlive the render that
+  // made them. The grace period holds the `publishNow` from the press that
+  // started it, and the whole point of the countdown is that the AI summary
+  // arrives after that — so the values that decide what gets committed cannot
+  // come from that closure.
+  const latest = useRef({
+    value,
+    hasEdited,
+    defaultSummary,
+    aiState: ai.state,
+  });
+  latest.current = { value, hasEdited, defaultSummary, aiState: ai.state };
+
   const publishNow = () => {
+    const current = latest.current;
+    const text = resolvePublishText({
+      hasEdited: current.hasEdited,
+      currentValue: current.value,
+      defaultSummary: current.defaultSummary,
+      aiText: current.aiState.status === "ready" ? current.aiState.text : null,
+    });
+    // The box has not necessarily re-rendered with the summary that is about to
+    // be committed — the effect that applies it and this one fire in the same
+    // flush. Setting it keeps the two in agreement, which matters if the
+    // publish fails and the user is left looking at what was sent.
+    if (text !== current.value) {
+      setSummary({ type: "ai", text });
+    }
     // Publishing means nobody is going to read the summary session any more.
     ai.cancel();
-    onPublish?.();
+    onPublish?.(text);
   };
 
   return (

--- a/packages/ui/spa/components/publish/defaultCommitSummary.test.ts
+++ b/packages/ui/spa/components/publish/defaultCommitSummary.test.ts
@@ -1,6 +1,7 @@
 import {
   buildDefaultCommitSummary,
   moduleDisplayName,
+  resolvePublishText,
   shouldAutoApplyAiSummary,
 } from "./defaultCommitSummary";
 
@@ -154,5 +155,58 @@ describe("shouldAutoApplyAiSummary", () => {
         defaultSummary,
       }),
     ).toBe(true);
+  });
+});
+
+describe("resolvePublishText", () => {
+  const defaultSummary = "Update Home";
+  const aiText = "Rewrite the hero to lead with the product name";
+
+  test("commits the summary that arrived while the countdown ran", () => {
+    // The bug this pins: pressing Publish while the AI was writing published
+    // the default, because the text was read from the closure the press
+    // created — the box had the AI's summary and the commit did not.
+    expect(
+      resolvePublishText({
+        hasEdited: false,
+        currentValue: defaultSummary,
+        defaultSummary,
+        aiText,
+      }),
+    ).toBe(aiText);
+  });
+
+  test("commits what the user wrote, whatever the AI came back with", () => {
+    expect(
+      resolvePublishText({
+        hasEdited: true,
+        currentValue: "Fix the typo in the footer",
+        defaultSummary,
+        aiText,
+      }),
+    ).toBe("Fix the typo in the footer");
+  });
+
+  test("commits the box when there is no finished summary", () => {
+    // No AI configured, still writing, or failed — all the same answer.
+    expect(
+      resolvePublishText({
+        hasEdited: false,
+        currentValue: defaultSummary,
+        defaultSummary,
+        aiText: null,
+      }),
+    ).toBe(defaultSummary);
+  });
+
+  test("does not re-apply a summary the box already holds", () => {
+    expect(
+      resolvePublishText({
+        hasEdited: false,
+        currentValue: aiText,
+        defaultSummary,
+        aiText,
+      }),
+    ).toBe(aiText);
   });
 });

--- a/packages/ui/spa/components/publish/defaultCommitSummary.ts
+++ b/packages/ui/spa/components/publish/defaultCommitSummary.ts
@@ -92,3 +92,31 @@ export function shouldAutoApplyAiSummary(args: {
   }
   return args.currentValue.trim() === args.defaultSummary.trim();
 }
+
+/**
+ * The text to commit, decided at the moment publishing actually goes through.
+ *
+ * The box is React state, and publishing is not always triggered by the render
+ * that holds the newest of it: pressing Publish while the AI is still writing
+ * stores a callback, and the grace period fires that callback later — after the
+ * summary has arrived and been applied to the box, but from a closure created
+ * before either happened. Reading the text off that closure committed the
+ * default while the box on screen said the AI's summary.
+ *
+ * So the same rule `shouldAutoApplyAiSummary` applies to the box is applied
+ * once more here, against the latest values, and its answer is what gets
+ * committed. `aiText` is null whenever there is no finished summary — no AI
+ * configured, still writing, or failed — which is the case where the box is
+ * already the whole answer.
+ */
+export function resolvePublishText(args: {
+  hasEdited: boolean;
+  currentValue: string;
+  defaultSummary: string;
+  aiText: string | null;
+}): string {
+  if (args.aiText !== null && shouldAutoApplyAiSummary(args)) {
+    return args.aiText;
+  }
+  return args.currentValue;
+}


### PR DESCRIPTION
Pressing Publish while the AI is still writing the commit message starts a 10-second countdown, so the summary gets a chance to land before the commit goes out. It landed — the box on screen filled with it — and the commit said "Update Home" anyway.

## The bug

`PublishButton` read the text back out of the summary state, from its own render:

```tsx
onPublish={() => {
  const summaryText = summary.text.trim();  // this render's copy
  publish(summaryText);
}}
```

The countdown fires a callback created when Publish was pressed. When the summary arrives, the effect that applies it to the box and the effect that ends the wait run in the **same flush** — so `publish` was always called before React had committed the new state, with the text from before the summary existed. No amount of waiting could have fixed it; the grace period was buying time for a value nothing was going to read.

## The fix

- `onPublish` takes the text to commit instead of the button reading it back out of state.
- `publishNow` decides that text at the moment publishing goes through, from a ref written on every render, so the countdown's stale closure cannot decide it.
- New `resolvePublishText` in `publish/defaultCommitSummary.ts` — `shouldAutoApplyAiSummary` asked a second time, so the box and the commit answer to one rule.

The rule itself is unchanged, and is still the one thing this flow guarantees: **an AI summary takes over only a box nobody has typed in.** Anyone who wrote their own summary publishes exactly what they wrote, whenever the AI happens to answer.

## Tests

`PublishSummary.test.tsx` is new and pins the flow end to end, asserting on the text handed to `onPublish` rather than on the textarea — that gap is where the bug lived:

- the box is seeded without a network call
- the AI summary takes over a box nobody has typed in
- **a summary that lands during the grace period is what gets committed** (fails on `main`)
- the wait ends on its own, with the box as it stands
- a second press skips the rest of the wait
- what the user wrote is committed, and is not rewritten by a later arrival
- an AI summary already in the box is committed as it stands
- a failed summary is not waited for

Reverting `publishNow` to the old behavior fails exactly the grace-period test, so it catches the regression rather than merely describing it. `resolvePublishText` also has its own unit tests alongside `shouldAutoApplyAiSummary`.

Full CI run locally: `lint`, `prettier --check`, recursive `typecheck`, and `pnpm test` (3736 tests) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KjrV18ZL7gm2F7akji2c1F

---
_Generated by [Claude Code](https://claude.ai/code/session_01KjrV18ZL7gm2F7akji2c1F)_