### PR TITLE
Pin the History button to every breakpoint

### DIFF
--- a/packages/ui/spa/components/shell/historyAffordance.test.tsx
+++ b/packages/ui/spa/components/shell/historyAffordance.test.tsx
@@ -1,0 +1,81 @@
+/** @jest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { TopBar } from "./TopBar";
+import { ShellBreakpoint } from "./types";
+
+/**
+ * The way into history, at every size.
+ *
+ * The History button sits in the top bar's icon row, and the buttons around it
+ * are NOT all rendered at every breakpoint: Review, Preview, Publish and Quick
+ * actions are each behind `!isMobile`. A refactor that widened one of those
+ * guards to cover this button would take history away from phones and tablets
+ * without failing anything - the desktop screenshot would look untouched, and
+ * the only symptom is a feature that silently does not exist on an iPad.
+ *
+ * So the breakpoints are pinned rather than the layout. The panel itself is
+ * already responsive (`mobileVariant="bottom-sheet"`), and `HistorySplit`
+ * turns the two panes into "Now" / the commit as tabs below desktop.
+ */
+/*
+ * jsdom has no `matchMedia`, and the non-desktop top bar reaches it through
+ * `usePrefersReducedMotion`. Stubbed rather than worked around: the reduced
+ * motion answer is irrelevant here, and without it the mobile and tablet cases
+ * fail for a reason that has nothing to do with the button.
+ */
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      dispatchEvent: () => false,
+    }),
+  });
+});
+
+function topBar(breakpoint: ShellBreakpoint, historyEnabled: boolean) {
+  return (
+    <TopBar
+      breakpoint={breakpoint}
+      projectName="Test"
+      openPanel={null}
+      onTogglePanel={() => undefined}
+      onOpenMenu={() => undefined}
+      onOpenSearch={() => undefined}
+      onPreview={() => undefined}
+      isCanvasOpen={false}
+      onPublish={() => undefined}
+      pendingChanges={0}
+      historyEnabled={historyEnabled}
+    />
+  );
+}
+
+const BREAKPOINTS: ShellBreakpoint[] = ["mobile", "tablet", "desktop"];
+
+describe("the History button", () => {
+  test.each(BREAKPOINTS)("is offered on %s", (breakpoint) => {
+    render(topBar(breakpoint, true));
+    expect(screen.getByRole("button", { name: "History" })).not.toBeNull();
+  });
+
+  /*
+   * Hidden in fs mode, where `historySlot` is undefined: local dev has git
+   * rather than a commit archive, and /history/commits answers
+   * `not-supported-in-fs-mode`. A button that can only open an apology is
+   * worse than no button - and that has to hold on a phone too.
+   */
+  test.each(BREAKPOINTS)(
+    "is hidden on %s when there is no published history",
+    (breakpoint) => {
+      render(topBar(breakpoint, false));
+      expect(screen.queryByRole("button", { name: "History" })).toBeNull();
+    },
+  );
+});


### PR DESCRIPTION
Test only — no behaviour change.

The History button is already offered on mobile and tablet: it sits **outside** the `!isMobile` guards in the top bar. But nothing said so, and the four buttons immediately around it are each behind one — Review, Preview, Publish and Quick actions.

A refactor that widened one of those guards over this button would take history away from phones and tablets **without failing anything**. The desktop screenshot would look untouched, and the only symptom is a feature that silently does not exist on an iPad.

## What's pinned

The breakpoints, not the layout:

- offered at `mobile`, `tablet` and `desktop`
- hidden at all three when `historyEnabled` is false — fs mode, where there is no published history and the button could only open an apology

Verified by putting it behind `!isMobile`: the mobile case goes red.

## Context

The rest of the responsive behaviour was already in place and this doesn't change it — recorded here so the test explains itself:

- the panel is `mobileVariant="bottom-sheet"`
- `HistorySplit` turns the two panes into `Now` / the commit as **tabs** below desktop, keeping both mounted so scroll position and half-typed edits survive toggling
- breakpoints are mobile `< 768px`, tablet `768–1199px`, desktop `≥ 1200px` — so an iPad in portrait is tablet, and a 12.9" iPad Pro in landscape is desktop

`jsdom` has no `matchMedia` and the non-desktop top bar reaches it through `usePrefersReducedMotion`, so the test stubs it — otherwise the mobile and tablet cases fail for a reason unrelated to the button.

Typecheck, prettier and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1XGRuPC6BTaMcxizVttCb

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1XGRuPC6BTaMcxizVttCb)_