### PR TITLE
create: ask which framework first, and take it as a flag

### DIFF
--- a/.changeset/create-framework-choice.md
+++ b/.changeset/create-framework-choice.md
@@ -1,0 +1,27 @@
+---
+"@valbuild/create": minor
+---
+
+`npm create @valbuild` now asks which framework you want
+
+TanStack Start joins Next.js as a starter, and choosing between them is the
+first question — before the project name, because everything after it depends
+on the answer.
+
+```sh
+pnpm create @valbuild@latest my-app --tanstack
+pnpm create @valbuild@latest my-app --framework tanstack   # same thing
+pnpm create @valbuild@latest my-app --nextjs
+```
+
+Like every other question here, a flag answers it and the prompt is skipped, so
+a scripted setup never blocks. `--framework` also takes `next`, `next.js` and
+`tanstack-start`, and the last flag wins if you pass more than one. A framework
+we do not have a starter for is an error naming the ones we do, rather than a
+silent fall back to Next.js.
+
+The feature questions now follow the starter. The TanStack Start starter does
+not ship an MCP endpoint yet, so it is not asked about there — and a `--mcp` or
+`--image-uploads` flag given anyway is turned off with a note, rather than
+producing a project whose success message points a coding agent at an endpoint
+that is not in it.

--- a/packages/create/README.md
+++ b/packages/create/README.md
@@ -10,6 +10,26 @@ npm create @valbuild@latest
 pnpm create @valbuild@latest
 ```
 
+## Which framework
+
+The first question is which framework to build on:
+
+- **Next.js** — [`valbuild/template-nextjs-starter`](https://github.com/valbuild/template-nextjs-starter)
+- **TanStack Start** — [`valbuild/template-tanstack-starter`](https://github.com/valbuild/template-tanstack-starter)
+
+Answer it up front to skip the prompt:
+
+```sh
+pnpm create @valbuild@latest my-app --framework tanstack
+pnpm create @valbuild@latest my-app --tanstack          # shorthand
+pnpm create @valbuild@latest my-app --nextjs
+```
+
+`--framework` also takes `next`, `next.js` and `tanstack-start`, and the last
+flag wins if you pass more than one.
+
+## Package manager
+
 The new project is installed with the package manager that ran the command, so
 `pnpm create` gives you a pnpm project (`pnpm-lock.yaml`, `pnpm run dev`) and
 `npm create` an npm one. yarn and bun are detected the same way.
@@ -31,7 +51,11 @@ pnpm create @valbuild@latest my-app
 
 ## Features it asks about
 
-Two parts of the template are optional, and both default to yes.
+Two parts of the template are optional, and both default to yes. They are asked
+about only where the chosen starter has them — the TanStack Start starter does
+not ship an MCP endpoint yet, so neither question is asked for it, and a
+`--mcp` flag given anyway is turned off with a note rather than silently
+producing a project whose endpoint is not there.
 
 - **MCP.** Serves Val's content tools at `/api/mcp`, so a coding agent can read
   your schemas, look content up, validate it and edit it. The endpoint refuses

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@valbuild/create",
   "version": "0.123.0",
-  "description": "Create a new Val project with Next.js",
+  "description": "Create a new Val project with Next.js or TanStack Start",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/valbuild/val.git"
@@ -38,7 +38,8 @@
     "valbuild",
     "create",
     "cli",
-    "nextjs"
+    "nextjs",
+    "tanstack"
   ],
   "author": "Valbuild",
   "license": "MIT",

--- a/packages/create/src/framework.test.ts
+++ b/packages/create/src/framework.test.ts
@@ -1,0 +1,165 @@
+import {
+  DEFAULT_FRAMEWORK,
+  dropUnsupportedFeatures,
+  FRAMEWORKS,
+  parseFrameworkArgs,
+  resolveFrameworkName,
+  TEMPLATES,
+} from "./framework";
+
+/**
+ * Choosing a framework, from a flag or from the prompt's default.
+ *
+ * The parsing is what these are mostly about: a flag that is silently not
+ * understood is how a scripted setup produces a Next project when it asked for
+ * a TanStack one, and the project name is whatever survives the flags — so a
+ * framework flag that fails to consume itself becomes the project's name.
+ */
+
+describe("TEMPLATES", () => {
+  it("has a template for every framework, keyed by its own name", () => {
+    for (const framework of FRAMEWORKS) {
+      expect(TEMPLATES[framework].framework).toBe(framework);
+    }
+  });
+
+  it("covers both frameworks we ship", () => {
+    expect(FRAMEWORKS.sort()).toEqual(["nextjs", "tanstack"]);
+  });
+
+  it("has a default that is one of them", () => {
+    expect(FRAMEWORKS).toContain(DEFAULT_FRAMEWORK);
+  });
+
+  it("points each framework at its own repository", () => {
+    expect(TEMPLATES.nextjs.repo).toBe("valbuild/template-nextjs-starter");
+    expect(TEMPLATES.tanstack.repo).toBe("valbuild/template-tanstack-starter");
+  });
+});
+
+describe("resolveFrameworkName", () => {
+  it("takes the canonical names", () => {
+    expect(resolveFrameworkName("nextjs")).toBe("nextjs");
+    expect(resolveFrameworkName("tanstack")).toBe("tanstack");
+  });
+
+  it("takes the aliases people actually type", () => {
+    expect(resolveFrameworkName("next")).toBe("nextjs");
+    expect(resolveFrameworkName("next.js")).toBe("nextjs");
+    expect(resolveFrameworkName("tanstack-start")).toBe("tanstack");
+  });
+
+  it("ignores case and surrounding space", () => {
+    expect(resolveFrameworkName("  NextJS ")).toBe("nextjs");
+    expect(resolveFrameworkName("TanStack")).toBe("tanstack");
+  });
+
+  it("is null for anything else", () => {
+    expect(resolveFrameworkName("svelte")).toBeNull();
+    expect(resolveFrameworkName("")).toBeNull();
+  });
+});
+
+describe("parseFrameworkArgs", () => {
+  it("asks nothing when no flag was given", () => {
+    const parsed = parseFrameworkArgs(["my-app"]);
+    expect(parsed.framework).toBeNull();
+    expect(parsed.invalidFlag).toBeNull();
+    expect(parsed.rest).toEqual(["my-app"]);
+  });
+
+  it("reads --framework <name> and consumes the value", () => {
+    const parsed = parseFrameworkArgs(["--framework", "tanstack", "my-app"]);
+    expect(parsed.framework).toBe("tanstack");
+    expect(parsed.rest).toEqual(["my-app"]);
+  });
+
+  it("reads --framework=<name>", () => {
+    const parsed = parseFrameworkArgs(["--framework=tanstack", "my-app"]);
+    expect(parsed.framework).toBe("tanstack");
+    expect(parsed.rest).toEqual(["my-app"]);
+  });
+
+  it("reads the bare shorthands", () => {
+    expect(parseFrameworkArgs(["--tanstack"]).framework).toBe("tanstack");
+    expect(parseFrameworkArgs(["--nextjs"]).framework).toBe("nextjs");
+    expect(parseFrameworkArgs(["--next"]).framework).toBe("nextjs");
+  });
+
+  it("consumes the shorthand, so it cannot become the project name", () => {
+    const parsed = parseFrameworkArgs(["--tanstack", "my-app"]);
+    expect(parsed.rest).toEqual(["my-app"]);
+  });
+
+  it("leaves other people's flags alone", () => {
+    const parsed = parseFrameworkArgs(["--use-pnpm", "--no-mcp", "my-app"]);
+    expect(parsed.framework).toBeNull();
+    expect(parsed.rest).toEqual(["--use-pnpm", "--no-mcp", "my-app"]);
+  });
+
+  it("lets the last flag win", () => {
+    expect(
+      parseFrameworkArgs(["--framework", "nextjs", "--tanstack"]).framework,
+    ).toBe("tanstack");
+    expect(
+      parseFrameworkArgs(["--tanstack", "--framework=nextjs"]).framework,
+    ).toBe("nextjs");
+  });
+
+  it("reports a framework it does not have, with the value", () => {
+    const parsed = parseFrameworkArgs(["--framework", "svelte"]);
+    expect(parsed.framework).toBeNull();
+    expect(parsed.invalidFlag).toBe("--framework svelte");
+  });
+
+  it("reports --framework with nothing after it", () => {
+    const parsed = parseFrameworkArgs(["--framework"]);
+    expect(parsed.invalidFlag).toBe("--framework");
+  });
+
+  it("keeps the first complaint when there are two", () => {
+    const parsed = parseFrameworkArgs([
+      "--framework=svelte",
+      "--framework=solid",
+    ]);
+    expect(parsed.invalidFlag).toBe("--framework=svelte");
+  });
+});
+
+describe("dropUnsupportedFeatures", () => {
+  it("leaves a template that supports MCP alone", () => {
+    const result = dropUnsupportedFeatures(
+      { mcp: true, imageUploads: true },
+      TEMPLATES.nextjs,
+    );
+    expect(result.features).toEqual({ mcp: true, imageUploads: true });
+    expect(result.warning).toBeNull();
+  });
+
+  it("turns MCP off, and says so, where the starter has no endpoint", () => {
+    const result = dropUnsupportedFeatures(
+      { mcp: true, imageUploads: true },
+      TEMPLATES.tanstack,
+    );
+    expect(result.features).toEqual({ mcp: false, imageUploads: false });
+    expect(result.warning).toContain("TanStack Start");
+  });
+
+  it("says nothing when nothing was asked for", () => {
+    const result = dropUnsupportedFeatures(
+      { mcp: false, imageUploads: false },
+      TEMPLATES.tanstack,
+    );
+    expect(result.features).toEqual({ mcp: false, imageUploads: false });
+    expect(result.warning).toBeNull();
+  });
+
+  it("still reports image uploads asked for on their own", () => {
+    const result = dropUnsupportedFeatures(
+      { mcp: false, imageUploads: true },
+      TEMPLATES.tanstack,
+    );
+    expect(result.features).toEqual({ mcp: false, imageUploads: false });
+    expect(result.warning).not.toBeNull();
+  });
+});

--- a/packages/create/src/framework.test.ts
+++ b/packages/create/src/framework.test.ts
@@ -24,7 +24,9 @@ describe("TEMPLATES", () => {
   });
 
   it("covers both frameworks we ship", () => {
-    expect(FRAMEWORKS.sort()).toEqual(["nextjs", "tanstack"]);
+    // Copied before sorting: `sort` is in-place, and `FRAMEWORKS` is an
+    // exported singleton the CLI reads for its help text and error messages.
+    expect([...FRAMEWORKS].sort()).toEqual(["nextjs", "tanstack"]);
   });
 
   it("has a default that is one of them", () => {

--- a/packages/create/src/framework.ts
+++ b/packages/create/src/framework.ts
@@ -1,0 +1,179 @@
+import type { Features } from "./features";
+
+/**
+ * Which framework the new project is built on.
+ *
+ * The first question, and the one every later answer depends on: it decides
+ * which template is downloaded, and therefore which of the optional features
+ * there is anything to turn on. A flag answers it, in which case nothing is
+ * asked — same contract as the feature flags and the package manager.
+ */
+
+export type Framework = "nextjs" | "tanstack";
+
+/**
+ * The optional parts of the template a given starter actually ships.
+ *
+ * Not a statement about the framework package: `@valbuild/tanstack/server`
+ * exports `initValMcp` just as `@valbuild/next/server` does. It is a statement
+ * about the STARTER, and it exists so the prompts cannot offer a feature that
+ * the downloaded repository has no files for — which would produce a project
+ * whose success message points a coding agent at an endpoint that is not there.
+ */
+export type FeatureSupport = {
+  /** Serves Val's content tools at `/api/mcp`. */
+  mcp: boolean;
+};
+
+export type Template = {
+  framework: Framework;
+  /** Shown in the picker, and in any message that names the starter. */
+  name: string;
+  description: string;
+  repo: string;
+  supports: FeatureSupport;
+};
+
+export const TEMPLATES: Record<Framework, Template> = {
+  nextjs: {
+    framework: "nextjs",
+    name: "Next.js",
+    description: "App Router, TypeScript, Tailwind CSS, and examples",
+    repo: "valbuild/template-nextjs-starter",
+    supports: { mcp: true },
+  },
+  tanstack: {
+    framework: "tanstack",
+    name: "TanStack Start",
+    description: "React, TypeScript, Tailwind CSS, and examples",
+    repo: "valbuild/template-tanstack-starter",
+    // The starter has no `api/mcp` route or `src/val/mcp.ts` yet. Flip this to
+    // `true` in the same change that adds them, and `applyFeatures` will need
+    // this framework's paths — the ones it removes today are Next's.
+    supports: { mcp: false },
+  },
+};
+
+function isFramework(value: string): value is Framework {
+  return Object.prototype.hasOwnProperty.call(TEMPLATES, value);
+}
+
+/**
+ * Every framework we have a starter for, derived from the templates so the two
+ * cannot drift: a `Framework` added to the union without a template is a type
+ * error, and one added with a template shows up in the picker, the help text
+ * and the error messages for free.
+ */
+export const FRAMEWORKS: Framework[] =
+  Object.keys(TEMPLATES).filter(isFramework);
+
+export const DEFAULT_FRAMEWORK: Framework = "nextjs";
+
+/**
+ * What people type when they mean one of these.
+ *
+ * `--framework next` is what someone reaches for first, and refusing it to
+ * insist on `nextjs` teaches nothing.
+ */
+const FRAMEWORK_ALIASES: Record<string, Framework> = {
+  next: "nextjs",
+  "next.js": "nextjs",
+  nextjs: "nextjs",
+  start: "tanstack",
+  tanstack: "tanstack",
+  "tanstack-start": "tanstack",
+};
+
+/** The framework this value names, or null if it names none of them. */
+export function resolveFrameworkName(value: string): Framework | null {
+  const key = value.trim().toLowerCase();
+  if (isFramework(key)) {
+    return key;
+  }
+  return FRAMEWORK_ALIASES[key] ?? null;
+}
+
+export type FrameworkArgs = {
+  /** The framework the flags asked for, or null if none did. */
+  framework: Framework | null;
+  /** The first flag we could not make sense of, verbatim, for the error message. */
+  invalidFlag: string | null;
+  /** `args` without the framework flags, so other parsing is unaffected. */
+  rest: string[];
+};
+
+/**
+ * Read `--framework <name>` (or `--framework=<name>`) and the `--nextjs` /
+ * `--tanstack` shorthands out of `args`.
+ *
+ * The last flag wins, so a later `--tanstack` overrides an earlier
+ * `--framework nextjs` rather than erroring — the same rule the package
+ * manager flags follow.
+ */
+export function parseFrameworkArgs(args: string[]): FrameworkArgs {
+  let framework: Framework | null = null;
+  let invalidFlag: string | null = null;
+  const rest: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--framework") {
+      const value = args[i + 1];
+      const resolved = value === undefined ? null : resolveFrameworkName(value);
+      if (resolved) {
+        framework = resolved;
+      } else if (invalidFlag === null) {
+        invalidFlag = value === undefined ? arg : `${arg} ${value}`;
+      }
+      // Skip the value too, unless the flag was last and has none.
+      if (value !== undefined) {
+        i++;
+      }
+      continue;
+    }
+    const valueMatch = /^--framework=(.*)$/.exec(arg);
+    if (valueMatch) {
+      const resolved = resolveFrameworkName(valueMatch[1]);
+      if (resolved) {
+        framework = resolved;
+      } else if (invalidFlag === null) {
+        invalidFlag = arg;
+      }
+      continue;
+    }
+    // A bare `--nextjs` / `--tanstack`. Only when it names a framework we have:
+    // anything else is someone else's flag and is passed through untouched.
+    const shorthandMatch = /^--(.+)$/.exec(arg);
+    if (shorthandMatch) {
+      const resolved = resolveFrameworkName(shorthandMatch[1]);
+      if (resolved) {
+        framework = resolved;
+        continue;
+      }
+    }
+    rest.push(arg);
+  }
+
+  return { framework, invalidFlag, rest };
+}
+
+/**
+ * Turn off whatever the chosen starter has no files for.
+ *
+ * Resolved rather than refused, for the reason `reconcile` gives about
+ * `--image-uploads`: the answer is not ambiguous. A flag that asked for MCP is
+ * still reported, because a scripted setup that asked for something and did
+ * not get it should be told so rather than find out from the finished project.
+ */
+export function dropUnsupportedFeatures(
+  features: Features,
+  template: Template,
+): { features: Features; warning: string | null } {
+  if (template.supports.mcp || !(features.mcp || features.imageUploads)) {
+    return { features, warning: null };
+  }
+  return {
+    features: { mcp: false, imageUploads: false },
+    warning: `The ${template.name} starter does not ship an MCP endpoint yet, so MCP and image uploads are off for this project.`,
+  };
+}

--- a/packages/create/src/index.ts
+++ b/packages/create/src/index.ts
@@ -2,10 +2,18 @@ import { execSync } from "child_process";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import degit from "degit";
-import { confirm, input } from "@inquirer/prompts";
+import { confirm, input, select } from "@inquirer/prompts";
 import chalk from "chalk";
 import { applyFeatures, type Features } from "./features";
 import { parseFeatureFlags, reconcile } from "./featureFlags";
+import {
+  DEFAULT_FRAMEWORK,
+  dropUnsupportedFeatures,
+  FRAMEWORKS,
+  parseFrameworkArgs,
+  TEMPLATES,
+  type Template,
+} from "./framework";
 import {
   foreignLockFiles,
   PACKAGE_MANAGER_COMMANDS,
@@ -19,23 +27,6 @@ const PKG = {
   version: "0.1.0",
 };
 
-interface Template {
-  name: string;
-  description: string;
-  repo: string;
-  default?: boolean;
-}
-
-const TEMPLATES: Template[] = [
-  {
-    name: "starter",
-    description:
-      "Full-featured Next.js app with Val, TypeScript, Tailwind CSS, and examples",
-    repo: "valbuild/template-nextjs-starter",
-    default: true,
-  },
-];
-
 const DEFAULT_PROJECT_NAME = "my-val-app";
 
 function printHelp() {
@@ -48,6 +39,10 @@ ${chalk.bold("Options:")}
   -h, --help Show help
   -v, --version Show version
   --root <path> Specify the root directory for project creation (default: current directory)
+  --framework <${FRAMEWORKS.join(
+    "|",
+  )}> Which framework to build on (asked if not given)
+  --nextjs, --tanstack Same, as a shorthand
   --use-npm, --use-pnpm, --use-yarn, --use-bun Use this package manager instead of the one that ran this command
   --package-manager <${PACKAGE_MANAGERS.join(
     "|",
@@ -74,6 +69,7 @@ process.on("SIGINT", handleExit);
 
 // Timeline stepper logic
 const timelineSteps = [
+  "Choose framework",
   "Enter project name",
   "Choose features",
   "Download template",
@@ -167,7 +163,22 @@ ${chalk.green("Happy coding! 🚀")}
  * because it is the one answer with a cost a person might not want: a compiled
  * binary per platform, in a project that may never upload an image.
  */
-async function chooseFeatures(given: Partial<Features>): Promise<Features> {
+async function chooseFeatures(
+  given: Partial<Features>,
+  template: Template,
+): Promise<Features> {
+  if (!template.supports.mcp) {
+    // Nothing to ask: neither question has anything to turn on in this
+    // starter. A flag that asked anyway is reported rather than ignored.
+    const narrowed = dropUnsupportedFeatures(
+      { mcp: given.mcp ?? false, imageUploads: given.imageUploads ?? false },
+      template,
+    );
+    if (narrowed.warning !== null) {
+      console.log(chalk.yellow(narrowed.warning));
+    }
+    return narrowed.features;
+  }
   const mcp =
     given.mcp ??
     (await confirm({
@@ -196,6 +207,27 @@ async function chooseFeatures(given: Partial<Features>): Promise<Features> {
   return reconciled.features;
 }
 
+/**
+ * Which starter to download, asked unless a flag already said.
+ *
+ * First, because everything after it depends on the answer: the repository to
+ * clone, and which of the optional features that repository has any files for.
+ */
+async function chooseFramework(given: Template | null): Promise<Template> {
+  if (given) {
+    return given;
+  }
+  return await select({
+    message: chalk.bold("Which framework?"),
+    choices: FRAMEWORKS.map((framework) => ({
+      name: TEMPLATES[framework].name,
+      value: TEMPLATES[framework],
+      description: TEMPLATES[framework].description,
+    })),
+    default: TEMPLATES[DEFAULT_FRAMEWORK],
+  });
+}
+
 /** True, or the reason this is not a usable project name. */
 function validateProjectName(value: string): true | string {
   if (!value || value.trim().length === 0) {
@@ -216,6 +248,8 @@ function processTemplateFiles(projectPath: string, projectName: string) {
     "package.json",
     "README.md",
     "next.config.js",
+    "vite.config.ts",
+    "tsr.config.json",
     "val.config.ts",
     "val.config.js",
   ];
@@ -315,9 +349,27 @@ async function main() {
     const packageManager = resolved.packageManager;
     const commands = PACKAGE_MANAGER_COMMANDS[packageManager];
 
+    // Which starter to download, if a flag said. Taken out of `args` before
+    // the project name for the same reason the others are.
+    const frameworkArgs = parseFrameworkArgs(resolved.rest);
+    if (frameworkArgs.invalidFlag !== null) {
+      console.error(
+        chalk.red(
+          `❌ Error: unknown framework "${frameworkArgs.invalidFlag}".`,
+        ),
+      );
+      console.error(
+        chalk.yellow(`Supported frameworks: ${FRAMEWORKS.join(", ")}`),
+      );
+      process.exit(1);
+    }
+    const givenTemplate = frameworkArgs.framework
+      ? TEMPLATES[frameworkArgs.framework]
+      : null;
+
     // The help text has always advertised `[project-name]`: whatever is left
     // once the flags are out is it.
-    const projectNameArg = resolved.rest[0];
+    const projectNameArg = frameworkArgs.rest[0];
     if (projectNameArg !== undefined) {
       const invalid = validateProjectName(projectNameArg);
       if (invalid !== true) {
@@ -329,7 +381,12 @@ async function main() {
     let currentStep = 0;
     renderTimeline(currentStep);
 
-    // Step 1: Enter project name — unless it was given as an argument
+    // Step 1: Which framework — unless a flag already said
+    const selectedTemplate = await chooseFramework(givenTemplate);
+    currentStep++;
+    renderTimeline(currentStep);
+
+    // Step 2: Enter project name — unless it was given as an argument
     const projectName =
       projectNameArg ??
       (await input({
@@ -340,14 +397,12 @@ async function main() {
     currentStep++;
     renderTimeline(currentStep);
 
-    // Step 2: Which optional parts of the template to keep
-    const features = await chooseFeatures(flags.answers);
+    // Step 3: Which optional parts of the template to keep
+    const features = await chooseFeatures(flags.answers, selectedTemplate);
     currentStep++;
     renderTimeline(currentStep);
 
-    const selectedTemplate = TEMPLATES[0];
-
-    // Step 3: Download template
+    // Step 4: Download template
     const projectPath = join(rootDir, projectName);
     if (existsSync(projectPath)) {
       renderTimeline(currentStep, currentStep);


### PR DESCRIPTION
`npm create @valbuild` only ever made Next.js projects, so there was nothing to ask. There are two starters now, and which one you want decides the repository to download — and therefore which of the optional features there is anything to turn on. So it is the first question, before the project name.

```sh
pnpm create @valbuild@latest my-app --tanstack
pnpm create @valbuild@latest my-app --framework tanstack   # same thing
pnpm create @valbuild@latest my-app --nextjs
```

A flag answers it and the prompt is skipped, which is the contract the package-manager and feature flags already have: a scripted setup never blocks. `--framework` takes `next`, `next.js` and `tanstack-start` too, because those are what people type; the last flag wins, matching `parsePackageManagerArgs`; and a framework we have no starter for is an error naming the ones we do, rather than a quiet fall back to Next.

## Each template declares what it can provide

The templates are a `Record<Framework, Template>` rather than an array with `default: true` on one entry, and `FRAMEWORKS` is derived from its keys — so a framework added to the union without a template is a type error, and one added with a template reaches the picker, the help text and the error messages without being listed anywhere else.

The TanStack starter has no `api/mcp` route yet, so `supports.mcp` is false and neither feature question is asked for it. A `--mcp` flag given anyway is turned off with a note — the same treatment `reconcile` gives `--image-uploads` without an endpoint, and for the same reason: the answer is not ambiguous, but a scripted setup that asked for something and did not get it should be told rather than find out from the finished project. Without this the success message would hand someone a `claude mcp add` command for an endpoint that is not in their project.

This is a gap in the **starter**, not the package: `@valbuild/tanstack/server` exports `initValMcp` just as `@valbuild/next/server` does. Adding the route to the template and flipping one boolean is the whole job, and the comment at `supports` says so — along with the one thing that has to move with it, since the paths `applyFeatures` removes today are Next's.

Also: `vite.config.ts` and `tsr.config.json` join the list of files placeholders are substituted into, so the TanStack starter can use one there later without this being the reason it does not work.

## Verified by running it

Not just the units. `--tanstack` downloads `template-tanstack-starter`, substitutes the project name and asks nothing:

```
✔ Choose framework
✔ Enter project name
✔ Choose features
✔ Download template
```

That run also surfaced something this PR does not fix, and it is worth knowing before the release: the TanStack starter's `@valbuild/*` pins were stale — `@valbuild/cli@0.123.1` was never published, so `npm install` failed with `ETARGET`. 0.124.0 is not the fix either, because `@valbuild/tanstack@0.124.0` pins its siblings exactly and core/shared/cli at 0.124.0 predate the TanStack work; installed together they typecheck and then fail with `[MISSING_EXPORT] "getTanStackRouterSourceFolder" is not exported by @valbuild/shared/client`, and `val validate` reports "No router modules found in the project". All of it lands in **0.125.0**, and the starter is pinned to that in [`template-tanstack-starter@cf53d9c`](https://github.com/valbuild/template-tanstack-starter/commit/cf53d9c).

`lint`, `format`, `typecheck` and the full suite (334 suites, 3952 tests — 22 of them new, covering the flag parsing, the alias table and the feature narrowing) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pq5ov51Y4mTqqsjjNfmBTb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pq5ov51Y4mTqqsjjNfmBTb)_