### PR TITLE
Carry the git message on deployments Val did not publish

### DIFF
--- a/.changeset/activity-shows-publishes.md
+++ b/.changeset/activity-shows-publishes.md
@@ -1,0 +1,23 @@
+---
+"@valbuild/ui": patch
+---
+
+Recent activity now shows publishes, not just edits
+
+The Studio's Recent activity list only ever showed unpublished edits. Publishes
+lived in the status bar's deploy feed, which is a live-progress indicator — it
+closes itself once a build lands, and rows can be dismissed — so as soon as a
+publish had finished, nothing in the Studio said it had.
+
+Publishes are now rows in the same list, interleaved with the edits by time, so
+the panel reads as what happened here: you changed the hero, it went out, a
+colleague changed the pricing. A publish row carries the commit message (or the
+short sha when there is none), who published it, and how the build is doing —
+with the same labels and the same spinner/warning icons the deploy feed uses, so
+one publish never reads two ways in two places.
+
+Edits stay clickable and open the field they changed; a publish is a commit and
+opens nothing, so it renders as a line rather than a button. Publishes take at
+most three of the eight rows: an afternoon of publishing must not push out the
+edits the panel exists to get you back to, and the full feed is still in the
+status bar.

--- a/.changeset/deployment-git-message.md
+++ b/.changeset/deployment-git-message.md
@@ -1,0 +1,23 @@
+---
+"@valbuild/shared": patch
+"@valbuild/server": patch
+"@valbuild/ui": patch
+---
+
+Show the git message on deployments Val did not publish
+
+The deploy feed could only name a publish when Val itself had made the commit:
+the message came off Val's own `ValCommit`, and every other deployment — a
+developer's push, a merged pull request, a revert — showed a seven-character
+sha. On most projects those are the majority, so "what went out at 14:02?" had
+no answer in the Studio.
+
+A deployment can now carry its own `commitMessage`, which the Studio uses
+wherever there is no Val commit to prefer. It is optional and nullable, so a
+content service that does not report messages is unaffected — those publishes
+keep showing the short sha, exactly as before.
+
+Deployment rows also show only the subject line of a message now. A git message
+is a subject, a blank line and a body, and the rows are one truncated line — so
+a real push arrived as "Subject The body went on like this…". The classic
+Draft changes view still has the whole message in its tooltip.

--- a/.changeset/mobile-ai-button.md
+++ b/.changeset/mobile-ai-button.md
@@ -1,0 +1,16 @@
+---
+"@valbuild/ui": patch
+---
+
+Move the assistant button to the bottom bar on mobile
+
+On a phone the Sparkles button sat in the top right of the top bar, sharing
+that corner with the navigation menu, History, notifications and the account
+avatar — the furthest point on the screen from a thumb, and the row you reach
+for least.
+
+It is now in the sticky bottom bar, beside Quick actions, where Preview and
+Publish already are. The top bar drops its own button below the mobile
+breakpoint, so there is still exactly one way in rather than two places to look
+for the same panel. Nothing changes on tablet or desktop, and a project with no
+assistant configured shows no button in either place.

--- a/.changeset/review-always-shown.md
+++ b/.changeset/review-always-shown.md
@@ -1,0 +1,22 @@
+---
+"@valbuild/ui": patch
+---
+
+Review stays in the top bar with nothing pending, and says so
+
+Above the mobile breakpoint — a phone reaches Review through Quick actions, and
+still does — the Review button was hidden whenever nothing was pending: present
+in the layout so the bar would not reflow, but unreachable and invisible to
+screen readers. That made "is anything of mine still unpublished?" unanswerable from
+the top bar: a hidden button and a button whose data has not loaded yet look
+exactly the same, so the only way to find out was to publish and see what
+happened. The Quick actions row on a phone already answered it; the bar now
+does too.
+
+Opening it with nothing pending gives a real screen instead of the single grey
+"No pending changes." line: it says the editor and the published site agree, and
+what the view will show once they do not. The wording follows the mode, so a
+local dev project is told about its working tree rather than about publishing.
+
+The change count is still a badge that only appears when there is one, so an
+empty Review reads as "nothing pending" rather than as "0 changes".

--- a/packages/server/src/ValOpsHttp.ts
+++ b/packages/server/src/ValOpsHttp.ts
@@ -112,6 +112,10 @@ const GetApplicablePatches = z.object({
         deploymentState: z.string(),
         createdAt: z.string(),
         updatedAt: z.string(),
+        // The git message, where the content service knows it. See
+        // `ValDeployment`: this is the only source for a deployment that Val
+        // did not publish, and zod would otherwise strip it here.
+        commitMessage: z.string().nullable().optional(),
       }),
     )
     .optional(),
@@ -873,6 +877,7 @@ export class ValOpsHttp extends ValOps {
                 deploymentState: deployment.deploymentState,
                 createdAt: deployment.createdAt,
                 updatedAt: deployment.updatedAt,
+                commitMessage: deployment.commitMessage,
               });
             }
           }

--- a/packages/shared/src/internal/ApiRoutes.ts
+++ b/packages/shared/src/internal/ApiRoutes.ts
@@ -12,6 +12,7 @@ import {
 import { Patch, PatchId } from "./zod/Patch";
 import { SerializedSchema } from "./zod/SerializedSchema";
 import { ValCommit } from "./zod/ValCommit";
+import { ValDeployment } from "./zod/ValDeployment";
 import {
   HistoricalCommit,
   HistoricalModule,
@@ -630,6 +631,21 @@ export const Api = {
                */
               headCommitSha: z.string().optional(),
               commits: z.array(ValCommit),
+              /**
+               * The publishes the content service knows about.
+               *
+               * Declared, at last. `getStat` has always returned these in
+               * `http` mode and the Studio has always read them - the response
+               * validator strips unknown keys rather than rejecting them, and
+               * the raw json is what the client hands back, so they arrived
+               * while the contract said they could not. That was survivable
+               * until a deployment started carrying a commit MESSAGE: a field
+               * nobody has declared is a field the next person deletes.
+               *
+               * Optional, because a content service that reports no
+               * deployments sends none.
+               */
+              deployments: z.array(ValDeployment).optional(),
               config: ValConfig,
               profileId: z.string().nullable(),
               mode: z.union([z.literal("http"), z.literal("fs")]),

--- a/packages/shared/src/internal/zod/ValDeployment.ts
+++ b/packages/shared/src/internal/zod/ValDeployment.ts
@@ -6,6 +6,23 @@ export const ValDeployment = z.object({
   commitSha: z.string(),
   updatedAt: z.string(),
   createdAt: z.string(),
+  /**
+   * The commit message, as the deployment's host reported it.
+   *
+   * Val's OWN publishes carry their message on the commit (`ValCommit`), and
+   * that is the one the Studio prefers — it is the message Val wrote. This is
+   * for every OTHER deployment: a developer's push, a merged pull request, a
+   * revert. Those have no Val commit at all, so without this the deploy feed
+   * could only name them by their short sha, and "what went out at 14:02?" had
+   * no answer inside the Studio.
+   *
+   * Optional AND nullable, and the two mean different things: absent is a
+   * content service that does not report messages (or an older one), null is
+   * one that reports having none. Both render as the short sha, so nothing
+   * depends on telling them apart — but a schema that demanded the field would
+   * reject the whole deployment feed of a service that does not send it.
+   */
+  commitMessage: z.string().nullable().optional(),
 });
 
 export type ValDeployment = z.infer<typeof ValDeployment>;

--- a/packages/ui/spa/components/ComparePatchSets.stories.tsx
+++ b/packages/ui/spa/components/ComparePatchSets.stories.tsx
@@ -1220,6 +1220,14 @@ export const EverythingReverted: Story = {
   ),
 };
 
+/**
+ * Nothing pending, which is a screen someone reaches on purpose.
+ *
+ * Review is in the top bar whether or not anything is queued — a button that
+ * comes and goes cannot answer "is anything of mine still unpublished?" — so
+ * this is what it opens most of the time. It used to be one grey line reading
+ * "No pending changes.", which looks like a view that failed to load.
+ */
 export const NoChanges: Story = {
   render: () => (
     <StorySetup

--- a/packages/ui/spa/components/ComparePatchSets.tsx
+++ b/packages/ui/spa/components/ComparePatchSets.tsx
@@ -264,11 +264,7 @@ export function ComparePatchSets({
         </div>
       );
     }
-    return (
-      <div className="text-sm text-fg-secondary py-8 text-center">
-        No pending changes.
-      </div>
-    );
+    return <NothingToReview mode={mode} />;
   }
 
   const schemasData = schemas.status === "success" ? schemas.data : undefined;
@@ -692,6 +688,67 @@ function collectAuthorIds(rows: ChangeTreeNode[]): string[] {
     }
   }
   return ids;
+}
+
+/**
+ * The review view with nothing in it.
+ *
+ * Reachable deliberately now: Review is always in the top bar, whether or not
+ * anything is pending, because "is anything of mine still unpublished?" is a
+ * question that has to be answerable — and a button that comes and goes cannot
+ * answer it. So the empty case is a screen rather than the single grey line
+ * ("No pending changes.") it used to be, which read as a view that had failed
+ * to load rather than as an answer.
+ *
+ * It says what IS true — the editor and the published site agree — and what
+ * this view will show when it is not, because someone who came here on purpose
+ * came to find out what this screen is for.
+ */
+/**
+ * What "nothing pending" means, in the mode this Studio is actually in.
+ *
+ * `unknown` gets its own sentence rather than the `http` one. It is the state
+ * before the client has been told which mode it is in, and against a local dev
+ * project "matches what is published" is not merely vague - there is nothing
+ * published, and the sentence names a thing that does not exist. Saying only
+ * what is true in both modes costs a little precision for the second it lasts.
+ */
+function describeNothingPending(mode: "fs" | "http" | "unknown"): string {
+  switch (mode) {
+    case "fs":
+      return "Everything in the editor matches the content in your working tree. Nothing is waiting to be saved.";
+    case "http":
+      return "Everything in the editor matches what is published. Nothing is waiting to go out.";
+    case "unknown":
+      return "Nothing is waiting to go out: every change made here has already been saved.";
+  }
+}
+
+function NothingToReview({ mode }: { mode: "fs" | "http" | "unknown" }) {
+  return (
+    <div
+      className="mx-auto flex max-w-md min-w-0 flex-col items-center gap-4 px-6 py-16 text-center"
+      // A statement, not a status: this is the whole column, and a reader
+      // arriving by keyboard should be told what it says.
+      role="status"
+    >
+      <span className="grid h-10 w-10 place-items-center rounded-full bg-bg-secondary text-fg-secondary">
+        <Check size={18} aria-hidden />
+      </span>
+      <div className="space-y-1.5">
+        <h2 className="text-sm font-medium text-fg-primary">
+          No changes to review
+        </h2>
+        <p className="text-xs leading-relaxed text-fg-secondary">
+          {describeNothingPending(mode)}
+        </p>
+        <p className="text-xs leading-relaxed text-fg-secondary-alt">
+          Edit something and it shows up here, side by side with the value it
+          replaces, so you can check it before publishing.
+        </p>
+      </div>
+    </div>
+  );
 }
 
 /**

--- a/packages/ui/spa/components/DraftChanges.tsx
+++ b/packages/ui/spa/components/DraftChanges.tsx
@@ -63,7 +63,10 @@ import {
   SheetTrigger,
 } from "./designSystem/sheet";
 import * as RadixAccordion from "@radix-ui/react-accordion";
-import { ValEnrichedDeployment } from "../utils/mergeCommitsAndDeployments";
+import {
+  commitSubject,
+  ValEnrichedDeployment,
+} from "../utils/mergeCommitsAndDeployments";
 import {
   Tooltip,
   TooltipContent,
@@ -583,8 +586,14 @@ function Deployment({
         <Tooltip>
           <TooltipPortal container={portalContainer} />
           <TooltipTrigger>
+            {/*
+              The subject line only: this row is one truncated line, and
+              `truncate` collapses a git message's newlines into spaces - so a
+              message with a body arrived as "Subject The body went on like
+              this…". The tooltip below still has the whole of it.
+            */}
             <div className="max-w-[180px] overflow-clip font-light truncate">
