### PR TITLE
Adjudicate the remote-ref check in the editor, don't publish its placeholder

### DIFF
--- a/.changeset/remote-ref-editor-diagnostics.md
+++ b/.changeset/remote-ref-editor-diagnostics.md
@@ -1,0 +1,23 @@
+---
+"@valbuild/language-server": patch
+---
+
+The editor no longer warns "Remote image was not checked." on every remote image
+and file.
+
+That message is a placeholder: core cannot reach the content host, so
+`s.image().remote()` reports it unconditionally and leaves the real check to
+whoever can make it. `val validate` makes it and prints nothing when the ref is
+sound; the language server was publishing the placeholder raw, so every remote
+image in a project carried a permanent warning that no quick fix could clear.
+
+It is now adjudicated the same way the metadata placeholder already was — by
+running Val's own check — so a valid ref reports nothing, and a ref that no
+longer matches the bytes behind it reports what the CLI reports:
+
+```
+Remote ref: https://remote.val.build/file/p/…/renaming.gif is not valid. Use the --fix flag to fix this issue.
+```
+
+Nothing is downloaded for a ref that still adds up; only a stale one is fetched,
+into the same `.val/remote-file-cache` the CLI uses.

--- a/packages/language-server/src/diagnostics.ts
+++ b/packages/language-server/src/diagnostics.ts
@@ -20,10 +20,10 @@ import {
 } from "vscode-languageserver";
 import { createModulePathMap, getModulePathRange } from "./modulePathMap";
 import {
-  isDeferredMediaMetadataCheckAt,
-  mediaMetadataCheckKey,
-  type MediaMetadataVerdict,
-} from "./mediaMetadataChecks";
+  isDeferredMediaCheckAt,
+  mediaCheckKey,
+  type MediaCheckVerdict,
+} from "./mediaChecks";
 import type { ValModuleContent } from "./ValProject";
 
 /** Marks diagnostics as ours, so a client can filter on it. */
@@ -133,18 +133,26 @@ const FALLBACK_RANGE: Range = {
   end: { line: 0, character: 0 },
 };
 
