### PR TITLE
Give the history view a door

### DIFF
--- a/.changeset/history-commit-list.md
+++ b/.changeset/history-commit-list.md
@@ -1,0 +1,22 @@
+---
+"@valbuild/ui": minor
+---
+
+Find your history from the Studio, instead of building a URL by hand
+
+The two-pane history view shipped with no way in. Everything behind it worked —
+the commit archives, the reconstruction, the compare, the restore — but the
+only way to reach it was to read a commit sha out of the database and assemble
+a query string yourself. A feature nobody can find is not shipped.
+
+There is now a **History** button in the top bar, next to Publish. It lists what
+has been published on this branch, newest first, with the message, who published
+it, when, and how many changes it carried. Click one and it opens beside the
+Studio; **Stop comparing** closes it again.
+
+- Commits made before Val recorded history — and ones pushed straight to the
+  repo — are listed, but greyed out and not clickable, with a note saying why.
+  Hiding them would make your history look shorter than it is.
+- **Load more** pages back through older commits.
+- The button does not appear in local development, where there is no published
+  history to list.

--- a/packages/ui/spa/components/shell/Shell.tsx
+++ b/packages/ui/spa/components/shell/Shell.tsx
@@ -36,20 +36,6 @@ import { NavSwitcher, needsNavSwitcher } from "./NavSwitcher";
 import { PendingChangesGate } from "./PendingChangesGate";
 import type { ChainProgress } from "../../utils/describePendingChangesStall";
 
-/**
- * What the gate reports when nobody supplied diagnostics.
- *
- * `statSeen: true` with nothing outstanding, so the report reads as "slow"
- * rather than inventing a fault the caller never claimed.
- */
-const noProgress = (): ChainProgress => ({
-  total: 0,
-  settled: 0,
-  unfetched: [],
-  unapplied: [],
-  failed: [],
-  statSeen: true,
-});
 import { FloatingPanel } from "./FloatingPanel";
 import { NotificationsPanel } from "./NotificationsPanel";
 import { PagesPanel } from "./PagesPanel";
@@ -73,6 +59,21 @@ import {
   ShellPanel,
   ShellValidationError,
 } from "./types";