-              {deployment.commitMessage}
+              {commitSubject(deployment.commitMessage)}
             </div>
           </TooltipTrigger>
           <TooltipContent className="max-w-[320px]">

--- a/packages/ui/spa/components/ValProvider.tsx
+++ b/packages/ui/spa/components/ValProvider.tsx
@@ -572,7 +572,18 @@ export function ValProvider({
   const deploymentsFingerprint =
     "data" in stat && stat.data?.deployments
       ? stat.data.deployments
-          .map((d) => `${d.deploymentId}:${d.deploymentState}:${d.updatedAt}`)
+          .map(
+            (d) =>
+              // The message is part of what a poll can CHANGE, not just of what
+              // it carries: a content service that learns a deployment's git
+              // message after the fact - the webhook resolves it from GitHub,
+              // and that call can fail and be retried - sends the same
+              // deployment, in the same state, at the same instant, with a
+              // message where there was none. Left out of the fingerprint, that
+              // update reached `stat` and stopped there, and the row stayed on
+              // its short sha until something else moved.
+              `${d.deploymentId}:${d.deploymentState}:${d.updatedAt}:${d.commitMessage ?? ""}`,
+          )
           .join(",")
       : "";
   const commitsFingerprint =

--- a/packages/ui/spa/components/shell/Deployments.tsx
+++ b/packages/ui/spa/components/shell/Deployments.tsx
@@ -8,7 +8,7 @@ import {
   X,
 } from "lucide-react";
 import { cn } from "../designSystem/cn";
-import { ShellDeployment } from "./types";
+import { DeploymentProgress, ShellDeployment } from "./types";
 
 /**
  * What the deploy feed adds up to right now.
@@ -108,6 +108,23 @@ function isFailed(deployment: ShellDeployment): boolean {
     return false;
   }
   return deployment.state === "failure" || deployment.state === "error";
+}
+
+/**
+ * The three states a publish can be rendered in.
+ *
+ * Exported because Recent activity shows publishes too, and a publish that
+ * reads as "Building" in the status bar and as finished in the activity list is
+ * two answers to one question. `isBuilding` and `isFailed` stay private: the
+ * order they are asked in is part of the rule — a live commit is neither — and
+ * this is that rule, once.
+ */
+export function deploymentProgress(
+  deployment: ShellDeployment,
+): DeploymentProgress {
+  if (isBuilding(deployment)) return "building";
+  if (isFailed(deployment)) return "failed";
+  return "settled";
 }
 
 export type DeploymentsStatusProps = {
@@ -428,8 +445,9 @@ function DeploymentRow({
   deployment: ShellDeployment;
   onDismiss: () => void;
 }) {
-  const building = isBuilding(deployment);
-  const failed = isFailed(deployment);
+  const progress = deploymentProgress(deployment);
+  const building = progress === "building";
+  const failed = progress === "failed";
   return (
     <li className="flex items-start gap-2.5 px-3 py-2.5 border-b border-border-float last:border-b-0">
       <span className="mt-0.5 shrink-0">
@@ -448,7 +466,7 @@ function DeploymentRow({
           {deployment.message ?? deployment.commitSha.slice(0, 7)}
         </div>
         <div className="text-[11px] text-fg-secondary-alt truncate">
-          {describeState(deployment)}
+          {describeDeploymentState(deployment)}
           {deployment.author ? ` · ${deployment.author}` : ""} ·{" "}
           {deployment.timestamp}
         </div>
@@ -467,7 +485,13 @@ function DeploymentRow({
   );
 }
 
-function describeState(deployment: ShellDeployment): string {
+/**
+ * What happened to a publish, in a word or two.
+ *
+ * Exported for the same reason as {@link deploymentProgress}: the activity list
+ * says it about the same publishes.
+ */
+export function describeDeploymentState(deployment: ShellDeployment): string {
   // The site answering with this commit outranks anything the build host said
   // about it, including having said nothing at all. See `isBuilding`.
   if (deployment.isLive) {

--- a/packages/ui/spa/components/shell/MobileChrome.tsx
+++ b/packages/ui/spa/components/shell/MobileChrome.tsx
@@ -1,11 +1,18 @@
-import { Info, PanelRight } from "lucide-react";
+import { Info, PanelRight, Sparkles } from "lucide-react";
 import { ReactNode } from "react";
+import { cn } from "../designSystem/cn";
 import { PreviewButton, PublishButton } from "./TopBar";
 
 /**
  * The sticky mobile bottom bar. Preview and Publish are always reachable
  * here; auto save, dev mode and branch move behind the status button rather
  * than taking a permanent row.
+ *
+ * The assistant is here too, rather than in the top bar. On a phone the top
+ * right corner is the furthest point from a thumb, and it was sharing that
+ * corner with navigation, notifications and the account avatar - four icons in
+ * the row you reach for least. The top bar drops its Sparkles button below the
+ * mobile breakpoint, so there is still only one.
  */
 export function MobileBottomBar({
   pendingChanges,
@@ -15,6 +22,8 @@ export function MobileBottomBar({
   publishSlot,
   onOpenStatus,
   onOpenQuickActions,
+  onOpenAI,
+  isAIOpen,
   onToggleCanvas,
   isCanvasOpen,
   canvasActionLabel,
@@ -34,6 +43,16 @@ export function MobileBottomBar({
    * Upload media, none of which were reachable on a phone at all.
    */
   onOpenQuickActions?: () => void;
+  /**
+   * Open the assistant.
+   *
+   * Absent when the project has no assistant configured — see
+   * `ShellProps.aiEnabled` — and the button is then not offered at all, the
+   * same rule the top bar's follows.
+   */
+  onOpenAI?: () => void;
+  /** Whether the assistant panel is the one currently open. */
+  isAIOpen?: boolean;
   /** Absent when the selection has no route Val can put on a canvas. */
   onToggleCanvas?: () => void;
   isCanvasOpen?: boolean;
@@ -62,6 +81,24 @@ export function MobileBottomBar({
           <PanelRight size={16} />
         </button>
       )}
+      {onOpenAI && (
+        <button
+          type="button"
+          onClick={onOpenAI}
+          aria-label="AI assistant"
+          aria-pressed={isAIOpen}
+          className={cn(
+            "grid h-9 w-9 shrink-0 place-items-center rounded-md border border-border-float",
+            // The open state is shown the same way the top bar's icon buttons
+            // show it, so the assistant looks open in the same way everywhere.
+            isAIOpen
+              ? "bg-bg-float-raised text-fg-primary"
+              : "text-fg-secondary",
+          )}
+        >
+          <Sparkles size={16} />
+        </button>
+      )}
       {/*
        * The same control as on desktop, not a second design of it.
        *
@@ -70,6 +107,14 @@ export function MobileBottomBar({
        * the exact thing the split button was built to stop. It also meant the
        * two behaviours drifted: the desktop menu explains what each one does and
        * the phone's pair of icons explained nothing.
+       */}
+      {/*
+       * `min-w-0` on both, because a flex item's default minimum is its own
+       * content: without it neither of these can shrink below its label, and
+       * the row - three 36px icons, two labelled controls and the gaps between
+       * them - overflows a 320px phone and takes Publish off the edge. With it
+       * they give up width in step, and each clips its own label (the Preview
+       * split button is already `overflow-hidden`; Publish truncates).
        */}
       <PreviewButton
         onPreview={onPreview}
@@ -80,13 +125,13 @@ export function MobileBottomBar({
         onExitCanvas={onExitCanvas}
         menuPlacement="above"
         alwaysShowLabel
-        className="h-9 flex-1"
+        className="h-9 min-w-0 flex-1"
       />
       {publishSlot ?? (
         <PublishButton
           pendingChanges={pendingChanges}
           onPublish={onPublish}
-          className="flex-1 h-9"
+          className="h-9 min-w-0 flex-1"
         />
       )}
     </div>

--- a/packages/ui/spa/components/shell/Shell.tsx
+++ b/packages/ui/spa/components/shell/Shell.tsx
@@ -989,6 +989,16 @@ export function Shell({
               publishSlot={publishSlot}
               onOpenStatus={() => setOpenPanel("account")}
               onOpenQuickActions={() => setOpenPanel("utility")}
+              /*
+               * The same gate and the same ACT as the top bar's button above
+               * this breakpoint: absent when there is no assistant, and a
+               * toggle rather than an open, so the button that shows the panel
+               * as open is the button that closes it. It only opened, which on
+               * a phone - where the panel covers the editor - meant the
+               * obvious way to dismiss it did nothing.
+               */
+              onOpenAI={aiEnabled ? () => togglePanel("ai") : undefined}
+              isAIOpen={openPanel === "ai"}
             />
           </>
         ) : (

--- a/packages/ui/spa/components/shell/Shell.tsx
+++ b/packages/ui/spa/components/shell/Shell.tsx
@@ -50,7 +50,7 @@ import { availableDestinations } from "./shellDataMapping";
 import { servedPath } from "../../utils/mediaPath";
 import { useShellBreakpoint } from "./useShellBreakpoint";
 import {
-  ShellActivityEntry,
+  ShellChangeActivity,
   ShellData,
   ShellDataModule,
   ShellExternalPage,
@@ -337,7 +337,8 @@ export type ShellProps = {
   /** The last error from fetching patches, for that same report. */
   pendingChangesError?: string | null;
   onSelectValidationError?: (error: ShellValidationError) => void;
-  onSelectActivity?: (entry: ShellActivityEntry) => void;
+  /** Open a change row's field. Publishes are not selectable — see `UtilityPanelProps`. */
+  onSelectActivity?: (entry: ShellChangeActivity) => void;
   /** Create a page under a route. See `PagesPanelProps`. */
   onNewPage?: (moduleFilePath: ModuleFilePath, urlPath: string) => void;
   /** Copy a page to another URL under the same route. See `PagesPanelProps`. */
@@ -573,17 +574,24 @@ export function Shell({
    * already grouped by the thing that changed. Five, because this is a "take me
    * back" list rather than a history: past that it stops being a shortcut and
    * starts being something to read.
+   *
+   * Changes only: the feed also carries publishes, and a search result is a
+   * thing to open. Filtered BEFORE the slice, so a busy publishing afternoon
+   * does not leave the recent list short.
    */
   const recentSearchResults = useMemo(
     (): SearchResult[] =>
-      (data.activity ?? []).slice(0, RECENT_SEARCH_LIMIT).map((entry) => ({
-        id: entry.sourcePath,
-        kind: "recent",
-        label: entry.title,
-        detail: entry.author
-          ? `${entry.timestamp} · ${entry.author}`
-          : entry.timestamp,
-      })),
+      (data.activity ?? [])
+        .filter((entry) => entry.kind === "change")
+        .slice(0, RECENT_SEARCH_LIMIT)
+        .map((entry) => ({
+          id: entry.sourcePath,
+          kind: "recent",
+          label: entry.title,
+          detail: entry.author
+            ? `${entry.timestamp} · ${entry.author}`
+            : entry.timestamp,
+        })),
     [data.activity],
   );
 

--- a/packages/ui/spa/components/shell/TopBar.tsx
+++ b/packages/ui/spa/components/shell/TopBar.tsx
@@ -115,7 +115,8 @@ export type TopBarProps = {
    * Whether this project has an assistant. See `ShellProps.aiEnabled`.
    *
    * Absent hides the button rather than disabling it: it is the only thing in
-   * the bar that opens a panel with nothing behind it.
+   * the bar that opens a panel with nothing behind it. On mobile the button is
+   * not here at all — the bottom bar carries it.
    */
   aiEnabled?: boolean;
 };
@@ -127,9 +128,10 @@ export type PublishState = "idle" | "publishing" | "error" | "blocked";
  * The floating top bar.
  *
  * Review, Preview and Publish stay visible at every breakpoint above mobile —
- * in that order, which is the order they are done in; on mobile Preview and
- * Publish move to the sticky bottom bar, Review moves to the Quick actions
- * panel, and the top bar keeps only navigation, notifications, AI and account.
+ * in that order, which is the order they are done in; on mobile Preview,
+ * Publish and the assistant move to the sticky bottom bar, Review moves to the
+ * Quick actions panel, and the top bar keeps only navigation, history,
+ * notifications and account.
  */
 export function TopBar({
   breakpoint,
@@ -217,7 +219,13 @@ export function TopBar({
             <History size={16} />
           </IconButton>
         )}
-        {aiEnabled && (
+        {/*
+         * Above mobile only: on a phone the assistant is in the bottom bar,
+         * where the thumb is - see `MobileBottomBar`. Two Sparkles buttons on
+         * one screen would be two places to look for the same panel, and the
+         * top right corner of a phone is the furthest point from a thumb.
+         */}
+        {aiEnabled && !isMobile && (
           <IconButton
             label="AI assistant"
             active={openPanel === "ai"}
@@ -676,19 +684,29 @@ export function PublishButton({
       )}
     >
       {publishState === "publishing" ? (
-        <Loader2 size={14} className="animate-spin" />
+        <Loader2 size={14} className="shrink-0 animate-spin" />
       ) : publishState === "error" ? (
-        <AlertTriangle size={14} />
+        <AlertTriangle size={14} className="shrink-0" />
       ) : (
-        <Upload size={14} />
+        <Upload size={14} className="shrink-0" />
       )}
-      {publishState === "publishing"
-        ? "Publishing…"
-        : publishState === "error"
-          ? "Publish failed"
-          : "Publish"}
+      {/*
+       * Truncates, so the button can be narrower than its word. On the phone's
+       * bottom bar this shares a row with Preview and three icon buttons, and
+       * `min-w-0` there is only half the answer: a label that cannot clip makes
+       * the button refuse to shrink however small its box is asked to be.
+       */}
+      <span className="truncate">
+        {publishState === "publishing"
+          ? "Publishing…"
+          : publishState === "error"
+            ? "Publish failed"
+            : "Publish"}
+      </span>
       {publishState === "idle" && pendingChanges > 0 && (
-        <span className="tabular-nums opacity-80">{pendingChanges}</span>
+        <span className="shrink-0 tabular-nums opacity-80">
+          {pendingChanges}
+        </span>
       )}
     </button>
   );

--- a/packages/ui/spa/components/shell/TopBar.tsx
+++ b/packages/ui/spa/components/shell/TopBar.tsx
@@ -553,22 +553,25 @@ function BarDivider() {
 /**
  * Review, first of the three actions and to the left of Preview.
  *
- * Present whenever the shell can review at all, and merely INVISIBLE until
- * there is something to review. Not `null`, which is what it was: this group is
- * `ml-auto`, so its right edge is pinned and its left edge grows — a button
- * mounting inside it moves the group's left edge, and everything left of that
- * edge, by its own width. That happens exactly when the first change lands,
- * which is exactly when someone is working in there, and while Review sat
- * BETWEEN Preview and Publish it also moved Preview out from under a click that
- * had already started. `canvas.spec.ts` caught it as a click that hit nothing;
- * a person gets the same miss and no error. Being leftmost now spares Preview
- * and Publish specifically, but the space still has to be held: the search
- * field and the project name are to the left of it, and they would take the
- * jump instead.
+ * Offered whether or not anything is pending. It used to be `invisible` with
+ * nothing queued — present in the layout so the bar would not reflow, but
+ * unreachable and hidden from assistive tech. That made "is anything of mine
+ * still unpublished?" unanswerable from the bar: an absent button and a button
+ * whose data has not loaded look identical, so the only way to find out was to
+ * publish and see what happened. The phone's Quick actions row already answers
+ * it — see `reviewChangesLabel` — and this is the same rule above that
+ * breakpoint. What it opens says the same thing in a sentence; see
+ * `NothingToReview`.
  *
- * `visibility: hidden` rather than opacity: it holds the space, takes no
- * clicks, takes no tab stop, and is not announced — so nothing is offered that
- * cannot be used.
+ * Never `null`, which is what it was before it was `invisible`, and the reason
+ * survives both: this group is `ml-auto`, so its right edge is pinned and its
+ * left edge grows — a button mounting inside it moves the group's left edge,
+ * and everything left of that edge, by its own width. That happens exactly when
+ * the first change lands, which is exactly when someone is working in there,
+ * and while Review sat BETWEEN Preview and Publish it also moved Preview out
+ * from under a click that had already started. `canvas.spec.ts` caught it as a
+ * click that hit nothing; a person gets the same miss and no error. A button
+ * that is always there holds the space by being there.
  *
  * The badge shows `reviewCount`, which is the pending patch count zeroed when
  * all of it has been reverted. In that case the button stays — the review view
@@ -592,7 +595,6 @@ function ReviewButton({
     <button
       type="button"
       onClick={onCompare}
-      {...(hasWork ? {} : { "aria-hidden": true, tabIndex: -1 })}
       aria-label={
         showCount
           ? `Review ${reviewCount} ${reviewCount === 1 ? "change" : "changes"}`
@@ -602,7 +604,6 @@ function ReviewButton({
         "relative inline-flex items-center gap-1.5 h-8 px-2.5 rounded-md shrink-0",
         "text-fg-secondary hover:bg-bg-float-raised hover:text-fg-primary",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus",
-        !hasWork && "invisible",
       )}
     >
       <GitCompare size={15} />

--- a/packages/ui/spa/components/shell/UtilityPanel.tsx
+++ b/packages/ui/spa/components/shell/UtilityPanel.tsx
@@ -1,9 +1,12 @@
 import {
   AlertTriangle,
+  CircleAlert,
   Clock,
   FilePlus2,
   GitCompare,
   ImagePlus,
+  Loader2,
+  Rocket,
   Sparkles,
   Undo2,
 } from "lucide-react";
@@ -22,6 +25,8 @@ import {
 import {
   ShellActivityEntry,
   ShellBreakpoint,
+  ShellChangeActivity,
+  ShellDeployActivity,
   ShellDestination,
   ShellValidationError,
 } from "./types";
@@ -99,7 +104,14 @@ export type UtilityPanelProps = {
   reviewCount?: number;
   /** How many changes `onCompare` would show. */
   pendingChanges?: number;
-  onSelectActivity: (entry: ShellActivityEntry) => void;
+  /**
+   * Open what a change row points at.
+   *
+   * Change rows only: a publish is a commit, and there is nothing in the
+   * Studio for it to open. Narrowing the callback rather than handing over the
+   * whole union is what keeps that from being the caller's problem.
+   */
+  onSelectActivity: (entry: ShellChangeActivity) => void;
   onClose: () => void;
 };
 
@@ -235,31 +247,30 @@ export function UtilityPanel({
         <PanelSectionLabel divided>Recent activity</PanelSectionLabel>
         {activity.length === 0 ? (
           <PanelEmptyState>
-            No recent activity. Your changes will show up here.
+            No recent activity. Your changes and publishes will show up here.
           </PanelEmptyState>
         ) : (
           <ul className="px-3 pt-0.5">
             {activity.map((entry) => (
               <li key={entry.id}>
-                <button
-                  type="button"
-                  onClick={() => onSelectActivity(entry)}
-                  className="flex gap-2 w-full px-1.5 py-1.5 rounded-md text-left hover:bg-bg-float-raised"
-                >
-                  <Clock
-                    size={13}
-                    className="mt-0.5 shrink-0 text-fg-secondary-alt"
-                  />
-                  <span className="min-w-0">
-                    <span className="block text-xs text-fg-primary truncate">
-                      {entry.title}
-                    </span>
-                    <span className="block text-[0.6875rem] text-fg-secondary-alt">
-                      {entry.author ? `${entry.author} · ` : ""}
-                      {entry.timestamp}
-                    </span>
-                  </span>
-                </button>
+                {entry.kind === "deploy" ? (
+                  <DeployActivityRow entry={entry} />
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => onSelectActivity(entry)}
+                    className="flex gap-2 w-full px-1.5 py-1.5 rounded-md text-left hover:bg-bg-float-raised"
+                  >
+                    <Clock
+                      size={13}
+                      className="mt-0.5 shrink-0 text-fg-secondary-alt"
+                    />
+                    <ActivityLines
+                      title={entry.title}
+                      detail={`${entry.author ? `${entry.author} · ` : ""}${entry.timestamp}`}
+                    />
+                  </button>
+                )}
               </li>
             ))}
           </ul>
@@ -279,6 +290,53 @@ export function UtilityPanel({
         )}
       </div>
     </FloatingPanel>
+  );
+}
+
+/**
+ * A publish, in the activity list.
+ *
+ * A line rather than a button: the row says what happened to the site, and a
+ * commit is not something the Studio can open. Its icon is the deploy feed's —
+ * a spinner while it builds, a warning when it failed — so the same publish
+ * looks the same in both places.
+ */
+function DeployActivityRow({ entry }: { entry: ShellDeployActivity }) {
+  return (
+    <div className="flex gap-2 w-full px-1.5 py-1.5">
+      <span className="mt-0.5 shrink-0">
+        {entry.progress === "building" ? (
+          <Loader2 size={13} className="animate-spin text-fg-secondary" />
+        ) : entry.progress === "failed" ? (
+          <CircleAlert size={13} className="text-fg-error-on-surface" />
+        ) : (
+          <Rocket size={13} className="text-fg-secondary-alt" />
+        )}
+      </span>
+      <ActivityLines
+        title={entry.title}
+        detail={`${entry.state}${entry.author ? ` · ${entry.author}` : ""} · ${
+          entry.timestamp
+        }`}
+      />
+    </div>
+  );
+}
+
+/**
+ * The two lines every activity row has, so a publish and an edit line up.
+ *
+ * `min-w-0` on the wrapper is what lets the title truncate rather than push the
+ * row wide - the panel is 260px, and a commit message is not.
+ */
+function ActivityLines({ title, detail }: { title: string; detail: string }) {
+  return (
+    <span className="min-w-0">
+      <span className="block text-xs text-fg-primary truncate">{title}</span>
+      <span className="block text-[0.6875rem] text-fg-secondary-alt truncate">
+        {detail}
+      </span>
+    </span>
   );
 }
 

--- a/packages/ui/spa/components/shell/aiAffordances.test.tsx
+++ b/packages/ui/spa/components/shell/aiAffordances.test.tsx
@@ -1,7 +1,9 @@
 /** @jest-environment jsdom */
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MobileBottomBar } from "./MobileChrome";
 import { TopBar } from "./TopBar";
 import { UtilityPanel } from "./UtilityPanel";
+import { ShellBreakpoint } from "./types";
 
 /**
  * The ways into the assistant, in a project that has no assistant.
@@ -16,10 +18,33 @@ import { UtilityPanel } from "./UtilityPanel";
  * with it the whole shared bundle — so what is pinned is the two controls that
  * lead to it.
  */
-function topBar(aiEnabled: boolean) {
+/*
+ * jsdom has no `matchMedia`, and the non-desktop top bar reaches it through
+ * `usePrefersReducedMotion`. Stubbed for the same reason
+ * `historyAffordance.test.tsx` stubs it: the reduced motion answer is
+ * irrelevant here, and without it the mobile case fails for a reason that has
+ * nothing to do with the assistant.
+ */
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      dispatchEvent: () => false,
+    }),
+  });
+});
+
+function topBar(aiEnabled: boolean, breakpoint: ShellBreakpoint = "desktop") {
   return (
     <TopBar
-      breakpoint="desktop"
+      breakpoint={breakpoint}
       projectName="Test"
       openPanel={null}
       onTogglePanel={() => undefined}
@@ -30,6 +55,19 @@ function topBar(aiEnabled: boolean) {
       onPublish={() => undefined}
       pendingChanges={0}
       aiEnabled={aiEnabled}
+    />
+  );
+}
+
+function mobileBar(onOpenAI?: () => void) {
+  return (
+    <MobileBottomBar
+      pendingChanges={0}
+      onPreview={() => undefined}
+      onPublish={() => undefined}
+      onOpenStatus={() => undefined}
+      onOpenQuickActions={() => undefined}
+      onOpenAI={onOpenAI}
     />
   );
 }
@@ -57,6 +95,55 @@ describe("the ways into the assistant", () => {
     render(topBar(false));
     expect(screen.queryByLabelText("AI assistant")).toBeNull();
     // The rest of the bar is untouched — this hides one button, not the row.
+    expect(screen.queryByLabelText("Quick actions")).not.toBeNull();
+  });
+
+  /**
+   * On a phone the button is in the BOTTOM bar, not the top one.
+   *
+   * The top right corner of a phone is the furthest point from a thumb, and it
+   * already holds navigation, notifications and the account avatar. Two
+   * Sparkles buttons would also be two places to look for one panel, which is
+   * the pair of tests below.
+   */
+  test("on a phone it is in the bottom bar", () => {
+    render(mobileBar(() => undefined));
+    expect(screen.queryByLabelText("AI assistant")).not.toBeNull();
+  });
+
+  test("and not in the top bar", () => {
+    render(topBar(true, "mobile"));
+    expect(screen.queryByLabelText("AI assistant")).toBeNull();
+  });
+
+  test("the phone's button closes the panel it opened", () => {
+    // The top bar's button toggles, and on a phone the panel COVERS the
+    // editor - so a button that only ever opens leaves the obvious way to
+    // dismiss it doing nothing.
+    const onOpenAI = jest.fn();
+    render(
+      <MobileBottomBar
+        pendingChanges={0}
+        onPreview={() => undefined}
+        onPublish={() => undefined}
+        onOpenStatus={() => undefined}
+        onOpenQuickActions={() => undefined}
+        onOpenAI={onOpenAI}
+        isAIOpen
+      />,
+    );
+    const button = screen.getByLabelText("AI assistant");
+    expect(button.getAttribute("aria-pressed")).toBe("true");
+    fireEvent.click(button);
+    // `Shell` hands this a toggle; what is pinned here is that the button is
+    // live while the panel is open rather than inert.
+    expect(onOpenAI).toHaveBeenCalledTimes(1);
+  });
+
+  test("the bottom bar offers none when the project has no assistant", () => {
+    render(mobileBar(undefined));
+    expect(screen.queryByLabelText("AI assistant")).toBeNull();
+    // As above: this hides one button, not the row.
     expect(screen.queryByLabelText("Quick actions")).not.toBeNull();
   });
 

--- a/packages/ui/spa/components/shell/deployments.test.ts
+++ b/packages/ui/spa/components/shell/deployments.test.ts
@@ -183,6 +183,40 @@ describe("toDeployments", () => {
     ).toBe(true);
   });
 
+  /**
+   * A git message is a subject, a blank line and a body. Val's own messages are
+   * one line, so this only shows up on the deployments Val did not publish -
+   * and the rows truncate, so the whole body arrived as one long line with the
+   * subject lost at the front of it.
+   */
+  test("shows the subject line of a multi-line git message", () => {
+    const [row] = toDeployments(
+      [
+        {
+          ...enriched,
+          commitMessage:
+            "Bump the dependency\n\nThe old one pinned a transitive package we\nno longer use.",
+        },
+      ],
+      new Set(),
+      {},
+      now,
+    );
+    expect(row.message).toBe("Bump the dependency");
+  });
+
+  test("a message that is only whitespace is no message", () => {
+    // Which is what makes the row fall back to the short sha rather than
+    // rendering an empty title.
+    const [row] = toDeployments(
+      [{ ...enriched, commitMessage: "  \n\n" }],
+      new Set(),
+      {},
+      now,
+    );
+    expect(row.message).toBeNull();
+  });
+
   test("keeps the feed short enough to read", () => {
     const many = Array.from({ length: 25 }, (_, index) => ({
       ...enriched,

--- a/packages/ui/spa/components/shell/mockShellData.ts
+++ b/packages/ui/spa/components/shell/mockShellData.ts
@@ -531,6 +531,24 @@ export const mockDeployments: ShellDeployment[] = [
     updatedAt: mockMinutesAgo(60),
     isLive: false,
   },
+  /*
+   * A deployment nobody published from Val: a developer's push, a merged pull
+   * request, a revert. On most projects these are the majority of the feed.
+   *
+   * No `author`, because there is no Val commit and therefore no profile to
+   * resolve - and the message is the SUBJECT of a git message, which is what
+   * `commitSubject` leaves of one that has a body. The row is a single
+   * truncated line, so a body rendered into it arrives as "Subject The body
+   * went on like this…".
+   */
+  {
+    commitSha: "7d4e1b0c58a2946fbb31e70d5c8f2a6391e4c0af",
+    state: "success",
+    message: "Move the pricing table into its own component",
+    timestamp: "3 hours ago",
+    updatedAt: mockMinutesAgo(180),
+    isLive: true,
+  },
 ];
 
 /**

--- a/packages/ui/spa/components/shell/mockShellData.ts
+++ b/packages/ui/spa/components/shell/mockShellData.ts
@@ -423,13 +423,27 @@ export const mockValidationErrors: ShellValidationError[] = [
 ];
 
 /**
- * Recent activity, as `toActivity` builds it: the module's file label followed
- * by the patch path, and the author id resolved to a name where a profile is
- * known. A local dev project has no profiles, which is why the last entry has
- * no author rather than a placeholder one.
+ * Recent activity, as `toActivity` builds it: the edits and the publishes,
+ * interleaved by time.
+ *
+ * A change row is the module's file label followed by the patch path, and the
+ * author id resolved to a name where a profile is known — a local dev project
+ * has no profiles, which is why the last entry has no author rather than a
+ * placeholder one. The deploy rows are the same publishes `mockDeployments`
+ * has, which is what the real mapping does with them.
  */
 export const mockActivity: ShellActivityEntry[] = [
   {
+    kind: "deploy",
+    id: "deploy-9f21c4ae0b7d1e5a3c8f2d6b04e7a915cd83f620",
+    title: "Update hero copy and pricing table",
+    state: "Building",
+    progress: "building",
+    timestamp: "just now",
+    author: "Fredrik Ekholdt",
+  },
+  {
+    kind: "change",
     id: '/app/page.val.ts?p="/"/hero/title-0',
     sourcePath: '/app/page.val.ts?p="/"."hero"."title"',
     title: "page › hero › title",
@@ -437,6 +451,16 @@ export const mockActivity: ShellActivityEntry[] = [
     author: "Fredrik Ekholdt",
   },
   {
+    kind: "deploy",
+    id: "deploy-3ab77c1902ef4d885b16c0da79f3e421ab5c9d08",
+    title: "Add customer story: nordic-retail",
+    state: "Live",
+    progress: "settled",
+    timestamp: "12 minutes ago",
+    author: "Ida Sørensen",
+  },
+  {
+    kind: "change",
     id: '/app/pricing/page.val.ts?p="/pricing"/plans-1',
     sourcePath: '/app/pricing/page.val.ts?p="/pricing"."plans"',
     title: "page › plans",
@@ -444,6 +468,7 @@ export const mockActivity: ShellActivityEntry[] = [
     author: "Fredrik Ekholdt",
   },
   {
+    kind: "change",
     id: "/content/navigation.val.ts?primary-2",
     sourcePath: '/content/navigation.val.ts?p="primary"',
     title: "navigation › primary",
@@ -451,6 +476,16 @@ export const mockActivity: ShellActivityEntry[] = [
     author: "Ida Sørensen",
   },
   {
+    kind: "deploy",
+    id: "deploy-c05e9182aab34f6072d1e5b8c4a09f37e6215dba",
+    title: "Swap footer links",
+    state: "Build failed",
+    progress: "failed",
+    timestamp: "1 hour ago",
+    author: "Fredrik Ekholdt",
+  },
+  {
+    kind: "change",
     id: '/app/blog/[slug]/page.val.ts?p="/blog/why-we-built-val"/text-3',
     sourcePath:
       '/app/blog/[slug]/page.val.ts?p="/blog/why-we-built-val"."text"',

--- a/packages/ui/spa/components/shell/recentActivity.test.tsx
+++ b/packages/ui/spa/components/shell/recentActivity.test.tsx
@@ -1,0 +1,77 @@
+/** @jest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { UtilityPanel } from "./UtilityPanel";
+import { ShellActivityEntry } from "./types";
+
+/**
+ * Recent activity, which is now edits AND publishes.
+ *
+ * The publishes were visible only in the status bar's deploy feed, which is a
+ * live-progress indicator: it empties itself as builds land, so the moment a
+ * publish finished there was nowhere in the Studio that said it had.
+ *
+ * What is pinned here is the two kinds of row being different kinds of thing —
+ * an edit is somewhere to go, a publish is something that happened — because
+ * that is the part a later refactor would flatten.
+ */
+const change: ShellActivityEntry = {
+  kind: "change",
+  id: "change-1",
+  sourcePath: '/content/home.val.ts?p="hero"."title"',
+  title: "home › hero › title",
+  timestamp: "2 minutes ago",
+  author: "Ada",
+};
+
+const deploy: ShellActivityEntry = {
+  kind: "deploy",
+  id: "deploy-abc1234",
+  title: "Update the hero",
+  state: "Live",
+  progress: "settled",
+  timestamp: "12 minutes ago",
+  author: "Ida",
+};
+
+function panel(
+  activity: ShellActivityEntry[],
+  onSelectActivity: () => void = () => undefined,
+) {
+  return (
+    <UtilityPanel
+      breakpoint="desktop"
+      activity={activity}
+      onNewPage={() => undefined}
+      onUploadMedia={() => undefined}
+      onSelectActivity={onSelectActivity}
+      onClose={() => undefined}
+    />
+  );
+}
+
+describe("recent activity", () => {
+  test("lists publishes alongside changes", () => {
+    render(panel([change, deploy]));
+    expect(screen.queryByText("home › hero › title")).not.toBeNull();
+    expect(screen.queryByText("Update the hero")).not.toBeNull();
+  });
+
+  test("says how a publish is doing, and who published it", () => {
+    render(panel([deploy]));
+    expect(screen.queryByText("Live · Ida · 12 minutes ago")).not.toBeNull();
+  });
+
+  test("a change is something to open", () => {
+    const onSelectActivity = jest.fn();
+    render(panel([change], onSelectActivity));
+    screen.getByRole("button", { name: /home › hero › title/ }).click();
+    expect(onSelectActivity).toHaveBeenCalledTimes(1);
+  });
+
+  test("a publish is not - there is nothing in the Studio a commit opens", () => {
+    render(panel([deploy]));
+    expect(
+      screen.queryByRole("button", { name: /Update the hero/ }),
+    ).toBeNull();
+  });
+});

--- a/packages/ui/spa/components/shell/shellDataMapping.test.ts
+++ b/packages/ui/spa/components/shell/shellDataMapping.test.ts
@@ -10,7 +10,14 @@ import {
   toValidationErrors,
 } from "./shellDataMapping";
 import { ExplorerItem, SitemapItem } from "../NavMenu/types";
-import { ShellData, ShellDataModule, ShellMediaGallery } from "./types";
+import {
+  ShellActivityEntry,
+  ShellChangeActivity,
+  ShellData,
+  ShellDataModule,
+  ShellDeployment,
+  ShellMediaGallery,
+} from "./types";
 
 /**
  * The provider-to-shell mapping.
@@ -253,10 +260,46 @@ describe("toActivity", () => {
   /** Ten minutes after the timestamps below, so "10 minutes ago" is stable. */
   const now = new Date("2026-08-24T10:10:00Z").getTime();
 
+  /**
+   * A publish, as `toDeployments` produces one. `isLive` false is the state
+   * every publish starts in and the one `state` still speaks for.
+   */
+  const deployment = (
+    overrides: Partial<ShellDeployment> & Pick<ShellDeployment, "commitSha">,
+  ): ShellDeployment => ({
+    state: "success",
+    message: "A publish",
+    timestamp: "just now",
+    updatedAt: "2026-08-24T10:09:00Z",
+    isLive: false,
+    ...overrides,
+  });
+
+  /**
+   * The change rows, narrowed.
+   *
+   * The feed is a union now, so a test that means "the edits" has to say so —
+   * and one that reads `sourcePath` off whatever came first would pass for the
+   * wrong reason the day a publish sorts above it.
+   */
+  const changes = (entries: ShellActivityEntry[]): ShellChangeActivity[] =>
+    entries.filter(
+      (entry): entry is ShellChangeActivity => entry.kind === "change",
+    );
+
   test("reads as a trail from the file to what changed in it", () => {
-    const [entry] = toActivity(
-      [set("/content/home.val.ts", ["hero", "title"], "2026-08-24T10:00:00Z")],
-      now,
+    const [entry] = changes(
+      toActivity(
+        [
+          set(
+            "/content/home.val.ts",
+            ["hero", "title"],
+            "2026-08-24T10:00:00Z",
+          ),
+        ],
+        [],
+        now,
+      ),
     );
     expect(entry.title).toBe("home › hero › title");
     expect(entry.author).toBe("ada");
@@ -267,15 +310,20 @@ describe("toActivity", () => {
   test("carries a source path that resolves", () => {
     // The grammar matters: string keys are quoted, array indices are bare. A
     // hand-joined path looks close enough to work and then opens nothing.
-    const [entry] = toActivity(
-      [set("/content/home.val.ts", ["items", "0", "title"], "x")],
-      now,
+    const [entry] = changes(
+      toActivity(
+        [set("/content/home.val.ts", ["items", "0", "title"], "x")],
+        [],
+        now,
+      ),
     );
     expect(entry.sourcePath).toBe('/content/home.val.ts?p="items".0."title"');
   });
 
   test("a whole-module change points at the module", () => {
-    const [entry] = toActivity([set("/content/home.val.ts", [], "x")], now);
+    const [entry] = changes(
+      toActivity([set("/content/home.val.ts", [], "x")], [], now),
+    );
     expect(entry.sourcePath).toBe("/content/home.val.ts");
   });
 
@@ -283,7 +331,7 @@ describe("toActivity", () => {
     const many = Array.from({ length: 20 }, (_, i) =>
       set("/content/home.val.ts", [`field${i}`], "2026-08-24T10:00:00Z"),
     );
-    const activity = toActivity(many, now);
+    const activity = toActivity(many, [], now);
     expect(activity).toHaveLength(8);
     expect(activity[0].title).toBe("home › field0");
   });
@@ -295,17 +343,144 @@ describe("toActivity", () => {
         set("/content/home.val.ts", ["title"], "2026-08-24T10:00:00Z"),
         set("/content/home.val.ts", ["title"], "2026-08-23T10:00:00Z"),
       ],
+      [],
       now,
     );
     expect(activity[0].id).not.toBe(activity[1].id);
   });
 
   test("survives a patch with no author", () => {
-    const [entry] = toActivity(
-      [{ ...set("/content/home.val.ts", ["title"], "x"), lastUpdatedBy: null }],
-      now,
+    const [entry] = changes(
+      toActivity(
+        [
+          {
+            ...set("/content/home.val.ts", ["title"], "x"),
+            lastUpdatedBy: null,
+          },
+        ],
+        [],
+        now,
+      ),
     );
     expect(entry.author).toBeUndefined();
+  });
+
+  /**
+   * The publishes, which used to be visible only in the status bar's deploy
+   * feed — a live-progress indicator that empties itself as builds land, so
+   * once a publish had finished nothing in the Studio said it had.
+   */
+  describe("publishes", () => {
+    test("show up beside the changes, interleaved by time", () => {
+      const activity = toActivity(
+        [
+          set("/content/home.val.ts", ["title"], "2026-08-24T10:08:00Z"),
+          set("/content/home.val.ts", ["intro"], "2026-08-24T10:00:00Z"),
+        ],
+        [
+          deployment({
+            commitSha: "abc1234def",
+            updatedAt: "2026-08-24T10:05:00Z",
+          }),
+        ],
+        now,
+      );
+      expect(activity.map((entry) => entry.kind)).toEqual([
+        "change",
+        "deploy",
+        "change",
+      ]);
+    });
+
+    test("are named by their commit message", () => {
+      const [entry] = toActivity(
+        [],
+        [deployment({ commitSha: "abc1234def", message: "Update the hero" })],
+        now,
+      );
+      expect(entry.title).toBe("Update the hero");
+    });
+
+    test("fall back to the short sha when there is no message", () => {
+      // Which is what the deploy feed shows for the same publish.
+      const [entry] = toActivity(
+        [],
+        [deployment({ commitSha: "abc1234def5678", message: null })],
+        now,
+      );
+      expect(entry.title).toBe("abc1234");
+    });
+
+    test("say how the publish is doing", () => {
+      const [building, failed, live] = toActivity(
+        [],
+        [
+          deployment({
+            commitSha: "a",
+            state: "pending",
+            updatedAt: "2026-08-24T10:09:00Z",
+          }),
+          deployment({
+            commitSha: "b",
+            state: "failure",
+            updatedAt: "2026-08-24T10:08:00Z",
+          }),
+          deployment({
+            commitSha: "c",
+            state: "success",
+            isLive: true,
+            updatedAt: "2026-08-24T10:07:00Z",
+          }),
+        ],
+        now,
+      );
+      expect(building).toMatchObject({
+        state: "Building",
+        progress: "building",
+      });
+      expect(failed).toMatchObject({
+        state: "Build failed",
+        progress: "failed",
+      });
+      // The site answering with the commit outranks the build state, which is
+      // the deploy feed's rule and has to stay one rule.
+      expect(live).toMatchObject({ state: "Live", progress: "settled" });
+    });
+
+    test("keep the ids apart from the changes'", () => {
+      const [entry] = toActivity([], [deployment({ commitSha: "abc" })], now);
+      expect(entry.id).toBe("deploy-abc");
+    });
+
+    /**
+     * A run of publishes must not push out the edits: this panel exists to get
+     * back to them, and the whole feed is in the status bar's list anyway.
+     */
+    test("never take more than a few of the rows", () => {
+      const activity = toActivity(
+        [set("/content/home.val.ts", ["title"], "2026-08-20T10:00:00Z")],
+        Array.from({ length: 10 }, (_, i) =>
+          deployment({
+            commitSha: `sha${i}`,
+            updatedAt: `2026-08-24T10:0${i % 10}:00Z`,
+          }),
+        ),
+        now,
+      );
+      expect(activity.filter((entry) => entry.kind === "deploy")).toHaveLength(
+        3,
+      );
+      expect(changes(activity)).toHaveLength(1);
+    });
+
+    test("an unreadable timestamp sorts last rather than scrambling the feed", () => {
+      const activity = toActivity(
+        [set("/content/home.val.ts", ["title"], "2026-08-24T10:00:00Z")],
+        [deployment({ commitSha: "abc", updatedAt: "not a date" })],
+        now,
+      );
+      expect(activity.map((entry) => entry.kind)).toEqual(["change", "deploy"]);
+    });
   });
 });
 

--- a/packages/ui/spa/components/shell/shellDataMapping.ts
+++ b/packages/ui/spa/components/shell/shellDataMapping.ts
@@ -3,11 +3,13 @@ import { ExplorerItem, SitemapItem } from "../NavMenu/types";
 import { AvailableRoute } from "../NavMenu/NewPageForm";
 import { routePatternToString } from "../NavMenu/SitemapItem";
 import { ValEnrichedDeployment } from "../../utils/mergeCommitsAndDeployments";
+import { deploymentProgress, describeDeploymentState } from "./Deployments";
 import {
   ShellActivityEntry,
   ShellAdminLinks,
   ShellData,
   ShellDataModule,
+  ShellDeployActivity,
   ShellDeployment,
   ShellDestination,
   ShellExternalPage,
@@ -158,10 +160,29 @@ export function toValidationErrors(
 const ACTIVITY_LIMIT = 8;
 
 /**
- * Recent activity, from the patch sets.
+ * How many of those may be publishes.
+ *
+ * An afternoon of publishing produces a run of deploys — one of yours, one of a
+ * colleague's, a retried build — and a straight merge by time would fill the
+ * whole list with them and push out the edits the panel exists to get back to.
+ * The deploy feed in the status bar has them all; here they are context, so
+ * they get a minority of the rows and never the last edit's place.
+ */
+const DEPLOY_ACTIVITY_LIMIT = 3;
+
+/**
+ * Recent activity: the unpublished edits and the publishes, newest first.
  *
  * Patch sets are already newest first and already grouped by the thing that
- * changed, which is exactly what this list wants.
+ * changed, which is exactly what this list wants. Publishes come in as the rows
+ * the deploy feed renders — same labels, same three states — because a publish
+ * that reads one way in the status bar and another here is two answers to one
+ * question.
+ *
+ * The two are then interleaved by time, which is what makes it a feed rather
+ * than two lists in one box: "I changed the hero, then it went out, then Ida
+ * changed the pricing" is the sentence someone opening this panel is trying to
+ * read.
  */
 export function toActivity(
   patchSets: Array<{
@@ -171,35 +192,92 @@ export function toActivity(
     lastUpdatedBy: string | null;
   }>,
   /**
+   * The publishes, already mapped by {@link toDeployments}.
+   *
+   * Rows rather than the raw feed, so this cannot disagree with the deploy list
+   * about what a publish is called or how it is doing.
+   */
+  deployments: ShellDeployment[],
+  /**
    * A parameter rather than a call to `Date.now()`, so the result is a function
    * of its inputs and can be tested — the same reason `toDeployments` takes one.
    */
   now: number,
 ): ShellActivityEntry[] {
-  return patchSets.slice(0, ACTIVITY_LIMIT).map(
-    (set, index): ShellActivityEntry => ({
-      // The index is load-bearing: two patch sets can share a module and a path,
-      // and React needs them apart. `sourcePath` is the one that means something.
-      id: `${set.moduleFilePath}?${set.patchPath.join("/")}-${index}`,
-      /**
-       * Where the change was, as a real source path.
-       *
-       * Built with `patchPathToModulePath`, which is the only thing that knows
-       * the grammar — string keys are JSON-quoted, array indices are bare — so
-       * `["items", "0", "title"]` becomes `"items".0."title"` and not something
-       * that looks close enough to work and then does not resolve.
-       */
-      sourcePath: Internal.joinModuleFilePathAndModulePath(
-        set.moduleFilePath,
-        Internal.patchPathToModulePath(set.patchPath),
-      ),
-      title: [fileLabel(set.moduleFilePath), ...set.patchPath].join(" › "),
-      // Relative, because this is a "what have I been doing" list and an ISO
-      // timestamp is not an answer to that. It was rendered raw.
-      timestamp: formatRelativeTime(set.lastUpdated, now),
-      author: set.lastUpdatedBy ?? undefined,
+  const changes = patchSets.slice(0, ACTIVITY_LIMIT).map(
+    (set, index): Dated<ShellActivityEntry> => ({
+      at: timeOf(set.lastUpdated),
+      entry: {
+        kind: "change",
+        // The index is load-bearing: two patch sets can share a module and a
+        // path, and React needs them apart. `sourcePath` is the one that means
+        // something.
+        id: `${set.moduleFilePath}?${set.patchPath.join("/")}-${index}`,
+        /**
+         * Where the change was, as a real source path.
+         *
+         * Built with `patchPathToModulePath`, which is the only thing that knows
+         * the grammar — string keys are JSON-quoted, array indices are bare — so
+         * `["items", "0", "title"]` becomes `"items".0."title"` and not something
+         * that looks close enough to work and then does not resolve.
+         */
+        sourcePath: Internal.joinModuleFilePathAndModulePath(
+          set.moduleFilePath,
+          Internal.patchPathToModulePath(set.patchPath),
+        ),
+        title: [fileLabel(set.moduleFilePath), ...set.patchPath].join(" › "),
+        // Relative, because this is a "what have I been doing" list and an ISO
+        // timestamp is not an answer to that. It was rendered raw.
+        timestamp: formatRelativeTime(set.lastUpdated, now),
+        author: set.lastUpdatedBy ?? undefined,
+      },
     }),
   );
+  const deploys = deployments.slice(0, DEPLOY_ACTIVITY_LIMIT).map(
+    (deployment): Dated<ShellActivityEntry> => ({
+      at: timeOf(deployment.updatedAt),
+      entry: toDeployActivity(deployment),
+    }),
+  );
+  return (
+    [...changes, ...deploys]
+      // Newest first. A stable sort, so patch sets that share a timestamp stay
+      // in the order the store gave them — which is the order they happened in.
+      .sort((a, b) => b.at - a.at)
+      .slice(0, ACTIVITY_LIMIT)
+      .map(({ entry }) => entry)
+  );
+}
+
+/** An entry with the instant it is sorted by, which the entry itself has lost. */
+type Dated<T> = { at: number; entry: T };
+
+/**
+ * An ISO timestamp as milliseconds, for sorting only.
+ *
+ * An unreadable one sorts oldest rather than throwing the whole feed off: `NaN`
+ * makes every comparison false, which leaves the sort's output unspecified.
+ */
+function timeOf(iso: string): number {
+  const at = new Date(iso).getTime();
+  return Number.isNaN(at) ? 0 : at;
+}
+
+/** One publish, as an activity row. */
+function toDeployActivity(deployment: ShellDeployment): ShellDeployActivity {
+  return {
+    kind: "deploy",
+    // Prefixed, because a commit sha and a patch set id share one list now.
+    id: `deploy-${deployment.commitSha}`,
+    // The commit message when there is one. Without it there is nothing to say
+    // about the publish but which commit it was, and the short sha is what the
+    // deploy feed shows for the same publish.
+    title: deployment.message ?? deployment.commitSha.slice(0, 7),
+    state: describeDeploymentState(deployment),
+    progress: deploymentProgress(deployment),
+    timestamp: deployment.timestamp,
+    author: deployment.author,
+  };
 }
 
 /** How many publishes the deployment feed keeps. */

--- a/packages/ui/spa/components/shell/shellDataMapping.ts
+++ b/packages/ui/spa/components/shell/shellDataMapping.ts
@@ -2,7 +2,10 @@ import { Internal, ModuleFilePath, SourcePath } from "@valbuild/core";
 import { ExplorerItem, SitemapItem } from "../NavMenu/types";
 import { AvailableRoute } from "../NavMenu/NewPageForm";
 import { routePatternToString } from "../NavMenu/SitemapItem";
-import { ValEnrichedDeployment } from "../../utils/mergeCommitsAndDeployments";
+import {
+  commitSubject,
+  ValEnrichedDeployment,
+} from "../../utils/mergeCommitsAndDeployments";
 import { deploymentProgress, describeDeploymentState } from "./Deployments";
 import {
   ShellActivityEntry,
@@ -300,7 +303,7 @@ export function toDeployments(
     (deployment): ShellDeployment => ({
       commitSha: deployment.commitSha,
       state: deployment.deploymentState,
-      message: deployment.commitMessage,
+      message: commitSubject(deployment.commitMessage),
       author: deployment.creator
         ? profilesByAuthorId[deployment.creator]?.fullName
         : undefined,

--- a/packages/ui/spa/components/shell/stories/Shell.stories.tsx
+++ b/packages/ui/spa/components/shell/stories/Shell.stories.tsx
@@ -146,6 +146,14 @@ type HarnessProps = {
   openPanel: ShellPanel | null;
   selectionId: string | null;
   empty: boolean;
+  /**
+   * Nothing queued, without emptying the project.
+   *
+   * Its own control because "no pending changes" and "a project with nothing
+   * in it" are different stories, and Review is the affordance that has to be
+   * there in both — see `ReviewButton`.
+   */
+  noPendingChanges: boolean;
   withoutRouters: boolean;
   searchOpen: boolean;
   aiEnabled: boolean;
@@ -243,6 +251,7 @@ function ShellHarness({
   openPanel,
   selectionId,
   empty,
+  noPendingChanges,
   withoutRouters,
   aiEnabled,
   searchOpen,
@@ -286,7 +295,7 @@ function ShellHarness({
   return (
     <Shell
       renderSettings={() => <MockSettingsSections />}
-      key={`${openPanel}-${selectionId}-${empty}-${withoutRouters}-${aiEnabled}-${searchOpen}-${isLoading}-${loadError}-${mode}-${deployments}-${deploymentsOpen}-${canvasOpen}-${canvasView}-${canvasReported}`}
+      key={`${openPanel}-${selectionId}-${empty}-${noPendingChanges}-${withoutRouters}-${aiEnabled}-${searchOpen}-${isLoading}-${loadError}-${mode}-${deployments}-${deploymentsOpen}-${canvasOpen}-${canvasView}-${canvasReported}`}
       data={data}
       initialPanel={openPanel}
       initialSelectionId={selectionId}
@@ -294,7 +303,15 @@ function ShellHarness({
       aiEnabled={aiEnabled}
       theme={currentTheme}
       onThemeChange={setCurrentTheme}
-      pendingChanges={empty ? 0 : 12}
+      pendingChanges={empty || noPendingChanges ? 0 : 12}
+      /*
+       * The review view, which every story has and none of them used to.
+       *
+       * Without `onCompare` the top bar renders no Review button at all, so
+       * the one control in the bar that answers "is anything of mine still
+       * unpublished?" could not be seen in Storybook - in either state.
+       */
+      onCompare={() => console.log("open the review view")}
       publishState={publishState}
       saveState={saveState}
       mode={mode}
@@ -364,6 +381,7 @@ export const Default: Story = {
     openPanel: null,
     selectionId: null,
     empty: false,
+    noPendingChanges: false,
     withoutRouters: false,
     searchOpen: false,
     aiEnabled: true,
@@ -380,6 +398,24 @@ export const Default: Story = {
     simulatePublish: false,
     canvasOpen: false,
     canvasView: "normal",
+  },
+};
+
+/**
+ * Nothing queued, in a project that is otherwise full.
+ *
+ * Review is in the bar all the same. It used to be `invisible` here - in the
+ * layout so the bar would not reflow, but unreachable by pointer, keyboard or
+ * screen reader - which made "is anything of mine still unpublished?"
+ * unanswerable from the bar: a hidden button and a button whose data has not
+ * loaded are the same picture. Publish is disabled, which is the difference
+ * between the two controls: one ships work, the other looks at it.
+ */
+export const NothingPendingToReview: Story = {
+  args: {
+    ...Default.args,
+    selectionId: mockSelectionIds.home,
+    noPendingChanges: true,
   },
 };
 

--- a/packages/ui/spa/components/shell/topBarActionOrder.test.tsx
+++ b/packages/ui/spa/components/shell/topBarActionOrder.test.tsx
@@ -63,22 +63,19 @@ describe("Review, Preview, Publish", () => {
     ).toBe(true);
   });
 
-  test("the space Review holds is to the left of Preview too", () => {
-    // Nothing pending: the button is invisible but still in the layout, so the
-    // bar must not reflow when the first change lands. See `ReviewButton`.
-    render(topBar({ pendingChanges: 0, reviewCount: 0 }));
+  test("Review is offered with nothing pending, and still comes first", () => {
     /*
-     * By label, not by role, and this is the one query that works.
-     *
-     * With nothing pending the button carries `aria-hidden`, and the
-     * accessible NAME of an element hidden from the accessibility tree
-     * computes as the empty string — so
-     * `getByRole("button", { name: "Review changes", hidden: true })` matches
-     * nothing, `hidden: true` included: that option widens which elements are
-     * considered, not how their names are computed. `getByLabelText` reads the
-     * `aria-label` attribute itself, which is unaffected.
+     * It used to be `invisible` here - in the layout so the bar would not
+     * reflow, but unreachable and hidden from assistive tech, which made "is
+     * anything of mine still unpublished?" unanswerable from the bar. Queried
+     * by ROLE and NAME, which is what a keyboard or screen reader user gets:
+     * under the old behaviour this query matched nothing at all, `hidden: true`
+     * included, because the accessible name of an `aria-hidden` element
+     * computes as the empty string.
      */
-    const review = screen.getByLabelText("Review changes");
+    render(topBar({ pendingChanges: 0, reviewCount: 0 }));
+    const review = screen.getByRole("button", { name: "Review changes" });
+    expect(review.getAttribute("aria-hidden")).toBeNull();
     expect(
       precedes(review, screen.getByRole("button", { name: "Preview" })),
     ).toBe(true);

--- a/packages/ui/spa/components/shell/types.ts
+++ b/packages/ui/spa/components/shell/types.ts
@@ -157,7 +157,24 @@ export type ShellValidationError = {
   count: number;
 };
 
-export type ShellActivityEntry = {
+/**
+ * One row of Recent activity.
+ *
+ * Two kinds, because "what has been happening here?" has always had two halves
+ * and the panel only ever answered one of them. An edit somebody made is
+ * something to go back to; a publish is something that happened to the site.
+ * Publishes were visible only in the status bar's deploy feed, which is a
+ * live-progress indicator that empties itself as builds land — so the moment a
+ * publish finished there was nowhere in the Studio that said it had.
+ *
+ * Both carry `title` and `timestamp` so the list can be rendered in one pass;
+ * everything that differs is behind `kind`.
+ */
+export type ShellActivityEntry = ShellChangeActivity | ShellDeployActivity;
+
+/** An unpublished edit, from the patch sets. */
+export type ShellChangeActivity = {
+  kind: "change";
   /**
    * A React key, not a target: two patch sets can share a module and a path, so
    * this carries an index to keep them apart. Use `sourcePath` to go anywhere.
@@ -170,6 +187,40 @@ export type ShellActivityEntry = {
   timestamp: string;
   author?: string;
 };
+
+/**
+ * A publish, from the deploy feed.
+ *
+ * Not selectable — there is nothing in the Studio a commit opens — so unlike a
+ * change row this carries no `sourcePath` and the panel renders it as a line
+ * rather than a button. What it does carry is the state, because a publish that
+ * is still building and one that failed are the two things worth reading here.
+ */
+export type ShellDeployActivity = {
+  kind: "deploy";
+  /** The commit sha, prefixed: it is unique per publish. */
+  id: string;
+  /** The commit message, or the short sha when there is none. */
+  title: string;
+  /** What happened to it, e.g. "Live", "Building", "Build failed". */
+  state: string;
+  /**
+   * The state as the row's icon reads it.
+   *
+   * `state` is the sentence and this is the shape: the same three cases the
+   * deploy feed's rows use, so a publish looks the same in both places.
+   */
+  progress: DeploymentProgress;
+  /** Already relative, e.g. "2 minutes ago". */
+  timestamp: string;
+  author?: string;
+};
+
+/**
+ * How a publish is doing, reduced to the three states anything rendering one
+ * cares about. See `deploymentProgress`.
+ */
+export type DeploymentProgress = "building" | "failed" | "settled";
 
 /**
  * A destination: what the left rail switches between.
@@ -261,7 +312,12 @@ export type ShellData = {
    * surface while the bell stays hidden until something populates it.
    */
   notifications?: ShellNotification[];
-  /** Derived from patch sets. Absent while they are still loading. */
+  /**
+   * The edits and the publishes, newest first. See `toActivity`.
+   *
+   * Built from whichever half has arrived: the patch sets and the deploy feed
+   * load separately, and a list that waits for both hides the one it has.
+   */
   activity?: ShellActivityEntry[];
   validationErrors: ShellValidationError[];
   /** Absent until a profile has loaded, and in modes that have none. */

--- a/packages/ui/spa/components/shell/useShellData.ts
+++ b/packages/ui/spa/components/shell/useShellData.ts
@@ -148,10 +148,22 @@ export function useShellData(): ShellDataState {
           ? toDataModules(navData.explorer, modulesWithDrafts)
           : [],
         validationErrors: toValidationErrors(validationErrors),
-        activity:
-          patchSets.status === "success"
-            ? toActivity(patchSets.data, Date.now())
-            : undefined,
+        /*
+         * The publishes ride along: this list is "what has been happening",
+         * and a publish is the other half of that. See `toActivity`.
+         *
+         * Built from whatever is known, rather than only once the PATCH SETS
+         * are. The two halves load separately - patch sets come off a worker
+         * that has to group them, publishes off the stat feed - so gating the
+         * whole list on the first one hid every publish while that worker was
+         * still grouping, and for good if it failed. An empty change list is
+         * the honest input in that state, not a reason to say nothing.
+         */
+        activity: toActivity(
+          patchSets.status === "success" ? patchSets.data : [],
+          shellDeployments,
+          Date.now(),
+        ),
         pendingChanges: currentPatchIds.length - committedPatchIds.size,
         deployments: shellDeployments,
         user: profile

--- a/packages/ui/spa/hooks/useStatus.ts
+++ b/packages/ui/spa/hooks/useStatus.ts
@@ -543,6 +543,11 @@ async function execStat(
                           deploymentState: message.deployment.deploymentState,
                           createdAt: message.deployment.createdAt,
                           updatedAt: message.deployment.updatedAt,
+                          // The git message, where the content service sends
+                          // one. Copied field by field here, so leaving it out
+                          // dropped it as surely as the schema stripping it
+                          // would have. See `ValDeployment`.
+                          commitMessage: message.deployment.commitMessage,
                         }),
                       },
                       waitStart:

--- a/packages/ui/spa/utils/mergeCommitsAndDeployments.test.ts
+++ b/packages/ui/spa/utils/mergeCommitsAndDeployments.test.ts
@@ -228,4 +228,156 @@ describe("mergeCommitsAndDeployments", () => {
         .deploymentState,
     ).toBe("success");
   });
+
+  /**
+   * A deployment nobody published from Val: a developer's push, a merged pull
+   * request, a revert. There is no `ValCommit` for it, so the git message can
+   * only come off the deployment - and without it the feed could name the
+   * publish by nothing but its short sha.
+   */
+  it("takes the git message off a deployment that has no Val commit", () => {
+    const result = mergeCommitsAndDeployments(
+      [],
+      [],
+      [
+        {
+          commitSha: "abc123",
+          deploymentId: "deployment-abc123",
+          deploymentState: "success",
+          commitMessage: "Bump the dependency",
+          createdAt: "2023-01-01T00:00:00Z",
+          updatedAt: "2023-01-01T01:00:00Z",
+        },
+      ],
+    );
+    expect(result[0].commitMessage).toBe("Bump the dependency");
+  });
+
+  it("prefers Val's own commit message over the host's", () => {
+    // Val wrote that one, and it is known before any build is reported. The
+    // two describe the same immutable commit either way.
+    const result = mergeCommitsAndDeployments(
+      [],
+      [
+        {
+          commitSha: "abc123",
+          clientCommitSha: "client-abc123",
+          parentCommitSha: "parent-abc123",
+          branch: "main",
+          commitMessage: "Update hero copy",
+          creator: "user1",
+          createdAt: "2023-01-01T00:00:00Z",
+        },
+      ],
+      [
+        {
+          commitSha: "abc123",
+          deploymentId: "deployment-abc123",
+          deploymentState: "success",
+          commitMessage: "val: update hero copy [skip ci]",
+          createdAt: "2023-01-01T00:00:00Z",
+          updatedAt: "2023-01-01T01:00:00Z",
+        },
+      ],
+    );
+    expect(result[0].commitMessage).toBe("Update hero copy");
+  });
+
+  it("survives a content service that reports no messages at all", () => {
+    // The field is optional as well as nullable: absent is an older service,
+    // null is one that has no message for this commit. Both are the short sha.
+    const result = mergeCommitsAndDeployments(
+      [],
+      [],
+      [
+        {
+          commitSha: "abc123",
+          deploymentId: "deployment-abc123",
+          deploymentState: "pending",
+          createdAt: "2023-01-01T00:00:00Z",
+          updatedAt: "2023-01-01T01:00:00Z",
+        },
+        {
+          commitSha: "def456",
+          deploymentId: "deployment-def456",
+          deploymentState: "pending",
+          commitMessage: null,
+          createdAt: "2023-01-01T00:00:00Z",
+          updatedAt: "2023-01-01T00:30:00Z",
+        },
+      ],
+    );
+    expect(result.map((d) => d.commitMessage)).toEqual([null, null]);
+  });
+
+  /**
+   * The deployment side of a commit can arrive FIRST - the socket delivers
+   * whatever happens first, and a build often starts before this client has
+   * fetched the commit that triggered it. The row is then already there when
+   * Val's own commit turns up, and skipping it outright (which is what this
+   * loop used to do) left a publish of Val's own named by whatever the host
+   * had said about the commit, for the whole life of the tab.
+   */
+  it("lets Val's commit message replace a host message already held", () => {
+    const prev: ValEnrichedDeployment[] = [
+      {
+        commitSha: "abc123",
+        deploymentState: "pending",
+        commitMessage: "val: update hero copy [skip ci]",
+        creator: null,
+        createdAt: "2023-01-01T00:00:00Z",
+        updatedAt: "2023-01-01T00:30:00Z",
+      },
+    ];
+    const result = mergeCommitsAndDeployments(
+      prev,
+      [
+        {
+          commitSha: "abc123",
+          clientCommitSha: "client-abc123",
+          parentCommitSha: "parent-abc123",
+          branch: "main",
+          commitMessage: "Update hero copy",
+          creator: "user1",
+          createdAt: "2023-01-01T00:00:00Z",
+        },
+      ],
+      [],
+    );
+    expect(result[0].commitMessage).toBe("Update hero copy");
+    // And the author, which a deployment-only row never has.
+    expect(result[0].creator).toBe("user1");
+    // What the HOST reports is still the host's: the build state and the time
+    // it last moved are not Val's to overwrite.
+    expect(result[0].deploymentState).toBe("pending");
+    expect(result[0].updatedAt).toBe("2023-01-01T00:30:00Z");
+  });
+
+  it("keeps the host's message when Val's commit has none", () => {
+    const result = mergeCommitsAndDeployments(
+      [
+        {
+          commitSha: "abc123",
+          deploymentState: "success",
+          commitMessage: "Bump the dependency",
+          creator: null,
+          createdAt: "2023-01-01T00:00:00Z",
+          updatedAt: "2023-01-01T00:30:00Z",
+        },
+      ],
+      [
+        {
+          commitSha: "abc123",
+          clientCommitSha: "client-abc123",
+          parentCommitSha: "parent-abc123",
+          branch: "main",
+          commitMessage: null,
+          creator: "user1",
+          createdAt: "2023-01-01T00:00:00Z",
+        },
+      ],
+      [],
+    );
+    expect(result[0].commitMessage).toBe("Bump the dependency");
+  });
 });

--- a/packages/ui/spa/utils/mergeCommitsAndDeployments.ts
+++ b/packages/ui/spa/utils/mergeCommitsAndDeployments.ts
@@ -3,6 +3,13 @@ import { ValCommit, ValDeployment } from "@valbuild/shared/internal";
 /**
  * We merge Val commits (which are created by Val and immutable) and
  * deployments which basically comes from GitHub.
+ *
+ * A deployment can arrive with no Val commit behind it at all — a developer's
+ * push, a merged pull request, a revert — and those are the majority on most
+ * projects. Their message therefore has to come off the deployment itself; see
+ * `ValDeployment.commitMessage`. Val's own commit wins where there is one: it
+ * is the message Val wrote, and it is known before any host has reported a
+ * build.
  */
 export type ValEnrichedDeployment = {
   deploymentState: "pending" | "success" | "failure" | "error" | "created";
@@ -25,7 +32,8 @@ export function mergeCommitsAndDeployments(
   }
   for (const commit of commits) {
     // Assumes commits (of a given commit sha) are immutable so if we already found something for this commit sha, we don't need to add it again
-    if (!deploymentsByCommitSha[commit.commitSha]) {
+    const existing = deploymentsByCommitSha[commit.commitSha];
+    if (!existing) {
       deploymentsByCommitSha[commit.commitSha] = {
         commitMessage: commit?.commitMessage || null,
         deploymentState: "created",
@@ -34,7 +42,26 @@ export function mergeCommitsAndDeployments(
         updatedAt: commit.createdAt,
         commitSha: commit.commitSha,
       };
+      continue;
     }
+    /**
+     * Something is already here, and it came from the HOST: the same commit
+     * seen from the deployment side, which can arrive first - the socket
+     * delivers whatever happens first, and a build often starts before this
+     * client has fetched the commit that triggered it.
+     *
+     * Its build state and its timestamps are the host's to report and are left
+     * alone. The message and the author are not: this is the commit Val wrote,
+     * so they win here - which is the precedence claimed above and everywhere
+     * else in this file. Skipping the row outright, as this used to, left a
+     * publish of Val's own named by whatever the host had said about the
+     * commit, for the whole life of the tab.
+     */
+    deploymentsByCommitSha[commit.commitSha] = {
+      ...existing,
+      commitMessage: commit.commitMessage || existing.commitMessage,
+      creator: commit.creator || existing.creator,
+    };
   }
   /**
    * Oldest first, so the newest state for a commit is the one that survives.
@@ -52,8 +79,13 @@ export function mergeCommitsAndDeployments(
     // NOTE: we ignore the deployments without commit sha - this is a new property, in the future they should all have it. We can't really do much useful stuff without knowing the commit?
     if (deployment.commitSha) {
       deploymentsByCommitSha[deployment.commitSha] = {
+        // What we already know first — a Val commit's own message, or a message
+        // an earlier row for this sha carried — then the host's. A commit sha
+        // is immutable, so these cannot be messages for different things.
         commitMessage:
-          deploymentsByCommitSha[deployment.commitSha]?.commitMessage || null,
+          deploymentsByCommitSha[deployment.commitSha]?.commitMessage ||
+          deployment.commitMessage ||
+          null,
         deploymentState:
           deployment.deploymentState as ValEnrichedDeployment["deploymentState"],
         creator: deploymentsByCommitSha[deployment.commitSha]?.creator || null,
@@ -69,4 +101,22 @@ export function mergeCommitsAndDeployments(
   return Object.values(deploymentsByCommitSha).sort((a, b) => {
     return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
   });
+}
+
+/**
+ * The first line of a commit message, which is the whole of what a row shows.
+ *
+ * Val writes single-line messages, so this did nothing until deployments Val
+ * did NOT publish started arriving with their own messages — a push, a merged
+ * pull request — and a git message is a subject, a blank line and a body. The
+ * rows truncate, so the body was rendered as one long line with the subject
+ * lost somewhere at the front of it.
+ *
+ * A message that is only whitespace is no message: `null`, which is what makes
+ * the row fall back to the short sha rather than showing an empty title.
+ */
+export function commitSubject(message: string | null): string | null {
+  if (message === null) return null;
+  const subject = message.split("\n", 1)[0].trim();
+  return subject === "" ? null : subject;
 }


### PR DESCRIPTION
**Stack: 4 of 6.** Base is [#648](https://github.com/valbuild/val/pull/648) — review the last commit only.

The deploy feed took a publish's message from Val's own `ValCommit`, so it could only name the publishes Val made. Every other deployment — a developer's push, a merged pull request, a revert — reached the feed with `commitMessage: null` and rendered as a seven-character sha. Those are the majority on most projects, so "what went out at 14:02?" had no answer inside the Studio.

`ValDeployment` now carries an optional, nullable `commitMessage`, and `mergeCommitsAndDeployments` falls back to it. Val's own commit still wins where there is one — it is the message Val wrote, known before any build is reported — and a commit sha is immutable, so the two cannot be describing different things.

Optional **and** nullable is deliberate: absent is a content service that does not report messages, null is one that has none for this commit. Both render as the short sha, so nothing has to tell them apart, but a required field would reject the whole deployment feed of a service that does not send it.

### Where the field had to be added

Three places, because each of them rebuilds the deployment field by field and would have dropped it as surely as a schema stripping it: the `/patches` response in `ValOpsHttp`, the socket handler in `useStatus`, and the merge itself.

`deployments` is also declared on the `/stat` contract at last. `getStat` has always returned them in http mode and the Studio has always read them — the response validator strips unknown keys rather than rejecting them, and the raw json is what the client hands back — so they arrived while the contract said they could not. Survivable until one of them carries a message: a field nobody has declared is a field the next person deletes.

### Also: rows show the subject line

`truncate` collapses newlines into spaces, so a git message with a body arrived as one long line with the subject lost at the front of it. `commitSubject` is shared by the shell's feed and the classic Draft changes row, whose tooltip still holds the whole message.

**Note for the content service:** this is the client half. A deployment shows a git message only once the content service includes one on its deployment rows — until then these publishes keep showing the short sha, exactly as they do today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rsb27g1N8ibmWL1iRkdUtc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rsb27g1N8ibmWL1iRkdUtc)_