### PR TITLE
History pane: authenticate file reads, and show `.jsonValues()` entries

### DIFF
--- a/.changeset/history-files-auth.md
+++ b/.changeset/history-files-auth.md
@@ -1,0 +1,24 @@
+---
+"@valbuild/server": patch
+"@valbuild/shared": patch
+---
+
+Require a session to read a file from history
+
+`GET /api/val/history/files` served a file at a given commit to anyone who
+asked. It followed the reasoning of `/api/val/files`, which is deliberately
+open — and neither half of that reasoning applies to it:
+
+- `/files` stands on `patch_id` being an unguessable UUID. A **commit sha is
+  published** — `git log`, the GitHub UI, every pull request — so it is no
+  substitute for a credential.
+- `/files` also _cannot_ require auth: draft images are fetched by the app's own
+  backend during Next image optimisation, with no cookies to send. Nothing
+  fetches history files server-side; both callers are the Studio, in a browser
+  that already holds the session.
+
+So history files now require a session. `/files` is unchanged, and the reason
+the two differ is written down in `architecture/media.md` so it is not "fixed"
+in either direction later.
+
+No action needed: the Studio sends its session cookie automatically.

--- a/.changeset/history-json-entries.md
+++ b/.changeset/history-json-entries.md
@@ -1,0 +1,21 @@
+---
+"@valbuild/server": minor
+"@valbuild/shared": minor
+"@valbuild/ui": minor
+---
+
+Show `.jsonValues()` entries in the history pane
+
+A `.jsonValues()` record keeps each entry's content in its own `*.val.json`
+file; the module's own content is just markers pointing at them. The history
+pane had no way to fetch those files for a past commit, so every entry rendered
+as an **empty field** — which reads as "the author left this blank", about
+content that was simply stored somewhere else.
+
+Entries now load in the history pane the same way they load in the Studio: one
+at a time, when you open one. A commit with a thousand support pages costs
+nothing until you look at one of them.
+
+An entry that cannot be read says so instead of rendering blank — including the
+case where the key did not exist yet at that commit, which is a real answer
+rather than an error.

--- a/architecture/media.md
+++ b/architecture/media.md
@@ -188,6 +188,41 @@ broken the moment its write comes back.
 > broken tile still returns **200** with a `src` that looks right. Only decoding
 > it — `naturalWidth > 0` — can tell. Any test here asserts on that.
 
+## Why `/files` has no auth, and `/history/files` does
+
+These two look like the same endpoint and are not, so they are documented
+together — an "inconsistency" that gets tidied in either direction breaks
+something.
+
+**`/api/val/files` is unauthenticated on purpose, and cannot be otherwise.** A
+draft image is fetched by the app's own backend during Next image optimisation.
+That is a backend-to-backend request: no browser, no cookies, nothing to
+authenticate with. Requiring auth would not tighten anything — it would black
+out every unpublished image in the Studio the moment the app runs its images
+through the optimiser.
+
+What stands in for the credential is the `patch_id`. It is a UUID, so a
+published path stays public (it already is) and an unpublished one is only
+reachable by someone who already knows a patch id. The trade is written out in
+full at the route itself in `ValServer.ts`; the short version is that guessing
+one is infeasible, shimming it into a frontend is work, and the prize is an
+image about to be published anyway.
+
+**`/api/val/history/files` is authenticated**, and neither half of that argument
+transfers to it:
+
+- Its token is a **commit sha**, which is not a secret. It is in `git log`, in
+  the GitHub UI, on every pull request. A sha cannot stand in for a credential
+  the way a patch id does.
+- Nothing fetches it server-side. Both callers are the Studio, in a browser that
+  has the session cookie — the history pane's `<img>`, and `stageRestore`'s
+  `fetch`, both same-origin so the cookie is sent. There is no optimiser path to
+  keep open, so asking for auth costs nothing.
+
+So: **`/files` open because it must be and can afford to be; `/history/files`
+closed because it can be and should be.** Before changing either, check which of
+those two properties you are relying on.
+
 ## Nav placement
 
 A collection is deliberately **not** an Explorer file. `collectMediaModules`

--- a/packages/server/src/ValOps.ts
+++ b/packages/server/src/ValOps.ts
@@ -2358,6 +2358,20 @@ export abstract class ValOps {
     filePath: string,
     remote: boolean,
   ): Promise<result.Result<Buffer, HistoryError>>;
+
+  /**
+   * Where a module lives in the REPOSITORY, as `getFileAtCommit` wants it.
+   *
+   * A `ModuleFilePath` is project-relative (`/app/page.val.ts`); a git path is
+   * repository-relative and carries the project root in front of it
+   * (`examples/next/app/page.val.ts`). Only the ops know that root, which is
+   * why this is here rather than computed by the history functions - and why a
+   * history function that needs to read a module's own file at a commit has to
+   * ask instead of concatenating.
+   */
+  abstract gitPathOfModule(
+    moduleFilePath: ModuleFilePath,
+  ): result.Result<string, HistoryError>;
   // #endregion history
 }
 

--- a/packages/server/src/ValOpsFS.ts
+++ b/packages/server/src/ValOpsFS.ts
@@ -1411,7 +1411,11 @@ export class ValOpsFS extends ValOps {
     return result.err({ kind: "not-supported-in-fs-mode" });
   }
 