-/** Fixes that operate on a file or image reference. */
+/**
+ * Fixes that operate on a LOCAL file or image reference.
+ *
+ * `*:check-remote` is deliberately absent. A remote value's bytes are on the
+ * content host by design, so "is it on disk" is never its question -- and for
+ * a path that is neither under `/public` nor a parseable remote ref, this
+ * check answered "File <root>/... does not exist" and pre-empted the remote
+ * adjudication, which has the real answer ("Invalid remote ref: ..."). The
+ * upload/download fixes stay: `*:upload-remote` is reported on a local path
+ * and a missing file really is its problem.
+ */
 const FILE_FIXES: readonly string[] = [
   "image:add-metadata",
   "image:check-metadata",
   "image:upload-remote",
   "image:download-remote",
-  "image:check-remote",
   "file:add-metadata",
   "file:check-metadata",
   "file:upload-remote",
   "file:download-remote",
-  "file:check-remote",
 ];
 
 function build(
@@ -169,7 +177,7 @@ export function createValDiagnostics({
   valRoot,
   snapshot,
   galleryChecks,
-  mediaMetadataChecks,
+  mediaChecks,
 }: {
   moduleFilePath: ModuleFilePath;
   content: ValModuleContent;
@@ -199,14 +207,14 @@ export function createValDiagnostics({
    */
   galleryChecks?: ReadonlyMap<string, GalleryCheckVerdict>;
   /**
-   * Verdicts for the media metadata placeholders core emits unconditionally,
-   * from {@link resolveMediaMetadataChecks}. Without it the placeholders are
-   * dropped, for the same reason the gallery ones are: core reports
-   * `image:check-metadata` on every `s.image()` that carries metadata whether
-   * or not anything is wrong, so publishing them raw puts a permanent warning
-   * on every image in the project.
+   * Verdicts for the media placeholders core emits unconditionally, from
+   * {@link resolveMediaChecks}. Without it the placeholders are dropped, for
+   * the same reason the gallery ones are: core reports `image:check-metadata`
+   * on every `s.image()` that carries metadata, and `image:check-remote` on
+   * every remote image, whether or not anything is wrong -- so publishing them
+   * raw puts a permanent warning on every image in the project.
    */
-  mediaMetadataChecks?: ReadonlyMap<string, MediaMetadataVerdict>;
+  mediaChecks?: ReadonlyMap<string, MediaCheckVerdict>;
 }): Diagnostic[] {
   if (content.errors === false) {
     return [];
@@ -286,16 +294,16 @@ export function createValDiagnostics({
         continue;
       }
 
-      // An unconditional media metadata placeholder: core reports
-      // `image:check-metadata` on every `s.image()` carrying metadata, whether
-      // or not it disagrees with the file. Show only what the adjudication
-      // actually found, and nothing when it found nothing. Deliberately after
-      // the missing-file branch above, so a deleted file is still reported as
-      // `val/file-not-found` rather than as a metadata mismatch.
-      if (isDeferredMediaMetadataCheckAt({ sourcePath, error, content })) {
-        const verdict = mediaMetadataChecks?.get(
-          mediaMetadataCheckKey(sourcePath, error),
-        );
+      // An unconditional media placeholder: core reports
+      // `image:check-metadata` on every `s.image()` carrying metadata whether
+      // or not it disagrees with the file, and `Remote image was not checked.`
+      // on every remote image whether or not its ref is stale. Show only what
+      // the adjudication actually found, and nothing when it found nothing.
+      // Deliberately after the missing-file branch above, so a deleted file is
+      // still reported as `val/file-not-found` rather than as a metadata
+      // mismatch.
+      if (isDeferredMediaCheckAt({ sourcePath, error, content })) {
+        const verdict = mediaChecks?.get(mediaCheckKey(sourcePath, error));
         for (const finding of verdict ?? []) {
           diagnostics.push(
             build(rangeOf(sourcePath, modulePathMap), finding.message, {

--- a/packages/language-server/src/mediaChecks.test.ts
+++ b/packages/language-server/src/mediaChecks.test.ts
@@ -1,13 +1,15 @@
 import fs from "fs";
 import os from "os";
 import path from "path";
-import { initVal } from "@valbuild/core";
+import { Internal, initVal } from "@valbuild/core";
 import type {
   FileSchema,
   FileSource,
   ImageSchema,
   ImageSource,
   ModuleFilePath,
+  SerializedImageSchema,
+  SerializedSchema,
   SourcePath,
   ValidationError,
   ValidationErrors,
@@ -15,10 +17,11 @@ import type {
 import { createValDiagnostics } from "./diagnostics";
 import {
   isDeferredMediaMetadataCheck,
-  mediaMetadataCheckKey,
-  resolveMediaMetadataChecks,
-  type MediaMetadataVerdict,
-} from "./mediaMetadataChecks";
+  isDeferredRemoteCheck,
+  mediaCheckKey,
+  resolveMediaChecks,
+  type MediaCheckVerdict,
+} from "./mediaChecks";
 import type { ValModuleContent } from "./ValProject";
 
 const { s } = initVal();
@@ -83,6 +86,17 @@ function validateFile(
     schema: schema["executeSerialize"](),
     source,
   };
+}
+
+/**
+ * Narrow what `executeSerialize` hands back, which is the whole
+ * `SerializedSchema` union, to the image schema `getValidationHash` wants.
+ */
+function asImageSchema(schema: SerializedSchema): SerializedImageSchema {
+  if (schema.type !== "image") {
+    throw Error(`Expected an image schema, got: ${schema.type}`);
+  }
+  return schema;
 }
 
 /** The single error core reported, failing loudly if it reported none or many. */
@@ -303,7 +317,7 @@ describe("isDeferredMediaMetadataCheck: nothing to go on", () => {
   });
 });
 
-describe("resolveMediaMetadataChecks", () => {
+describe("resolveMediaChecks", () => {
   let valRoot: string;
 
   const IMAGE_REF = "/public/val/logo.png";
@@ -329,12 +343,12 @@ describe("resolveMediaMetadataChecks", () => {
 
   const resolve = async (value: unknown) => {
     const error = deferralFor(value);
-    const verdicts = await resolveMediaMetadataChecks({
+    const verdicts = await resolveMediaChecks({
       validation: { [SOURCE_PATH]: [error] },
       content: contentFor(value),
       valRoot,
     });
-    return verdicts.get(mediaMetadataCheckKey(SOURCE_PATH, error));
+    return verdicts.get(mediaCheckKey(SOURCE_PATH, error));
   };
 
   const CORRECT = {
@@ -470,7 +484,7 @@ describe("resolveMediaMetadataChecks", () => {
       value: { path: IMAGE_REF },
       fixes: ["image:add-metadata"],
     };
-    const verdicts = await resolveMediaMetadataChecks({
+    const verdicts = await resolveMediaChecks({
       validation: { [SOURCE_PATH]: [error] },
       content: contentFor(error.value),
       valRoot,
@@ -483,6 +497,207 @@ describe("resolveMediaMetadataChecks", () => {
     fs.rmSync(path.join(valRoot, IMAGE_REF));
     expect(await resolve(CORRECT)).toHaveLength(1);
   });
+});
+
+describe("isDeferredRemoteCheck", () => {
+  /**
+   * Driven through core, like the metadata cases above: the claim being pinned
+   * is that a remote image's ONLY error is the deferral, so no re-derivation of
+   * core's conditions is needed to tell it apart from a real finding.
+   */
+  test("a remote image with a remote path defers, and says nothing else", () => {
+    const { errors } = validateImage(s.image().remote(), {
+      path: "https://remote.val.build/file/p/abc/b/v0/v/1/h/dead/f/beef/p/public/val/logo.png",
+      width: 1,
+      height: 1,
+      mimeType: "image/png",
+    });
+    const error = onlyError(errors);
+    expect(error.message).toBe("Remote image was not checked.");
+    expect(error.fixes).toEqual(["image:check-remote"]);
+    expect(isDeferredRemoteCheck(error)).toBe(true);
+  });
+
+  test("a remote file with a remote path defers the same way", () => {
+    const { errors } = validateFile(s.file().remote(), {
+      path: "https://remote.val.build/file/p/abc/b/v0/v/1/h/dead/f/beef/p/public/val/doc.pdf",
+      mimeType: "application/pdf",
+    });
+    const error = onlyError(errors);
+    expect(error.message).toBe("Remote file was not checked.");
+    expect(isDeferredRemoteCheck(error)).toBe(true);
+  });
+
+  test("a remote schema holding a local path is a real finding, not a deferral", () => {
+    const { errors } = validateImage(s.image().remote(), {
+      path: "/public/val/logo.png",
+      width: 1,
+      height: 1,
+      mimeType: "image/png",
+    });
+    const error = onlyError(errors);
+    expect(error.fixes).toEqual(["image:upload-remote"]);
+    expect(isDeferredRemoteCheck(error)).toBe(false);
+  });
+
+  test("a gallery's own remote check is a finding and is never adjudicated", () => {
+    // `RecordSchema.validateMediaKey` emits `images:check-remote` only for a
+    // key that is already wrong, and `createFixPatch` has no branch for it --
+    // adjudicating one would come back empty and drop a real error.
+    expect(
+      isDeferredRemoteCheck({
+        message: "Invalid remote URL format. Got: nope",
+        fixes: ["images:check-remote"],
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("resolveMediaChecks: the remote-ref placeholder", () => {
+  let valRoot: string;
+
+  const REMOTE_HOST = "https://remote.val.build";
+  const REMOTE_FILE_PATH = "public/val/logo.png";
+  const PROJECT_ID = "abc123";
+  const BUCKET = "v0";
+  const CORE_VERSION = Internal.VERSION.core || "unknown";
+  const FILE_HASH = Internal.remote.getFileHash(PNG_1X1);
+  const SCHEMA = asImageSchema(s.image().remote()["executeSerialize"]());
+  const METADATA = { width: 1, height: 1, mimeType: "image/png" };
+
+  /**
+   * A remote ref whose validation hash is computed from `metadata`.
+   *
+   * Pass the metadata the value actually carries and `checkRemoteRef` agrees
+   * with the ref, which is the whole happy path and costs no network. Pass
+   * anything else and the ref no longer adds up, which is the stale case.
+   */
+  const remoteRef = (metadata: Record<string, unknown>) =>
+    Internal.remote.createRemoteRef(REMOTE_HOST, {
+      publicProjectId: PROJECT_ID,
+      coreVersion: CORE_VERSION,
+      bucket: BUCKET,
+      validationHash: Internal.remote.getValidationHash(
+        CORE_VERSION,
+        SCHEMA,
+        "png",
+        metadata,
+        FILE_HASH,
+        new TextEncoder(),
+      ),
+      fileHash: FILE_HASH,
+      filePath: REMOTE_FILE_PATH,
+    });
+
+  const contentFor = (source: unknown): ValModuleContent =>
+    ({
+      source,
+      schema: SCHEMA,
+      errors: false,
+      path: SOURCE_PATH,
+    }) as ValModuleContent;
+
+  const deferralFor = (value: unknown): ValidationError => ({
+    message: "Remote image was not checked.",
+    value,
+    fixes: ["image:check-remote"],
+  });
+
+  const resolve = async (value: unknown) => {
+    const error = deferralFor(value);
+    const verdicts = await resolveMediaChecks({
+      validation: { [SOURCE_PATH]: [error] },
+      content: contentFor(value),
+      valRoot,
+      remoteHost: REMOTE_HOST,
+    });
+    return verdicts.get(mediaCheckKey(SOURCE_PATH, error));
+  };
+
+  beforeEach(() => {
+    valRoot = fs.mkdtempSync(path.join(os.tmpdir(), "val-remote-checks-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(valRoot, { recursive: true, force: true });
+  });
+
+  test("a ref that still adds up publishes nothing", async () => {
+    // The reported bug: every remote image carried a permanent
+    // "Remote image was not checked." No file is on disk and none is
+    // downloaded -- the hashes settle it.
+    expect(await resolve({ path: remoteRef(METADATA), ...METADATA })).toEqual(
+      [],
+    );
+  });
+
+  /**
+   * A value whose metadata was edited after the ref was minted: the ref's
+   * validation hash was computed from the real 1x1 bytes, the value now claims
+   * 800x600, and the two cannot both be right.
+   */
+  const STALE_VALUE = {
+    path: remoteRef(METADATA),
+    width: 800,
+    height: 600,
+    mimeType: "image/png",
+  };
+
+  test("a stale ref is reported with the CLI's own wording", async () => {
+    // Seeding the download cache is what keeps this offline: `checkRemoteRef`
+    // reads `.val/remote-file-cache` before it reaches for the network, and
+    // only a ref that no longer adds up gets that far at all.
+    seedRemoteFileCache();
+    const verdict = await resolve(STALE_VALUE);
+    expect(verdict).toHaveLength(1);
+    expect(verdict?.[0].message).toMatch(
+      /^Remote ref: https:\/\/remote\.val\.build\/file\/p\/abc123\/.* is not valid\. Use the --fix flag to fix this issue\.$/,
+    );
+  });
+
+  test("a finding carries no fix, so it is an Error and not a lightbulb", async () => {
+    // `createFixPatch` clears `fixes` on it, no quick fix is registered for
+    // `image:check-remote`, and dropping them is what matches the CLI's `✘`.
+    seedRemoteFileCache();
+    const verdict = await resolve(STALE_VALUE);
+    expect(verdict?.[0].fixes).toBeUndefined();
+  });
+
+  test("a path that is not a remote ref at all is reported, not hidden", async () => {
+    const verdict = await resolve({ path: "not-a-ref", ...METADATA });
+    expect(verdict).toHaveLength(1);
+    expect(verdict?.[0].message).toBe("Invalid remote ref: not-a-ref");
+  });
+
+  test("a check that could not be made keeps the placeholder", async () => {
+    // `createFixPatch` resolves the source path to find the schema, and throws
+    // on a path the source does not have. Claiming a ref is sound on no
+    // evidence is the worse failure, so the placeholder stands.
+    const value = { path: remoteRef(METADATA), ...METADATA };
+    const error = deferralFor(value);
+    const at = Internal.createValPathOfItem(SOURCE_PATH, "img") as SourcePath;
+    const verdicts = await resolveMediaChecks({
+      validation: { [at]: [error] },
+      content: {
+        source: {},
+        schema: s.object({ img: s.image().remote() })["executeSerialize"](),
+        errors: false,
+        path: SOURCE_PATH,
+      } as unknown as ValModuleContent,
+      valRoot,
+      remoteHost: REMOTE_HOST,
+    });
+    const verdict = verdicts.get(mediaCheckKey(at, error));
+    expect(verdict).toHaveLength(1);
+    expect(verdict?.[0].message).toBe("Remote image was not checked.");
+  });
+
+  /** The bytes `checkRemoteRef` would otherwise download, put where it looks. */
+  function seedRemoteFileCache() {
+    const dir = path.join(valRoot, ".val", "remote-file-cache");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, `${FILE_HASH}.png`), PNG_1X1);
+  }
 });
 
 describe("createValDiagnostics: publishing a verdict", () => {
@@ -508,15 +723,15 @@ describe("createValDiagnostics: publishing a verdict", () => {
       path: SOURCE_PATH,
     }) as unknown as ValModuleContent;
 
-  const diagnose = (error: ValidationError, verdict?: MediaMetadataVerdict) =>
+  const diagnose = (error: ValidationError, verdict?: MediaCheckVerdict) =>
     createValDiagnostics({
       moduleFilePath: MODULE_FILE_PATH,
       content: contentWith(error),
       text: "export default c.define('/content/media.val.ts', s.image(), {})",
       ...(verdict
         ? {
-            mediaMetadataChecks: new Map([
-              [mediaMetadataCheckKey(SOURCE_PATH, error), verdict],
+            mediaChecks: new Map([
+              [mediaCheckKey(SOURCE_PATH, error), verdict],
             ]),
           }
         : {}),
@@ -561,6 +776,42 @@ describe("createValDiagnostics: publishing a verdict", () => {
     // adjudicate must not publish an unconditional warning, because a warning
     // that is always there is one nobody reads -- which is this whole bug.
     expect(diagnose(deferral)).toEqual([]);
+  });
+
+  test("an empty remote verdict publishes nothing either", () => {
+    // The reported bug's other half: every remote image carried a permanent
+    // "Remote image was not checked."
+    const remote: ValidationError = {
+      message: "Remote image was not checked.",
+      value: {
+        path: "https://remote.val.build/file/p/a/b/v0/v/1/h/d/f/e/p/public/val/logo.png",
+      },
+      fixes: ["image:check-remote"],
+    };
+    expect(diagnose(remote, [])).toEqual([]);
+  });
+
+  test("a stale remote ref publishes an Error with no quick fix", () => {
+    const remote: ValidationError = {
+      message: "Remote image was not checked.",
+      value: {
+        path: "https://remote.val.build/file/p/a/b/v0/v/1/h/d/f/e/p/public/val/logo.png",
+      },
+      fixes: ["image:check-remote"],
+    };
+    const diagnostics = diagnose(remote, [
+      {
+        message:
+          "Remote ref: https://remote.val.build/file/p/a/b/v0/v/1/h/x/f/e/p/public/val/logo.png is not valid. Use the --fix flag to fix this issue.",
+        value: remote.value,
+      },
+    ]);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toMatch(/is not valid\. Use the --fix flag/);
+    expect(diagnostics[0].severity).toBe(1); // Error, as the CLI's `✘`
+    expect(diagnostics[0].data).not.toMatchObject({
+      fixes: expect.anything(),
+    });
   });
 
   test("an error that is not a deferral is published without any verdict", () => {

--- a/packages/language-server/src/mediaChecks.ts
+++ b/packages/language-server/src/mediaChecks.ts
@@ -1,17 +1,26 @@
 /**
- * Adjudicating the media metadata placeholders core emits unconditionally.
+ * Adjudicating the media placeholders core emits unconditionally.
  *
- * `ImageSchema.validate` cannot read bytes, so it never answers "does the
- * stored width/height/mimeType match the file". It defers instead: any
- * `s.image()` carrying metadata gets an `image:check-metadata` error whether
- * or not anything is wrong (`packages/core/src/schema/image.ts`), and
- * `s.file()` does the same with `file:check-metadata`.
+ * A media schema cannot answer two of its own questions, because both need
+ * something core has no access to -- the bytes on disk, or the bytes on the
+ * content host. So it defers, by reporting an error that only means "nobody
+ * has looked yet":
  *
- * `val validate` resolves those by running the fix handler and then
- * `createFixPatch` in report mode, which compares each field against the file
- * and returns one error per field that disagrees. The Studio cannot do that at
- * all -- a browser has no filesystem -- so it drops them wholesale
- * (`partitionValidationErrors` in `@valbuild/shared`).
+ *  - **Metadata.** Any `s.image()` carrying metadata gets an
+ *    `image:check-metadata` error whether or not anything is wrong
+ *    (`packages/core/src/schema/image.ts`), and `s.file()` does the same with
+ *    `file:check-metadata`.
+ *  - **Remote refs.** Every `s.image().remote()` / `s.file().remote()` value
+ *    whose path is a remote ref gets `Remote image was not checked.` with
+ *    `image:check-remote` -- unconditionally, for every remote image in the
+ *    project.
+ *
+ * `val validate` resolves both by running the fix handler and then
+ * `createFixPatch` in report mode, which returns one error per real problem
+ * and nothing at all when there is none. The Studio cannot do that -- a
+ * browser has neither the filesystem nor the project's remote credentials --
+ * so it drops them wholesale (`partitionValidationErrors` in
+ * `@valbuild/shared`).
  *
  * An editor is in the CLI's position, not the browser's, and publishing the
  * placeholders raw put a permanent warning on every image in the project. So
@@ -43,8 +52,23 @@ const METADATA_CHECK_FIXES: readonly string[] = [
   "file:check-metadata",
 ];
 
-/** One field of a media value that disagrees with the file behind it. */
-export type MediaMetadataFinding = {
+/**
+ * The fixes that carry an unconditional remote-ref placeholder.
+ *
+ * The plural `images:check-remote` / `files:check-remote` are deliberately
+ * absent. `RecordSchema.validateMediaKey` emits those only for a key that is
+ * already wrong -- an unparseable remote URL, or one outside the gallery's
+ * directory -- and their messages say so. They are findings, not deferrals,
+ * and `createFixPatch` has no branch for them at all, so adjudicating one
+ * would come back empty and silently drop a real error.
+ */
+const REMOTE_CHECK_FIXES: readonly string[] = [
+  "image:check-remote",
+  "file:check-remote",
+];
+
+/** One thing about a media value that a real check found to be wrong. */
+export type MediaCheckFinding = {
   message: string;
   /** The placeholder's own fixes, so the quick fix and severity survive. */
   fixes?: ValidationFix[];
@@ -53,13 +77,28 @@ export type MediaMetadataFinding = {
 };
 
 /**
- * The verdict on one placeholder. Empty means the metadata agrees with the
- * file and nothing should be published.
+ * The verdict on one placeholder. Empty means the check passed -- the metadata
+ * agrees with the file, or the remote ref is sound -- and nothing should be
+ * published.
  */
-export type MediaMetadataVerdict = MediaMetadataFinding[];
+export type MediaCheckVerdict = MediaCheckFinding[];
 
 /**
- * Whether this error is the unconditional deferral rather than a real finding.
+ * Whether this error is the unconditional remote-ref deferral.
+ *
+ * Unlike the metadata deferral this needs no re-derivation: `image:check-remote`
+ * is attached to exactly one error in `ImageSchema.executeValidate`, the
+ * fall-through for a remote schema with a remote path, and `FileSchema` mirrors
+ * it. Everything else a remote media field can be wrong about carries a
+ * different fix (`image:upload-remote`, `image:download-remote`) or none.
+ */
+export function isDeferredRemoteCheck(error: ValidationError): boolean {
+  return (error.fixes ?? []).some((fix) => REMOTE_CHECK_FIXES.includes(fix));
+}
+
+/**
+ * Whether this error is the unconditional METADATA deferral rather than a real
+ * finding.
  *
  * This is the whole difficulty of the change. `image:check-metadata` is
  * attached to FIVE different image errors, and only the last is a placeholder:
@@ -78,7 +117,7 @@ export type MediaMetadataVerdict = MediaMetadataFinding[];
  * There is no flag on `ValidationError` saying which is which, so the four
  * conditions are re-derived here from the same inputs core used. They are
  * transcribed from `ImageSchema.executeValidate`, in its order, and
- * `mediaMetadataChecks.test.ts` drives real core through all five cases to
+ * `mediaChecks.test.ts` drives real core through all five cases to
  * check that this agrees with it. If core grows a sixth condition, that test is
  * what catches it.
  *
@@ -139,14 +178,14 @@ export function isDeferredMediaMetadataCheck({
 }
 
 /**
- * {@link isDeferredMediaMetadataCheck} for an error in a module, resolving the
- * schema it needs.
+ * Whether an error in a module is either deferral, resolving the schema the
+ * metadata classification needs.
  *
  * Both the adjudicator and `createValDiagnostics` have to make the same call,
  * on the same inputs -- one to decide what to adjudicate, the other to decide
  * what to publish -- so it lives here rather than being written out twice.
  */
-export function isDeferredMediaMetadataCheckAt({
+export function isDeferredMediaCheckAt({
   sourcePath,
   error,
   content,
@@ -155,21 +194,24 @@ export function isDeferredMediaMetadataCheckAt({
   error: ValidationError;
   content: ValModuleContent;
 }): boolean {
-  return isDeferredMediaMetadataCheck({
-    error,
-    schema: resolveSchemaAt(sourcePath, content),
-  });
+  return (
+    isDeferredRemoteCheck(error) ||
+    isDeferredMediaMetadataCheck({
+      error,
+      schema: resolveSchemaAt(sourcePath, content),
+    })
+  );
 }
 
 /**
- * Adjudicate every deferred metadata placeholder in `validation`.
+ * Adjudicate every deferred media placeholder in `validation`.
  *
  * Async, and therefore separate from `createValDiagnostics`, which stays
  * synchronous so it can be tested without a project -- the same split
  * `resolveGalleryChecks` uses. The caller runs this first and passes the
  * result in.
  */
-export async function resolveMediaMetadataChecks({
+export async function resolveMediaChecks({
   validation,
   content,
   valRoot,
@@ -179,17 +221,17 @@ export async function resolveMediaMetadataChecks({
   content: ValModuleContent;
   valRoot: string;
   remoteHost?: string;
-}): Promise<Map<string, MediaMetadataVerdict>> {
-  const verdicts = new Map<string, MediaMetadataVerdict>();
+}): Promise<Map<string, MediaCheckVerdict>> {
+  const verdicts = new Map<string, MediaCheckVerdict>();
   for (const [sourcePath, errors] of Object.entries(validation) as [
     SourcePath,
     ValidationError[],
   ][]) {
     for (const error of errors) {
-      if (!isDeferredMediaMetadataCheckAt({ sourcePath, error, content })) {
+      if (!isDeferredMediaCheckAt({ sourcePath, error, content })) {
         continue;
       }
-      const key = mediaMetadataCheckKey(sourcePath, error);
+      const key = mediaCheckKey(sourcePath, error);
       try {
         verdicts.set(
           key,
@@ -198,7 +240,7 @@ export async function resolveMediaMetadataChecks({
       } catch {
         // This runs inside `validate`, which publishes NOTHING if it throws --
         // one bad image would silently clear every Val diagnostic in the file.
-        // Keep the placeholder rather than claiming the metadata is fine.
+        // Keep the placeholder rather than claiming the check passed.
         verdicts.set(key, keep(error));
       }
     }
@@ -210,7 +252,7 @@ export async function resolveMediaMetadataChecks({
  * Key for one placeholder. A value can in principle carry more than one, so
  * the fix names are part of the key -- as they are for the gallery checks.
  */
-export function mediaMetadataCheckKey(
+export function mediaCheckKey(
   sourcePath: string,
   error: ValidationError,
 ): string {
@@ -218,7 +260,7 @@ export function mediaMetadataCheckKey(
 }
 
 /** Keeping the placeholder: what to publish when we learned nothing. */
-function keep(error: ValidationError): MediaMetadataVerdict {
+function keep(error: ValidationError): MediaCheckVerdict {
   return [
     {
       message: error.message,
@@ -230,6 +272,25 @@ function keep(error: ValidationError): MediaMetadataVerdict {
 
 /**
  * What `createFixPatch` says about one placeholder, in report mode.
+ *
+ * Which placeholder decides only what has to be true before asking; the asking
+ * is the same call either way, and `reportFixPatch` is it.
+ */
+async function adjudicate(args: {
+  sourcePath: SourcePath;
+  error: ValidationError;
+  content: ValModuleContent;
+  valRoot: string;
+  remoteHost: string;
+}): Promise<MediaCheckVerdict> {
+  return isDeferredRemoteCheck(args.error)
+    ? adjudicateRemote(args)
+    : adjudicateMetadata(args);
+}
+
+/**
+ * The metadata placeholder: does the stored width/height/mimeType match the
+ * bytes?
  *
  * `val validate` runs the fix handler first and then `createFixPatch`, but for
  * these four fixes the handler is `handleFileMetadata`, whose whole job is the
@@ -252,7 +313,7 @@ function keep(error: ValidationError): MediaMetadataVerdict {
  * `createFixPatch` reads and decodes the image itself, so this is one file read
  * per media field per validation pass, and nothing here should add another.
  */
-async function adjudicate({
+async function adjudicateMetadata({
   sourcePath,
   error,
   content,
@@ -264,7 +325,7 @@ async function adjudicate({
   content: ValModuleContent;
   valRoot: string;
   remoteHost: string;
-}): Promise<MediaMetadataVerdict> {
+}): Promise<MediaCheckVerdict> {
   const ref = mediaValueOf(error.value)?.path;
   if (typeof ref !== "string") {
     return keep(error);
@@ -279,23 +340,17 @@ async function adjudicate({
     // means this verdict never has the last word on a file that is not there.
     return keep(error);
   }
-  let fixed;
-  try {
-    fixed = await createFixPatch(
-      { projectRoot: valRoot, remoteHost },
-      // `false`: this is a question, not a fix. Asking for the patch would have
-      // createFixPatch read and rewrite files behind the editor's back.
-      false,
-      sourcePath,
-      error,
-      {},
-      content.source,
-      content.schema,
-    );
-  } catch {
+  const reported = await reportFixPatch({
+    sourcePath,
+    error,
+    content,
+    valRoot,
+    remoteHost,
+  });
+  if (reported === undefined) {
     return keep(error);
   }
-  return (fixed?.remainingErrors ?? []).map((remaining) => ({
+  return reported.map((remaining) => ({
     message: remaining.message,
     // `createFixPatch` clears `fixes` on the per-field errors it reports, but
     // the fix is still available and still the remedy -- it is what the
@@ -305,6 +360,92 @@ async function adjudicate({
     ...(error.fixes ? { fixes: error.fixes } : {}),
     ...(error.value !== undefined ? { value: error.value } : {}),
   }));
+}
+
+/**
+ * The remote-ref placeholder: is the ref this value carries still the ref the
+ * bytes behind it produce?
+ *
+ * `handleRemoteFileCheck` is a no-op that asks for the patch, so unlike the
+ * metadata case there is no precondition of its own to stand in for -- the
+ * whole check is `checkRemoteRef` inside `createFixPatch`. It recomputes the
+ * validation hash from the schema, the file extension, the metadata on the
+ * value and the file hash in the ref; when that agrees with the ref, nothing is
+ * downloaded and nothing is reported. Only a ref that no longer adds up costs a
+ * download, and that is cached under `.val/remote-file-cache`.
+ *
+ * The findings deliberately carry no `fixes`. `createFixPatch` clears them
+ * (`Remote ref: ... is not valid. Use the --fix flag to fix this issue.`
+ * arrives with `fixes: undefined`), no quick fix is registered for
+ * `image:check-remote` -- rewriting the ref needs the bytes off the content
+ * host, so it is `val validate --fix`'s job, not a lightbulb's -- and dropping
+ * them is what makes this an Error rather than a Warning, matching the `✘` the
+ * CLI prints for the same finding.
+ */
+async function adjudicateRemote({
+  sourcePath,
+  error,
+  content,
+  valRoot,
+  remoteHost,
+}: {
+  sourcePath: SourcePath;
+  error: ValidationError;
+  content: ValModuleContent;
+  valRoot: string;
+  remoteHost: string;
+}): Promise<MediaCheckVerdict> {
+  const reported = await reportFixPatch({
+    sourcePath,
+    error,
+    content,
+    valRoot,
+    remoteHost,
+  });
+  if (reported === undefined) {
+    return keep(error);
+  }
+  return reported.map((remaining) => ({
+    message: remaining.message,
+    ...(error.value !== undefined ? { value: error.value } : {}),
+  }));
+}
+
+/**
+ * `createFixPatch` in report mode, or `undefined` if it could not answer.
+ *
+ * `false` is the load-bearing argument: this is a question, not a fix. Asking
+ * for the patch would have `createFixPatch` read and rewrite files behind the
+ * editor's back -- and, for a remote ref, re-derive one from bytes it had to
+ * download first.
+ */
+async function reportFixPatch({
+  sourcePath,
+  error,
+  content,
+  valRoot,
+  remoteHost,
+}: {
+  sourcePath: SourcePath;
+  error: ValidationError;
+  content: ValModuleContent;
+  valRoot: string;
+  remoteHost: string;
+}): Promise<ValidationError[] | undefined> {
+  try {
+    const fixed = await createFixPatch(
+      { projectRoot: valRoot, remoteHost },
+      false,
+      sourcePath,
+      error,
+      {},
+      content.source,
+      content.schema,
+    );
+    return fixed?.remainingErrors ?? [];
+  } catch {
+    return undefined;
+  }
 }
 
 /**

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -40,7 +40,7 @@ import {
   resolveGalleryChecks,
   type ValDiagnosticData,
 } from "./diagnostics";
-import { resolveMediaMetadataChecks } from "./mediaMetadataChecks";
+import { resolveMediaChecks } from "./mediaChecks";
 import {
   createValCodeActions,
   createMissingModuleCodeAction,
@@ -359,11 +359,13 @@ export function createValLanguageServer(connection: Connection): {
             })
           : undefined;
       // Core also defers "does this image's stored metadata match its file",
-      // reporting it on every `s.image()` that carries any metadata. Same
-      // treatment: adjudicate with the fix machinery before showing anything.
-      const mediaMetadataChecks =
+      // reporting it on every `s.image()` that carries any metadata, and
+      // "is this remote ref still valid", reporting it on every remote image.
+      // Same treatment: adjudicate with the fix machinery before showing
+      // anything.
+      const mediaChecks =
         result.content.errors !== false && result.content.errors.validation
-          ? await resolveMediaMetadataChecks({
+          ? await resolveMediaChecks({
               validation: result.content.errors.validation,
               content: result.content,
               valRoot: activeProject.valRoot,
@@ -378,7 +380,7 @@ export function createValLanguageServer(connection: Connection): {
           ? { snapshot: snapshotResult.snapshot }
           : {}),
         ...(galleryChecks ? { galleryChecks } : {}),
-        ...(mediaMetadataChecks ? { mediaMetadataChecks } : {}),
+        ...(mediaChecks ? { mediaChecks } : {}),
       });
       const unregistered = findMissingModuleDiagnostic(
         project.valRoot,


### PR DESCRIPTION
## The bug

In the VS Code extension, every remote image and file carries:

```
Remote image was not checked.val(val/validation)
```

That message is a **placeholder**, not a finding. `ImageSchema.executeValidate` (`packages/core/src/schema/image.ts:209`) emits it for *every* remote value, unconditionally — core cannot reach the content host, so it defers with `fixes: ["image:check-remote"]` and leaves the real check to whoever can make it. `FileSchema` does the same.

`val validate` makes that check: `handleRemoteFileCheck` is a no-op that asks for the patch, so `createFixPatch` in report mode runs `checkRemoteRef`, which returns nothing when the ref is sound and this when it isn't:

```
✘  Remote ref: https://remote.val.build/file/p/…/renaming.gif is not valid. Use the --fix flag to fix this issue.
```

The language server was publishing the placeholder raw. Since no quick fix is registered for `image:check-remote`, it was an unclearable warning on every remote image in the project — and the real finding was never shown.

## The fix

The language server already had exactly this machinery for the metadata placeholder (`image:check-metadata`, which core also emits unconditionally). The remote deferral now goes through the same path:

- **`mediaMetadataChecks.ts` → `mediaChecks.ts`.** The two deferrals are the same phenomenon and resolve through one `createFixPatch` report-mode call, so one verdict map is simpler for `createValDiagnostics` than two. `adjudicate` dispatches on which placeholder it has; `reportFixPatch` is the shared call.
- **A valid ref publishes nothing.** A stale one publishes what the CLI publishes, as an **Error** with no `fixes` — matching the CLI's `✘`, and honest about there being no lightbulb: rewriting a ref needs bytes off the content host, so it is `val validate --fix`'s job.
- **Only the singular `image:check-remote` / `file:check-remote` are treated as deferrals.** `RecordSchema.validateMediaKey` emits the plural pair only for a key that is *already* wrong (an unparseable remote URL, or one outside the gallery's directory), and `createFixPatch` has no branch for it — adjudicating one would come back empty and silently drop a real error.
- **Dropped `*:check-remote` from the local missing-file precheck.** A remote value's bytes are on the content host by design; for a path that was neither under `/public` nor a parseable remote ref, that check reported `File <root>/… does not exist` ahead of the remote adjudication, which has the real answer (`Invalid remote ref: …`).

## Cost

Near zero on the happy path: `checkRemoteRef` settles a valid ref by recomputing the validation hash from the schema, file extension, metadata and file hash — no network, no file read. Only a ref that no longer adds up is fetched, into the same `.val/remote-file-cache` the CLI uses, so a broken ref is downloaded once rather than once per keystroke.

## Testing

- `mediaChecks.test.ts`: 42 tests, 12 new. The classification cases are driven through real core (`s.image().remote()`, `s.file().remote()`) rather than `ValidationError` literals, so they keep agreeing with core rather than with themselves. The stale-ref case is offline — it seeds `.val/remote-file-cache` with the bytes `checkRemoteRef` would otherwise download.
- Full suite: 3941 passed. `lint`, `prettier --check`, `typecheck -r` all green.

Changeset included (`@valbuild/language-server` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qBRDkGr7nGbBMJ4fLJTWR

---
_Generated by [Claude Code](https://claude.ai/code/session_014qBRDkGr7nGbBMJ4fLJTWR)_