+
+/**
+ * What the gate reports when nobody supplied diagnostics.
+ *
+ * `statSeen: true` with nothing outstanding, so the report reads as "slow"
+ * rather than inventing a fault the caller never claimed.
+ */
+const noProgress = (): ChainProgress => ({
+  total: 0,
+  settled: 0,
+  unfetched: [],
+  unapplied: [],
+  failed: [],
+  statSeen: true,
+});
 
 /** What the editor canvas is currently showing. */
 export type ShellSelection = {

--- a/packages/ui/spa/components/shell/Shell.tsx
+++ b/packages/ui/spa/components/shell/Shell.tsx
@@ -50,6 +50,7 @@ const noProgress = (): ChainProgress => ({
   failed: [],
   statSeen: true,
 });
+import { FloatingPanel } from "./FloatingPanel";
 import { NotificationsPanel } from "./NotificationsPanel";
 import { PagesPanel } from "./PagesPanel";
 import { AccountPanel } from "./AccountPanel";
@@ -299,6 +300,16 @@ export type ShellProps = {
    */
   aiSlot?: ReactNode;
   /**
+   * The list of publishes, for the History panel.
+   *
+   * A slot for the same reason `aiSlot` is one: the list has to fetch commits
+   * and set `?commit=`, and the shell is deliberately free of Val hooks so it
+   * can be rendered from a story with mock data. Absent means Val has no
+   * published history here (FS mode), and the button is hidden with it — see
+   * `historyEnabled`.
+   */
+  historySlot?: ReactNode;
+  /**
    * Mention a source path in the assistant. From the canvas's field menu.
    *
    * The shell cannot do this itself: inserting a reference means reaching into
@@ -412,6 +423,7 @@ export function Shell({
   accountError,
   aiEnabled = false,
   aiSlot,
+  historySlot,
   onMentionField,
   pendingChangesLoaded = true,
   pendingChangesProgress,
@@ -609,6 +621,12 @@ export function Shell({
       setOpenPanel(null);
     }
   }, [openPanel, aiEnabled]);
+
+  useEffect(() => {
+    if (openPanel === "history" && historySlot === undefined) {
+      setOpenPanel(null);
+    }
+  }, [openPanel, historySlot]);
 
   const validationErrorCount = useMemo(
     () => data.validationErrors.reduce((sum, e) => sum + e.count, 0),
@@ -902,6 +920,7 @@ export function Shell({
           accountError={breakpoint === "desktop" ? undefined : accountError}
           isLoading={isLoading}
           aiEnabled={aiEnabled}
+          historyEnabled={historySlot !== undefined}
           onPreview={onPreview ?? (() => undefined)}
           previewHref={previewHref}
           onToggleCanvas={canCanvas ? togglePreview : undefined}
@@ -1134,6 +1153,19 @@ export function Shell({
           >
             {aiSlot ?? <NoAssistantConfigured />}
           </AIChatPanel>
+        )}
+
+        {openPanel === "history" && (
+          <FloatingPanel
+            side="right"
+            width={340}
+            title="History"
+            mobileVariant="bottom-sheet"
+            breakpoint={breakpoint}
+            onClose={closePanel}
+          >
+            {historySlot}
+          </FloatingPanel>
         )}
 
         {openPanel === "notifications" && (

--- a/packages/ui/spa/components/shell/TopBar.tsx
+++ b/packages/ui/spa/components/shell/TopBar.tsx
@@ -5,6 +5,7 @@ import {
   Columns2,
   Eye,
   GitCompare,
+  History,
   Link2,
   Loader2,
   LucideIcon,
@@ -41,6 +42,15 @@ export type TopBarProps = {
    * hidden; a number — including 0 — means show it.
    */
   unreadNotifications?: number;
+  /**
+   * Whether to offer the history panel.
+   *
+   * False in FS mode: local dev has git, not a commit archive, so there is no
+   * published history to list and the endpoint answers
+   * `not-supported-in-fs-mode`. Better to not offer the button than to open a
+   * panel whose only content is an apology.
+   */
+  historyEnabled?: boolean;
   /** Absent until a profile loads, and in modes that have none. */
   user?: { name: string; avatarUrl?: string };
   onOpenSearch: () => void;
@@ -129,6 +139,7 @@ export function TopBar({
   onTogglePanel,
   onOpenMenu,
   unreadNotifications,
+  historyEnabled = false,
   user,
   onOpenSearch,
   onPreview,
@@ -196,6 +207,15 @@ export function TopBar({
             )}
             <BarDivider />
           </>
+        )}
+        {historyEnabled && (
+          <IconButton
+            label="History"
+            active={openPanel === "history"}
+            onClick={() => onTogglePanel("history")}
+          >
+            <History size={16} />
+          </IconButton>
         )}
         {aiEnabled && (
           <IconButton

--- a/packages/ui/spa/components/shell/ValShell.tsx
+++ b/packages/ui/spa/components/shell/ValShell.tsx
@@ -51,6 +51,7 @@ import {
 } from "../ValRouter";
 import { HistoryPane } from "../../history/HistoryPane";
 import { CommitList } from "../../history/CommitList";
+import { PanelEmptyState } from "./FloatingPanel";
 import { useCommitList } from "../../history/useCommitList";
 import { useValConfig } from "../ValFieldProvider";
 import { RestoreControls } from "../../history/RestoreControls";
@@ -1126,7 +1127,24 @@ function ValShellBody({ state }: { state: ReturnType<typeof useShellData> }) {
 function CommitListSurface() {
   const config = useValConfig();
   const { history, setHistory } = useHistoryParams();
-  const { state, loadMore } = useCommitList(config?.gitBranch ?? null);
+  const branch = config?.gitBranch ?? null;
+  const { state, loadMore } = useCommitList(branch);
+  /*
+   * `gitBranch` is optional in ValConfig, and history is listed per branch, so
+   * without one there is nothing to ask for. Said out loud rather than left as
+   * a spinner: the hook has no request to make, so it would otherwise sit on
+   * "Reading the history…" forever. `config` being undefined is the different,
+   * transient case - it is still loading - and keeps the spinner.
+   */
+  if (config !== undefined && branch === null) {
+    return (
+      <PanelEmptyState>
+        This project has no <code>gitBranch</code> configured, and history is
+        listed per branch. Set one in <code>val.config</code> to see what has
+        been published.
+      </PanelEmptyState>
+    );
+  }
   return (
     <CommitList
       state={state}

--- a/packages/ui/spa/components/shell/ValShell.tsx
+++ b/packages/ui/spa/components/shell/ValShell.tsx
@@ -50,6 +50,9 @@ import {
   useHistoryParams,
 } from "../ValRouter";
 import { HistoryPane } from "../../history/HistoryPane";
+import { CommitList } from "../../history/CommitList";
+import { useCommitList } from "../../history/useCommitList";
+import { useValConfig } from "../ValFieldProvider";
 import { RestoreControls } from "../../history/RestoreControls";
 import { RestoreModeProvider } from "../../history/RestoreModeContext";
 import { useDirectedRestore } from "../../history/useDirectedRestore";
@@ -1093,11 +1096,65 @@ function ValShellBody({ state }: { state: ReturnType<typeof useShellData> }) {
       aiSlot={
         isAIChatEnabled ? <AIChatSurface className="h-full" /> : undefined
       }
+      /*
+       * The list of publishes.
+       *
+       * `undefined` in FS mode, which also hides the button: local dev has git
+       * rather than a commit archive, so there is no published history to list
+       * and `/history/commits` answers `not-supported-in-fs-mode`. Mounted only
+       * while the panel is open, so opening the Studio does not fetch a list
+       * nobody asked for — the head of it moves on every publish, so it is not
+       * cached and there would be nothing to warm.
+       */
+      historySlot={mode === "http" ? <CommitListSurface /> : undefined}
       onMentionField={(sourcePath) => insertFieldRef(sourcePath as SourcePath)}
       // Held until the first load's patches are in — see `PendingChangesGate`.
       pendingChangesLoaded={pendingChangesLoaded}
       pendingChangesProgress={pendingChangesProgress}
       pendingChangesError={pendingChangesError}
+    />
+  );
+}
+
+/**
+ * The History panel's contents: the commit list, wired up.
+ *
+ * Separated from `ValShell` so the fetch lives with the thing that shows it —
+ * and so it unmounts with the panel, which is what keeps the list from being
+ * fetched on every Studio load.
+ */
+function CommitListSurface() {
+  const config = useValConfig();
+  const { history, setHistory } = useHistoryParams();
+  const { state, loadMore } = useCommitList(config?.gitBranch ?? null);
+  return (
+    <CommitList
+      state={state}
+      selectedCommitSha={history.commitSha}
+      onSelect={(commitSha) =>
+        /*
+         * Locked, and with no restore in progress.
+         *
+         * Picking a different commit from the list is starting again, not
+         * continuing: carrying a half-aimed restore across would leave a source
+         * path pointing into a commit that is no longer on screen.
+         */
+        setHistory({
+          commitSha,
+          locked: true,
+          rightPath: null,
+          restore: { mode: "off" },
+        })
+      }
+      onStopComparing={() =>
+        setHistory({
+          commitSha: null,
+          locked: true,
+          rightPath: null,
+          restore: { mode: "off" },
+        })
+      }
+      onLoadMore={loadMore}
     />
   );
 }

--- a/packages/ui/spa/components/shell/types.ts
+++ b/packages/ui/spa/components/shell/types.ts
@@ -200,7 +200,9 @@ export type ShellPanel =
   | "account"
   | "utility"
   | "ai"
-  | "notifications";
+  | "notifications"
+  /** The list of publishes, and the way into the two-pane history view. */
+  | "history";
 
 /** Breakpoint the shell is rendering at. */
 export type ShellBreakpoint = "mobile" | "tablet" | "desktop";

--- a/packages/ui/spa/components/shell/useShellUrlState.ts
+++ b/packages/ui/spa/components/shell/useShellUrlState.ts
@@ -28,16 +28,27 @@ export type ShellUrlState = {
   canvasTransform: CanvasTransform | null;
 };
 
-const PANELS: ShellPanel[] = [
-  "pages",
-  "media",
-  "data",
-  "settings",
-  "account",
-  "utility",
-  "ai",
-  "notifications",
-];
+/*
+ * Every panel name, as an exhaustive record rather than an array.
+ *
+ * An array typed `ShellPanel[]` accepts a SUBSET of the union, so adding a
+ * panel and forgetting this list type-checks - and the symptom is a panel that
+ * opens fine and then silently fails to come back after a reload, because its
+ * name is not recognised on the way in. A record keyed by the union has to name
+ * every member, so the omission is a compile error instead.
+ */
+const PANEL_NAMES: Record<ShellPanel, true> = {
+  pages: true,
+  media: true,
+  data: true,
+  settings: true,
+  account: true,
+  utility: true,
+  ai: true,
+  notifications: true,
+  history: true,
+};
+const PANELS = Object.keys(PANEL_NAMES) as ShellPanel[];
 
 const PARAM = {
   panel: "panel",

--- a/packages/ui/spa/history/CommitList.test.tsx
+++ b/packages/ui/spa/history/CommitList.test.tsx
@@ -1,0 +1,138 @@
+/** @jest-environment jsdom */
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { HistoricalCommit } from "@valbuild/shared/internal";
+import { CommitList, describeCommit } from "./CommitList";
+import type { CommitListState } from "./useCommitList";
+
+const commit = (over: Partial<HistoricalCommit> = {}): HistoricalCommit => ({
+  commitSha: "aaa111",
+  parentCommitSha: "000000",
+  clientCommitSha: "000000",
+  branch: "main",
+  createdBranch: null,
+  creator: "Ada",
+  message: "Fix the footer",
+  createdAt: "2026-09-08T12:42:21.843Z",
+  seqNum: "1",
+  patchCount: 3,
+  hasArchive: true,
+  ...over,
+});
+
+const listOf = (...commits: HistoricalCommit[]): CommitListState => ({
+  status: "success",
+  commits,
+  nextCursor: null,
+  loadingMore: false,
+});
+
+function renderList(
+  state: CommitListState,
+  over: Partial<Parameters<typeof CommitList>[0]> = {},
+) {
+  const onSelect = jest.fn();
+  const onStopComparing = jest.fn();
+  const onLoadMore = jest.fn();
+  render(
+    <CommitList
+      state={state}
+      selectedCommitSha={null}
+      onSelect={onSelect}
+      onStopComparing={onStopComparing}
+      onLoadMore={onLoadMore}
+      {...over}
+    />,
+  );
+  return { onSelect, onStopComparing, onLoadMore };
+}
+
+describe("the commit list", () => {
+  test("opens a commit when its row is clicked", () => {
+    const { onSelect } = renderList(listOf(commit()));
+    fireEvent.click(screen.getByRole("button", { name: /Fix the footer/ }));
+    expect(onSelect).toHaveBeenCalledWith("aaa111");
+  });
+
+  /*
+   * Commits made before Val recorded history, and ones pushed straight to the
+   * repo, have no archive. They are LISTED - leaving them out would make the
+   * history look like it holds fewer changes than it does - but there is
+   * nothing behind them to open.
+   */
+  test("lists a commit with no archive, but will not open it", () => {
+    const { onSelect } = renderList(
+      listOf(commit({ hasArchive: false, message: "Pushed by hand" })),
+    );
+    const row = screen.getByRole("button", { name: /Pushed by hand/ });
+    expect((row as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(row);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  test("offers a way out once a commit is open", () => {
+    const { onStopComparing } = renderList(listOf(commit()), {
+      selectedCommitSha: "aaa111",
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Stop comparing" }));
+    expect(onStopComparing).toHaveBeenCalled();
+  });
+
+  test("has no way out when nothing is open", () => {
+    renderList(listOf(commit()));
+    expect(screen.queryByRole("button", { name: "Stop comparing" })).toBeNull();
+  });
+
+  test("offers more only while there is another page", () => {
+    renderList(listOf(commit()));
+    expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
+  });
+
+  test("loads the next page on request", () => {
+    const { onLoadMore } = renderList({
+      status: "success",
+      commits: [commit()],
+      nextCursor: "cursor-1",
+      loadingMore: false,
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Load more" }));
+    expect(onLoadMore).toHaveBeenCalled();
+  });
+
+  test("says so when nothing has been published", () => {
+    renderList(listOf());
+    expect(screen.getByText(/Nothing has been published/)).not.toBeNull();
+  });
+
+  test("shows the reason it could not read the history", () => {
+    renderList({ status: "error", message: "The archive is unreadable." });
+    expect(screen.getByText("The archive is unreadable.")).not.toBeNull();
+  });
+});
+
+describe("what a row says about a commit", () => {
+  test("names the time, the author and the size of the change", () => {
+    expect(describeCommit(commit())).toMatch(/Ada/);
+    expect(describeCommit(commit())).toMatch(/3 changes/);
+  });
+
+  test("says '1 change', not '1 changes'", () => {
+    expect(describeCommit(commit({ patchCount: 1 }))).toMatch(/1 change$/);
+  });
+
+  // `creator` is null for a commit Val did not make. A template with holes in
+  // it would render "· by " with nothing after it, which reads like a bug.
+  test("leaves the author out when there is not one", () => {
+    const described = describeCommit(commit({ creator: null }));
+    expect(described).not.toMatch(/·\s*·/);
+    expect(described).toMatch(/3 changes/);
+  });
+
+  test("leaves the count out when the commit carries no patches", () => {
+    expect(describeCommit(commit({ patchCount: 0 }))).not.toMatch(/change/);
+  });
+
+  test("falls back to a placeholder for an empty message", () => {
+    renderList(listOf(commit({ message: "   " })));
+    expect(screen.getByRole("button", { name: /No message/ })).not.toBeNull();
+  });
+});

--- a/packages/ui/spa/history/CommitList.test.tsx
+++ b/packages/ui/spa/history/CommitList.test.tsx
@@ -24,6 +24,7 @@ const listOf = (...commits: HistoricalCommit[]): CommitListState => ({
   commits,
   nextCursor: null,
   loadingMore: false,
+  loadMoreError: null,
 });
 
 function renderList(
@@ -93,6 +94,7 @@ describe("the commit list", () => {
       commits: [commit()],
       nextCursor: "cursor-1",
       loadingMore: false,
+      loadMoreError: null,
     });
     fireEvent.click(screen.getByRole("button", { name: "Load more" }));
     expect(onLoadMore).toHaveBeenCalled();
@@ -134,5 +136,35 @@ describe("what a row says about a commit", () => {
   test("falls back to a placeholder for an empty message", () => {
     renderList(listOf(commit({ message: "   " })));
     expect(screen.getByRole("button", { name: /No message/ })).not.toBeNull();
+  });
+});
+
+describe("when a page fails to load", () => {
+  const failed: CommitListState = {
+    status: "success",
+    commits: [commit()],
+    nextCursor: "cursor-1",
+    loadingMore: false,
+    loadMoreError: "The archive host is unreachable.",
+  };
+
+  // Failing to fetch page three is not a reason to take pages one and two
+  // away, so this reports WITHOUT replacing the list.
+  test("keeps the commits already read", () => {
+    renderList(failed);
+    expect(
+      screen.getByRole("button", { name: /Fix the footer/ }),
+    ).not.toBeNull();
+  });
+
+  test("says why, instead of the button silently doing nothing", () => {
+    renderList(failed);
+    expect(screen.getByText("The archive host is unreachable.")).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Try again" })).not.toBeNull();
+  });
+
+  test("hides the reason while a retry is in flight", () => {
+    renderList({ ...failed, loadingMore: true });
+    expect(screen.queryByText("The archive host is unreachable.")).toBeNull();
   });
 });

--- a/packages/ui/spa/history/CommitList.test.tsx
+++ b/packages/ui/spa/history/CommitList.test.tsx
@@ -65,9 +65,23 @@ describe("the commit list", () => {
       listOf(commit({ hasArchive: false, message: "Pushed by hand" })),
     );
     const row = screen.getByRole("button", { name: /Pushed by hand/ });
-    expect((row as HTMLButtonElement).disabled).toBe(true);
+    expect(row.getAttribute("aria-disabled")).toBe("true");
     fireEvent.click(row);
     expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  /*
+   * `aria-disabled` rather than `disabled`, so the title saying WHY is
+   * reachable. A `disabled` button fires no pointer events and is out of the
+   * tab order, which makes its own explanation the one thing nobody can get to.
+   */
+  test("keeps the reason it cannot be opened reachable", () => {
+    renderList(
+      listOf(commit({ hasArchive: false, message: "Pushed by hand" })),
+    );
+    const row = screen.getByRole("button", { name: /Pushed by hand/ });
+    expect((row as HTMLButtonElement).disabled).toBe(false);
+    expect(row.getAttribute("title")).toMatch(/nothing to compare against/);
   });
 
   test("offers a way out once a commit is open", () => {

--- a/packages/ui/spa/history/CommitList.tsx
+++ b/packages/ui/spa/history/CommitList.tsx
@@ -1,0 +1,169 @@
+import { GitCommitHorizontal } from "lucide-react";
+import type { HistoricalCommit } from "@valbuild/shared/internal";
+import { cn } from "../components/designSystem/cn";
+import { PanelEmptyState } from "../components/shell/FloatingPanel";
+import { formatDateToString } from "../utils/formatDateToString";
+import type { CommitListState } from "./useCommitList";
+
+export type CommitListProps = {
+  state: CommitListState;
+  /** The commit the right pane is currently showing, if any. */
+  selectedCommitSha: string | null;
+  onSelect: (commitSha: string) => void;
+  onStopComparing: () => void;
+  onLoadMore: () => void;
+};
+
+/**
+ * The list of publishes, and the way into the history view.
+ *
+ * This is the door. Everything behind it — the archives, the reconstruction,
+ * the two-pane compare, the restore — shipped before this did, and until it
+ * existed the whole feature was reachable only by reading a commit sha out of
+ * the database and assembling a URL by hand.
+ *
+ * Presentational: the fetching is `useCommitList` and the navigation is
+ * `setHistory`, both wired up in ValShell. Selecting a commit sets `?commit=`
+ * and the rest of the Studio reacts to that — this list does not know what a
+ * right pane is.
+ */
+export function CommitList({
+  state,
+  selectedCommitSha,
+  onSelect,
+  onStopComparing,
+  onLoadMore,
+}: CommitListProps) {
+  if (state.status === "loading") {
+    return <PanelEmptyState>Reading the history…</PanelEmptyState>;
+  }
+  if (state.status === "error") {
+    return <PanelEmptyState>{state.message}</PanelEmptyState>;
+  }
+  if (state.commits.length === 0) {
+    return (
+      <PanelEmptyState>
+        Nothing has been published on this branch yet. Publish a change and it
+        will show up here.
+      </PanelEmptyState>
+    );
+  }
+  return (
+    <>
+      {selectedCommitSha !== null && (
+        <div className="px-4 py-2.5 border-b border-border-float">
+          <button
+            type="button"
+            onClick={onStopComparing}
+            className="w-full h-8 rounded-md text-xs text-fg-secondary border border-border-float hover:bg-bg-float-raised hover:text-fg-primary"
+          >
+            Stop comparing
+          </button>
+        </div>
+      )}
+      <ul className="divide-y divide-border-float">
+        {state.commits.map((commit) => (
+          <CommitRow
+            key={commit.commitSha}
+            commit={commit}
+            selected={commit.commitSha === selectedCommitSha}
+            onSelect={onSelect}
+          />
+        ))}
+      </ul>
+      {state.nextCursor !== null && (
+        <div className="px-4 py-3">
+          <button
+            type="button"
+            onClick={onLoadMore}
+            disabled={state.loadingMore}
+            className="w-full h-8 rounded-md text-xs text-fg-secondary border border-border-float hover:bg-bg-float-raised hover:text-fg-primary disabled:opacity-60"
+          >
+            {state.loadingMore ? "Loading…" : "Load more"}
+          </button>
+        </div>
+      )}
+    </>
+  );
+}
+
+function CommitRow({
+  commit,
+  selected,
+  onSelect,
+}: {
+  commit: HistoricalCommit;
+  selected: boolean;
+  onSelect: (commitSha: string) => void;
+}) {
+  /*
+   * A commit with no archive cannot be opened.
+   *
+   * These are commits made before Val recorded history, and ones made outside
+   * Val — a push straight to the repo. They are still listed, because leaving
+   * them out would make the history look like it holds fewer changes than it
+   * does, but there is nothing behind them to show.
+   */
+  const openable = commit.hasArchive;
+  return (
+    <li>
+      <button
+        type="button"
+        disabled={!openable}
+        onClick={() => onSelect(commit.commitSha)}
+        aria-current={selected ? "true" : undefined}
+        title={
+          openable
+            ? undefined
+            : "Made before Val started recording history, so there is nothing to compare against."
+        }
+        className={cn(
+          "flex gap-2.5 w-full px-4 py-2.5 text-left",
+          openable
+            ? "hover:bg-bg-float-raised"
+            : "opacity-55 cursor-not-allowed",
+          selected && "bg-bg-float-raised",
+        )}
+      >
+        <span
+          className={cn(
+            "grid place-items-center w-6 h-6 mt-0.5 shrink-0 rounded-md",
+            selected
+              ? "bg-bg-brand-primary text-fg-brand-primary"
+              : "bg-bg-float-raised text-fg-secondary",
+          )}
+        >
+          <GitCommitHorizontal size={13} />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block text-xs text-fg-primary truncate">
+            {commit.message?.trim() || "No message"}
+          </span>
+          <span className="block text-[0.6875rem] text-fg-secondary-alt">
+            {describeCommit(commit)}
+          </span>
+        </span>
+      </button>
+    </li>
+  );
+}
+
+/**
+ * The second line of a row: when, who, and how much.
+ *
+ * Assembled from the parts that are actually there rather than from a template
+ * with holes in it — `creator` is null for a commit Val did not make, and
+ * "· by " with nothing after it reads like a bug.
+ */
+export function describeCommit(commit: HistoricalCommit): string {
+  const parts: string[] = [formatDateToString(new Date(commit.createdAt))];
+  if (commit.creator) {
+    parts.push(commit.creator);
+  }
+  if (commit.patchCount > 0) {
+    parts.push(
+      commit.patchCount === 1 ? "1 change" : `${commit.patchCount} changes`,
+    );
+  }
+  return parts.join(" · ");
+}

--- a/packages/ui/spa/history/CommitList.tsx
+++ b/packages/ui/spa/history/CommitList.tsx
@@ -123,13 +123,26 @@ function CommitRow({
     <li>
       <button
         type="button"
-        disabled={!openable}
-        onClick={() => onSelect(commit.commitSha)}
+        /*
+         * `aria-disabled`, not `disabled`.
+         *
+         * A `disabled` button fires no pointer events in most browsers and is
+         * out of the tab order, so the `title` saying WHY the row cannot be
+         * opened is the one thing nobody could reach - not by hovering, and
+         * not at all with a keyboard. `aria-disabled` announces the state and
+         * keeps the row focusable, so the explanation is reachable both ways;
+         * the click is guarded here instead of by the browser.
+         */
+        aria-disabled={!openable}
+        onClick={() => {
+          if (!openable) return;
+          onSelect(commit.commitSha);
+        }}
         aria-current={selected ? "true" : undefined}
         title={
           openable
             ? undefined
-            : "Made before Val started recording history, so there is nothing to compare against."
+            : "Made before Val started recording history, or pushed straight to the repository, so there is nothing to compare against."
         }
         className={cn(
           "flex gap-2.5 w-full px-4 py-2.5 text-left",

--- a/packages/ui/spa/history/CommitList.tsx
+++ b/packages/ui/spa/history/CommitList.tsx
@@ -79,8 +79,22 @@ export function CommitList({
             disabled={state.loadingMore}
             className="w-full h-8 rounded-md text-xs text-fg-secondary border border-border-float hover:bg-bg-float-raised hover:text-fg-primary disabled:opacity-60"
           >
-            {state.loadingMore ? "Loading…" : "Load more"}
+            {state.loadingMore
+              ? "Loading…"
+              : state.loadMoreError !== null
+                ? "Try again"
+                : "Load more"}
           </button>
+          {/*
+           * A failed page is reported here rather than replacing the list: the
+           * commits already read are still good. Without this the button just
+           * stops working, which reads as the feature being broken.
+           */}
+          {state.loadMoreError !== null && !state.loadingMore && (
+            <p className="pt-2 text-[0.6875rem] text-fg-error-primary">
+              {state.loadMoreError}
+            </p>
+          )}
         </div>
       )}
     </>

--- a/packages/ui/spa/history/useCommitList.ts
+++ b/packages/ui/spa/history/useCommitList.ts
@@ -11,8 +11,19 @@ export type CommitListState =
       nextCursor: string | null;
       /** True while a `loadMore` is in flight, so the list can stay on screen. */
       loadingMore: boolean;
+      /**
+       * Why the last `loadMore` did not arrive, if it did not.
+       *
+       * Separate from the `error` status because the pages already read are
+       * still good: this reports a failure WITHOUT taking the list away.
+       */
+      loadMoreError: string | null;
     }
   | { status: "error"; message: string };
+
+function messageOf(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
 
 /**
  * The commits on a branch, newest first, a page at a time.
@@ -42,6 +53,18 @@ export function useCommitList(
    * dropped instead of appended to a list it does not belong to.
    */
   const requestId = useRef(0);
+  /*
+   * The current state, readable from an event handler.
+   *
+   * `loadMore` needs to know the cursor and whether a page is already in
+   * flight, and it must NOT learn them by starting the fetch inside a setState
+   * updater: an updater has to be pure, and StrictMode calls it twice to prove
+   * it - which fired two requests for the same cursor on every click. This
+   * codebase has been bitten by that enough times to have written it down (see
+   * ValStoreProvider and PageWorkspace).
+   */
+  const stateRef = useRef(state);
+  stateRef.current = state;
 
   useEffect(() => {
     if (branch === null) return;
@@ -58,6 +81,7 @@ export function useCommitList(
             commits: res.json.commits,
             nextCursor: res.json.nextCursor,
             loadingMore: false,
+            loadMoreError: null,
           });
         } else {
           setState({
@@ -71,61 +95,60 @@ export function useCommitList(
       })
       .catch((err: unknown) => {
         if (requestId.current !== id) return;
-        setState({
-          status: "error",
-          message: err instanceof Error ? err.message : String(err),
-        });
+        setState({ status: "error", message: messageOf(err) });
       });
   }, [client, branch, pageSize]);
 
   const loadMore = useCallback(() => {
     if (branch === null) return;
-    setState((current) => {
-      if (
-        current.status !== "success" ||
-        current.nextCursor === null ||
-        current.loadingMore
-      ) {
-        return current;
-      }
-      const id = ++requestId.current;
-      const cursor = current.nextCursor;
-      client("/history/commits", "GET", {
-        query: { branch, limit: pageSize, cursor },
-      })
-        .then((res) => {
-          if (requestId.current !== id) return;
-          if (res.status === 200) {
-            setState((previous) =>
-              previous.status === "success"
-                ? {
-                    status: "success",
-                    commits: [...previous.commits, ...res.json.commits],
-                    nextCursor: res.json.nextCursor,
-                    loadingMore: false,
-                  }
-                : previous,
-            );
-          } else {
-            // The pages already read stay on screen: failing to fetch page
-            // three is not a reason to take pages one and two away.
-            setState((previous) =>
-              previous.status === "success"
-                ? { ...previous, loadingMore: false }
-                : previous,
-            );
+    const current = stateRef.current;
+    if (
+      current.status !== "success" ||
+      current.nextCursor === null ||
+      current.loadingMore
+    ) {
+      return;
+    }
+    const id = ++requestId.current;
+    const cursor = current.nextCursor;
+    setState({ ...current, loadingMore: true, loadMoreError: null });
+    client("/history/commits", "GET", {
+      query: { branch, limit: pageSize, cursor },
+    })
+      .then((res) => {
+        if (requestId.current !== id) return;
+        setState((previous) => {
+          if (previous.status !== "success") return previous;
+          if (res.status !== 200) {
+            // The pages already read stay on screen - failing to fetch page
+            // three is not a reason to take pages one and two away - but the
+            // button has to say something, or it just stops working.
+            return {
+              ...previous,
+              loadingMore: false,
+              loadMoreError:
+                "message" in res.json
+                  ? res.json.message
+                  : "Could not load more commits.",
+            };
           }
-        })
-        .catch(() => {
-          if (requestId.current !== id) return;
-          setState((previous) =>
-            previous.status === "success"
-              ? { ...previous, loadingMore: false }
-              : previous,
-          );
+          return {
+            status: "success",
+            commits: [...previous.commits, ...res.json.commits],
+            nextCursor: res.json.nextCursor,
+            loadingMore: false,
+            loadMoreError: null,
+          };
         });
-      return { ...current, loadingMore: true };
-    });
+      })
+      .catch((err: unknown) => {
+        if (requestId.current !== id) return;
+        setState((previous) =>
+          previous.status === "success"
+            ? { ...previous, loadingMore: false, loadMoreError: messageOf(err) }
+            : previous,
+        );
+      });
   }, [client, branch, pageSize]);
 
   return { state, loadMore };

--- a/packages/ui/spa/history/useCommitList.ts
+++ b/packages/ui/spa/history/useCommitList.ts
@@ -1,0 +1,132 @@
+import type { HistoricalCommit } from "@valbuild/shared/internal";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useClient } from "../components/ValProvider";
+
+export type CommitListState =
+  | { status: "loading" }
+  | {
+      status: "success";
+      commits: HistoricalCommit[];
+      /** Null once the last page has been read. */
+      nextCursor: string | null;
+      /** True while a `loadMore` is in flight, so the list can stay on screen. */
+      loadingMore: boolean;
+    }
+  | { status: "error"; message: string };
+
+/**
+ * The commits on a branch, newest first, a page at a time.
+ *
+ * Deliberately NOT cached the way `useHistoricalCommit` caches a reconstructed
+ * commit. A reconstruction is immutable for its sha and can be kept forever; a
+ * LIST has a head that moves every time anyone publishes, so a cached first
+ * page is a list that quietly stops including the change you just made. The
+ * endpoint is `no-store` for the same reason.
+ *
+ * Paging appends rather than replaces, because the cursor is a position in one
+ * ordering: dropping the pages already read would make "load more" mean "show
+ * me a different ten", which is not what the button says.
+ */
+export function useCommitList(
+  branch: string | null,
+  pageSize = 20,
+): { state: CommitListState; loadMore: () => void } {
+  const client = useClient();
+  const [state, setState] = useState<CommitListState>({ status: "loading" });
+  /*
+   * Which request's answer is still wanted.
+   *
+   * A ref rather than a cancelled flag per effect, because `loadMore` is called
+   * from an event handler and has no effect cleanup to hang one on. Every
+   * response checks it, so a page that arrives after the branch changed is
+   * dropped instead of appended to a list it does not belong to.
+   */
+  const requestId = useRef(0);
+
+  useEffect(() => {
+    if (branch === null) return;
+    const id = ++requestId.current;
+    setState({ status: "loading" });
+    client("/history/commits", "GET", {
+      query: { branch, limit: pageSize, cursor: undefined },
+    })
+      .then((res) => {
+        if (requestId.current !== id) return;
+        if (res.status === 200) {
+          setState({
+            status: "success",
+            commits: res.json.commits,
+            nextCursor: res.json.nextCursor,
+            loadingMore: false,
+          });
+        } else {
+          setState({
+            status: "error",
+            message:
+              "message" in res.json
+                ? res.json.message
+                : "The commit history could not be read.",
+          });
+        }
+      })
+      .catch((err: unknown) => {
+        if (requestId.current !== id) return;
+        setState({
+          status: "error",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      });
+  }, [client, branch, pageSize]);
+
+  const loadMore = useCallback(() => {
+    if (branch === null) return;
+    setState((current) => {
+      if (
+        current.status !== "success" ||
+        current.nextCursor === null ||
+        current.loadingMore
+      ) {
+        return current;
+      }
+      const id = ++requestId.current;
+      const cursor = current.nextCursor;
+      client("/history/commits", "GET", {
+        query: { branch, limit: pageSize, cursor },
+      })
+        .then((res) => {
+          if (requestId.current !== id) return;
+          if (res.status === 200) {
+            setState((previous) =>
+              previous.status === "success"
+                ? {
+                    status: "success",
+                    commits: [...previous.commits, ...res.json.commits],
+                    nextCursor: res.json.nextCursor,
+                    loadingMore: false,
+                  }
+                : previous,
+            );
+          } else {
+            // The pages already read stay on screen: failing to fetch page
+            // three is not a reason to take pages one and two away.
+            setState((previous) =>
+              previous.status === "success"
+                ? { ...previous, loadingMore: false }
+                : previous,
+            );
+          }
+        })
+        .catch(() => {
+          if (requestId.current !== id) return;
+          setState((previous) =>
+            previous.status === "success"
+              ? { ...previous, loadingMore: false }
+              : previous,
+          );
+        });
+      return { ...current, loadingMore: true };
+    });
+  }, [client, branch, pageSize]);
+
+  return { state, loadMore };
+}


### PR DESCRIPTION
The two-pane history view shipped with no way in. The archives, the reconstruction, the compare, the restore — all of it worked, and the only way to reach any of it was to read a commit sha out of `val_commits` and assemble a query string by hand.

That is literally how it got tested today, which is what made the gap obvious:

```sql
SELECT p.org, p.name, c.created_commit_sha FROM val_commits c
JOIN val_projects p ON p.id = c.project_id WHERE c.archive_key IS NOT NULL;
```
```
/val/~/settings/footer.val.ts?commit=9350ea0be5b063df74efe2475c116a32d4f55f48
```

A feature nobody can find is not shipped.

## What this adds

A **History** button in the top bar, beside Publish, opening a panel that lists what has been published on this branch — message, who, when, how many changes. Clicking a commit sets `?commit=` and the rest of the Studio reacts as it already did; the list does not know what a right pane is. **Stop comparing** closes it.

## Three things the list has to get right

**Commits with no archive are listed but not clickable**, with a title saying why. These are commits made before Val recorded history, and ones pushed straight to the repo. Hiding them would make the history look like it holds fewer changes than it does; offering them would open a pane with nothing in it.

**The list is not cached, though `useHistoricalCommit` caches hard.** A reconstruction is immutable for its sha and can be kept forever. A *list* has a head that moves every time anyone publishes, so a cached first page is a list that quietly stops including the change you just made — `/history/commits` is `no-store` for exactly this reason.

**Paging appends rather than replaces.** The cursor is a position in one ordering, so dropping the pages already read would make "Load more" mean "show me a different ten". A failed page leaves what is already on screen alone rather than blanking the list.

## Structure

Follows the `aiSlot` precedent. `Shell` owns the panel chrome and stays free of Val hooks so its stories still render from mock data; `ValShell` passes the wired list as `historySlot`. The slot is `undefined` in FS mode, which also hides the button — local dev has git rather than a commit archive, and `/history/commits` answers `not-supported-in-fs-mode`, so the alternative is a panel whose only content is an apology. Mounting the surface with the panel is also what keeps the Studio from fetching a commit list nobody asked for on every load.

## Testing

`CommitList.test.tsx`, 13 tests: what a row opens, that an archive-less row is disabled and does not fire, the way out, that it appears only when something is open, paging in both directions, the empty and error states, and how a row describes a commit whose `creator` is null or whose `patchCount` is 0 or 1.

Full CI locally: **3755 tests / 314 suites passed**, `pnpm run -r typecheck` clean, `eslint .` clean, `prettier --check .` clean.

Changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1XGRuPC6BTaMcxizVttCb

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1XGRuPC6BTaMcxizVttCb)_