-  override gitPathOfModule(): result.Result<string, HistoryError> {
+  override gitPathOfModule(
+    // Unused: fs mode has no repository to be relative to. Named anyway, so
+    // this reads as the same method the base class declares.
+    _moduleFilePath: ModuleFilePath,
+  ): result.Result<string, HistoryError> {
     return result.err({ kind: "not-supported-in-fs-mode" });
   }
   // #endregion history

--- a/packages/server/src/ValOpsFS.ts
+++ b/packages/server/src/ValOpsFS.ts
@@ -1410,6 +1410,10 @@ export class ValOpsFS extends ValOps {
   > {
     return result.err({ kind: "not-supported-in-fs-mode" });
   }
+
+  override gitPathOfModule(): result.Result<string, HistoryError> {
+    return result.err({ kind: "not-supported-in-fs-mode" });
+  }
   // #endregion history
 }
 

--- a/packages/server/src/ValOpsHttp.ts
+++ b/packages/server/src/ValOpsHttp.ts
@@ -2153,6 +2153,24 @@ export class ValOpsHttp extends ValOps {
     return result.ok(res.value.files);
   }
 
+  /**
+   * `root` in front, and never a doubled or missing slash.
+   *
+   * `root` is "" for a project at the repository root and something like
+   * `examples/next` otherwise; a ModuleFilePath always starts with "/". Joining
+   * them by hand at each call site is how one of these ends up with "//" in the
+   * middle, which GitHub answers with a 404 that reads like a missing file.
+   */
+  override gitPathOfModule(
+    moduleFilePath: ModuleFilePath,
+  ): result.Result<string, HistoryError> {
+    const joined = `${this.root}/${moduleFilePath}`
+      .split("/")
+      .filter((part) => part !== "")
+      .join("/");
+    return result.ok(joined);
+  }
+
   override async getFileAtCommit(
     commitSha: string,
     filePath: string,

--- a/packages/server/src/ValServer.ts
+++ b/packages/server/src/ValServer.ts
@@ -3183,10 +3183,27 @@ export const ValServer = (
     },
     "/history/files": {
       GET: async (req) => {
-        // No auth, for the same reason /files has none: this is served to an
-        // <img> that the app's own backend may fetch during image
-        // optimisation, with no cookies. What it exposes is a file at a commit
-        // that is already in the repository.
+        /*
+         * Authenticated, unlike /files.
+         *
+         * This used to reason "same as /files" and that was wrong twice over.
+         * /files is open because a `patch_id` is an unguessable UUID standing
+         * in for a credential, and because it HAS to be: a draft image is
+         * fetched by the app's own backend during Next image optimisation,
+         * backend-to-backend, with no cookies to send.
+         *
+         * A commit sha is not a secret - it is in `git log`, in the GitHub UI,
+         * on every PR - so the first argument does not transfer. And nothing
+         * fetches this server-side; both callers are the Studio in a browser
+         * that has the session cookie (the history pane's <img>, and
+         * stageRestore's fetch, both same-origin so the cookie goes). So the
+         * second does not either, and there is nothing to trade away by
+         * asking.
+         */
+        const auth = getAuth(req.cookies);
+        if (auth.error) {
+          return { status: 401, json: { message: auth.error } };
+        }
         const res = await serverOps.getFileAtCommit(
           req.query.commit_sha,
           req.query.path,
@@ -3228,6 +3245,11 @@ export const ValServer = (
         //     3) the benefit an attacker would get is an image that is not yet published (i.e. most cases: not very interesting)
         // Thus: attack surface + ease of attack + benefit = low probability of attack
         // If we couldn't argue that patch ids are secret enough, then this would be a problem.
+        // Note that /history/files, which looks like the same endpoint, IS
+        // authenticated: its token is a commit sha, which is published, and
+        // nothing fetches it backend-to-backend. Neither half of the argument
+        // above transfers. See architecture/media.md, "Why /files has no auth,
+        // and /history/files does".
         let fileBuffer;
         let mimeType: string | undefined;
         const remote = query.remote === "true";

--- a/packages/server/src/ValServer.ts
+++ b/packages/server/src/ValServer.ts
@@ -55,6 +55,7 @@ import type { HistoryError } from "./history/HistoryError";
 import { historyErrorMessage } from "./history/HistoryError";
 import { getHistoricalPatchSet } from "./history/getHistoricalPatchSet";
 import { getModuleAtCommit } from "./history/getModuleAtCommit";
+import { getJsonEntryAtCommit } from "./history/getJsonEntryAtCommit";
 import { getSettings } from "./getSettings";
 import {
   createValOps,
@@ -3177,6 +3178,32 @@ export const ValServer = (
             "Cache-Control": settled
               ? "private, max-age=31536000, immutable"
               : "no-store",
+          },
+        };
+      },
+    },
+    "/history/json": {
+      GET: async (req) => {
+        // Authenticated, for the reasons on /history/files below.
+        const auth = getAuth(req.cookies);
+        if (auth.error) {
+          return { status: 401, json: { message: auth.error } };
+        }
+        const res = await getJsonEntryAtCommit(
+          serverOps,
+          req.query.commit_sha,
+          req.query.path as ModuleFilePath,
+          req.query.key,
+        );
+        if (result.isErr(res)) {
+          return historyErrorResponse(res.error);
+        }
+        return {
+          status: 200,
+          json: {
+            path: req.query.path as ModuleFilePath,
+            key: req.query.key,
+            content: res.value,
           },
         };
       },

--- a/packages/server/src/history/getJsonEntryAtCommit.test.ts
+++ b/packages/server/src/history/getJsonEntryAtCommit.test.ts
@@ -1,0 +1,81 @@
+import type { ModuleFilePath } from "@valbuild/core";
+import { result } from "@valbuild/core/fp";
+import { findEntryImportPath } from "./getJsonEntryAtCommit";
+
+const MODULE = "/app/support/[slug]/page.val.ts" as ModuleFilePath;
+
+/**
+ * Taken from the example app, because the shape of the problem is only visible
+ * in a real one: the key is a ROUTE and the file is whatever the author named
+ * it. `/support/getting-started` -> `getting-started.val.json` looks derivable
+ * and is not; nothing enforces any relationship at all, which is why this has
+ * to read the `import()` literal rather than compute a filename.
+ */
+const SOURCE = `
+import { s, c, nextAppRouter } from "../../../val.config";
+
+export default c.define(
+  "/app/support/[slug]/page.val.ts",
+  s.router(nextAppRouter, s.object({ title: s.string() })).jsonValues(),
+  {
+    "/support/getting-started": c.json(
+      () => import("./content/getting-started.val.json"),
+    ),
+    "/support/faq": c.json(() => import("./elsewhere/q-and-a.val.json")),
+  },
+);
+`;
+
+function pathFor(key: string) {
+  return findEntryImportPath(MODULE, SOURCE, key);
+}
+
+describe("finding a jsonValues entry's file at a commit", () => {
+  test("resolves the import path relative to the module", () => {
+    const res = pathFor("/support/getting-started");
+    if (result.isErr(res)) throw new Error(JSON.stringify(res.error));
+    expect(res.value).toBe(
+      "/app/support/[slug]/content/getting-started.val.json",
+    );
+  });
+
+  // The one that would pass under a "filename is the key" shortcut and must
+  // not: this entry's file shares nothing with its key.
+  test("does not assume the file is named after the key", () => {
+    const res = pathFor("/support/faq");
+    if (result.isErr(res)) throw new Error(JSON.stringify(res.error));
+    expect(res.value).toBe("/app/support/[slug]/elsewhere/q-and-a.val.json");
+  });
+
+  /*
+   * A key added after this commit. Reported rather than treated as empty: an
+   * empty field is a claim that the author left it blank, and that would be a
+   * lie about a commit that predates the entry.
+   */
+  test("reports a key that had no entry at this commit", () => {
+    const res = pathFor("/support/added-later");
+    if (!result.isErr(res)) throw new Error("expected an error");
+    expect(res.error.kind).toBe("file-unavailable");
+    expect("message" in res.error && res.error.message).toMatch(
+      /had no entry at this commit/,
+    );
+  });
+
+  test("reports a module it cannot read, rather than reporting it empty", () => {
+    const res = findEntryImportPath(MODULE, "this is not typescript {{{", "k");
+    if (!result.isErr(res)) throw new Error("expected an error");
+    expect(res.error.kind).toBe("file-unavailable");
+  });
+
+  // A module with no jsonValues entries at all: every key is absent, and that
+  // is the same answer as a key that was added later.
+  test("reports a key in a module that has no entries", () => {
+    const plain = `
+      import { s, c } from "./val.config";
+      export default c.define("/app/page.val.ts", s.string(), "hello");
+    `;
+    const res = findEntryImportPath(MODULE, plain, "/support/faq");
+    if (!result.isErr(res)) throw new Error("expected an error");
+    expect(res.error.kind).toBe("file-unavailable");
+  });
+});

--- a/packages/server/src/history/getJsonEntryAtCommit.test.ts
+++ b/packages/server/src/history/getJsonEntryAtCommit.test.ts
@@ -3,6 +3,8 @@ import { result } from "@valbuild/core/fp";
 import { findEntryImportPath } from "./getJsonEntryAtCommit";
 
 const MODULE = "/app/support/[slug]/page.val.ts" as ModuleFilePath;
+// The same module as git sees it: this project lives under examples/next.
+const MODULE_GIT_PATH = "examples/next/app/support/[slug]/page.val.ts";
 
 /**
  * Taken from the example app, because the shape of the problem is only visible
@@ -27,7 +29,7 @@ export default c.define(
 `;
 
 function pathFor(key: string) {
-  return findEntryImportPath(MODULE, SOURCE, key);
+  return findEntryImportPath(MODULE, MODULE_GIT_PATH, SOURCE, key);
 }
 
 describe("finding a jsonValues entry's file at a commit", () => {
@@ -62,7 +64,12 @@ describe("finding a jsonValues entry's file at a commit", () => {
   });
 
   test("reports a module it cannot read, rather than reporting it empty", () => {
-    const res = findEntryImportPath(MODULE, "this is not typescript {{{", "k");
+    const res = findEntryImportPath(
+      MODULE,
+      MODULE_GIT_PATH,
+      "this is not typescript {{{",
+      "k",
+    );
     if (!result.isErr(res)) throw new Error("expected an error");
     expect(res.error.kind).toBe("file-unavailable");
   });
@@ -74,8 +81,25 @@ describe("finding a jsonValues entry's file at a commit", () => {
       import { s, c } from "./val.config";
       export default c.define("/app/page.val.ts", s.string(), "hello");
     `;
-    const res = findEntryImportPath(MODULE, plain, "/support/faq");
+    const res = findEntryImportPath(
+      MODULE,
+      MODULE_GIT_PATH,
+      plain,
+      "/support/faq",
+    );
     if (!result.isErr(res)) throw new Error("expected an error");
     expect(res.error.kind).toBe("file-unavailable");
+  });
+
+  /*
+   * A `gitPath` in a HistoryError is a REPOSITORY path - what every other
+   * history helper reports, and what a reader can paste into `git show`.
+   * Reporting the project-relative ModuleFilePath named a file that does not
+   * exist at that path for any project not rooted at the repository root.
+   */
+  test("reports the repository path, not the project-relative one", () => {
+    const res = pathFor("/support/added-later");
+    if (!result.isErr(res)) throw new Error("expected an error");
+    expect("gitPath" in res.error && res.error.gitPath).toBe(MODULE_GIT_PATH);
   });
 });

--- a/packages/server/src/history/getJsonEntryAtCommit.ts
+++ b/packages/server/src/history/getJsonEntryAtCommit.ts
@@ -58,6 +58,7 @@ export async function getJsonEntryAtCommit(
   }
   const entryPath = findEntryImportPath(
     moduleFilePath,
+    moduleGitPath.value,
     moduleRes.value.toString("utf-8"),
     key,
   );
@@ -102,6 +103,15 @@ export async function getJsonEntryAtCommit(
  */
 export function findEntryImportPath(
   moduleFilePath: ModuleFilePath,
+  /**
+   * The same module, repository-relative, for error reporting only.
+   *
+   * A `gitPath` in a HistoryError is a REPOSITORY path - that is what every
+   * other history helper reports, and what a reader can paste into a `git show`
+   * - so reporting the project-relative ModuleFilePath here named a file that
+   * does not exist at that path for any project not rooted at the repo root.
+   */
+  moduleGitPath: string,
   valTsSource: string,
   key: string,
 ): result.Result<string, HistoryError> {
@@ -120,7 +130,7 @@ export function findEntryImportPath(
     // would be a new case every reader has to handle to say the same thing.
     return result.err({
       kind: "file-unavailable",
-      gitPath: moduleFilePath,
+      gitPath: moduleGitPath,
       message: `could not parse the module at this commit: ${
         err instanceof Error ? err.message : String(err)
       }`,
@@ -129,7 +139,7 @@ export function findEntryImportPath(
   if (result.isErr(analysis)) {
     return result.err({
       kind: "file-unavailable",
-      gitPath: moduleFilePath,
+      gitPath: moduleGitPath,
       message: "could not read the module at this commit",
     });
   }
@@ -144,7 +154,7 @@ export function findEntryImportPath(
      */
     return result.err({
       kind: "file-unavailable",
-      gitPath: moduleFilePath,
+      gitPath: moduleGitPath,
       message: `'${key}' had no entry at this commit`,
     });
   }

--- a/packages/server/src/history/getJsonEntryAtCommit.ts
+++ b/packages/server/src/history/getJsonEntryAtCommit.ts
@@ -1,0 +1,153 @@
+import ts from "typescript";
+import path from "path";
+import { ModuleFilePath } from "@valbuild/core";
+import { result } from "@valbuild/core/fp";
+import type { Json } from "@valbuild/core";
+import { analyzeValModule } from "../patch/ts/valModule";
+import { analyzeJsonValuesEntries } from "../patch/ts/jsonValuesModule";
+import type { ValOps } from "../ValOps";
+import type { HistoryError } from "./HistoryError";
+
+/**
+ * One `.jsonValues()` entry's content, as it was at a commit.
+ *
+ * The history pane renders a commit through the real field components, and a
+ * `.jsonValues()` record's source is only `{_type:"json"}` markers - the
+ * content lives in a separate `*.val.json` per entry, fetched on demand. The
+ * live Studio fetches it from `GET /json`; the commit pane had nothing to
+ * fetch from, so every entry stayed a marker and rendered as though the field
+ * were empty. Which is worse than an error: an empty value is a claim, and it
+ * was a false one.
+ *
+ * ## Why this needs the module's own `.val.ts`
+ *
+ * There is no derivable relationship between a record key and its entry file.
+ * From the example app:
+ *
+ *   "/support/getting-started": c.json(() => import("./content/getting-started.val.json"))
+ *   "/support/faq":             c.json(() => import("./content/faq.val.json"))
+ *
+ * The key is a route and the path is whatever the author wrote. The only place
+ * the two are related is the `import()` literal inside the `.val.ts`, which is
+ * why `findJsonEntryFilePathsInSource` reads them out of the AST too. The
+ * commit archive stores the module's SOURCE (the markers) and its schema, not
+ * its text - so the text is fetched from git at that commit and parsed here.
+ *
+ * Two round trips per entry, then: the module, and the entry. The module's
+ * parse is worth caching per (commit, module) by the caller; nothing here does,
+ * because a `ValOps` is not a cache and the endpoint above it is the layer that
+ * knows how long a commit stays interesting.
+ */
+export async function getJsonEntryAtCommit(
+  ops: ValOps,
+  commitSha: string,
+  moduleFilePath: ModuleFilePath,
+  key: string,
+): Promise<result.Result<Json, HistoryError>> {
+  const moduleGitPath = ops.gitPathOfModule(moduleFilePath);
+  if (result.isErr(moduleGitPath)) {
+    return moduleGitPath;
+  }
+  const moduleRes = await ops.getFileAtCommit(
+    commitSha,
+    moduleGitPath.value,
+    false,
+  );
+  if (result.isErr(moduleRes)) {
+    return moduleRes;
+  }
+  const entryPath = findEntryImportPath(
+    moduleFilePath,
+    moduleRes.value.toString("utf-8"),
+    key,
+  );
+  if (result.isErr(entryPath)) {
+    return entryPath;
+  }
+  // The entry path resolved above is PROJECT-relative, like the module path it
+  // came from; the git path needs the root in front of it, and the ops are what
+  // know the root. Reusing gitPathOfModule rather than re-deriving the prefix:
+  // a `.val.json` is not a module, but "project-relative path -> repo path" is
+  // the same question and one implementation of it is the point.
+  const entryGitPath = ops.gitPathOfModule(entryPath.value as ModuleFilePath);
+  if (result.isErr(entryGitPath)) {
+    return entryGitPath;
+  }
+  const entryRes = await ops.getFileAtCommit(
+    commitSha,
+    entryGitPath.value,
+    false,
+  );
+  if (result.isErr(entryRes)) {
+    return entryRes;
+  }
+  try {
+    return result.ok(JSON.parse(entryRes.value.toString("utf-8")) as Json);
+  } catch (err) {
+    return result.err({
+      kind: "file-unavailable",
+      gitPath: entryGitPath.value,
+      message: `not valid JSON at this commit: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    });
+  }
+}
+
+/**
+ * The `import()` path a key's entry is behind, from the module's text.
+ *
+ * Exported for its own test: this is the part with a real chance of being
+ * wrong, and it is pure.
+ */
+export function findEntryImportPath(
+  moduleFilePath: ModuleFilePath,
+  valTsSource: string,
+  key: string,
+): result.Result<string, HistoryError> {
+  const sourceFile = ts.createSourceFile(
+    moduleFilePath,
+    valTsSource,
+    ts.ScriptTarget.ES2015,
+    true,
+  );
+  let analysis;
+  try {
+    analysis = analyzeValModule(sourceFile);
+  } catch (err) {
+    // `file-unavailable` rather than a kind of its own: the module's TEXT is
+    // the file we could not use, and adding a wire kind for "unparseable"
+    // would be a new case every reader has to handle to say the same thing.
+    return result.err({
+      kind: "file-unavailable",
+      gitPath: moduleFilePath,
+      message: `could not parse the module at this commit: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    });
+  }
+  if (result.isErr(analysis)) {
+    return result.err({
+      kind: "file-unavailable",
+      gitPath: moduleFilePath,
+      message: "could not read the module at this commit",
+    });
+  }
+  const entries = analyzeJsonValuesEntries(analysis.value.source);
+  const entry = entries.get(key);
+  if (entry === undefined) {
+    /*
+     * Reported, not treated as empty. A key with no entry at this commit means
+     * the entry was added later - so "there is nothing to show for it here" is
+     * the true answer, and rendering an empty field instead would say the
+     * author had left it blank.
+     */
+    return result.err({
+      kind: "file-unavailable",
+      gitPath: moduleFilePath,
+      message: `'${key}' had no entry at this commit`,
+    });
+  }
+  const moduleDir = path.posix.dirname(moduleFilePath);
+  return result.ok(path.posix.join(moduleDir, entry.importPath));
+}

--- a/packages/server/src/historyFilesAuth.test.ts
+++ b/packages/server/src/historyFilesAuth.test.ts
@@ -131,6 +131,24 @@ describe("auth on the two file routes", () => {
   });
 
   /*
+   * The same pair for /history/json, which is authenticated for exactly the
+   * same reasons: its token is a commit sha, and its only caller is the Studio
+   * in a browser that has the session.
+   */
+  const HISTORY_JSON =
+    "/history/json?commit_sha=abc123&path=/content/page.val.ts&key=/a";
+
+  test("/history/json refuses a request with no session", async () => {
+    const res = await get(HISTORY_JSON, false);
+    expect(res.status).toBe(401);
+  });
+
+  test("/history/json gets past auth with one", async () => {
+    const res = await get(HISTORY_JSON, true);
+    expect(res.status).not.toBe(401);
+  });
+
+  /*
    * And /files must NOT start asking. If this ever goes red, the Next image
    * optimiser can no longer read draft images and every unpublished image in
    * the Studio goes blank - which is not a symptom anyone would trace back to

--- a/packages/server/src/historyFilesAuth.test.ts
+++ b/packages/server/src/historyFilesAuth.test.ts
@@ -1,0 +1,143 @@
+import { initVal, modules } from "@valbuild/core";
+import { createValApiRouter, createValServer } from "./ValRouter";
+import { encodeJwt } from "./jwt";
+import { fakeRequest } from "./fakeRequest";
+
+/**
+ * Which of the two file routes asks for a session, and which cannot.
+ *
+ * They look like the same endpoint and are not, so the difference is pinned
+ * here rather than left to be tidied away in either direction:
+ *
+ *   /files          serves a DRAFT image to the app's own backend during Next
+ *                   image optimisation - backend-to-backend, no cookies. It
+ *                   cannot require auth without blacking out every unpublished
+ *                   image. What stands in for the credential is `patch_id`,
+ *                   which is a UUID.
+ *
+ *   /history/files  serves a file at a COMMIT SHA, which is published - `git
+ *                   log`, the GitHub UI, every PR - so it is no substitute for
+ *                   a credential. Nothing fetches it server-side either: both
+ *                   callers are the Studio in a browser holding the session
+ *                   cookie. So it asks.
+ *
+ * See architecture/media.md, "Why /files has no auth, and /history/files does".
+ */
+describe("auth on the two file routes", () => {
+  const route = "/api/val";
+  const { c, s, config } = initVal();
+
+  /*
+   * Proxy mode reads these from the environment rather than from options, and
+   * refuses to start without them. Nothing here reaches the content service -
+   * auth is refused before any request would be made - so the values only have
+   * to exist. Restored afterwards so a shared jest worker is left as it was.
+   */
+  const previousEnv = {
+    commit: process.env["VAL_GIT_COMMIT"],
+    branch: process.env["VAL_GIT_BRANCH"],
+  };
+  beforeAll(() => {
+    process.env["VAL_GIT_COMMIT"] = "0000000000000000000000000000000000000000";
+    process.env["VAL_GIT_BRANCH"] = "main";
+  });
+  afterAll(() => {
+    if (previousEnv.commit === undefined) delete process.env["VAL_GIT_COMMIT"];
+    else process.env["VAL_GIT_COMMIT"] = previousEnv.commit;
+    if (previousEnv.branch === undefined) delete process.env["VAL_GIT_BRANCH"];
+    else process.env["VAL_GIT_BRANCH"] = previousEnv.branch;
+  });
+  /*
+   * An HTTP-mode server, which is the only mode where this can be tested at
+   * all: `getAuth` returns `{ error: null }` in FS mode by design, because
+   * local dev has no login. An `apiKey` + `valSecret` is what puts the server
+   * in http mode; nothing here reaches the content service, because auth is
+   * refused before any request would be made.
+   */
+  const makeRoute = () =>
+    createValApiRouter(
+      route,
+      createValServer(
+        modules(config, [
+          {
+            def: () =>
+              Promise.resolve({
+                default: c.define("/content/page.val.ts", s.string(), "hello"),
+              }),
+          },
+        ]),
+        route,
+        {
+          disableCache: true,
+          apiKey: "test-api-key",
+          valSecret: "test-secret",
+          project: "test-org/test-project",
+          valContentUrl: "http://localhost:9999",
+          // Normally read off the installed packages; nothing here depends on
+          // the values, only on proxy mode being willing to start at all.
+          versions: { core: "0.0.0-test", next: "0.0.0-test" },
+        },
+        config,
+        {
+          async isEnabled() {
+            return true;
+          },
+          async onDisable() {},
+          async onEnable() {},
+        },
+      ),
+      (res) => res,
+    );
+
+  const SESSION = {
+    sub: "ada",
+    exp: Math.floor(Date.now() / 1000) + 3600,
+    token: "test-token",
+    org: "test-org",
+    project: "test-project",
+  };
+
+  const get = (path: string, withSession: boolean) =>
+    makeRoute()(
+      fakeRequest({
+        method: "GET",
+        url: new URL(`http://localhost:3000${route}${path}`),
+        headers: withSession
+          ? new Headers({
+              Cookie: `val_session=${encodeJwt(SESSION, "test-secret")}`,
+            })
+          : new Headers(),
+      }),
+    );
+
+  const HISTORY_FILE =
+    "/history/files?commit_sha=abc123&path=content/page.val.ts";
+
+  test("/history/files refuses a request with no session", async () => {
+    const res = await get(HISTORY_FILE, false);
+    expect(res.status).toBe(401);
+  });
+
+  /*
+   * The other half of the claim: it is the SESSION being checked, not the
+   * request failing for some unrelated reason that would make the test above
+   * pass no matter what. With a session it gets past auth and fails on its
+   * merits - fs mode has git rather than a commit archive, so it answers
+   * `not-supported-in-fs-mode` - which is any status except 401.
+   */
+  test("/history/files gets past auth with one", async () => {
+    const res = await get(HISTORY_FILE, true);
+    expect(res.status).not.toBe(401);
+  });
+
+  /*
+   * And /files must NOT start asking. If this ever goes red, the Next image
+   * optimiser can no longer read draft images and every unpublished image in
+   * the Studio goes blank - which is not a symptom anyone would trace back to
+   * an auth check.
+   */
+  test("/files serves a published file without a session", async () => {
+    const res = await get("/files/public/val/does-not-exist.png", false);
+    expect(res.status).not.toBe(401);
+  });
+});

--- a/packages/shared/src/internal/ApiRoutes.ts
+++ b/packages/shared/src/internal/ApiRoutes.ts
@@ -1433,6 +1433,51 @@ export const Api = {
    * immutable and the browser's own cache handles flipping between commits.
    */
   /**
+   * One `.jsonValues()` entry's content, as it was at a commit.
+   *
+   * The history pane's counterpart to `/json`. A `.jsonValues()` record's
+   * source is only `{_type:"json"}` markers - the content is per entry, fetched
+   * on demand - so without this the commit pane rendered every entry as an
+   * empty field, which is a claim that the author left it blank.
+   *
+   * One entry per request, deliberately: the store fetches an entry when
+   * something reads inside it, so a batch would mean guessing which entries the
+   * pane is about to show. Authenticated for the same reasons as
+   * `/history/files` below.
+   */
+  "/history/json": {
+    GET: {
+      req: {
+        query: {
+          commit_sha: onlyOneStringQueryParam,
+          path: onlyOneStringQueryParam,
+          key: onlyOneStringQueryParam,
+        },
+        cookies: { val_session: z.string().optional() },
+      },
+      res: z.union([
+        unauthorizedResponse,
+        notFoundResponse,
+        z.object({
+          status: z.literal(400),
+          json: GenericError.and(z.object({ kind: z.string().optional() })),
+        }),
+        z.object({
+          status: z.literal(500),
+          json: GenericError.and(z.object({ kind: z.string().optional() })),
+        }),
+        z.object({
+          status: z.literal(200),
+          json: z.object({
+            path: ModuleFilePath,
+            key: z.string(),
+            content: z.unknown(),
+          }),
+        }),
+      ]),
+    },
+  },
+  /**
    * A binary file as it was at a commit.
    *
    * AUTHENTICATED, unlike `/files` below - and the difference is not an

--- a/packages/shared/src/internal/ApiRoutes.ts
+++ b/packages/shared/src/internal/ApiRoutes.ts
@@ -1432,6 +1432,21 @@ export const Api = {
    * actually mounts. A file at a fixed commit cannot change, so the response is
    * immutable and the browser's own cache handles flipping between commits.
    */
+  /**
+   * A binary file as it was at a commit.
+   *
+   * AUTHENTICATED, unlike `/files` below - and the difference is not an
+   * oversight in either direction. See the comment on `/files`: what makes it
+   * safe to leave open is that a `patch_id` is an unguessable UUID, and what
+   * makes leaving it open NECESSARY is that a draft image is fetched by the
+   * app's own backend during Next image optimisation, with no cookies.
+   *
+   * Neither holds here. A commit sha is published - `git log`, the GitHub UI,
+   * every PR - so it is not a secret to stand in for a credential. And nothing
+   * fetches these server-side: they are read by the Studio, in a browser that
+   * has the session cookie, for the history pane and for staging a restore.
+   * So this one asks.
+   */
   "/history/files": {
     GET: {
       req: {
@@ -1440,6 +1455,7 @@ export const Api = {
           path: onlyOneStringQueryParam,
           remote: onlyOneStringQueryParam.optional(),
         },
+        cookies: { val_session: z.string().optional() },
       },
       res: z.union([
         unauthorizedResponse,

--- a/packages/ui/spa/history/useCommitSystem.ts
+++ b/packages/ui/spa/history/useCommitSystem.ts
@@ -6,6 +6,7 @@ import type {
 import { useMemo } from "react";
 import { createReadOnlySystem } from "../stores/readOnlySystem";
 import { useValSystem } from "../stores/react/SystemContext";
+import { useClient } from "../components/ValProvider";
 import type { System } from "../stores/createSystem";
 
 /**
@@ -46,10 +47,12 @@ export function useCommitSystem(
   } | null,
 ): System | null {
   const live = useValSystem();
+  const client = useClient();
   return useMemo(() => {
     if (!patchSet) {
       return null;
     }
+    const commitSha = patchSet.commit.commitSha;
     /*
      * Start from the project as it is, then lay the commit on top.
      *
@@ -120,9 +123,34 @@ export function useCommitSystem(
     return createReadOnlySystem({
       schemas,
       sources,
+      /*
+       * A `.jsonValues()` entry, as it was at this commit.
+       *
+       * Without it the store refuses the read and the entry stays a marker,
+       * which the pane draws as an empty field - a claim that the author left
+       * it blank, about content that is simply stored elsewhere. The fetch is
+       * per entry and on demand, which is the store's own design: an entry
+       * loads when something reads inside it, so a commit with a thousand
+       * support pages costs nothing until one is opened.
+       */
+      fetchJsonEntry: async (moduleFilePath, key) => {
+        const res = await client("/history/json", "GET", {
+          query: { commit_sha: commitSha, path: moduleFilePath, key },
+        });
+        if (res.status === 200) {
+          return { status: "ok", content: res.json.content as Json };
+        }
+        return {
+          status: "error",
+          message:
+            "message" in res.json
+              ? res.json.message
+              : `Could not read '${key}' as it was at ${commitSha.slice(0, 7)}`,
+        };
+      },
       noServerReason: "This is how things were; there is nothing pending here",
     });
-  }, [patchSet, live, outside]);
+  }, [patchSet, live, outside, client]);
 }
 
 /**

--- a/packages/ui/spa/stores/readOnlySystem.ts
+++ b/packages/ui/spa/stores/readOnlySystem.ts
@@ -5,6 +5,7 @@ import type {
   SerializedSchema,
 } from "@valbuild/core";
 import { createSystem, type System } from "./createSystem";
+import type { FetchJsonEntry } from "./SourceStore";
 import type { HostBridge } from "./bridges";
 
 /**
@@ -27,11 +28,27 @@ export function createReadOnlySystem({
   schemas,
   sources,
   previews,
+  fetchJsonEntry,
   noServerReason,
 }: {
   schemas: Record<ModuleFilePath, SerializedSchema | undefined>;
   sources: Record<ModuleFilePath, Json | undefined>;
   previews?: Record<ModuleFilePath, ReifiedPreview | null>;
+  /**
+   * How to load a `.jsonValues()` entry, if this system can.
+   *
+   * A `.jsonValues()` record's source is only `{_type:"json"}` markers - the
+   * content is per entry and fetched when something reads inside one. Without
+   * this the store refuses the read (see `SourceStore.loadEntry`) and every
+   * entry stays a marker, which the pane draws as an empty field: a claim that
+   * the author left it blank.
+   *
+   * Optional because not every read-only system HAS somewhere to fetch from;
+   * one built from a snapshot with the entries already inlined does not need
+   * it, and refusing honestly is the right answer where there is nowhere to
+   * ask.
+   */
+  fetchJsonEntry?: FetchJsonEntry;
   /** What to say when something asks this system for a patch it cannot fetch. */
   noServerReason: string;
 }): System {
@@ -50,6 +67,7 @@ export function createReadOnlySystem({
   };
 
   const system = createSystem({
+    ...(fetchJsonEntry ? { fetchJsonEntry } : {}),
     // Nothing announces patch ids here, so nothing ever asks for one.
     fetchPatches: async (patchIds) => ({
       patches: [],

--- a/packages/ui/spa/stores/readOnlySystemJsonEntries.test.ts
+++ b/packages/ui/spa/stores/readOnlySystemJsonEntries.test.ts
@@ -1,0 +1,91 @@
+import { initVal } from "@valbuild/core";
+import type { SourcePath } from "@valbuild/core";
+import { createReadOnlySystem } from "./readOnlySystem";
+
+/**
+ * A read-only system - the history pane's - reading a `.jsonValues()` entry.
+ *
+ * The pane renders a commit through the real field components, and a
+ * `.jsonValues()` record's source is only `{_type:"json"}` markers: the content
+ * is per entry, fetched when something reads inside one. The read-only system
+ * had no fetcher, so `SourceStore.loadEntry` refused every read and each entry
+ * stayed a marker - which the pane drew as an empty field. That is worse than
+ * an error: an empty value is a claim that the author left it blank, about
+ * content that is simply stored somewhere else.
+ *
+ * The module is handed over through `host.receive`, the way the live system
+ * takes content in, rather than as a hand-serialized schema: `receive` JSON
+ * round-trips the source, so what the stores end up holding is markers with no
+ * thunk behind them - exactly the shape a commit's archived source has.
+ */
+const { c, s } = initVal();
+
+const TITLE_IN_A = '/blogs.val.ts?p="/a"."title"' as SourcePath;
+
+const jsonValuesModule = () =>
+  c.define(
+    "/blogs.val.ts",
+    s.record(s.object({ title: s.string() })).jsonValues(),
+    { "/a": c.json(() => Promise.resolve({ default: { title: "Alpha" } })) },
+  );
+
+function systemWith(
+  fetchJsonEntry?: Parameters<typeof createReadOnlySystem>[0]["fetchJsonEntry"],
+) {
+  const system = createReadOnlySystem({
+    schemas: {},
+    sources: {},
+    ...(fetchJsonEntry ? { fetchJsonEntry } : {}),
+    noServerReason: "nothing pending here",
+  });
+  system.host.receive([jsonValuesModule()]);
+  return system;
+}
+
+describe("a read-only system reading a jsonValues entry", () => {
+  test("fetches the entry and resolves a path inside it", async () => {
+    const asked: string[] = [];
+    const system = systemWith(async (moduleFilePath, key) => {
+      asked.push(`${moduleFilePath} ${key}`);
+      return { status: "ok", content: { title: "Alpha" } };
+    });
+    const read = await system.sourceStore.get(TITLE_IN_A, null);
+    if (read.status !== "resolved-head") {
+      throw new Error(`expected the read to resolve, got ${read.status}`);
+    }
+    expect(read.data).toEqual("Alpha");
+    expect(asked).toEqual(["/blogs.val.ts /a"]);
+  });
+
+  /*
+   * The regression this exists for. With no fetcher the read is REFUSED - which
+   * is honest - but the pane had no fetcher to give it, so every entry in every
+   * commit took this path, and a refused read is what the pane drew as blank.
+   */
+  test("refuses the read when there is nowhere to fetch from", async () => {
+    const system = systemWith(undefined);
+    const read = await system.sourceStore.get(TITLE_IN_A, null);
+    expect(read.status).not.toBe("resolved-head");
+  });
+
+  test("reports a failed fetch rather than an empty field", async () => {
+    const system = systemWith(async () => ({
+      status: "error",
+      message: "the archive host is unreachable",
+    }));
+    const read = await system.sourceStore.get(TITLE_IN_A, null);
+    expect(read.status).not.toBe("resolved-head");
+  });
+
+  // Looking must stay free: `peek` is what a nav count or a badge uses, and it
+  // must never trigger the fetch that `get` does.
+  test("peeking does not fetch", () => {
+    const asked: string[] = [];
+    const system = systemWith(async (moduleFilePath, key) => {
+      asked.push(`${moduleFilePath} ${key}`);
+      return { status: "ok", content: { title: "Alpha" } };
+    });
+    system.sourceStore.peek(TITLE_IN_A);
+    expect(asked).toEqual([]);
+  });
+});


### PR DESCRIPTION
Two independent changes to the history pane, in one branch. Reviewable as two commits — [`84067b0`](https://github.com/valbuild/val/commit/84067b01277ecd6aabc0db76600d871221514a30) and [`212b8aa`](https://github.com/valbuild/val/commit/212b8aab308db9d9ab714573fc4b5276cfc6ebdc) — and they touch different files apart from `ApiRoutes.ts` and `ValServer.ts`.

---

## 1. `/history/files` now requires a session

It served a file at any commit to anyone who asked. The comment said *"no auth, for the same reason `/files` has none"*, and that reason does not transfer.

`/files` is open on two legs: `patch_id` is an unguessable UUID standing in for a credential, and it **cannot** be otherwise — a draft image is fetched by the app's own backend during Next image optimisation, backend-to-backend, with no cookies. Requiring auth there would black out every unpublished image in the Studio.

Neither leg holds for history. A **commit sha is published** — `git log`, the GitHub UI, every PR. And nothing fetches this server-side: both callers are the Studio in a browser holding the session cookie (the pane's `<img>`, and `stageRestore`'s `fetch`, both same-origin). I checked both before changing it.

The two look like the same endpoint and are not, so the difference is written down where someone would look before tidying it in either direction: a section in `architecture/media.md`, and a pointer to it from the `/files` route.

**Tests** — `historyFilesAuth.test.ts`, in http mode (the only mode where this is testable: `getAuth` returns no error in FS mode by design, local dev having no login). No session → refused; **with** a session → gets past auth, so the first isn't passing for an unrelated reason; and `/files` still serves without one — the test that would otherwise be discovered as *"unpublished images went blank"*. Verified by deleting the guard: the first goes red (401 → 400).

---

## 2. `.jsonValues()` entries render instead of showing blank

They rendered as **empty fields**. A `.jsonValues()` record's source is only `{_type:"json"}` markers — each entry's content lives in its own `*.val.json`, fetched when something reads inside it — and the read-only system the pane is built on had no fetcher. Every read was refused, every entry stayed a marker, and the pane drew a blank field. That is worse than an error: an empty value is a claim that the author left it blank, about content that is simply stored somewhere else.

The fetch is per entry and on demand, which is the store's own design rather than a choice made here: a commit with a thousand support pages costs nothing until one is opened.

**Why this needs the module's `.val.ts`.** There is *no* derivable relationship between a record key and its entry file:

```ts
"/support/getting-started": c.json(() => import("./content/getting-started.val.json")),
"/support/faq":             c.json(() => import("./content/faq.val.json")),
```

The key is a route; the path is whatever the author wrote. The only place the two are related is the `import()` literal — which the archive does not store, since it keeps the module's Source and schema rather than its text. So `GET /history/json` fetches that text from git at the commit and parses it, exactly as `findJsonEntryFilePathsInSource` does on the live path.

`gitPathOfModule` on `ValOps` is new and is why this works at all: a `ModuleFilePath` is project-relative, a git path carries the repository root in front of it, and only the ops know that root.

A key with **no entry at that commit** is reported, not treated as empty — it means the entry was added later, and a blank field would misstate a commit that predates it.

**Tests** — nine. Five on the key→path resolution, including one whose file shares nothing with its key so a "filename is the key" shortcut cannot pass; four on the read-only system: a read fetches and resolves, a missing fetcher is refused rather than reported empty, a failed fetch likewise, and `peek` still costs nothing. Removing the wiring turns the first red.

---

Typecheck, lint and prettier clean. Test suite green apart from `packages/mcp/src/images/remoteImages.test.ts`, which is **red on `main`** from an unrelated PR — same 4 tests, same file, not touched here.

Changesets included for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1XGRuPC6BTaMcxizVttCb