### PR TITLE
Show publishes under Recent activity

### DIFF
--- a/.changeset/activity-shows-publishes.md
+++ b/.changeset/activity-shows-publishes.md
@@ -1,0 +1,23 @@
+---
+"@valbuild/ui": patch
+---
+
+Recent activity now shows publishes, not just edits
+
+The Studio's Recent activity list only ever showed unpublished edits. Publishes
+lived in the status bar's deploy feed, which is a live-progress indicator — it
+closes itself once a build lands, and rows can be dismissed — so as soon as a
+publish had finished, nothing in the Studio said it had.
+
+Publishes are now rows in the same list, interleaved with the edits by time, so
+the panel reads as what happened here: you changed the hero, it went out, a
+colleague changed the pricing. A publish row carries the commit message (or the
+short sha when there is none), who published it, and how the build is doing —
+with the same labels and the same spinner/warning icons the deploy feed uses, so
+one publish never reads two ways in two places.
+
+Edits stay clickable and open the field they changed; a publish is a commit and
+opens nothing, so it renders as a line rather than a button. Publishes take at
+most three of the eight rows: an afternoon of publishing must not push out the
+edits the panel exists to get you back to, and the full feed is still in the
+status bar.

--- a/packages/ui/spa/components/shell/Deployments.tsx
+++ b/packages/ui/spa/components/shell/Deployments.tsx
@@ -8,7 +8,7 @@ import {
   X,
 } from "lucide-react";
 import { cn } from "../designSystem/cn";
