### PR TITLE
Fix the remote gallery fixture that #622 left broken on main

### DIFF
--- a/packages/mcp/src/tools/toolsFixture.ts
+++ b/packages/mcp/src/tools/toolsFixture.ts
@@ -173,7 +173,7 @@ export default c.define(
 /**
  * A gallery whose images live on Val's content host.
  *
- * `remote: true` changes what the content POINTS AT — a `remote.val.build` URL
+ * `.remote()` changes what the content POINTS AT — a `remote.val.build` URL
  * instead of a `/public` path — and nothing about where an unpublished upload's
  * bytes go, which is the patch store either way.
  */
@@ -182,7 +182,7 @@ import { s, c } from "val.config";
 
 export default c.define(
   "${REMOTE_GALLERY_PATH}",
-  s.images({ remote: true, directory: "/public/val/remote" }),
+  s.images({ directory: "/public/val/remote" }).remote(),
   {}
 );
 `;


### PR DESCRIPTION
## Summary

`main` is red: `packages/mcp/src/images/remoteImages.test.ts` fails 4 assertions. This is the two-line fix.

`toolsFixture.ts` declares its remote gallery inside a **template literal** — TypeScript source as a string, evaluated by the module loader at test time — using the `remote` option that #622 removed. Because it is a string, nothing typechecked it: the option was silently ignored, the gallery became local, and the upload wrote a `/public/...` path with `remote: false` instead of a remote ref.

```diff
-  s.images({ remote: true, directory: "/public/val/remote" }),
+  s.images({ directory: "/public/val/remote" }).remote(),
```

## Why nothing caught it

Neither PR could have. #622 branched before `packages/mcp` existed, so its CI never saw this fixture. #623 branched before the option was removed, so its CI saw a fixture that still worked. The break exists only in the combination, and appeared the moment the second one merged.

The general shape is worth noting: an option removal is a compile error at every normal call site, but schema code inside a string is invisible to `tsc`. This fixture was the only such call site in the repo — I checked the rest.

## Scope

Deliberately minimal, so it can land immediately and independently of review on the renames in #637.

- The fixture line, plus the comment directly above it that described the same removed option.
- **No changeset** — a test fixture, so nothing about the shipped API changes.

Other places on `main` that still *document* the removed option (the `upload_image` tool description, the "not connected to Val Build" error, the mcp README, `docs/plans/mcp-remote-images.md`) are corrected in #637. They are wrong but not breaking, so they are not urgent and are left out of this fix.

#637 contains this same fix, so it no-ops once this lands; I will rebase it.

## Verification

- The failing suite: 4 failed → **8 passed**.
- Full suite: **316 suites / 3804 tests** pass.
- Typecheck (13 packages), lint and `prettier --check` all clean.
- Confirmed red first at `5674237` (current `main`) before changing anything, so the attribution is measured rather than assumed.

https://claude.ai/code/session_0144L5wjVw6u8vmqq4GT8Cyh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0144L5wjVw6u8vmqq4GT8Cyh)_