-import { ShellDeployment } from "./types";
+import { DeploymentProgress, ShellDeployment } from "./types";
 
 /**
  * What the deploy feed adds up to right now.
@@ -108,6 +108,23 @@ function isFailed(deployment: ShellDeployment): boolean {
     return false;
   }
   return deployment.state === "failure" || deployment.state === "error";
+}
+
+/**
+ * The three states a publish can be rendered in.
+ *
+ * Exported because Recent activity shows publishes too, and a publish that
+ * reads as "Building" in the status bar and as finished in the activity list is
+ * two answers to one question. `isBuilding` and `isFailed` stay private: the
+ * order they are asked in is part of the rule — a live commit is neither — and
+ * this is that rule, once.
+ */
+export function deploymentProgress(
+  deployment: ShellDeployment,
+): DeploymentProgress {
+  if (isBuilding(deployment)) return "building";
+  if (isFailed(deployment)) return "failed";
+  return "settled";
 }
 
 export type DeploymentsStatusProps = {
@@ -428,8 +445,9 @@ function DeploymentRow({
   deployment: ShellDeployment;
   onDismiss: () => void;
 }) {
-  const building = isBuilding(deployment);
-  const failed = isFailed(deployment);
+  const progress = deploymentProgress(deployment);
+  const building = progress === "building";
+  const failed = progress === "failed";
   return (
     <li className="flex items-start gap-2.5 px-3 py-2.5 border-b border-border-float last:border-b-0">
       <span className="mt-0.5 shrink-0">
@@ -448,7 +466,7 @@ function DeploymentRow({
           {deployment.message ?? deployment.commitSha.slice(0, 7)}
         </div>
         <div className="text-[11px] text-fg-secondary-alt truncate">
-          {describeState(deployment)}
+          {describeDeploymentState(deployment)}
           {deployment.author ? ` · ${deployment.author}` : ""} ·{" "}
           {deployment.timestamp}
         </div>
@@ -467,7 +485,13 @@ function DeploymentRow({
   );
 }
 
-function describeState(deployment: ShellDeployment): string {
+/**
+ * What happened to a publish, in a word or two.
+ *
+ * Exported for the same reason as {@link deploymentProgress}: the activity list
+ * says it about the same publishes.
+ */
+export function describeDeploymentState(deployment: ShellDeployment): string {
   // The site answering with this commit outranks anything the build host said
   // about it, including having said nothing at all. See `isBuilding`.
   if (deployment.isLive) {

--- a/packages/ui/spa/components/shell/Shell.tsx
+++ b/packages/ui/spa/components/shell/Shell.tsx
@@ -50,7 +50,7 @@ import { availableDestinations } from "./shellDataMapping";
 import { servedPath } from "../../utils/mediaPath";
 import { useShellBreakpoint } from "./useShellBreakpoint";
 import {
-  ShellActivityEntry,
+  ShellChangeActivity,
   ShellData,
   ShellDataModule,
   ShellExternalPage,
@@ -337,7 +337,8 @@ export type ShellProps = {
   /** The last error from fetching patches, for that same report. */
   pendingChangesError?: string | null;
   onSelectValidationError?: (error: ShellValidationError) => void;
-  onSelectActivity?: (entry: ShellActivityEntry) => void;
+  /** Open a change row's field. Publishes are not selectable — see `UtilityPanelProps`. */
+  onSelectActivity?: (entry: ShellChangeActivity) => void;
   /** Create a page under a route. See `PagesPanelProps`. */
   onNewPage?: (moduleFilePath: ModuleFilePath, urlPath: string) => void;
   /** Copy a page to another URL under the same route. See `PagesPanelProps`. */
@@ -573,17 +574,24 @@ export function Shell({
    * already grouped by the thing that changed. Five, because this is a "take me
    * back" list rather than a history: past that it stops being a shortcut and
    * starts being something to read.
+   *
+   * Changes only: the feed also carries publishes, and a search result is a
+   * thing to open. Filtered BEFORE the slice, so a busy publishing afternoon
+   * does not leave the recent list short.
    */
   const recentSearchResults = useMemo(
     (): SearchResult[] =>
-      (data.activity ?? []).slice(0, RECENT_SEARCH_LIMIT).map((entry) => ({
-        id: entry.sourcePath,
-        kind: "recent",
-        label: entry.title,
-        detail: entry.author
-          ? `${entry.timestamp} · ${entry.author}`
-          : entry.timestamp,
-      })),
+      (data.activity ?? [])
+        .filter((entry) => entry.kind === "change")
+        .slice(0, RECENT_SEARCH_LIMIT)
+        .map((entry) => ({
+          id: entry.sourcePath,
+          kind: "recent",
+          label: entry.title,
+          detail: entry.author
+            ? `${entry.timestamp} · ${entry.author}`
+            : entry.timestamp,
+        })),
     [data.activity],
   );
 

--- a/packages/ui/spa/components/shell/UtilityPanel.tsx
+++ b/packages/ui/spa/components/shell/UtilityPanel.tsx
@@ -1,9 +1,12 @@
 import {
   AlertTriangle,
+  CircleAlert,
   Clock,
   FilePlus2,
   GitCompare,
   ImagePlus,
+  Loader2,
+  Rocket,
   Sparkles,
   Undo2,
 } from "lucide-react";
@@ -22,6 +25,8 @@ import {
 import {
   ShellActivityEntry,
   ShellBreakpoint,
+  ShellChangeActivity,
+  ShellDeployActivity,
   ShellDestination,
   ShellValidationError,
 } from "./types";
@@ -99,7 +104,14 @@ export type UtilityPanelProps = {
   reviewCount?: number;
   /** How many changes `onCompare` would show. */
   pendingChanges?: number;
-  onSelectActivity: (entry: ShellActivityEntry) => void;
+  /**
+   * Open what a change row points at.
+   *
+   * Change rows only: a publish is a commit, and there is nothing in the
+   * Studio for it to open. Narrowing the callback rather than handing over the
+   * whole union is what keeps that from being the caller's problem.
+   */
+  onSelectActivity: (entry: ShellChangeActivity) => void;
   onClose: () => void;
 };
 
@@ -235,31 +247,30 @@ export function UtilityPanel({
         <PanelSectionLabel divided>Recent activity</PanelSectionLabel>
         {activity.length === 0 ? (
           <PanelEmptyState>
-            No recent activity. Your changes will show up here.
+            No recent activity. Your changes and publishes will show up here.
           </PanelEmptyState>
         ) : (
           <ul className="px-3 pt-0.5">
             {activity.map((entry) => (
               <li key={entry.id}>
-                <button
-                  type="button"
-                  onClick={() => onSelectActivity(entry)}
-                  className="flex gap-2 w-full px-1.5 py-1.5 rounded-md text-left hover:bg-bg-float-raised"
-                >
-                  <Clock
-                    size={13}
-                    className="mt-0.5 shrink-0 text-fg-secondary-alt"
-                  />
-                  <span className="min-w-0">
-                    <span className="block text-xs text-fg-primary truncate">
-                      {entry.title}
-                    </span>
-                    <span className="block text-[0.6875rem] text-fg-secondary-alt">
-                      {entry.author ? `${entry.author} · ` : ""}
-                      {entry.timestamp}
-                    </span>
-                  </span>
-                </button>
+                {entry.kind === "deploy" ? (
+                  <DeployActivityRow entry={entry} />
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => onSelectActivity(entry)}
+                    className="flex gap-2 w-full px-1.5 py-1.5 rounded-md text-left hover:bg-bg-float-raised"
+                  >
+                    <Clock
+                      size={13}
+                      className="mt-0.5 shrink-0 text-fg-secondary-alt"
+                    />
+                    <ActivityLines
+                      title={entry.title}
+                      detail={`${entry.author ? `${entry.author} · ` : ""}${entry.timestamp}`}
+                    />
+                  </button>
+                )}
               </li>
             ))}
           </ul>
@@ -279,6 +290,53 @@ export function UtilityPanel({
         )}
       </div>
     </FloatingPanel>
+  );
+}
+
+/**
+ * A publish, in the activity list.
+ *
+ * A line rather than a button: the row says what happened to the site, and a
+ * commit is not something the Studio can open. Its icon is the deploy feed's —
+ * a spinner while it builds, a warning when it failed — so the same publish
+ * looks the same in both places.
+ */
+function DeployActivityRow({ entry }: { entry: ShellDeployActivity }) {
+  return (
+    <div className="flex gap-2 w-full px-1.5 py-1.5">
+      <span className="mt-0.5 shrink-0">
+        {entry.progress === "building" ? (
+          <Loader2 size={13} className="animate-spin text-fg-secondary" />
+        ) : entry.progress === "failed" ? (
+          <CircleAlert size={13} className="text-fg-error-on-surface" />
+        ) : (
+          <Rocket size={13} className="text-fg-secondary-alt" />
+        )}
+      </span>
+      <ActivityLines
+        title={entry.title}
+        detail={`${entry.state}${entry.author ? ` · ${entry.author}` : ""} · ${
+          entry.timestamp
+        }`}
+      />
+    </div>
+  );
+}
+
+/**
+ * The two lines every activity row has, so a publish and an edit line up.
+ *
+ * `min-w-0` on the wrapper is what lets the title truncate rather than push the
+ * row wide - the panel is 260px, and a commit message is not.
+ */
+function ActivityLines({ title, detail }: { title: string; detail: string }) {
+  return (
+    <span className="min-w-0">
+      <span className="block text-xs text-fg-primary truncate">{title}</span>
+      <span className="block text-[0.6875rem] text-fg-secondary-alt truncate">
+        {detail}
+      </span>
+    </span>
   );
 }
 

--- a/packages/ui/spa/components/shell/mockShellData.ts
+++ b/packages/ui/spa/components/shell/mockShellData.ts
@@ -423,13 +423,27 @@ export const mockValidationErrors: ShellValidationError[] = [
 ];
 
 /**
- * Recent activity, as `toActivity` builds it: the module's file label followed
- * by the patch path, and the author id resolved to a name where a profile is
- * known. A local dev project has no profiles, which is why the last entry has
- * no author rather than a placeholder one.
+ * Recent activity, as `toActivity` builds it: the edits and the publishes,
+ * interleaved by time.
+ *
+ * A change row is the module's file label followed by the patch path, and the
+ * author id resolved to a name where a profile is known — a local dev project
+ * has no profiles, which is why the last entry has no author rather than a
+ * placeholder one. The deploy rows are the same publishes `mockDeployments`
+ * has, which is what the real mapping does with them.
  */
 export const mockActivity: ShellActivityEntry[] = [
   {
+    kind: "deploy",
+    id: "deploy-9f21c4ae0b7d1e5a3c8f2d6b04e7a915cd83f620",
+    title: "Update hero copy and pricing table",
+    state: "Building",
+    progress: "building",
+    timestamp: "just now",
+    author: "Fredrik Ekholdt",
+  },
+  {
+    kind: "change",
     id: '/app/page.val.ts?p="/"/hero/title-0',
     sourcePath: '/app/page.val.ts?p="/"."hero"."title"',
     title: "page › hero › title",
@@ -437,6 +451,16 @@ export const mockActivity: ShellActivityEntry[] = [
     author: "Fredrik Ekholdt",
   },
   {
+    kind: "deploy",
+    id: "deploy-3ab77c1902ef4d885b16c0da79f3e421ab5c9d08",
+    title: "Add customer story: nordic-retail",
+    state: "Live",
+    progress: "settled",
+    timestamp: "12 minutes ago",
+    author: "Ida Sørensen",
+  },
+  {
+    kind: "change",
     id: '/app/pricing/page.val.ts?p="/pricing"/plans-1',
     sourcePath: '/app/pricing/page.val.ts?p="/pricing"."plans"',
     title: "page › plans",
@@ -444,6 +468,7 @@ export const mockActivity: ShellActivityEntry[] = [
     author: "Fredrik Ekholdt",
   },
   {
+    kind: "change",
     id: "/content/navigation.val.ts?primary-2",
     sourcePath: '/content/navigation.val.ts?p="primary"',
     title: "navigation › primary",
@@ -451,6 +476,16 @@ export const mockActivity: ShellActivityEntry[] = [
     author: "Ida Sørensen",
   },
   {
+    kind: "deploy",
+    id: "deploy-c05e9182aab34f6072d1e5b8c4a09f37e6215dba",
+    title: "Swap footer links",
+    state: "Build failed",
+    progress: "failed",
+    timestamp: "1 hour ago",
+    author: "Fredrik Ekholdt",
+  },
+  {
+    kind: "change",
     id: '/app/blog/[slug]/page.val.ts?p="/blog/why-we-built-val"/text-3',
     sourcePath:
       '/app/blog/[slug]/page.val.ts?p="/blog/why-we-built-val"."text"',

--- a/packages/ui/spa/components/shell/recentActivity.test.tsx
+++ b/packages/ui/spa/components/shell/recentActivity.test.tsx
@@ -1,0 +1,77 @@
+/** @jest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { UtilityPanel } from "./UtilityPanel";
+import { ShellActivityEntry } from "./types";
+
+/**
+ * Recent activity, which is now edits AND publishes.
+ *
+ * The publishes were visible only in the status bar's deploy feed, which is a
+ * live-progress indicator: it empties itself as builds land, so the moment a
+ * publish finished there was nowhere in the Studio that said it had.
+ *
+ * What is pinned here is the two kinds of row being different kinds of thing —
+ * an edit is somewhere to go, a publish is something that happened — because
+ * that is the part a later refactor would flatten.
+ */
+const change: ShellActivityEntry = {
+  kind: "change",
+  id: "change-1",
+  sourcePath: '/content/home.val.ts?p="hero"."title"',
+  title: "home › hero › title",
+  timestamp: "2 minutes ago",
+  author: "Ada",
+};
+
+const deploy: ShellActivityEntry = {
+  kind: "deploy",
+  id: "deploy-abc1234",
+  title: "Update the hero",
+  state: "Live",
+  progress: "settled",
+  timestamp: "12 minutes ago",
+  author: "Ida",
+};
+
+function panel(
+  activity: ShellActivityEntry[],
+  onSelectActivity: () => void = () => undefined,
+) {
+  return (
+    <UtilityPanel
+      breakpoint="desktop"
+      activity={activity}
+      onNewPage={() => undefined}
+      onUploadMedia={() => undefined}
+      onSelectActivity={onSelectActivity}
+      onClose={() => undefined}
+    />
+  );
+}
+
+describe("recent activity", () => {
+  test("lists publishes alongside changes", () => {
+    render(panel([change, deploy]));
+    expect(screen.queryByText("home › hero › title")).not.toBeNull();
+    expect(screen.queryByText("Update the hero")).not.toBeNull();
+  });
+
+  test("says how a publish is doing, and who published it", () => {
+    render(panel([deploy]));
+    expect(screen.queryByText("Live · Ida · 12 minutes ago")).not.toBeNull();
+  });
+
+  test("a change is something to open", () => {
+    const onSelectActivity = jest.fn();
+    render(panel([change], onSelectActivity));
+    screen.getByRole("button", { name: /home › hero › title/ }).click();
+    expect(onSelectActivity).toHaveBeenCalledTimes(1);
+  });
+
+  test("a publish is not - there is nothing in the Studio a commit opens", () => {
+    render(panel([deploy]));
+    expect(
+      screen.queryByRole("button", { name: /Update the hero/ }),
+    ).toBeNull();
+  });
+});

--- a/packages/ui/spa/components/shell/shellDataMapping.test.ts
+++ b/packages/ui/spa/components/shell/shellDataMapping.test.ts
@@ -10,7 +10,14 @@ import {
   toValidationErrors,
 } from "./shellDataMapping";
 import { ExplorerItem, SitemapItem } from "../NavMenu/types";
-import { ShellData, ShellDataModule, ShellMediaGallery } from "./types";
+import {
+  ShellActivityEntry,
+  ShellChangeActivity,
+  ShellData,
+  ShellDataModule,
+  ShellDeployment,
+  ShellMediaGallery,
+} from "./types";
 
 /**
  * The provider-to-shell mapping.
@@ -253,10 +260,46 @@ describe("toActivity", () => {
   /** Ten minutes after the timestamps below, so "10 minutes ago" is stable. */
   const now = new Date("2026-08-24T10:10:00Z").getTime();
 
+  /**
+   * A publish, as `toDeployments` produces one. `isLive` false is the state
+   * every publish starts in and the one `state` still speaks for.
+   */
+  const deployment = (
+    overrides: Partial<ShellDeployment> & Pick<ShellDeployment, "commitSha">,
+  ): ShellDeployment => ({
+    state: "success",
+    message: "A publish",
+    timestamp: "just now",
+    updatedAt: "2026-08-24T10:09:00Z",
+    isLive: false,
+    ...overrides,
+  });
+
+  /**
+   * The change rows, narrowed.
+   *
+   * The feed is a union now, so a test that means "the edits" has to say so —
+   * and one that reads `sourcePath` off whatever came first would pass for the
+   * wrong reason the day a publish sorts above it.
+   */
+  const changes = (entries: ShellActivityEntry[]): ShellChangeActivity[] =>
+    entries.filter(
+      (entry): entry is ShellChangeActivity => entry.kind === "change",
+    );
+
   test("reads as a trail from the file to what changed in it", () => {
-    const [entry] = toActivity(
-      [set("/content/home.val.ts", ["hero", "title"], "2026-08-24T10:00:00Z")],
-      now,
+    const [entry] = changes(
+      toActivity(
+        [
+          set(
+            "/content/home.val.ts",
+            ["hero", "title"],
+            "2026-08-24T10:00:00Z",
+          ),
+        ],
+        [],
+        now,
+      ),
     );
     expect(entry.title).toBe("home › hero › title");
     expect(entry.author).toBe("ada");
@@ -267,15 +310,20 @@ describe("toActivity", () => {
   test("carries a source path that resolves", () => {
     // The grammar matters: string keys are quoted, array indices are bare. A
     // hand-joined path looks close enough to work and then opens nothing.
-    const [entry] = toActivity(
-      [set("/content/home.val.ts", ["items", "0", "title"], "x")],
-      now,
+    const [entry] = changes(
+      toActivity(
+        [set("/content/home.val.ts", ["items", "0", "title"], "x")],
+        [],
+        now,
+      ),
     );
     expect(entry.sourcePath).toBe('/content/home.val.ts?p="items".0."title"');
   });
 
   test("a whole-module change points at the module", () => {
-    const [entry] = toActivity([set("/content/home.val.ts", [], "x")], now);
+    const [entry] = changes(
+      toActivity([set("/content/home.val.ts", [], "x")], [], now),
+    );
     expect(entry.sourcePath).toBe("/content/home.val.ts");
   });
 
@@ -283,7 +331,7 @@ describe("toActivity", () => {
     const many = Array.from({ length: 20 }, (_, i) =>
       set("/content/home.val.ts", [`field${i}`], "2026-08-24T10:00:00Z"),
     );
-    const activity = toActivity(many, now);
+    const activity = toActivity(many, [], now);
     expect(activity).toHaveLength(8);
     expect(activity[0].title).toBe("home › field0");
   });
@@ -295,17 +343,144 @@ describe("toActivity", () => {
         set("/content/home.val.ts", ["title"], "2026-08-24T10:00:00Z"),
         set("/content/home.val.ts", ["title"], "2026-08-23T10:00:00Z"),
       ],
+      [],
       now,
     );
     expect(activity[0].id).not.toBe(activity[1].id);
   });
 
   test("survives a patch with no author", () => {
-    const [entry] = toActivity(
-      [{ ...set("/content/home.val.ts", ["title"], "x"), lastUpdatedBy: null }],
-      now,
+    const [entry] = changes(
+      toActivity(
+        [
+          {
+            ...set("/content/home.val.ts", ["title"], "x"),
+            lastUpdatedBy: null,
+          },
+        ],
+        [],
+        now,
+      ),
     );
     expect(entry.author).toBeUndefined();
+  });
+
+  /**
+   * The publishes, which used to be visible only in the status bar's deploy
+   * feed — a live-progress indicator that empties itself as builds land, so
+   * once a publish had finished nothing in the Studio said it had.
+   */
+  describe("publishes", () => {
+    test("show up beside the changes, interleaved by time", () => {
+      const activity = toActivity(
+        [
+          set("/content/home.val.ts", ["title"], "2026-08-24T10:08:00Z"),
+          set("/content/home.val.ts", ["intro"], "2026-08-24T10:00:00Z"),
+        ],
+        [
+          deployment({
+            commitSha: "abc1234def",
+            updatedAt: "2026-08-24T10:05:00Z",
+          }),
+        ],
+        now,
+      );
+      expect(activity.map((entry) => entry.kind)).toEqual([
+        "change",
+        "deploy",
+        "change",
+      ]);
+    });
+
+    test("are named by their commit message", () => {
+      const [entry] = toActivity(
+        [],
+        [deployment({ commitSha: "abc1234def", message: "Update the hero" })],
+        now,
+      );
+      expect(entry.title).toBe("Update the hero");
+    });
+
+    test("fall back to the short sha when there is no message", () => {
+      // Which is what the deploy feed shows for the same publish.
+      const [entry] = toActivity(
+        [],
+        [deployment({ commitSha: "abc1234def5678", message: null })],
+        now,
+      );
+      expect(entry.title).toBe("abc1234");
+    });
+
+    test("say how the publish is doing", () => {
+      const [building, failed, live] = toActivity(
+        [],
+        [
+          deployment({
+            commitSha: "a",
+            state: "pending",
+            updatedAt: "2026-08-24T10:09:00Z",
+          }),
+          deployment({
+            commitSha: "b",
+            state: "failure",
+            updatedAt: "2026-08-24T10:08:00Z",
+          }),
+          deployment({
+            commitSha: "c",
+            state: "success",
+            isLive: true,
+            updatedAt: "2026-08-24T10:07:00Z",
+          }),
+        ],
+        now,
+      );
+      expect(building).toMatchObject({
+        state: "Building",
+        progress: "building",
+      });
+      expect(failed).toMatchObject({
+        state: "Build failed",
+        progress: "failed",
+      });
+      // The site answering with the commit outranks the build state, which is
+      // the deploy feed's rule and has to stay one rule.
+      expect(live).toMatchObject({ state: "Live", progress: "settled" });
+    });
+
+    test("keep the ids apart from the changes'", () => {
+      const [entry] = toActivity([], [deployment({ commitSha: "abc" })], now);
+      expect(entry.id).toBe("deploy-abc");
+    });
+
+    /**
+     * A run of publishes must not push out the edits: this panel exists to get
+     * back to them, and the whole feed is in the status bar's list anyway.
+     */
+    test("never take more than a few of the rows", () => {
+      const activity = toActivity(
+        [set("/content/home.val.ts", ["title"], "2026-08-20T10:00:00Z")],
+        Array.from({ length: 10 }, (_, i) =>
+          deployment({
+            commitSha: `sha${i}`,
+            updatedAt: `2026-08-24T10:0${i % 10}:00Z`,
+          }),
+        ),
+        now,
+      );
+      expect(activity.filter((entry) => entry.kind === "deploy")).toHaveLength(
+        3,
+      );
+      expect(changes(activity)).toHaveLength(1);
+    });
+
+    test("an unreadable timestamp sorts last rather than scrambling the feed", () => {
+      const activity = toActivity(
+        [set("/content/home.val.ts", ["title"], "2026-08-24T10:00:00Z")],
+        [deployment({ commitSha: "abc", updatedAt: "not a date" })],
+        now,
+      );
+      expect(activity.map((entry) => entry.kind)).toEqual(["change", "deploy"]);
+    });
   });
 });
 

--- a/packages/ui/spa/components/shell/shellDataMapping.ts
+++ b/packages/ui/spa/components/shell/shellDataMapping.ts
@@ -3,11 +3,13 @@ import { ExplorerItem, SitemapItem } from "../NavMenu/types";
 import { AvailableRoute } from "../NavMenu/NewPageForm";
 import { routePatternToString } from "../NavMenu/SitemapItem";
 import { ValEnrichedDeployment } from "../../utils/mergeCommitsAndDeployments";
+import { deploymentProgress, describeDeploymentState } from "./Deployments";
 import {
   ShellActivityEntry,
   ShellAdminLinks,
   ShellData,
   ShellDataModule,
+  ShellDeployActivity,
   ShellDeployment,
   ShellDestination,
   ShellExternalPage,
@@ -158,10 +160,29 @@ export function toValidationErrors(
 const ACTIVITY_LIMIT = 8;
 
 /**
- * Recent activity, from the patch sets.
+ * How many of those may be publishes.
+ *
+ * An afternoon of publishing produces a run of deploys — one of yours, one of a
+ * colleague's, a retried build — and a straight merge by time would fill the
+ * whole list with them and push out the edits the panel exists to get back to.
+ * The deploy feed in the status bar has them all; here they are context, so
+ * they get a minority of the rows and never the last edit's place.
+ */
+const DEPLOY_ACTIVITY_LIMIT = 3;
+
+/**
+ * Recent activity: the unpublished edits and the publishes, newest first.
  *
  * Patch sets are already newest first and already grouped by the thing that
- * changed, which is exactly what this list wants.
+ * changed, which is exactly what this list wants. Publishes come in as the rows
+ * the deploy feed renders — same labels, same three states — because a publish
+ * that reads one way in the status bar and another here is two answers to one
+ * question.
+ *
+ * The two are then interleaved by time, which is what makes it a feed rather
+ * than two lists in one box: "I changed the hero, then it went out, then Ida
+ * changed the pricing" is the sentence someone opening this panel is trying to
+ * read.
  */
 export function toActivity(
   patchSets: Array<{
@@ -171,35 +192,92 @@ export function toActivity(
     lastUpdatedBy: string | null;
   }>,
   /**
+   * The publishes, already mapped by {@link toDeployments}.
+   *
+   * Rows rather than the raw feed, so this cannot disagree with the deploy list
+   * about what a publish is called or how it is doing.
+   */
+  deployments: ShellDeployment[],
+  /**
    * A parameter rather than a call to `Date.now()`, so the result is a function
    * of its inputs and can be tested — the same reason `toDeployments` takes one.
    */
   now: number,
 ): ShellActivityEntry[] {
-  return patchSets.slice(0, ACTIVITY_LIMIT).map(
-    (set, index): ShellActivityEntry => ({
-      // The index is load-bearing: two patch sets can share a module and a path,
-      // and React needs them apart. `sourcePath` is the one that means something.
-      id: `${set.moduleFilePath}?${set.patchPath.join("/")}-${index}`,
-      /**
-       * Where the change was, as a real source path.
-       *
-       * Built with `patchPathToModulePath`, which is the only thing that knows
-       * the grammar — string keys are JSON-quoted, array indices are bare — so
-       * `["items", "0", "title"]` becomes `"items".0."title"` and not something
-       * that looks close enough to work and then does not resolve.
-       */
-      sourcePath: Internal.joinModuleFilePathAndModulePath(
-        set.moduleFilePath,
-        Internal.patchPathToModulePath(set.patchPath),
-      ),
-      title: [fileLabel(set.moduleFilePath), ...set.patchPath].join(" › "),
-      // Relative, because this is a "what have I been doing" list and an ISO
-      // timestamp is not an answer to that. It was rendered raw.
-      timestamp: formatRelativeTime(set.lastUpdated, now),
-      author: set.lastUpdatedBy ?? undefined,
+  const changes = patchSets.slice(0, ACTIVITY_LIMIT).map(
+    (set, index): Dated<ShellActivityEntry> => ({
+      at: timeOf(set.lastUpdated),
+      entry: {
+        kind: "change",
+        // The index is load-bearing: two patch sets can share a module and a
+        // path, and React needs them apart. `sourcePath` is the one that means
+        // something.
+        id: `${set.moduleFilePath}?${set.patchPath.join("/")}-${index}`,
+        /**
+         * Where the change was, as a real source path.
+         *
+         * Built with `patchPathToModulePath`, which is the only thing that knows
+         * the grammar — string keys are JSON-quoted, array indices are bare — so
+         * `["items", "0", "title"]` becomes `"items".0."title"` and not something
+         * that looks close enough to work and then does not resolve.
+         */
+        sourcePath: Internal.joinModuleFilePathAndModulePath(
+          set.moduleFilePath,
+          Internal.patchPathToModulePath(set.patchPath),
+        ),
+        title: [fileLabel(set.moduleFilePath), ...set.patchPath].join(" › "),
+        // Relative, because this is a "what have I been doing" list and an ISO
+        // timestamp is not an answer to that. It was rendered raw.
+        timestamp: formatRelativeTime(set.lastUpdated, now),
+        author: set.lastUpdatedBy ?? undefined,
+      },
     }),
   );
+  const deploys = deployments.slice(0, DEPLOY_ACTIVITY_LIMIT).map(
+    (deployment): Dated<ShellActivityEntry> => ({
+      at: timeOf(deployment.updatedAt),
+      entry: toDeployActivity(deployment),
+    }),
+  );
+  return (
+    [...changes, ...deploys]
+      // Newest first. A stable sort, so patch sets that share a timestamp stay
+      // in the order the store gave them — which is the order they happened in.
+      .sort((a, b) => b.at - a.at)
+      .slice(0, ACTIVITY_LIMIT)
+      .map(({ entry }) => entry)
+  );
+}
+
+/** An entry with the instant it is sorted by, which the entry itself has lost. */
+type Dated<T> = { at: number; entry: T };
+
+/**
+ * An ISO timestamp as milliseconds, for sorting only.
+ *
+ * An unreadable one sorts oldest rather than throwing the whole feed off: `NaN`
+ * makes every comparison false, which leaves the sort's output unspecified.
+ */
+function timeOf(iso: string): number {
+  const at = new Date(iso).getTime();
+  return Number.isNaN(at) ? 0 : at;
+}
+
+/** One publish, as an activity row. */
+function toDeployActivity(deployment: ShellDeployment): ShellDeployActivity {
+  return {
+    kind: "deploy",
+    // Prefixed, because a commit sha and a patch set id share one list now.
+    id: `deploy-${deployment.commitSha}`,
+    // The commit message when there is one. Without it there is nothing to say
+    // about the publish but which commit it was, and the short sha is what the
+    // deploy feed shows for the same publish.
+    title: deployment.message ?? deployment.commitSha.slice(0, 7),
+    state: describeDeploymentState(deployment),
+    progress: deploymentProgress(deployment),
+    timestamp: deployment.timestamp,
+    author: deployment.author,
+  };
 }
 
 /** How many publishes the deployment feed keeps. */

--- a/packages/ui/spa/components/shell/types.ts
+++ b/packages/ui/spa/components/shell/types.ts
@@ -157,7 +157,24 @@ export type ShellValidationError = {
   count: number;
 };
 
-export type ShellActivityEntry = {
+/**
+ * One row of Recent activity.
+ *
+ * Two kinds, because "what has been happening here?" has always had two halves
+ * and the panel only ever answered one of them. An edit somebody made is
+ * something to go back to; a publish is something that happened to the site.
+ * Publishes were visible only in the status bar's deploy feed, which is a
+ * live-progress indicator that empties itself as builds land — so the moment a
+ * publish finished there was nowhere in the Studio that said it had.
+ *
+ * Both carry `title` and `timestamp` so the list can be rendered in one pass;
+ * everything that differs is behind `kind`.
+ */
+export type ShellActivityEntry = ShellChangeActivity | ShellDeployActivity;
+
+/** An unpublished edit, from the patch sets. */
+export type ShellChangeActivity = {
+  kind: "change";
   /**
    * A React key, not a target: two patch sets can share a module and a path, so
    * this carries an index to keep them apart. Use `sourcePath` to go anywhere.
@@ -170,6 +187,40 @@ export type ShellActivityEntry = {
   timestamp: string;
   author?: string;
 };
+
+/**
+ * A publish, from the deploy feed.
+ *
+ * Not selectable — there is nothing in the Studio a commit opens — so unlike a
+ * change row this carries no `sourcePath` and the panel renders it as a line
+ * rather than a button. What it does carry is the state, because a publish that
+ * is still building and one that failed are the two things worth reading here.
+ */
+export type ShellDeployActivity = {
+  kind: "deploy";
+  /** The commit sha, prefixed: it is unique per publish. */
+  id: string;
+  /** The commit message, or the short sha when there is none. */
+  title: string;
+  /** What happened to it, e.g. "Live", "Building", "Build failed". */
+  state: string;
+  /**
+   * The state as the row's icon reads it.
+   *
+   * `state` is the sentence and this is the shape: the same three cases the
+   * deploy feed's rows use, so a publish looks the same in both places.
+   */
+  progress: DeploymentProgress;
+  /** Already relative, e.g. "2 minutes ago". */
+  timestamp: string;
+  author?: string;
+};
+
+/**
+ * How a publish is doing, reduced to the three states anything rendering one
+ * cares about. See `deploymentProgress`.
+ */
+export type DeploymentProgress = "building" | "failed" | "settled";
 
 /**
  * A destination: what the left rail switches between.
@@ -261,7 +312,12 @@ export type ShellData = {
    * surface while the bell stays hidden until something populates it.
    */
   notifications?: ShellNotification[];
-  /** Derived from patch sets. Absent while they are still loading. */
+  /**
+   * The edits and the publishes, newest first. See `toActivity`.
+   *
+   * Built from whichever half has arrived: the patch sets and the deploy feed
+   * load separately, and a list that waits for both hides the one it has.
+   */
   activity?: ShellActivityEntry[];
   validationErrors: ShellValidationError[];
   /** Absent until a profile has loaded, and in modes that have none. */

--- a/packages/ui/spa/components/shell/useShellData.ts
+++ b/packages/ui/spa/components/shell/useShellData.ts
@@ -148,10 +148,22 @@ export function useShellData(): ShellDataState {
           ? toDataModules(navData.explorer, modulesWithDrafts)
           : [],
         validationErrors: toValidationErrors(validationErrors),
-        activity:
-          patchSets.status === "success"
-            ? toActivity(patchSets.data, Date.now())
-            : undefined,
+        /*
+         * The publishes ride along: this list is "what has been happening",
+         * and a publish is the other half of that. See `toActivity`.
+         *
+         * Built from whatever is known, rather than only once the PATCH SETS
+         * are. The two halves load separately - patch sets come off a worker
+         * that has to group them, publishes off the stat feed - so gating the
+         * whole list on the first one hid every publish while that worker was
+         * still grouping, and for good if it failed. An empty change list is
+         * the honest input in that state, not a reason to say nothing.
+         */
+        activity: toActivity(
+          patchSets.status === "success" ? patchSets.data : [],
+          shellDeployments,
+          Date.now(),
+        ),
         pendingChanges: currentPatchIds.length - committedPatchIds.size,
         deployments: shellDeployments,
         user: profile


### PR DESCRIPTION
**Stack: 1 of 6.** Base `main`.

Recent activity listed unpublished edits and nothing else. Publishes were visible only in the status bar's deploy feed, which is a live-progress indicator: it auto-closes once every build has landed and its rows can be dismissed, so the moment a publish finished there was nowhere in the Studio that said it had.

So the feed carries both now. `toActivity` takes the deploy rows alongside the patch sets and interleaves them by time — "I changed the hero, then it went out, then Ida changed the pricing" is the sentence someone opening this panel is reading.

### What is worth reviewing

- `ShellActivityEntry` becomes a union of `ShellChangeActivity` and `ShellDeployActivity`: an edit is somewhere to go, a publish is something that happened. That is carried through `onSelectActivity`, which takes a change — so "a commit opens nothing" is not left as the caller's problem — and through the global search's recent list, which filters to changes *before* it slices so a busy publishing afternoon does not leave it short.
- The publish rows are the deploy feed's rows: `deploymentProgress` and `describeDeploymentState` move out of `Deployments.tsx` rather than being re-derived, so a publish cannot read "Building" in the status bar and finished in the activity list. `isBuilding`/`isFailed` stay private — the order they are asked in is part of the rule, since a live commit is neither.
- Publishes take at most three of the eight rows. A run of deploys would otherwise fill the list by time alone and push out the edits the panel exists to get back to.

### Tests

`shellDataMapping.test.ts` covers the interleaving, the naming (message, then short sha), the three states, the row cap and an unreadable timestamp. `recentActivity.test.tsx` pins that a change row is a button and a publish row is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rsb27g1N8ibmWL1iRkdUtc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rsb27g1N8ibmWL1iRkdUtc)_