### PR TITLE
Drop the deploy list's dismiss buttons, and bound the feed instead

### DIFF
--- a/.changeset/activity-shows-publishes.md
+++ b/.changeset/activity-shows-publishes.md
@@ -1,0 +1,23 @@
+---
+"@valbuild/ui": patch
+---
+
+Recent activity now shows publishes, not just edits
+
+The Studio's Recent activity list only ever showed unpublished edits. Publishes
+lived in the status bar's deploy feed, which is a live-progress indicator — it
+closes itself once a build lands, and rows can be dismissed — so as soon as a
+publish had finished, nothing in the Studio said it had.
+
+Publishes are now rows in the same list, interleaved with the edits by time, so
+the panel reads as what happened here: you changed the hero, it went out, a
+colleague changed the pricing. A publish row carries the commit message (or the
+short sha when there is none), who published it, and how the build is doing —
+with the same labels and the same spinner/warning icons the deploy feed uses, so
+one publish never reads two ways in two places.
+
+Edits stay clickable and open the field they changed; a publish is a commit and
+opens nothing, so it renders as a line rather than a button. Publishes take at
+most three of the eight rows: an afternoon of publishing must not push out the
+edits the panel exists to get you back to, and the full feed is still in the
+status bar.

--- a/.changeset/all-changes-saved.md
+++ b/.changeset/all-changes-saved.md
@@ -1,0 +1,14 @@
+---
+"@valbuild/ui": patch
+---
+
+"All changes saved", not "All changes saved locally"
+
+The status bar's resting state claimed changes were saved _locally_, at every
+breakpoint and in both modes. Against a project that is wrong: the patch is on
+the content service, which is where it has to be for a colleague to see it and
+for Publish to ship it. "Locally" reads as "still only on this machine" — the
+one thing an editor would want to know, said backwards.
+
+It is not worth saying in local dev either, where the bar already shows "Dev
+mode" and the branch a couple of items to the left.

--- a/.changeset/canvas-preview-notice.md
+++ b/.changeset/canvas-preview-notice.md
@@ -1,0 +1,24 @@
+---
+"@valbuild/ui": patch
+---
+
+The canvas no longer covers the page to say preview mode is off
+
+Whenever the canvas could not do its job, a panel with a blurred backdrop
+covered the whole frame. That stopped the canvas being a canvas: the published
+page underneath is real and worth reading and scrolling, and none of it was
+reachable behind an explanation of why it could not be _edited_. And because
+the panel also appeared during ordinary slowness — a first `next dev` compile of
+a route, the enable redirect in flight — the normal path to a working canvas ran
+through a screen that looked like a failure.
+
+It is a small pill at the top of the canvas viewport now, with the page
+untouched behind it. For the first twenty seconds it shows a spinner and says
+only that the preview is not ready yet; after that it turns into a warning, with
+warning colours, and names what is actually wrong — "Preview mode is off" or "No
+answer from the page".
+
+"Turn on preview mode" is on the pill itself, as soon as there is something to
+turn on — it is the one thing most people here need, and it is one click. The
+explanation, "Reload" and the developer's setup checklist are behind a "Details"
+disclosure, so nobody has to read a wiring guide to look at their page.

--- a/.changeset/deploy-feed-last-few.md
+++ b/.changeset/deploy-feed-last-few.md
@@ -1,0 +1,24 @@
+---
+"@valbuild/ui": patch
+---
+
+The deploy feed is the last few publishes, with no rows to dismiss
+
+Every row in the deploy list carried a dismiss button, and the shell and the
+provider each kept a set of dismissed commits to subtract from the feed. That
+control existed because the list grew: the client accumulated every deployment
+and commit a session had ever seen, so a tab left open all day ended up with a
+list only clearing could shorten.
+
+The feed is bounded now — the content service returns the most recent publishes,
+and the client keeps the newest few of those — so there is nothing to tidy: what
+a row would be dismissed for is that it is old, and being old is what takes it
+off the end of the list on its own. The list still closes on its own once
+everything has landed, on Escape, and on a click outside.
+
+One behaviour follows from the feed carrying history: the list no longer opens
+itself for an old publish. It used to treat anything Val had not seen serving
+the site as news, which was true when the feed only held the publishes on the
+current chain — now that it holds the last few, "not live" is the resting state
+of every publish that has been superseded, and opening Val would have announced
+a build from last week. Freshness decides it instead.

--- a/.changeset/deployment-git-message.md
+++ b/.changeset/deployment-git-message.md
@@ -1,0 +1,23 @@
+---
+"@valbuild/shared": patch
+"@valbuild/server": patch
+"@valbuild/ui": patch
+---
+
+Show the git message on deployments Val did not publish
+
+The deploy feed could only name a publish when Val itself had made the commit:
+the message came off Val's own `ValCommit`, and every other deployment — a
+developer's push, a merged pull request, a revert — showed a seven-character
+sha. On most projects those are the majority, so "what went out at 14:02?" had
+no answer in the Studio.
+
+A deployment can now carry its own `commitMessage`, which the Studio uses
+wherever there is no Val commit to prefer. It is optional and nullable, so a
+content service that does not report messages is unaffected — those publishes
+keep showing the short sha, exactly as before.
+
+Deployment rows also show only the subject line of a message now. A git message
+is a subject, a blank line and a body, and the rows are one truncated line — so
+a real push arrived as "Subject The body went on like this…". The classic
+Draft changes view still has the whole message in its tooltip.

--- a/.changeset/mobile-ai-button.md
+++ b/.changeset/mobile-ai-button.md
@@ -1,0 +1,16 @@
+---
+"@valbuild/ui": patch
+---
+
+Move the assistant button to the bottom bar on mobile
+
+On a phone the Sparkles button sat in the top right of the top bar, sharing
+that corner with the navigation menu, History, notifications and the account
+avatar — the furthest point on the screen from a thumb, and the row you reach
+for least.
+
+It is now in the sticky bottom bar, beside Quick actions, where Preview and
+Publish already are. The top bar drops its own button below the mobile
+breakpoint, so there is still exactly one way in rather than two places to look
+for the same panel. Nothing changes on tablet or desktop, and a project with no
+assistant configured shows no button in either place.

--- a/.changeset/review-always-shown.md
+++ b/.changeset/review-always-shown.md
@@ -1,0 +1,22 @@
+---
+"@valbuild/ui": patch
+---
+
+Review stays in the top bar with nothing pending, and says so
+
+Above the mobile breakpoint — a phone reaches Review through Quick actions, and
+still does — the Review button was hidden whenever nothing was pending: present
+in the layout so the bar would not reflow, but unreachable and invisible to
+screen readers. That made "is anything of mine still unpublished?" unanswerable from
+the top bar: a hidden button and a button whose data has not loaded yet look
+exactly the same, so the only way to find out was to publish and see what
+happened. The Quick actions row on a phone already answered it; the bar now
+does too.
+
+Opening it with nothing pending gives a real screen instead of the single grey
+"No pending changes." line: it says the editor and the published site agree, and
+what the view will show once they do not. The wording follows the mode, so a
+local dev project is told about its working tree rather than about publishing.
+
+The change count is still a badge that only appears when there is one, so an
+empty Review reads as "nothing pending" rather than as "0 changes".

--- a/packages/server/src/ValOpsHttp.ts
+++ b/packages/server/src/ValOpsHttp.ts
@@ -112,6 +112,10 @@ const GetApplicablePatches = z.object({
         deploymentState: z.string(),
         createdAt: z.string(),
         updatedAt: z.string(),
+        // The git message, where the content service knows it. See
+        // `ValDeployment`: this is the only source for a deployment that Val
+        // did not publish, and zod would otherwise strip it here.
+        commitMessage: z.string().nullable().optional(),
       }),
     )
     .optional(),
@@ -873,6 +877,7 @@ export class ValOpsHttp extends ValOps {
                 deploymentState: deployment.deploymentState,
                 createdAt: deployment.createdAt,
                 updatedAt: deployment.updatedAt,
+                commitMessage: deployment.commitMessage,
               });
             }
           }

--- a/packages/shared/src/internal/ApiRoutes.ts
+++ b/packages/shared/src/internal/ApiRoutes.ts
@@ -12,6 +12,7 @@ import {
 import { Patch, PatchId } from "./zod/Patch";
 import { SerializedSchema } from "./zod/SerializedSchema";
 import { ValCommit } from "./zod/ValCommit";
+import { ValDeployment } from "./zod/ValDeployment";
 import {
   HistoricalCommit,
   HistoricalModule,
@@ -630,6 +631,21 @@ export const Api = {
                */
               headCommitSha: z.string().optional(),
               commits: z.array(ValCommit),
+              /**
+               * The publishes the content service knows about.
+               *
+               * Declared, at last. `getStat` has always returned these in
+               * `http` mode and the Studio has always read them - the response
+               * validator strips unknown keys rather than rejecting them, and
+               * the raw json is what the client hands back, so they arrived
+               * while the contract said they could not. That was survivable
+               * until a deployment started carrying a commit MESSAGE: a field
+               * nobody has declared is a field the next person deletes.
+               *
+               * Optional, because a content service that reports no
+               * deployments sends none.
+               */
+              deployments: z.array(ValDeployment).optional(),
               config: ValConfig,
               profileId: z.string().nullable(),
               mode: z.union([z.literal("http"), z.literal("fs")]),

--- a/packages/shared/src/internal/zod/ValDeployment.ts
+++ b/packages/shared/src/internal/zod/ValDeployment.ts
@@ -6,6 +6,23 @@ export const ValDeployment = z.object({
   commitSha: z.string(),
   updatedAt: z.string(),
   createdAt: z.string(),
+  /**
+   * The commit message, as the deployment's host reported it.
+   *
+   * Val's OWN publishes carry their message on the commit (`ValCommit`), and
+   * that is the one the Studio prefers — it is the message Val wrote. This is
+   * for every OTHER deployment: a developer's push, a merged pull request, a
+   * revert. Those have no Val commit at all, so without this the deploy feed
+   * could only name them by their short sha, and "what went out at 14:02?" had
+   * no answer inside the Studio.
+   *
+   * Optional AND nullable, and the two mean different things: absent is a
+   * content service that does not report messages (or an older one), null is
+   * one that reports having none. Both render as the short sha, so nothing
+   * depends on telling them apart — but a schema that demanded the field would
+   * reject the whole deployment feed of a service that does not send it.
+   */
+  commitMessage: z.string().nullable().optional(),
 });
 
 export type ValDeployment = z.infer<typeof ValDeployment>;

--- a/packages/ui/spa/components/ComparePatchSets.stories.tsx
+++ b/packages/ui/spa/components/ComparePatchSets.stories.tsx
@@ -1220,6 +1220,14 @@ export const EverythingReverted: Story = {
   ),
 };
 
+/**
+ * Nothing pending, which is a screen someone reaches on purpose.
+ *
+ * Review is in the top bar whether or not anything is queued — a button that
+ * comes and goes cannot answer "is anything of mine still unpublished?" — so
+ * this is what it opens most of the time. It used to be one grey line reading
+ * "No pending changes.", which looks like a view that failed to load.
+ */
 export const NoChanges: Story = {
   render: () => (
     <StorySetup

--- a/packages/ui/spa/components/ComparePatchSets.tsx
+++ b/packages/ui/spa/components/ComparePatchSets.tsx
@@ -264,11 +264,7 @@ export function ComparePatchSets({
         </div>
       );
     }
-    return (
-      <div className="text-sm text-fg-secondary py-8 text-center">
-        No pending changes.
-      </div>
-    );
+    return <NothingToReview mode={mode} />;
   }
 
   const schemasData = schemas.status === "success" ? schemas.data : undefined;
@@ -692,6 +688,67 @@ function collectAuthorIds(rows: ChangeTreeNode[]): string[] {
     }
   }
   return ids;
+}
+
+/**
+ * The review view with nothing in it.
+ *
+ * Reachable deliberately now: Review is always in the top bar, whether or not
+ * anything is pending, because "is anything of mine still unpublished?" is a
+ * question that has to be answerable — and a button that comes and goes cannot
+ * answer it. So the empty case is a screen rather than the single grey line
+ * ("No pending changes.") it used to be, which read as a view that had failed
+ * to load rather than as an answer.
+ *
+ * It says what IS true — the editor and the published site agree — and what
+ * this view will show when it is not, because someone who came here on purpose
+ * came to find out what this screen is for.
+ */
+/**
+ * What "nothing pending" means, in the mode this Studio is actually in.
+ *
+ * `unknown` gets its own sentence rather than the `http` one. It is the state
+ * before the client has been told which mode it is in, and against a local dev
+ * project "matches what is published" is not merely vague - there is nothing
+ * published, and the sentence names a thing that does not exist. Saying only
+ * what is true in both modes costs a little precision for the second it lasts.
+ */
+function describeNothingPending(mode: "fs" | "http" | "unknown"): string {
+  switch (mode) {
+    case "fs":
+      return "Everything in the editor matches the content in your working tree. Nothing is waiting to be saved.";
+    case "http":
+      return "Everything in the editor matches what is published. Nothing is waiting to go out.";
+    case "unknown":
+      return "Nothing is waiting to go out: every change made here has already been saved.";
+  }
+}
+
+function NothingToReview({ mode }: { mode: "fs" | "http" | "unknown" }) {
+  return (
+    <div
+      className="mx-auto flex max-w-md min-w-0 flex-col items-center gap-4 px-6 py-16 text-center"
+      // A statement, not a status: this is the whole column, and a reader
+      // arriving by keyboard should be told what it says.
+      role="status"
+    >
+      <span className="grid h-10 w-10 place-items-center rounded-full bg-bg-secondary text-fg-secondary">
+        <Check size={18} aria-hidden />
+      </span>
+      <div className="space-y-1.5">
+        <h2 className="text-sm font-medium text-fg-primary">
+          No changes to review
+        </h2>
+        <p className="text-xs leading-relaxed text-fg-secondary">
+          {describeNothingPending(mode)}
+        </p>
+        <p className="text-xs leading-relaxed text-fg-secondary-alt">
+          Edit something and it shows up here, side by side with the value it
+          replaces, so you can check it before publishing.
+        </p>
+      </div>
+    </div>
+  );
 }
 
 /**

--- a/packages/ui/spa/components/DraftChanges.tsx
+++ b/packages/ui/spa/components/DraftChanges.tsx
@@ -63,7 +63,10 @@ import {
   SheetTrigger,
 } from "./designSystem/sheet";
 import * as RadixAccordion from "@radix-ui/react-accordion";
-import { ValEnrichedDeployment } from "../utils/mergeCommitsAndDeployments";
+import {
+  commitSubject,
+  ValEnrichedDeployment,
+} from "../utils/mergeCommitsAndDeployments";
 import {
   Tooltip,
   TooltipContent,
@@ -583,8 +586,14 @@ function Deployment({
         <Tooltip>
           <TooltipPortal container={portalContainer} />
           <TooltipTrigger>
+            {/*
+              The subject line only: this row is one truncated line, and
+              `truncate` collapses a git message's newlines into spaces - so a
+              message with a body arrived as "Subject The body went on like
+              this…". The tooltip below still has the whole of it.
+            */}
             <div className="max-w-[180px] overflow-clip font-light truncate">
-              {deployment.commitMessage}
+              {commitSubject(deployment.commitMessage)}
             </div>
           </TooltipTrigger>
           <TooltipContent className="max-w-[320px]">

--- a/packages/ui/spa/components/DraftChanges.tsx
+++ b/packages/ui/spa/components/DraftChanges.tsx
@@ -28,7 +28,6 @@ import { Checkbox } from "./designSystem/checkbox";
 import classNames from "classnames";
 import {
   Bell,
-  Check,
   ChevronDown,
   Download,
   Loader2,
@@ -92,8 +91,7 @@ export function DraftChanges({ className }: { className?: string }) {
     }
     return count;
   }, [allValidationErrors]);
-  const { deployments, dismissDeployment, observedCommitShas } =
-    useDeployments();
+  const { deployments, observedCommitShas } = useDeployments();
   const { deletePatches } = useDeletePatches();
   const { patchErrors } = useAllPatchErrors();
 
@@ -104,7 +102,6 @@ export function DraftChanges({ className }: { className?: string }) {
           <Deployments
             deployments={deployments}
             observedCommitShas={observedCommitShas}
-            onDismiss={dismissDeployment}
           />
         </div>
       )}
@@ -513,24 +510,34 @@ export function TransientErrorsList({
   );
 }
 
+/**
+ * The publishes still on their way out, in the classic layout.
+ *
+ * In flight only, which is what the spinner in its header has always claimed.
+ * It used to list whatever the deploy feed held and clear rows as they landed:
+ * a five-second `setTimeout` per observed commit, dismissing it from the shared
+ * feed. That was already a leak - no cleanup, and it re-armed on every render -
+ * and it stopped being possible when the feed became the last N publishes
+ * rather than a list to be emptied. A publish leaves this block when Val sees
+ * the site answering with its commit, which is the same moment the timer was
+ * approximating.
+ *
+ * Note this whole layout is unrendered today: the shell replaced it, and only
+ * `TransientErrorsList` is still imported out of this file.
+ */
 function Deployments({
   deployments,
   observedCommitShas,
-  onDismiss,
 }: {
   deployments: ValEnrichedDeployment[];
   observedCommitShas: Set<string>;
-  onDismiss: (commitSha: string) => void;
 }) {
-  useEffect(() => {
-    for (const deployment of deployments) {
-      if (observedCommitShas.has(deployment.commitSha)) {
-        setTimeout(() => {
-          onDismiss(deployment.commitSha);
-        }, 5000);
-      }
-    }
-  }, [deployments, observedCommitShas]);
+  const inFlight = deployments.filter(
+    (deployment) => !observedCommitShas.has(deployment.commitSha),
+  );
+  if (inFlight.length === 0) {
+    return null;
+  }
   return (
     <div>
       <div className="flex justify-between items-center p-2 font-bold">
@@ -538,21 +545,14 @@ function Deployments({
         <Loader2 size={16} className="inline animate-spin" />
       </div>
       <div>
-        {[...deployments]
+        {[...inFlight]
           .sort(
             (a, b) =>
               new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
           )
           .map((deployment) => {
             return (
-              <Deployment
-                key={deployment.commitSha}
-                deployment={deployment}
-                isFinished={observedCommitShas.has(deployment.commitSha)}
-                onDismiss={() => {
-                  onDismiss(deployment.commitSha);
-                }}
-              />
+              <Deployment key={deployment.commitSha} deployment={deployment} />
             );
           })}
       </div>
@@ -560,15 +560,7 @@ function Deployments({
   );
 }
 
-function Deployment({
-  deployment,
-  isFinished,
-  onDismiss,
-}: {
-  deployment: ValEnrichedDeployment;
-  isFinished: boolean;
-  onDismiss: () => void;
-}) {
+function Deployment({ deployment }: { deployment: ValEnrichedDeployment }) {
   const profilesById = useProfilesByAuthorId();
   const portalContainer = useValPortal();
   const author = deployment.creator && profilesById[deployment.creator];
@@ -603,21 +595,7 @@ function Deployment({
           </TooltipContent>
         </Tooltip>
       </div>
-      {isFinished && (
-        <div className="flex gap-2 items-start">
-          <span className="text-xs font-light text-fg-quaternary">
-            Deployed
-          </span>
-          <button
-            onClick={() => {
-              onDismiss();
-            }}
-          >
-            <Check size={14} />
-          </button>
-        </div>
-      )}
-      {!isFinished && <TimeSpent since={new Date(deployment.createdAt)} />}
+      <TimeSpent since={new Date(deployment.createdAt)} />
     </div>
   );
 }

--- a/packages/ui/spa/components/ValProvider.tsx
+++ b/packages/ui/spa/components/ValProvider.tsx
@@ -146,7 +146,6 @@ type ValContextValue = {
   authenticationState: AuthenticationState;
   profiles: Record<AuthorId, Profile>;
   deployments: ValEnrichedDeployment[];
-  dismissDeployment: (deploymentId: string) => void;
   observedCommitShas: Set<string>;
   remoteFiles:
     | {
@@ -557,7 +556,6 @@ export function ValProvider({
   }, [system, statProfileId]);
 
   const [deployments, setDeployments] = useState<ValEnrichedDeployment[]>([]);
-  const dismissedDeploymentsRef = useRef<Set<string>>(new Set());
   /**
    * What is worth re-merging for, as a value rather than a reference.
    *
@@ -601,18 +599,12 @@ export function ValProvider({
             prev,
             stat.data?.commits || [],
             stat.data?.deployments || [],
-          ).filter((d) => !dismissedDeploymentsRef.current.has(d.commitSha));
+          );
         }
         return prev;
       });
     }
   }, [deploymentsFingerprint, commitsFingerprint]);
-  const dismissDeployment = useCallback((commitSha: string) => {
-    setDeployments((prev) => {
-      return prev.filter((d) => d.commitSha !== commitSha);
-    });
-    dismissedDeploymentsRef.current.add(commitSha);
-  }, []);
   const [observedCommitShas, setObservedCommitShas] = useState<Set<string>>(
     new Set(),
   );
@@ -803,7 +795,6 @@ export function ValProvider({
         baseSha,
         observedCommitShas,
         deployments,
-        dismissDeployment,
         authenticationState,
         config: runtimeConfig,
         profiles:
@@ -1226,9 +1217,8 @@ export function useAIModelSelection(): {
 }
 
 export function useDeployments() {
-  const { deployments, dismissDeployment, observedCommitShas } =
-    useContext(ValContext);
-  return { deployments, dismissDeployment, observedCommitShas };
+  const { deployments, observedCommitShas } = useContext(ValContext);
+  return { deployments, observedCommitShas };
 }
 
 /**
@@ -1519,10 +1509,9 @@ export function useCommittedPatches(): ReadonlySet<PatchId> {
  *
  * The deploy line is drawn over patches that shipped in a specific commit, and
  * that commit is the one thing they can be labelled with honestly. Reading the
- * newest entry of the deployment feed instead is wrong in three ways at once: the
- * feed is filtered by `dismissDeployment`, it can lag a commit the chain already
- * knows about, and two undeployed commits would both be described by whichever
- * one happened to be first.
+ * newest entry of the deployment feed instead is wrong in two ways at once: it
+ * can lag a commit the chain already knows about, and two undeployed commits
+ * would both be described by whichever one happened to be first.
  */
 export function useDeployingCommitShas(): string[] {
   const val = useValSystem();

--- a/packages/ui/spa/components/ValProvider.tsx
+++ b/packages/ui/spa/components/ValProvider.tsx
@@ -572,7 +572,18 @@ export function ValProvider({
   const deploymentsFingerprint =
     "data" in stat && stat.data?.deployments
       ? stat.data.deployments
-          .map((d) => `${d.deploymentId}:${d.deploymentState}:${d.updatedAt}`)
+          .map(
+            (d) =>
+              // The message is part of what a poll can CHANGE, not just of what
+              // it carries: a content service that learns a deployment's git
+              // message after the fact - the webhook resolves it from GitHub,
+              // and that call can fail and be retried - sends the same
+              // deployment, in the same state, at the same instant, with a
+              // message where there was none. Left out of the fingerprint, that
+              // update reached `stat` and stopped there, and the row stayed on
+              // its short sha until something else moved.
+              `${d.deploymentId}:${d.deploymentState}:${d.updatedAt}:${d.commitMessage ?? ""}`,
+          )
           .join(",")
       : "";
   const commitsFingerprint =

--- a/packages/ui/spa/components/shell/AccountPanel.tsx
+++ b/packages/ui/spa/components/shell/AccountPanel.tsx
@@ -44,7 +44,6 @@ export type AccountPanelProps = {
   branch?: string;
   /** Publishes in flight or recently finished. Absent when there is no feed. */
   deployments?: ShellDeployment[];
-  onDismissDeployment?: (commitSha: string) => void;
   /**
    * Ends the session. Absent where there is not one.
    *
@@ -83,7 +82,6 @@ export function AccountPanel({
   onAutoSaveChange,
   branch,
   deployments,
-  onDismissDeployment,
   onSignOut,
   onClose,
   navSwitcher,
@@ -185,10 +183,7 @@ export function AccountPanel({
           <>
             <PanelSectionLabel divided>Deployments</PanelSectionLabel>
             <div className="pt-1">
-              <DeploymentRows
-                deployments={deployments}
-                onDismiss={onDismissDeployment ?? (() => undefined)}
-              />
+              <DeploymentRows deployments={deployments} />
             </div>
           </>
         )}

--- a/packages/ui/spa/components/shell/Deployments.tsx
+++ b/packages/ui/spa/components/shell/Deployments.tsx
@@ -57,19 +57,23 @@ export const DEPLOYMENT_NEWS_WINDOW_MS = 10 * 60 * 1000;
  * colleague published while this tab was closed, or when the deploy feed
  * simply comes back in a different order.
  *
- * A publish still on its way out is always news: it is going to change again,
- * and its result is what the list exists to show. One already serving the site
- * is news only while it is fresh - past that, someone opening Val is not
- * looking at their own publish, so the list stays shut and the status bar says
- * "Deployed" like it would for anything else.
+ * So it is decided by the CLOCK, and only by the clock. `isLive` used to make
+ * anything not live news, which was true while the feed only carried the
+ * publishes on the current chain: a row that was not live was one on its way
+ * out. The feed is the last few publishes now — a push, a merged pull request,
+ * a revert, from any time — and Val only ever observes the CURRENT commit
+ * serving the site, so "not live" is the resting state of every publish that
+ * has been superseded. Left as it was, opening Val would pop the deploy list
+ * open to announce a build from last Tuesday.
+ *
+ * Nothing about a publish from an hour ago is new, whatever state it is in — a
+ * build that is somehow still running then is not news either, it is a
+ * problem the status bar's summary already reports.
  */
 export function isDeploymentNews(
   deployment: ShellDeployment,
   now: number,
 ): boolean {
-  if (!deployment.isLive) {
-    return true;
-  }
   const updatedAt = new Date(deployment.updatedAt).getTime();
   if (Number.isNaN(updatedAt)) {
     // An unreadable timestamp is not grounds for hiding a publish.
@@ -131,7 +135,6 @@ export type DeploymentsStatusProps = {
   deployments: ShellDeployment[];
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onDismiss: (commitSha: string) => void;
   /**
    * Close the list on its own once every publish is live.
    *
@@ -238,7 +241,6 @@ export function DeploymentsStatus({
   deployments,
   open,
   onOpenChange,
-  onDismiss,
   autoClose = false,
 }: DeploymentsStatusProps) {
   const summary = summarizeDeployments(deployments);
@@ -274,7 +276,6 @@ export function DeploymentsStatus({
       {open && (
         <DeploymentsList
           deployments={deployments}
-          onDismiss={onDismiss}
           onClose={() => onOpenChange(false)}
           onReadingChange={setIsReading}
           className="absolute bottom-full right-0 mb-2 w-80"
@@ -330,7 +331,6 @@ export function MobileDeployments({
   deployments,
   open,
   onOpenChange,
-  onDismiss,
   autoClose = false,
 }: DeploymentsStatusProps) {
   const { containerRef, setIsReading } = useDeploymentsList({
@@ -350,7 +350,6 @@ export function MobileDeployments({
     >
       <DeploymentsList
         deployments={deployments}
-        onDismiss={onDismiss}
         onClose={() => onOpenChange(false)}
         onReadingChange={setIsReading}
       />
@@ -359,20 +358,22 @@ export function MobileDeployments({
 }
 
 /**
- * The publish feed, newest first.
+ * The publish feed: the last few publishes, newest first.
  *
- * Rows are dismissable one at a time so a finished publish can be cleared
- * without losing sight of one that is still building.
+ * Rows used to be dismissable one at a time. That was a control for a list
+ * that grew — it accumulated every deployment a session had ever seen — and
+ * the list is bounded now, so there is nothing to tidy: what a row would be
+ * dismissed FOR is that it is old, and being old is what takes it off the end
+ * of the list on its own. See `mergeCommitsAndDeployments` and
+ * `DEPLOYMENT_LIMIT`.
  */
 export function DeploymentsList({
   deployments,
-  onDismiss,
   onClose,
   onReadingChange,
   className,
 }: {
   deployments: ShellDeployment[];
-  onDismiss: (commitSha: string) => void;
   onClose: () => void;
   /** True while the pointer is on the list, which holds off auto-close. */
   onReadingChange?: (isReading: boolean) => void;
@@ -401,7 +402,7 @@ export function DeploymentsList({
           <X size={14} />
         </button>
       </div>
-      <DeploymentRows deployments={deployments} onDismiss={onDismiss} />
+      <DeploymentRows deployments={deployments} />
     </div>
   );
 }
@@ -412,10 +413,8 @@ export function DeploymentsList({
  */
 export function DeploymentRows({
   deployments,
-  onDismiss,
 }: {
   deployments: ShellDeployment[];
-  onDismiss: (commitSha: string) => void;
 }) {
   if (deployments.length === 0) {
     return (
@@ -428,23 +427,13 @@ export function DeploymentRows({
   return (
     <ul className="max-h-64 overflow-y-auto scrollbar-slim">
       {deployments.map((deployment) => (
-        <DeploymentRow
-          key={deployment.commitSha}
-          deployment={deployment}
-          onDismiss={() => onDismiss(deployment.commitSha)}
-        />
+        <DeploymentRow key={deployment.commitSha} deployment={deployment} />
       ))}
     </ul>
   );
 }
 
-function DeploymentRow({
-  deployment,
-  onDismiss,
-}: {
-  deployment: ShellDeployment;
-  onDismiss: () => void;
-}) {
+function DeploymentRow({ deployment }: { deployment: ShellDeployment }) {
   const progress = deploymentProgress(deployment);
   const building = progress === "building";
   const failed = progress === "failed";
@@ -471,16 +460,6 @@ function DeploymentRow({
           {deployment.timestamp}
         </div>
       </div>
-      {!building && (
-        <button
-          type="button"
-          aria-label="Dismiss deployment"
-          onClick={onDismiss}
-          className="mt-0.5 shrink-0 text-fg-secondary-alt hover:text-fg-primary"
-        >
-          <X size={13} />
-        </button>
-      )}
     </li>
   );
 }

--- a/packages/ui/spa/components/shell/Deployments.tsx
+++ b/packages/ui/spa/components/shell/Deployments.tsx
@@ -8,7 +8,7 @@ import {
   X,
 } from "lucide-react";
 import { cn } from "../designSystem/cn";
-import { ShellDeployment } from "./types";
+import { DeploymentProgress, ShellDeployment } from "./types";
 
 /**
  * What the deploy feed adds up to right now.
@@ -108,6 +108,23 @@ function isFailed(deployment: ShellDeployment): boolean {
     return false;
   }
   return deployment.state === "failure" || deployment.state === "error";
+}
+
+/**
+ * The three states a publish can be rendered in.
+ *
+ * Exported because Recent activity shows publishes too, and a publish that
+ * reads as "Building" in the status bar and as finished in the activity list is
+ * two answers to one question. `isBuilding` and `isFailed` stay private: the
+ * order they are asked in is part of the rule — a live commit is neither — and
+ * this is that rule, once.
+ */
+export function deploymentProgress(
+  deployment: ShellDeployment,
+): DeploymentProgress {
+  if (isBuilding(deployment)) return "building";
+  if (isFailed(deployment)) return "failed";
+  return "settled";
 }
 
 export type DeploymentsStatusProps = {
@@ -428,8 +445,9 @@ function DeploymentRow({
   deployment: ShellDeployment;
   onDismiss: () => void;
 }) {
-  const building = isBuilding(deployment);
-  const failed = isFailed(deployment);
+  const progress = deploymentProgress(deployment);
+  const building = progress === "building";
+  const failed = progress === "failed";
   return (
     <li className="flex items-start gap-2.5 px-3 py-2.5 border-b border-border-float last:border-b-0">
       <span className="mt-0.5 shrink-0">
@@ -448,7 +466,7 @@ function DeploymentRow({
           {deployment.message ?? deployment.commitSha.slice(0, 7)}
         </div>
         <div className="text-[11px] text-fg-secondary-alt truncate">
-          {describeState(deployment)}
+          {describeDeploymentState(deployment)}
           {deployment.author ? ` · ${deployment.author}` : ""} ·{" "}
           {deployment.timestamp}
         </div>
@@ -467,7 +485,13 @@ function DeploymentRow({
   );
 }
 
-function describeState(deployment: ShellDeployment): string {
+/**
+ * What happened to a publish, in a word or two.
+ *
+ * Exported for the same reason as {@link deploymentProgress}: the activity list
+ * says it about the same publishes.
+ */
+export function describeDeploymentState(deployment: ShellDeployment): string {
   // The site answering with this commit outranks anything the build host said
   // about it, including having said nothing at all. See `isBuilding`.
   if (deployment.isLive) {

--- a/packages/ui/spa/components/shell/MobileChrome.tsx
+++ b/packages/ui/spa/components/shell/MobileChrome.tsx
@@ -1,11 +1,18 @@
-import { Info, PanelRight } from "lucide-react";
+import { Info, PanelRight, Sparkles } from "lucide-react";
 import { ReactNode } from "react";
+import { cn } from "../designSystem/cn";
 import { PreviewButton, PublishButton } from "./TopBar";
 
 /**
  * The sticky mobile bottom bar. Preview and Publish are always reachable
  * here; auto save, dev mode and branch move behind the status button rather
  * than taking a permanent row.
+ *
+ * The assistant is here too, rather than in the top bar. On a phone the top
+ * right corner is the furthest point from a thumb, and it was sharing that
+ * corner with navigation, notifications and the account avatar - four icons in
+ * the row you reach for least. The top bar drops its Sparkles button below the
+ * mobile breakpoint, so there is still only one.
  */
 export function MobileBottomBar({
   pendingChanges,
@@ -15,6 +22,8 @@ export function MobileBottomBar({
   publishSlot,
   onOpenStatus,
   onOpenQuickActions,
+  onOpenAI,
+  isAIOpen,
   onToggleCanvas,
   isCanvasOpen,
   canvasActionLabel,
@@ -34,6 +43,16 @@ export function MobileBottomBar({
    * Upload media, none of which were reachable on a phone at all.
    */
   onOpenQuickActions?: () => void;
+  /**
+   * Open the assistant.
+   *
+   * Absent when the project has no assistant configured — see
+   * `ShellProps.aiEnabled` — and the button is then not offered at all, the
+   * same rule the top bar's follows.
+   */
+  onOpenAI?: () => void;
+  /** Whether the assistant panel is the one currently open. */
+  isAIOpen?: boolean;
   /** Absent when the selection has no route Val can put on a canvas. */
   onToggleCanvas?: () => void;
   isCanvasOpen?: boolean;
@@ -62,6 +81,24 @@ export function MobileBottomBar({
           <PanelRight size={16} />
         </button>
       )}
+      {onOpenAI && (
+        <button
+          type="button"
+          onClick={onOpenAI}
+          aria-label="AI assistant"
+          aria-pressed={isAIOpen}
+          className={cn(
+            "grid h-9 w-9 shrink-0 place-items-center rounded-md border border-border-float",
+            // The open state is shown the same way the top bar's icon buttons
+            // show it, so the assistant looks open in the same way everywhere.
+            isAIOpen
+              ? "bg-bg-float-raised text-fg-primary"
+              : "text-fg-secondary",
+          )}
+        >
+          <Sparkles size={16} />
+        </button>
+      )}
       {/*
        * The same control as on desktop, not a second design of it.
        *
@@ -70,6 +107,14 @@ export function MobileBottomBar({
        * the exact thing the split button was built to stop. It also meant the
        * two behaviours drifted: the desktop menu explains what each one does and
        * the phone's pair of icons explained nothing.
+       */}
+      {/*
+       * `min-w-0` on both, because a flex item's default minimum is its own
+       * content: without it neither of these can shrink below its label, and
+       * the row - three 36px icons, two labelled controls and the gaps between
+       * them - overflows a 320px phone and takes Publish off the edge. With it
+       * they give up width in step, and each clips its own label (the Preview
+       * split button is already `overflow-hidden`; Publish truncates).
        */}
       <PreviewButton
         onPreview={onPreview}
@@ -80,13 +125,13 @@ export function MobileBottomBar({
         onExitCanvas={onExitCanvas}
         menuPlacement="above"
         alwaysShowLabel
-        className="h-9 flex-1"
+        className="h-9 min-w-0 flex-1"
       />
       {publishSlot ?? (
         <PublishButton
           pendingChanges={pendingChanges}
           onPublish={onPublish}
-          className="flex-1 h-9"
+          className="h-9 min-w-0 flex-1"
         />
       )}
     </div>

--- a/packages/ui/spa/components/shell/Shell.tsx
+++ b/packages/ui/spa/components/shell/Shell.tsx
@@ -524,19 +524,16 @@ export function Shell({
     setDeploymentsOpen(open);
     setDeploymentsAutoOpened(false);
   }, []);
-  const [dismissedDeployments, setDismissedDeployments] = useState<
-    ReadonlySet<string>
-  >(() => new Set());
-  const dismissDeployment = useCallback((commitSha: string) => {
-    setDismissedDeployments((current) => new Set(current).add(commitSha));
-  }, []);
-  const deployments = useMemo(
-    () =>
-      data.deployments?.filter(
-        (deployment) => !dismissedDeployments.has(deployment.commitSha),
-      ),
-    [data.deployments, dismissedDeployments],
-  );
+  /*
+   * The feed as it comes, unfiltered.
+   *
+   * The shell used to hold a set of dismissed commit shas and subtract it from
+   * the feed. That control existed for a list that grew - the client
+   * accumulated every deployment a session had ever seen - and the feed is the
+   * last few publishes now, oldest falling off the end on their own. See
+   * `mergeCommitsAndDeployments` and `toDeployments`.
+   */
+  const deployments = data.deployments;
 
   // A publish is the one thing here that finishes somewhere else, so the list
   // opens itself when a commit Val has not seen before shows up. The first
@@ -960,7 +957,6 @@ export function Shell({
                 deployments={deployments}
                 open={deploymentsOpen}
                 onOpenChange={setDeploymentsOpenByUser}
-                onDismiss={dismissDeployment}
                 autoClose={deploymentsAutoOpened}
               />
             )}
@@ -1013,7 +1009,6 @@ export function Shell({
             deploymentsOpen={deploymentsOpen}
             onDeploymentsOpenChange={setDeploymentsOpenByUser}
             deploymentsAutoOpened={deploymentsAutoOpened}
-            onDismissDeployment={dismissDeployment}
           />
         )}
 
@@ -1122,7 +1117,6 @@ export function Shell({
              * feed (`mode === "http"`); the panel was missed.
              */
             deployments={mode === "fs" ? undefined : deployments}
-            onDismissDeployment={dismissDeployment}
             // Passed through as-is: absent means there is no session to end, and
             // the panel then shows no Sign out button rather than a dead one.
             onSignOut={onSignOut}

--- a/packages/ui/spa/components/shell/Shell.tsx
+++ b/packages/ui/spa/components/shell/Shell.tsx
@@ -989,6 +989,16 @@ export function Shell({
               publishSlot={publishSlot}
               onOpenStatus={() => setOpenPanel("account")}
               onOpenQuickActions={() => setOpenPanel("utility")}
+              /*
+               * The same gate and the same ACT as the top bar's button above
+               * this breakpoint: absent when there is no assistant, and a
+               * toggle rather than an open, so the button that shows the panel
+               * as open is the button that closes it. It only opened, which on
+               * a phone - where the panel covers the editor - meant the
+               * obvious way to dismiss it did nothing.
+               */
+              onOpenAI={aiEnabled ? () => togglePanel("ai") : undefined}
+              isAIOpen={openPanel === "ai"}
             />
           </>
         ) : (

--- a/packages/ui/spa/components/shell/Shell.tsx
+++ b/packages/ui/spa/components/shell/Shell.tsx
@@ -50,7 +50,7 @@ import { availableDestinations } from "./shellDataMapping";
 import { servedPath } from "../../utils/mediaPath";
 import { useShellBreakpoint } from "./useShellBreakpoint";
 import {
-  ShellActivityEntry,
+  ShellChangeActivity,
   ShellData,
   ShellDataModule,
   ShellExternalPage,
@@ -337,7 +337,8 @@ export type ShellProps = {
   /** The last error from fetching patches, for that same report. */
   pendingChangesError?: string | null;
   onSelectValidationError?: (error: ShellValidationError) => void;
-  onSelectActivity?: (entry: ShellActivityEntry) => void;
+  /** Open a change row's field. Publishes are not selectable — see `UtilityPanelProps`. */
+  onSelectActivity?: (entry: ShellChangeActivity) => void;
   /** Create a page under a route. See `PagesPanelProps`. */
   onNewPage?: (moduleFilePath: ModuleFilePath, urlPath: string) => void;
   /** Copy a page to another URL under the same route. See `PagesPanelProps`. */
@@ -573,17 +574,24 @@ export function Shell({
    * already grouped by the thing that changed. Five, because this is a "take me
    * back" list rather than a history: past that it stops being a shortcut and
    * starts being something to read.
+   *
+   * Changes only: the feed also carries publishes, and a search result is a
+   * thing to open. Filtered BEFORE the slice, so a busy publishing afternoon
+   * does not leave the recent list short.
    */
   const recentSearchResults = useMemo(
     (): SearchResult[] =>
-      (data.activity ?? []).slice(0, RECENT_SEARCH_LIMIT).map((entry) => ({
-        id: entry.sourcePath,
-        kind: "recent",
-        label: entry.title,
-        detail: entry.author
-          ? `${entry.timestamp} · ${entry.author}`
-          : entry.timestamp,
-      })),
+      (data.activity ?? [])
+        .filter((entry) => entry.kind === "change")
+        .slice(0, RECENT_SEARCH_LIMIT)
+        .map((entry) => ({
+          id: entry.sourcePath,
+          kind: "recent",
+          label: entry.title,
+          detail: entry.author
+            ? `${entry.timestamp} · ${entry.author}`
+            : entry.timestamp,
+        })),
     [data.activity],
   );
 

--- a/packages/ui/spa/components/shell/StatusBar.tsx
+++ b/packages/ui/spa/components/shell/StatusBar.tsx
@@ -39,7 +39,6 @@ export type StatusBarProps = {
   onDeploymentsOpenChange?: (open: boolean) => void;
   /** True when the open list opened itself, which lets it close itself. */
   deploymentsAutoOpened?: boolean;
-  onDismissDeployment?: (commitSha: string) => void;
 };
 
 /**
@@ -66,7 +65,6 @@ export function StatusBar({
   deploymentsOpen = false,
   onDeploymentsOpenChange,
   deploymentsAutoOpened = false,
-  onDismissDeployment,
 }: StatusBarProps) {
   return (
     <footer
@@ -118,7 +116,6 @@ export function StatusBar({
               deployments={deployments}
               open={deploymentsOpen}
               onOpenChange={onDeploymentsOpenChange ?? (() => undefined)}
-              onDismiss={onDismissDeployment ?? (() => undefined)}
               autoClose={deploymentsAutoOpened}
             />
             <Divider />

--- a/packages/ui/spa/components/shell/StatusBar.tsx
+++ b/packages/ui/spa/components/shell/StatusBar.tsx
@@ -169,7 +169,20 @@ export function SaveIndicator({
   return (
     <span className="inline-flex items-center gap-1.5">
       <span className="w-1.5 h-1.5 rounded-full bg-bg-brand-secondary" />
-      {breakpoint === "tablet" ? "Saved locally" : "All changes saved locally"}
+      {/*
+       * Not "saved locally".
+       *
+       * It said that at every breakpoint and in every mode, and against a
+       * project it is simply wrong: the patch is on the content service, which
+       * is where it has to be for a colleague to see it and for Publish to ship
+       * it. "Locally" reads as "still only on this machine", which is the one
+       * thing an editor would want to know and the opposite of what is true.
+       *
+       * It is not worth saying in dev either. There the bar already says "Dev
+       * mode" two items to the left, and the branch beside it - "locally" adds
+       * a word to a sentence whose subject is already answered.
+       */}
+      {breakpoint === "tablet" ? "Saved" : "All changes saved"}
     </span>
   );
 }

--- a/packages/ui/spa/components/shell/TopBar.tsx
+++ b/packages/ui/spa/components/shell/TopBar.tsx
@@ -115,7 +115,8 @@ export type TopBarProps = {
    * Whether this project has an assistant. See `ShellProps.aiEnabled`.
    *
    * Absent hides the button rather than disabling it: it is the only thing in
-   * the bar that opens a panel with nothing behind it.
+   * the bar that opens a panel with nothing behind it. On mobile the button is
+   * not here at all — the bottom bar carries it.
    */
   aiEnabled?: boolean;
 };
@@ -127,9 +128,10 @@ export type PublishState = "idle" | "publishing" | "error" | "blocked";
  * The floating top bar.
  *
  * Review, Preview and Publish stay visible at every breakpoint above mobile —
- * in that order, which is the order they are done in; on mobile Preview and
- * Publish move to the sticky bottom bar, Review moves to the Quick actions
- * panel, and the top bar keeps only navigation, notifications, AI and account.
+ * in that order, which is the order they are done in; on mobile Preview,
+ * Publish and the assistant move to the sticky bottom bar, Review moves to the
+ * Quick actions panel, and the top bar keeps only navigation, history,
+ * notifications and account.
  */
 export function TopBar({
   breakpoint,
@@ -217,7 +219,13 @@ export function TopBar({
             <History size={16} />
           </IconButton>
         )}
-        {aiEnabled && (
+        {/*
+         * Above mobile only: on a phone the assistant is in the bottom bar,
+         * where the thumb is - see `MobileBottomBar`. Two Sparkles buttons on
+         * one screen would be two places to look for the same panel, and the
+         * top right corner of a phone is the furthest point from a thumb.
+         */}
+        {aiEnabled && !isMobile && (
           <IconButton
             label="AI assistant"
             active={openPanel === "ai"}
@@ -676,19 +684,29 @@ export function PublishButton({
       )}
     >
       {publishState === "publishing" ? (
-        <Loader2 size={14} className="animate-spin" />
+        <Loader2 size={14} className="shrink-0 animate-spin" />
       ) : publishState === "error" ? (
-        <AlertTriangle size={14} />
+        <AlertTriangle size={14} className="shrink-0" />
       ) : (
-        <Upload size={14} />
+        <Upload size={14} className="shrink-0" />
       )}
-      {publishState === "publishing"
-        ? "Publishing…"
-        : publishState === "error"
-          ? "Publish failed"
-          : "Publish"}
+      {/*
+       * Truncates, so the button can be narrower than its word. On the phone's
+       * bottom bar this shares a row with Preview and three icon buttons, and
+       * `min-w-0` there is only half the answer: a label that cannot clip makes
+       * the button refuse to shrink however small its box is asked to be.
+       */}
+      <span className="truncate">
+        {publishState === "publishing"
+          ? "Publishing…"
+          : publishState === "error"
+            ? "Publish failed"
+            : "Publish"}
+      </span>
       {publishState === "idle" && pendingChanges > 0 && (
-        <span className="tabular-nums opacity-80">{pendingChanges}</span>
+        <span className="shrink-0 tabular-nums opacity-80">
+          {pendingChanges}
+        </span>
       )}
     </button>
   );

--- a/packages/ui/spa/components/shell/TopBar.tsx
+++ b/packages/ui/spa/components/shell/TopBar.tsx
@@ -553,22 +553,25 @@ function BarDivider() {
 /**
  * Review, first of the three actions and to the left of Preview.
  *
- * Present whenever the shell can review at all, and merely INVISIBLE until
- * there is something to review. Not `null`, which is what it was: this group is
- * `ml-auto`, so its right edge is pinned and its left edge grows — a button
- * mounting inside it moves the group's left edge, and everything left of that
- * edge, by its own width. That happens exactly when the first change lands,
- * which is exactly when someone is working in there, and while Review sat
- * BETWEEN Preview and Publish it also moved Preview out from under a click that
- * had already started. `canvas.spec.ts` caught it as a click that hit nothing;
- * a person gets the same miss and no error. Being leftmost now spares Preview
- * and Publish specifically, but the space still has to be held: the search
- * field and the project name are to the left of it, and they would take the
- * jump instead.
+ * Offered whether or not anything is pending. It used to be `invisible` with
+ * nothing queued — present in the layout so the bar would not reflow, but
+ * unreachable and hidden from assistive tech. That made "is anything of mine
+ * still unpublished?" unanswerable from the bar: an absent button and a button
+ * whose data has not loaded look identical, so the only way to find out was to
+ * publish and see what happened. The phone's Quick actions row already answers
+ * it — see `reviewChangesLabel` — and this is the same rule above that
+ * breakpoint. What it opens says the same thing in a sentence; see
+ * `NothingToReview`.
  *
- * `visibility: hidden` rather than opacity: it holds the space, takes no
- * clicks, takes no tab stop, and is not announced — so nothing is offered that
- * cannot be used.
+ * Never `null`, which is what it was before it was `invisible`, and the reason
+ * survives both: this group is `ml-auto`, so its right edge is pinned and its
+ * left edge grows — a button mounting inside it moves the group's left edge,
+ * and everything left of that edge, by its own width. That happens exactly when
+ * the first change lands, which is exactly when someone is working in there,
+ * and while Review sat BETWEEN Preview and Publish it also moved Preview out
+ * from under a click that had already started. `canvas.spec.ts` caught it as a
+ * click that hit nothing; a person gets the same miss and no error. A button
+ * that is always there holds the space by being there.
  *
  * The badge shows `reviewCount`, which is the pending patch count zeroed when
  * all of it has been reverted. In that case the button stays — the review view
@@ -592,7 +595,6 @@ function ReviewButton({
     <button
       type="button"
       onClick={onCompare}
-      {...(hasWork ? {} : { "aria-hidden": true, tabIndex: -1 })}
       aria-label={
         showCount
           ? `Review ${reviewCount} ${reviewCount === 1 ? "change" : "changes"}`
@@ -602,7 +604,6 @@ function ReviewButton({
         "relative inline-flex items-center gap-1.5 h-8 px-2.5 rounded-md shrink-0",
         "text-fg-secondary hover:bg-bg-float-raised hover:text-fg-primary",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus",
-        !hasWork && "invisible",
       )}
     >
       <GitCompare size={15} />

--- a/packages/ui/spa/components/shell/UtilityPanel.tsx
+++ b/packages/ui/spa/components/shell/UtilityPanel.tsx
@@ -1,9 +1,12 @@
 import {
   AlertTriangle,
+  CircleAlert,
   Clock,
   FilePlus2,
   GitCompare,
   ImagePlus,
+  Loader2,
+  Rocket,
   Sparkles,
   Undo2,
 } from "lucide-react";
@@ -22,6 +25,8 @@ import {
 import {
   ShellActivityEntry,
   ShellBreakpoint,
+  ShellChangeActivity,
+  ShellDeployActivity,
   ShellDestination,
   ShellValidationError,
 } from "./types";
@@ -99,7 +104,14 @@ export type UtilityPanelProps = {
   reviewCount?: number;
   /** How many changes `onCompare` would show. */
   pendingChanges?: number;
-  onSelectActivity: (entry: ShellActivityEntry) => void;
+  /**
+   * Open what a change row points at.
+   *
+   * Change rows only: a publish is a commit, and there is nothing in the
+   * Studio for it to open. Narrowing the callback rather than handing over the
+   * whole union is what keeps that from being the caller's problem.
+   */
+  onSelectActivity: (entry: ShellChangeActivity) => void;
   onClose: () => void;
 };
 
@@ -235,31 +247,30 @@ export function UtilityPanel({
         <PanelSectionLabel divided>Recent activity</PanelSectionLabel>
         {activity.length === 0 ? (
           <PanelEmptyState>
-            No recent activity. Your changes will show up here.
+            No recent activity. Your changes and publishes will show up here.
           </PanelEmptyState>
         ) : (
           <ul className="px-3 pt-0.5">
             {activity.map((entry) => (
               <li key={entry.id}>
-                <button
-                  type="button"
-                  onClick={() => onSelectActivity(entry)}
-                  className="flex gap-2 w-full px-1.5 py-1.5 rounded-md text-left hover:bg-bg-float-raised"
-                >
-                  <Clock
-                    size={13}
-                    className="mt-0.5 shrink-0 text-fg-secondary-alt"
-                  />
-                  <span className="min-w-0">
-                    <span className="block text-xs text-fg-primary truncate">
-                      {entry.title}
-                    </span>
-                    <span className="block text-[0.6875rem] text-fg-secondary-alt">
-                      {entry.author ? `${entry.author} · ` : ""}
-                      {entry.timestamp}
-                    </span>
-                  </span>
-                </button>
+                {entry.kind === "deploy" ? (
+                  <DeployActivityRow entry={entry} />
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => onSelectActivity(entry)}
+                    className="flex gap-2 w-full px-1.5 py-1.5 rounded-md text-left hover:bg-bg-float-raised"
+                  >
+                    <Clock
+                      size={13}
+                      className="mt-0.5 shrink-0 text-fg-secondary-alt"
+                    />
+                    <ActivityLines
+                      title={entry.title}
+                      detail={`${entry.author ? `${entry.author} · ` : ""}${entry.timestamp}`}
+                    />
+                  </button>
+                )}
               </li>
             ))}
           </ul>
@@ -279,6 +290,53 @@ export function UtilityPanel({
         )}
       </div>
     </FloatingPanel>
+  );
+}
+
+/**
+ * A publish, in the activity list.
+ *
+ * A line rather than a button: the row says what happened to the site, and a
+ * commit is not something the Studio can open. Its icon is the deploy feed's —
+ * a spinner while it builds, a warning when it failed — so the same publish
+ * looks the same in both places.
+ */
+function DeployActivityRow({ entry }: { entry: ShellDeployActivity }) {
+  return (
+    <div className="flex gap-2 w-full px-1.5 py-1.5">
+      <span className="mt-0.5 shrink-0">
+        {entry.progress === "building" ? (
+          <Loader2 size={13} className="animate-spin text-fg-secondary" />
+        ) : entry.progress === "failed" ? (
+          <CircleAlert size={13} className="text-fg-error-on-surface" />
+        ) : (
+          <Rocket size={13} className="text-fg-secondary-alt" />
+        )}
+      </span>
+      <ActivityLines
+        title={entry.title}
+        detail={`${entry.state}${entry.author ? ` · ${entry.author}` : ""} · ${
+          entry.timestamp
+        }`}
+      />
+    </div>
+  );
+}
+
+/**
+ * The two lines every activity row has, so a publish and an edit line up.
+ *
+ * `min-w-0` on the wrapper is what lets the title truncate rather than push the
+ * row wide - the panel is 260px, and a commit message is not.
+ */
+function ActivityLines({ title, detail }: { title: string; detail: string }) {
+  return (
+    <span className="min-w-0">
+      <span className="block text-xs text-fg-primary truncate">{title}</span>
+      <span className="block text-[0.6875rem] text-fg-secondary-alt truncate">
+        {detail}
+      </span>
+    </span>
   );
 }
 

--- a/packages/ui/spa/components/shell/ValShell.tsx
+++ b/packages/ui/spa/components/shell/ValShell.tsx
@@ -757,11 +757,12 @@ function ValShellBody({ state }: { state: ReturnType<typeof useShellData> }) {
       height,
       reloadKey,
       isPicking,
-      onRequestReload,
       onRefreshingChange,
       onPinch,
       onZoom,
       onPicked,
+      enableKey,
+      onStatusChange,
     }: Parameters<NonNullable<PageWorkspaceProps["renderCanvas"]>>[0]) => (
       <CanvasFrame
         url={canvasUrl}
@@ -797,7 +798,14 @@ function ValShellBody({ state }: { state: ReturnType<typeof useShellData> }) {
         }}
         onPinch={onPinch}
         onZoom={onZoom}
-        onRequestReload={onRequestReload}
+        /*
+         * Preview mode, both ways. The button that turns it on is in the
+         * notice above the canvas - outside the zoom, where a status bar has
+         * to be - and the navigation that does it has to happen here, where
+         * the frame is. See `CanvasPreviewNotice`.
+         */
+        enableKey={enableKey}
+        onStatusChange={onStatusChange}
         onRefreshingChange={onRefreshingChange}
       />
     );

--- a/packages/ui/spa/components/shell/aiAffordances.test.tsx
+++ b/packages/ui/spa/components/shell/aiAffordances.test.tsx
@@ -1,7 +1,9 @@
 /** @jest-environment jsdom */
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MobileBottomBar } from "./MobileChrome";
 import { TopBar } from "./TopBar";
 import { UtilityPanel } from "./UtilityPanel";
+import { ShellBreakpoint } from "./types";
 
 /**
  * The ways into the assistant, in a project that has no assistant.
@@ -16,10 +18,33 @@ import { UtilityPanel } from "./UtilityPanel";
  * with it the whole shared bundle — so what is pinned is the two controls that
  * lead to it.
  */
-function topBar(aiEnabled: boolean) {
+/*
+ * jsdom has no `matchMedia`, and the non-desktop top bar reaches it through
+ * `usePrefersReducedMotion`. Stubbed for the same reason
+ * `historyAffordance.test.tsx` stubs it: the reduced motion answer is
+ * irrelevant here, and without it the mobile case fails for a reason that has
+ * nothing to do with the assistant.
+ */
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      dispatchEvent: () => false,
+    }),
+  });
+});
+
+function topBar(aiEnabled: boolean, breakpoint: ShellBreakpoint = "desktop") {
   return (
     <TopBar
-      breakpoint="desktop"
+      breakpoint={breakpoint}
       projectName="Test"
       openPanel={null}
       onTogglePanel={() => undefined}
@@ -30,6 +55,19 @@ function topBar(aiEnabled: boolean) {
       onPublish={() => undefined}
       pendingChanges={0}
       aiEnabled={aiEnabled}
+    />
+  );
+}
+
+function mobileBar(onOpenAI?: () => void) {
+  return (
+    <MobileBottomBar
+      pendingChanges={0}
+      onPreview={() => undefined}
+      onPublish={() => undefined}
+      onOpenStatus={() => undefined}
+      onOpenQuickActions={() => undefined}
+      onOpenAI={onOpenAI}
     />
   );
 }
@@ -57,6 +95,55 @@ describe("the ways into the assistant", () => {
     render(topBar(false));
     expect(screen.queryByLabelText("AI assistant")).toBeNull();
     // The rest of the bar is untouched — this hides one button, not the row.
+    expect(screen.queryByLabelText("Quick actions")).not.toBeNull();
+  });
+
+  /**
+   * On a phone the button is in the BOTTOM bar, not the top one.
+   *
+   * The top right corner of a phone is the furthest point from a thumb, and it
+   * already holds navigation, notifications and the account avatar. Two
+   * Sparkles buttons would also be two places to look for one panel, which is
+   * the pair of tests below.
+   */
+  test("on a phone it is in the bottom bar", () => {
+    render(mobileBar(() => undefined));
+    expect(screen.queryByLabelText("AI assistant")).not.toBeNull();
+  });
+
+  test("and not in the top bar", () => {
+    render(topBar(true, "mobile"));
+    expect(screen.queryByLabelText("AI assistant")).toBeNull();
+  });
+
+  test("the phone's button closes the panel it opened", () => {
+    // The top bar's button toggles, and on a phone the panel COVERS the
+    // editor - so a button that only ever opens leaves the obvious way to
+    // dismiss it doing nothing.
+    const onOpenAI = jest.fn();
+    render(
+      <MobileBottomBar
+        pendingChanges={0}
+        onPreview={() => undefined}
+        onPublish={() => undefined}
+        onOpenStatus={() => undefined}
+        onOpenQuickActions={() => undefined}
+        onOpenAI={onOpenAI}
+        isAIOpen
+      />,
+    );
+    const button = screen.getByLabelText("AI assistant");
+    expect(button.getAttribute("aria-pressed")).toBe("true");
+    fireEvent.click(button);
+    // `Shell` hands this a toggle; what is pinned here is that the button is
+    // live while the panel is open rather than inert.
+    expect(onOpenAI).toHaveBeenCalledTimes(1);
+  });
+
+  test("the bottom bar offers none when the project has no assistant", () => {
+    render(mobileBar(undefined));
+    expect(screen.queryByLabelText("AI assistant")).toBeNull();
+    // As above: this hides one button, not the row.
     expect(screen.queryByLabelText("Quick actions")).not.toBeNull();
   });
 

--- a/packages/ui/spa/components/shell/canvas/CanvasFrame.tsx
+++ b/packages/ui/spa/components/shell/canvas/CanvasFrame.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ChevronRight, Loader2, RefreshCw } from "lucide-react";
 import {
   isValCanvasPageMessage,
   VAL_CANVAS_MESSAGE,
@@ -8,8 +7,8 @@ import {
   withValCanvasParam,
 } from "@valbuild/shared/internal";
 import { ModuleFilePath, SourcePath } from "@valbuild/core";
-import { cn } from "../../designSystem/cn";
 import { CanvasPinch } from "./CanvasWindow";
+import { CanvasPreviewStatus } from "./CanvasPreviewNotice";
 import { CanvasPoint } from "./types";
 import {
   useValPendingSourceSnapshot,
@@ -37,7 +36,7 @@ type FrameState =
  * cost of being wrong in this direction is a spinner that lingers; in the other
  * it is telling someone to enable a mode that is already on.
  */
-const ANSWER_TIMEOUT_MS = 8000;
+export const ANSWER_TIMEOUT_MS = 8000;
 
 export type CanvasFrameProps = {
   /** The page's own URL, e.g. `/blogs/blog1`. */
@@ -64,8 +63,25 @@ export type CanvasFrameProps = {
   onPinch?: (gesture: CanvasPinch) => void;
   /** A ctrl/cmd + wheel zoom over the page, relayed for the same reason. */
   onZoom?: (factor: number, center: CanvasPoint) => void;
-  /** Ask for the page again — used when enabling preview needs a reload. */
-  onRequestReload: () => void;
+  /**
+   * Bumped to turn preview mode on.
+   *
+   * A key rather than a method, for the reason `reloadKey` is one: the act is a
+   * NAVIGATION of the frame, and only the thing holding the frame can perform
+   * it. The notice that offers the button sits outside the canvas's zoom
+   * transform — see `CanvasPreviewNotice` — so it cannot hold the frame.
+   *
+   * Ignored at its initial value, so mounting does not enable anything.
+   */
+  enableKey?: number;
+  /**
+   * How the conversation with the page is going.
+   *
+   * Reported rather than rendered here, because the thing that renders it must
+   * not be inside the zoom transform: a status bar that shrinks to 7px at
+   * auto-fit is not a status bar. See `CanvasPreviewNotice`.
+   */
+  onStatusChange?: (status: CanvasPreviewStatus) => void;
   /** Whether the page says it is re-rendering. See `ValCanvasBridge`. */
   onRefreshingChange?: (isRefreshing: boolean) => void;
 };
@@ -97,8 +113,9 @@ export function CanvasFrame({
   onPick,
   onPinch,
   onZoom,
-  onRequestReload,
   onRefreshingChange,
+  enableKey = 0,
+  onStatusChange,
 }: CanvasFrameProps) {
   const frameRef = useRef<HTMLIFrameElement>(null);
   const [state, setState] = useState<FrameState>({ status: "waiting" });
@@ -238,6 +255,18 @@ export function CanvasFrame({
    */
   const enablePreview = useCallback(() => {
     setIsEnabling(true);
+    /*
+     * A fresh attempt, on the same terms as a reload.
+     *
+     * The frame is about to hold a NEW document, and whatever the last one said
+     * no longer holds - so the wait for an answer starts again, and with it the
+     * timeout that turns silence into `no-answer`. Without this the state stayed
+     * wherever it was and `isEnabling`, which only a `ready` message clears, was
+     * the whole of what the notice had to go on: an enable that never landed -
+     * a redirect that 404s, a page that does not come back - said "Turning on…"
+     * for as long as the tab was open.
+     */
+    setState({ status: "waiting" });
     const redirectTo = new URL(frameSrc, window.location.origin).toString();
     const enableUrl = `/api/val/enable?redirect_to=${encodeURIComponent(
       redirectTo,
@@ -303,9 +332,57 @@ export function CanvasFrame({
     send({ val: VAL_CANVAS_MESSAGE, type: "sourcesSynced" });
   }, [isLive, documentEpoch, sendPendingSources, sendSourceUpdate, send]);
 
-  const blocked =
-    (state.status === "ready" && !state.draftMode) ||
-    state.status === "no-answer";
+  /**
+   * Turn preview mode on when asked from outside.
+   *
+   * The button lives in the notice above the canvas, which is outside the zoom
+   * transform and therefore cannot be this component; the navigation has to
+   * happen here, where the frame is. See `enableKey`.
+   *
+   * Guarded on the KEY's value rather than on "have I run before", and that is
+   * the whole of it. `enablePreview` is a `useCallback` over `frameSrc`, so the
+   * effect re-runs whenever the canvas changes route — and a "skip the first
+   * run" flag says yes to every run after it. The canvas then navigated itself
+   * through `/api/val/enable` the moment somebody typed a different route: it
+   * turned preview mode on by itself, which is a cookie being set on somebody's
+   * site because they looked at a second page.
+   */
+  const lastEnableKey = useRef(enableKey);
+  useEffect(() => {
+    if (enableKey === lastEnableKey.current) {
+      return;
+    }
+    lastEnableKey.current = enableKey;
+    enablePreview();
+  }, [enableKey, enablePreview]);
+
+  /**
+   * Say how it is going, once per change.
+   *
+   * `isEnabling` is part of it: an enable is a redirect and a fresh document,
+   * so between the click and the page answering there is nothing in `state`
+   * that distinguishes "waiting because we just asked" from "waiting because
+   * nothing is coming".
+   *
+   * But it does not outrank `no-answer`, which is the answer to exactly that
+   * question once the timeout has run: an enable that never lands has to reach
+   * a diagnosis and the actions that go with it, rather than saying "Turning
+   * on…" forever. `isEnabling` is cleared by the page announcing itself, and
+   * a page that never announces itself never clears it.
+   */
+  const status: CanvasPreviewStatus =
+    state.status === "no-answer"
+      ? "no-answer"
+      : isEnabling
+        ? "enabling"
+        : state.status === "waiting"
+          ? "connecting"
+          : state.draftMode
+            ? "live"
+            : "preview-off";
+  useEffect(() => {
+    onStatusChange?.(status);
+  }, [onStatusChange, status]);
 
   return (
     <div style={{ width, height }} className="relative bg-white">
@@ -320,158 +397,16 @@ export function CanvasFrame({
         style={{ width, height, border: "none", display: "block" }}
         referrerPolicy="same-origin"
       />
-      {blocked && (
-        <PreviewBlocked
-          isEnabling={isEnabling}
-          onEnable={enablePreview}
-          onReload={onRequestReload}
-          unreachable={state.status === "no-answer"}
-        />
-      )}
+      {/*
+       * Nothing is drawn over the page here any more.
+       *
+       * A panel with a blurred backdrop used to cover the frame whenever the
+       * canvas could not do its job, which stopped the canvas being a canvas:
+       * the published page underneath is real and worth reading and scrolling,
+       * and it was unreachable behind an explanation of why it could not be
+       * EDITED. `CanvasPreviewNotice`, above the viewport, says the same thing
+       * without taking the page away.
+       */}
     </div>
-  );
-}
-
-/**
- * Shown over the page when the canvas cannot do its job.
- *
- * Over rather than instead of: the published page underneath is real, and worth
- * seeing. What is missing is that nothing on it is selectable, which is what
- * this says.
- */
-function PreviewBlocked({
-  isEnabling,
-  onEnable,
-  onReload,
-  unreachable,
-}: {
-  isEnabling: boolean;
-  onEnable: () => void;
-  onReload: () => void;
-  /** True when the page never answered at all, rather than answering "off". */
-  unreachable: boolean;
-}) {
-  return (
-    <div className="absolute inset-0 grid place-items-center bg-bg-canvas/80 backdrop-blur-sm p-6">
-      <div className="max-w-sm rounded-lg border border-border-float bg-bg-float p-5 text-center shadow-lg">
-        <h3 className="text-sm font-medium text-fg-primary">
-          {unreachable ? "No answer from the page" : "Preview mode is off"}
-        </h3>
-        <p className="mt-2 text-xs leading-relaxed text-fg-secondary">
-          {unreachable
-            ? "The page loaded but did not report back. It may be an older version of Val, preview mode may have been turned off elsewhere, or the app may not be wired up yet."
-            : "Without preview mode the canvas shows the published page, and nothing on it can be selected or edited."}
-        </p>
-        {unreachable && <SetupInstructions />}
-        <div className="mt-4 flex items-center justify-center gap-2">
-          <button
-            type="button"
-            onClick={onEnable}
-            disabled={isEnabling}
-            className={cn(
-              "inline-flex items-center gap-1.5 h-8 px-3 rounded-md text-xs font-medium",
-              "bg-bg-brand-primary text-fg-brand-primary border border-border-brand-primary",
-              "hover:bg-bg-brand-primary-hover",
-              "disabled:bg-bg-disabled disabled:text-fg-disabled",
-            )}
-          >
-            {isEnabling && <Loader2 size={13} className="animate-spin" />}
-            {isEnabling ? "Turning on…" : "Turn on preview mode"}
-          </button>
-          <button
-            type="button"
-            onClick={onReload}
-            className="inline-flex items-center gap-1.5 h-8 px-3 rounded-md text-xs font-medium text-fg-secondary border border-border-float hover:bg-bg-float-raised hover:text-fg-primary"
-          >
-            <RefreshCw size={13} />
-            Reload
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-/**
- * What a DEVELOPER needs when the page never answers.
- *
- * The most likely cause of silence is not a fault at all — it is an app that has
- * not been wired up: no `ValProvider` in the root layout, or one that is not
- * above the page being previewed. That is a five-line fix and completely opaque
- * from this side of the iframe, so the answer is worth having on screen.
- *
- * Folded away, and that is the whole design of it. Most people looking at this
- * panel are editors, for whom a code snippet is noise and slightly alarming;
- * the developer they will ask is the one who needs it. A `details` gives both
- * audiences the right thing without a mode switch, and it is native, so it
- * needs no state and cannot get stuck open.
- */
-function SetupInstructions() {
-  return (
-    <details className="group mt-3 text-left">
-      <summary className="cursor-pointer list-none text-xs text-fg-secondary-alt hover:text-fg-primary [&::-webkit-details-marker]:hidden">
-        <span className="inline-flex items-center gap-1">
-          <ChevronRight
-            size={12}
-            // `group-open`, not an arbitrary `details[open] &`: the standard
-            // variant is what the config is certain to generate.
-            className="transition-transform group-open:rotate-90"
-            aria-hidden
-          />
-          Setup instructions
-        </span>
-      </summary>
-      <div className="mt-2 rounded-md border border-border-float bg-bg-secondary p-3">
-        <p className="text-xs leading-relaxed text-fg-secondary">
-          The canvas talks to the page through Val&apos;s provider. If it never
-          answers, check that:
-        </p>
-        <ol className="mt-2 list-decimal space-y-1.5 pl-4 text-xs leading-relaxed text-fg-secondary">
-          <li>
-            <code className="rounded bg-bg-tertiary px-1 py-0.5 font-mono text-[0.6875rem] text-fg-primary">
-              ValProvider
-            </code>{" "}
-            is in the ROOT layout —{" "}
-            <code className="font-mono">app/layout.tsx</code> — and therefore
-            above every page it should preview. A provider inside a route group
-            does not cover the pages outside it.
-          </li>
-          <li>
-            <code className="rounded bg-bg-tertiary px-1 py-0.5 font-mono text-[0.6875rem] text-fg-primary">
-              ValModulesClient
-            </code>{" "}
-            is rendered inside it, so the editor can read your schemas.
-          </li>
-          <li>
-            The API route exists at{" "}
-            <code className="font-mono">
-              app/(val)/api/val/[[...val]]/route.ts
-            </code>
-            , since preview mode is turned on through it.
-          </li>
-          <li>
-            The page is not served from a different origin than the studio: the
-            canvas and the page have to be able to talk to each other.
-          </li>
-          <li>
-            <code className="font-mono">@valbuild/next</code> and{" "}
-            <code className="font-mono">@valbuild/core</code> are on the same
-            version, in the app and in the editor.
-          </li>
-        </ol>
-        <p className="mt-2 text-xs leading-relaxed text-fg-secondary-alt">
-          The setup guide has the whole layout:{" "}
-          <a
-            href="https://github.com/valbuild/val/blob/main/packages/next/MANUAL_CONFIGURATION.md"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline hover:text-fg-primary"
-          >
-            manual configuration
-          </a>
-          .
-        </p>
-      </div>
-    </details>
   );
 }

--- a/packages/ui/spa/components/shell/canvas/CanvasPreviewNotice.tsx
+++ b/packages/ui/spa/components/shell/canvas/CanvasPreviewNotice.tsx
@@ -1,0 +1,419 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ChevronRight, Loader2, RefreshCw, TriangleAlert } from "lucide-react";
+import { cn } from "../../designSystem/cn";
+import { useDismissOnOutsidePointer } from "../useDismissOnOutsidePointer";
+
+/**
+ * How the canvas is getting on with the page it is showing.
+ *
+ * `connecting` is not the same as `no-answer`: a page that has not spoken yet
+ * might be about to, and `preview-off` is the page having answered that it is
+ * rendering published content. Reported by `CanvasFrame`, which owns the
+ * message protocol; rendered here, because this notice sits OUTSIDE the zoom
+ * transform and the frame is inside it.
+ */
+export type CanvasPreviewStatus =
+  | "connecting"
+  | "enabling"
+  | "no-answer"
+  | "preview-off"
+  | "live";
+
+/**
+ * How long the canvas looks like it is loading before it looks like a problem.
+ *
+ * Everything that stops the canvas working also happens transiently on the way
+ * to it working: `next dev` compiling a route for the first time, the enable
+ * redirect being in flight, the bridge mounting after hydration. Twenty seconds
+ * is well past all of those and well short of someone giving up, so a spinner
+ * that turns into a warning describes the situation without ever having accused
+ * a page that was simply slow.
+ */
+export const PREVIEW_WARNING_DELAY_MS = 20000;
+
+/**
+ * The canvas is not ready — said in a bar, not by covering the page up.
+ *
+ * This used to be a full-bleed panel over the frame with a blurred backdrop.
+ * It stopped the canvas being a canvas: the published page underneath is real
+ * and worth looking at, scrolling and reading, and none of that was possible
+ * while the thing explaining why it could not be EDITED was in the way. Worse,
+ * the panel appeared during ordinary slowness — a first `next dev` compile —
+ * so the normal path to a working canvas went through a screen that looked
+ * like a failure.
+ *
+ * So: a pill at the top of the viewport, the page untouched behind it, and the
+ * long explanation behind a disclosure for the person who wants it. The icon
+ * carries the state — a spinner for {@link PREVIEW_WARNING_DELAY_MS}, then a
+ * warning, with the colours following — because that is the part someone reads
+ * without stopping what they are doing.
+ */
+export function CanvasPreviewNotice({
+  status,
+  attempt,
+  onEnable,
+  onReload,
+  warnAfterMs = PREVIEW_WARNING_DELAY_MS,
+}: {
+  status: CanvasPreviewStatus;
+  /**
+   * Changes whenever the canvas asks for a NEW document - a reload, an enable.
+   *
+   * The clock cannot be driven by the status alone. Reloading a page that is
+   * already `connecting` (or one that has given up, at `no-answer`) starts a
+   * fresh attempt with the same status, so nothing here changes and the old
+   * timer runs on: the warning then arrives seconds into an attempt that has
+   * barely begun, describing the one before it.
+   */
+  attempt?: string | number;
+  /** Turn preview mode on: sets the cookie and draft mode in one navigation. */
+  onEnable: () => void;
+  /** Ask for the page again. */
+  onReload: () => void;
+  /**
+   * How long the spinner runs before this becomes a warning.
+   *
+   * A prop only so a story can show the far end of the clock: twenty seconds
+   * is longer than anyone looking at a design will wait, and a story that
+   * re-mounts to get there only restarts the wait. The app never passes it.
+   */
+  warnAfterMs?: number;
+}) {
+  const isWarning = useWarningAfterDelay(status, attempt, warnAfterMs);
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const close = useCallback(() => setIsOpen(false), []);
+  useDismissOnOutsidePointer(containerRef, isOpen, close);
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setIsOpen(false);
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [isOpen]);
+  // Nothing to say once the canvas works, and the details close with it so a
+  // page that sorts itself out does not leave an explanation of a past problem
+  // on screen.
+  useEffect(() => {
+    if (status === "live") setIsOpen(false);
+  }, [status]);
+  if (status === "live") return null;
+
+  const label = describePreviewStatus(status, isWarning);
+  return (
+    /*
+     * `pointer-events-none` on the layer, `auto` on the pill.
+     *
+     * The whole point is that the page behind stays usable: it can be
+     * scrolled, read and clicked while this is on screen. A full-size
+     * transparent layer that swallowed the pointer would be the old blocking
+     * panel again, with nothing drawn on it.
+     */
+    /*
+     * A column, and the LAYER is what the panel is measured against.
+     *
+     * The panel used to be absolutely positioned against the pill and capped at
+     * `100vw`, which is the browser's viewport - not this one. The canvas pane
+     * can be 280px wide and it is `overflow-hidden`, so a 20rem panel was
+     * clipped and took the setup checklist and Reload with it. Stacked in a
+     * column under the pill, `max-w-full` is the canvas viewport's own width,
+     * which is the constraint that was being violated.
+     */
+    <div
+      ref={containerRef}
+      className="pointer-events-none absolute inset-x-0 top-0 z-window flex flex-col items-center gap-1 p-2"
+    >
+      <div
+        className={cn(
+          "pointer-events-auto flex max-w-full items-center gap-1.5 rounded-lg border px-2 py-1 shadow-sm",
+          "text-[0.6875rem]",
+          isWarning
+            ? "border-border-warning-primary bg-bg-warning-primary text-fg-warning-primary"
+            : "border-border-float bg-bg-float text-fg-secondary",
+        )}
+      >
+        {/*
+         * `status`, so the change is announced once it settles rather than
+         * on every re-render of a spinner. The icon is `aria-hidden`: it says
+         * the same thing as the words beside it.
+         */}
+        {/*
+         * `min-w-0`, because the two controls beside this are `shrink-0`: a
+         * flex item's default minimum is its content, so without this the
+         * label refuses to shrink to its own `truncate` and the pill grows
+         * past the pane instead - taking the controls out of reach on a
+         * narrow canvas.
+         */}
+        <span className="flex min-w-0 items-center gap-1.5" role="status">
+          {isWarning ? (
+            <TriangleAlert size={12} className="shrink-0" aria-hidden />
+          ) : (
+            <Loader2 size={12} className="shrink-0 animate-spin" aria-hidden />
+          )}
+          <span className="truncate">{label}</span>
+        </span>
+        {/*
+         * The one-click fix, on the pill rather than behind the disclosure.
+         *
+         * Only once there is a DIAGNOSIS: the page has answered that it is
+         * not in draft mode, or it has stopped answering at all. During the
+         * first seconds - a route compiling, an enable redirect in flight -
+         * there is nothing to fix and a button saying so would be the
+         * accusation the pill is careful not to make. Both of those states
+         * are fixed by the same navigation, which is why the old panel
+         * offered this button for both.
+         */}
+        {(status === "preview-off" || status === "no-answer") && (
+          <button
+            type="button"
+            onClick={onEnable}
+            className={cn(
+              "inline-flex h-5 shrink-0 items-center gap-1 rounded px-1.5 font-medium",
+              "bg-bg-brand-primary text-fg-brand-primary",
+              "hover:bg-bg-brand-primary-hover",
+            )}
+          >
+            Turn on preview mode
+          </button>
+        )}
+        {status === "enabling" && (
+          <span className="inline-flex shrink-0 items-center gap-1 px-1 font-medium">
+            <Loader2 size={11} className="animate-spin" aria-hidden />
+            Turning on…
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={() => setIsOpen((open) => !open)}
+          aria-expanded={isOpen}
+          className={cn(
+            "inline-flex shrink-0 items-center gap-0.5 rounded px-1 py-0.5 font-medium",
+            "hover:bg-bg-float-raised",
+            isWarning
+              ? "text-fg-warning-primary-alt hover:bg-bg-warning-primary-hover"
+              : "text-fg-primary",
+          )}
+        >
+          Details
+          <ChevronRight
+            size={11}
+            aria-hidden
+            className={cn("transition-transform", isOpen && "rotate-90")}
+          />
+        </button>
+      </div>
+      {isOpen && (
+        <div
+          className={cn(
+            "pointer-events-auto w-80 max-w-full",
+            "rounded-lg border border-border-float bg-bg-float p-3 text-left shadow-xl",
+            /*
+             * Scrolls itself rather than being clipped. The canvas viewport
+             * is `overflow-hidden` - it has to be, the page inside it is
+             * zoomed and panned - so a panel taller than the pane loses its
+             * bottom, and with the setup instructions open that is where the
+             * links are.
+             */
+            "max-h-[min(70vh,32rem)] overflow-y-auto scrollbar-slim",
+          )}
+        >
+          <h3 className="text-xs font-medium text-fg-primary">{label}</h3>
+          <p className="mt-1.5 text-[0.6875rem] leading-relaxed text-fg-secondary">
+            {explainPreviewStatus(status, isWarning)}
+          </p>
+          {/*
+           * The developer's checklist, where the page never answered. Folded
+           * away for the same reason it always was: most people looking at
+           * this are editors, for whom a code snippet is noise and slightly
+           * alarming, and the developer they will ask is the one who needs
+           * it.
+           */}
+          {(status === "no-answer" || status === "connecting") && (
+            <SetupInstructions />
+          )}
+          {/*
+           * Reload only. Turning preview mode on is the ONE thing most
+           * people here need, so it is on the pill itself - see above -
+           * rather than a click away behind this. A second copy of it here
+           * would be a second thing to find and the same act.
+           */}
+          <div className="mt-3 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onReload}
+              className={cn(
+                "inline-flex items-center gap-1.5 h-7 px-2.5 rounded-md text-[0.6875rem] font-medium",
+                "text-fg-secondary border border-border-float",
+                "hover:bg-bg-float-raised hover:text-fg-primary",
+              )}
+            >
+              <RefreshCw size={11} aria-hidden />
+              Reload
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** What the pill says. */
+export function describePreviewStatus(
+  status: CanvasPreviewStatus,
+  isWarning: boolean,
+): string {
+  if (status === "enabling") {
+    return isWarning
+      ? "Still turning on preview mode"
+      : "Turning on preview mode…";
+  }
+  // Before the delay is up, nothing is diagnosed: every one of these states is
+  // also a step on the way to a working canvas, and naming a fault that is
+  // about to fix itself is how the old panel came to look like a failure
+  // screen on a slow first compile.
+  if (!isWarning) {
+    return "Preview is not ready yet";
+  }
+  return status === "preview-off"
+    ? "Preview mode is off"
+    : "No answer from the page";
+}
+
+/** What the disclosure says, which is the whole of the old panel's copy. */
+function explainPreviewStatus(
+  status: CanvasPreviewStatus,
+  isWarning: boolean,
+): string {
+  if (status === "enabling") {
+    return "Preview mode is being turned on: the page is being reloaded through Val's enable endpoint, which sets the cookie and turns on draft mode.";
+  }
+  if (!isWarning) {
+    return "The page has not reported what is on it yet. A route the dev server has not compiled before can take a few seconds the first time it is asked for.";
+  }
+  if (status === "preview-off") {
+    return "Without preview mode the canvas shows the published page, and nothing on it can be selected or edited. The page itself is fine — you are looking at the real thing, just not at your unpublished changes.";
+  }
+  return "The page loaded but did not report back. It may be an older version of Val, preview mode may have been turned off elsewhere, or the app may not be wired up yet.";
+}
+
+/**
+ * Whether the current attempt has been going long enough to call it a problem.
+ *
+ * The clock has to survive the STATUS changing: `connecting` becoming
+ * `preview-off` a moment later is the same attempt with a better diagnosis, not
+ * a new one, and restarting the wait there would mean the warning never
+ * arrived. So it is keyed on when the attempt began, and only a fresh attempt —
+ * a document loading, an enable redirect — moves that.
+ */
+function useWarningAfterDelay(
+  status: CanvasPreviewStatus,
+  attempt: string | number | undefined,
+  warnAfterMs: number,
+): boolean {
+  const [startedAt, setStartedAt] = useState(() => Date.now());
+  const isTrying = status === "connecting" || status === "enabling";
+  useEffect(() => {
+    if (isTrying) setStartedAt(Date.now());
+  }, [isTrying, status]);
+  /*
+   * And whenever a new document is asked for, whatever the status is doing.
+   * A reload while already `connecting` - or after giving up at `no-answer` -
+   * is a new attempt that the status cannot report, because it is the same
+   * status. See `attempt`.
+   */
+  const firstAttempt = useRef(attempt);
+  useEffect(() => {
+    if (attempt === firstAttempt.current) return;
+    firstAttempt.current = attempt;
+    setStartedAt(Date.now());
+  }, [attempt]);
+  const [isWarning, setIsWarning] = useState(false);
+  useEffect(() => {
+    setIsWarning(false);
+    const timeout = setTimeout(() => setIsWarning(true), warnAfterMs);
+    return () => clearTimeout(timeout);
+  }, [startedAt, warnAfterMs]);
+  return isWarning;
+}
+
+/**
+ * What a DEVELOPER needs when the page never answers.
+ *
+ * The most likely cause of silence is not a fault at all — it is an app that has
+ * not been wired up: no `ValProvider` in the root layout, or one that is not
+ * above the page being previewed. That is a five-line fix and completely opaque
+ * from this side of the iframe, so the answer is worth having on screen.
+ *
+ * A `details` gives the editor and the developer the right thing without a mode
+ * switch, and it is native, so it needs no state and cannot get stuck open.
+ */
+function SetupInstructions() {
+  return (
+    <details className="group mt-2 text-left">
+      <summary className="cursor-pointer list-none text-[0.6875rem] text-fg-secondary-alt hover:text-fg-primary [&::-webkit-details-marker]:hidden">
+        <span className="inline-flex items-center gap-1">
+          <ChevronRight
+            size={11}
+            // `group-open`, not an arbitrary `details[open] &`: the standard
+            // variant is what the config is certain to generate.
+            className="transition-transform group-open:rotate-90"
+            aria-hidden
+          />
+          Setup instructions
+        </span>
+      </summary>
+      <div className="mt-2 rounded-md border border-border-float bg-bg-secondary p-2.5">
+        <p className="text-[0.6875rem] leading-relaxed text-fg-secondary">
+          The canvas talks to the page through Val&apos;s provider. If it never
+          answers, check that:
+        </p>
+        <ol className="mt-2 list-decimal space-y-1.5 pl-4 text-[0.6875rem] leading-relaxed text-fg-secondary">
+          <li>
+            <code className="rounded bg-bg-tertiary px-1 py-0.5 font-mono text-[0.625rem] text-fg-primary">
+              ValProvider
+            </code>{" "}
+            is in the ROOT layout —{" "}
+            <code className="font-mono">app/layout.tsx</code> — and therefore
+            above every page it should preview. A provider inside a route group
+            does not cover the pages outside it.
+          </li>
+          <li>
+            <code className="rounded bg-bg-tertiary px-1 py-0.5 font-mono text-[0.625rem] text-fg-primary">
+              ValModulesClient
+            </code>{" "}
+            is rendered inside it, so the editor can read your schemas.
+          </li>
+          <li>
+            The API route exists at{" "}
+            <code className="font-mono">
+              app/(val)/api/val/[[...val]]/route.ts
+            </code>
+            , since preview mode is turned on through it.
+          </li>
+          <li>
+            The page is not served from a different origin than the studio: the
+            canvas and the page have to be able to talk to each other.
+          </li>
+          <li>
+            <code className="font-mono">@valbuild/next</code> and{" "}
+            <code className="font-mono">@valbuild/core</code> are on the same
+            version, in the app and in the editor.
+          </li>
+        </ol>
+        <p className="mt-2 text-[0.6875rem] leading-relaxed text-fg-secondary-alt">
+          The setup guide has the whole layout:{" "}
+          <a
+            href="https://github.com/valbuild/val/blob/main/packages/next/MANUAL_CONFIGURATION.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-fg-primary"
+          >
+            manual configuration
+          </a>
+          .
+        </p>
+      </div>
+    </details>
+  );
+}

--- a/packages/ui/spa/components/shell/canvas/PageWorkspace.tsx
+++ b/packages/ui/spa/components/shell/canvas/PageWorkspace.tsx
@@ -28,6 +28,10 @@ import {
 import { FieldsPanel } from "./FieldsPanel";
 import { CanvasFields } from "./CanvasFields";
 import { CanvasRouteBar } from "./CanvasRouteBar";
+import {
+  CanvasPreviewNotice,
+  CanvasPreviewStatus,
+} from "./CanvasPreviewNotice";
 import { CANVAS_MAX_WIDTH } from "../EditorCanvas";
 import { SourcePath } from "@valbuild/core";
 import { ShellBreakpoint } from "../types";
@@ -116,6 +120,22 @@ export type PageWorkspaceProps = {
      * canvas's business: the fields column, and on a phone the pane holding it.
      */
     onPicked: () => void;
+    /**
+     * Bumped when the notice's "Turn on preview mode" is used.
+     *
+     * The button is in the notice, which sits outside the zoom transform, and
+     * the act is a navigation of whatever is on the canvas — so, like
+     * `reloadKey`, it goes to the thing that can perform it.
+     */
+    enableKey: number;
+    /**
+     * How the canvas is getting on with what it is showing.
+     *
+     * Reported up here because the notice must NOT be inside the zoom
+     * transform: at auto-fit on a narrow pane that is a status bar rendered at
+     * half size. See `CanvasPreviewNotice`.
+     */
+    onStatusChange: (status: CanvasPreviewStatus) => void;
   }) => ReactNode;
   /**
    * The content paths the running page reported finding on itself.
@@ -579,6 +599,23 @@ export function PageWorkspace({
   const [isRefreshing, setIsRefreshing] = useState(false);
 
   /**
+   * How the canvas is getting on with the page, and the way to fix it.
+   *
+   * Held here rather than in `CanvasFrame` because the notice that shows it
+   * cannot be in there: everything `renderCanvas` returns is inside the zoom
+   * transform, so a bar drawn beside the page would shrink with the page — at
+   * auto-fit on a narrow pane, to about half legibility. `enableKey` goes the
+   * other way for the same reason: the button is here, and only the thing
+   * holding the frame can navigate it.
+   *
+   * `live` to begin with, so the demo page — which reports nothing, because
+   * Storybook has no frame to report — shows no notice at all.
+   */
+  const [previewStatus, setPreviewStatus] =
+    useState<CanvasPreviewStatus>("live");
+  const [enableKey, setEnableKey] = useState(0);
+
+  /**
    * Clears the floating rail, which the narrowed column now reaches under.
    *
    * Inline because `md:px-6` lives in a media query and would otherwise win
@@ -831,6 +868,26 @@ export function PageWorkspace({
         </div>
       )}
       <div className="relative min-h-0 flex-1 overflow-hidden rounded-xl border border-border-float bg-bg-float-raised">
+        {/*
+         * Above the page and outside the zoom, which is the whole reason the
+         * status is lifted out of the frame. It used to be a panel over the
+         * frame with a blurred backdrop, so the published page - which is real,
+         * and worth reading - was unreachable behind an explanation of why it
+         * could not be edited.
+         */}
+        <CanvasPreviewNotice
+          status={previewStatus}
+          /*
+           * Which attempt this is. Both counters, because both ask the frame
+           * for a new document and neither necessarily changes the STATUS -
+           * reloading a page that has already given up leaves it at
+           * `no-answer`, and the notice's clock would otherwise still be
+           * timing the attempt before it.
+           */
+          attempt={`${reloadKey}:${enableKey}`}
+          onEnable={() => setEnableKey((key) => key + 1)}
+          onReload={reload}
+        />
         <CanvasWindow
           ref={canvasWindowRef}
           pageWidth={pageWidth}
@@ -856,6 +913,8 @@ export function PageWorkspace({
               onPinch,
               onZoom: (factor, center) => zoomByUser(factor, center),
               onPicked,
+              enableKey,
+              onStatusChange: setPreviewStatus,
             }) ??
               (page && (
                 <CanvasPage

--- a/packages/ui/spa/components/shell/canvas/canvasCatchUp.test.tsx
+++ b/packages/ui/spa/components/shell/canvas/canvasCatchUp.test.tsx
@@ -40,7 +40,6 @@ describe("catching the canvas up", () => {
         reloadKey={0}
         isPicking={false}
         highlightedPath={null}
-        onRequestReload={() => {}}
       />,
     );
     const found = rendered.container.querySelector("iframe");

--- a/packages/ui/spa/components/shell/canvas/canvasPick.test.tsx
+++ b/packages/ui/spa/components/shell/canvas/canvasPick.test.tsx
@@ -47,7 +47,6 @@ describe("a pick on the page", () => {
         reloadKey={0}
         isPicking
         highlightedPath={highlightedPath}
-        onRequestReload={() => {}}
       />,
     );
     const found = rendered.container.querySelector("iframe");
@@ -102,7 +101,6 @@ describe("a pick on the page", () => {
         reloadKey={0}
         isPicking
         highlightedPath={PICKED}
-        onRequestReload={() => {}}
       />,
     );
 
@@ -126,7 +124,6 @@ describe("a pick on the page", () => {
         reloadKey={0}
         isPicking
         highlightedPath={ELSEWHERE}
-        onRequestReload={() => {}}
       />,
     );
     expect(lastHighlight()).toEqual({
@@ -148,7 +145,6 @@ describe("a pick on the page", () => {
         reloadKey={0}
         isPicking
         highlightedPath={ELSEWHERE}
-        onRequestReload={() => {}}
       />,
     );
 
@@ -166,7 +162,6 @@ describe("a pick on the page", () => {
           reloadKey={0}
           isPicking
           highlightedPath={path}
-          onRequestReload={() => {}}
         />,
       );
     click(PICKED);

--- a/packages/ui/spa/components/shell/canvas/canvasPreviewNotice.test.tsx
+++ b/packages/ui/spa/components/shell/canvas/canvasPreviewNotice.test.tsx
@@ -1,0 +1,336 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import {
+  VAL_CANVAS_MESSAGE,
+  type ValCanvasPageMessage,
+} from "@valbuild/shared/internal";
+import {
+  CanvasPreviewNotice,
+  CanvasPreviewStatus,
+  PREVIEW_WARNING_DELAY_MS,
+} from "./CanvasPreviewNotice";
+import { ANSWER_TIMEOUT_MS, CanvasFrame } from "./CanvasFrame";
+
+/**
+ * What the canvas says when it cannot do its job.
+ *
+ * It used to be a panel over the frame with a blurred backdrop: the published
+ * page underneath - which is real, and worth reading and scrolling - was
+ * unreachable behind an explanation of why it could not be EDITED. And because
+ * the panel appeared during ordinary slowness (a first `next dev` compile of a
+ * route), the normal path to a working canvas went through a screen that looked
+ * like a failure.
+ *
+ * Three things are pinned here: the notice is not a blocker, it looks like
+ * loading before it looks like a problem, and the long explanation is behind a
+ * disclosure rather than on screen.
+ */
+describe("the canvas preview notice", () => {
+  const notice = (status: CanvasPreviewStatus) => (
+    <CanvasPreviewNotice
+      status={status}
+      onEnable={() => undefined}
+      onReload={() => undefined}
+    />
+  );
+
+  test("says nothing at all once the canvas works", () => {
+    const { container } = render(notice("live"));
+    expect(container.textContent).toBe("");
+  });
+
+  test("does not take the pointer away from the page", () => {
+    // The layer is full width so the pill can be centred; only the pill itself
+    // may be clickable, or this is the old blocking panel with nothing drawn
+    // on it.
+    const { container } = render(notice("preview-off"));
+    const layer = container.firstElementChild;
+    expect(layer?.className).toContain("pointer-events-none");
+    expect(layer?.firstElementChild?.className).toContain(
+      "pointer-events-auto",
+    );
+  });
+
+  test("reads as loading before it reads as a problem", () => {
+    jest.useFakeTimers();
+    try {
+      // A page that has answered "draft mode is off" is a definite answer, and
+      // it is STILL not accused for the first stretch: turning preview on is a
+      // redirect and a fresh document, and compiling a route can take seconds.
+      render(notice("preview-off"));
+      expect(screen.queryByText("Preview is not ready yet")).not.toBeNull();
+      expect(screen.queryByText("Preview mode is off")).toBeNull();
+      act(() => {
+        jest.advanceTimersByTime(PREVIEW_WARNING_DELAY_MS);
+      });
+      expect(screen.queryByText("Preview mode is off")).not.toBeNull();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("a silent page is named as one, once the wait is up", () => {
+    jest.useFakeTimers();
+    try {
+      render(notice("no-answer"));
+      act(() => {
+        jest.advanceTimersByTime(PREVIEW_WARNING_DELAY_MS);
+      });
+      expect(screen.queryByText("No answer from the page")).not.toBeNull();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("the wait survives the diagnosis changing", () => {
+    jest.useFakeTimers();
+    try {
+      // `connecting` becoming `preview-off` is the same attempt ten
+      // milliseconds later, not a new one. Restarting the clock there is how
+      // the warning would never arrive on a page that answers immediately.
+      const { rerender } = render(notice("connecting"));
+      act(() => {
+        jest.advanceTimersByTime(PREVIEW_WARNING_DELAY_MS / 2);
+      });
+      rerender(notice("preview-off"));
+      act(() => {
+        jest.advanceTimersByTime(PREVIEW_WARNING_DELAY_MS / 2);
+      });
+      expect(screen.queryByText("Preview mode is off")).not.toBeNull();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  /**
+   * The one-click fix is one click. It used to be behind the disclosure, which
+   * put the commonest act in the Studio's canvas - "turn preview mode on" -
+   * two clicks away, and the E2E suites that drive the canvas found it there.
+   */
+  test("the fix is on the pill, once there is something to fix", () => {
+    render(notice("preview-off"));
+    expect(
+      screen.queryByRole("button", { name: /Turn on preview mode/ }),
+    ).not.toBeNull();
+  });
+
+  test("and not before: a page that has not answered yet is not accused", () => {
+    render(notice("connecting"));
+    expect(
+      screen.queryByRole("button", { name: /Turn on preview mode/ }),
+    ).toBeNull();
+  });
+
+  test("a page that never answered is offered it too", () => {
+    // The same navigation fixes both, which is why the old panel offered this
+    // button for both.
+    render(notice("no-answer"));
+    expect(
+      screen.queryByRole("button", { name: /Turn on preview mode/ }),
+    ).not.toBeNull();
+  });
+
+  /**
+   * A reload is a new attempt even when the STATUS cannot say so: reloading a
+   * page that has already given up leaves it at `no-answer`, and without an
+   * attempt identity the clock went on timing the attempt before it - so the
+   * warning was already showing a second into the new one.
+   */
+  test("a fresh attempt restarts the wait, whatever the status does", () => {
+    jest.useFakeTimers();
+    try {
+      const { rerender } = render(
+        <CanvasPreviewNotice
+          status="no-answer"
+          attempt="1:0"
+          onEnable={() => undefined}
+          onReload={() => undefined}
+        />,
+      );
+      act(() => {
+        jest.advanceTimersByTime(PREVIEW_WARNING_DELAY_MS);
+      });
+      expect(screen.queryByText("No answer from the page")).not.toBeNull();
+      rerender(
+        <CanvasPreviewNotice
+          status="no-answer"
+          attempt="2:0"
+          onEnable={() => undefined}
+          onReload={() => undefined}
+        />,
+      );
+      expect(screen.queryByText("Preview is not ready yet")).not.toBeNull();
+      act(() => {
+        jest.advanceTimersByTime(PREVIEW_WARNING_DELAY_MS);
+      });
+      expect(screen.queryByText("No answer from the page")).not.toBeNull();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("the explanation and the reload are behind Details", () => {
+    render(notice("preview-off"));
+    expect(screen.queryByText("Reload")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /Details/ }));
+    expect(screen.queryByText("Reload")).not.toBeNull();
+    // The explanation follows the same clock the pill does: before the wait is
+    // up it says what is happening, not what is wrong.
+    expect(
+      screen.queryByText(/The page has not reported what is on it yet/),
+    ).not.toBeNull();
+  });
+
+  test("the developer's checklist is offered only where the page is silent", () => {
+    const { unmount } = render(notice("no-answer"));
+    fireEvent.click(screen.getByRole("button", { name: /Details/ }));
+    expect(screen.queryByText("Setup instructions")).not.toBeNull();
+    unmount();
+    // A page that answered "preview mode is off" is wired up correctly: it
+    // answered. Nothing to check.
+    render(notice("preview-off"));
+    fireEvent.click(screen.getByRole("button", { name: /Details/ }));
+    expect(screen.queryByText("Setup instructions")).toBeNull();
+  });
+});
+
+/**
+ * The frame's half of it: it reports, and it draws nothing over the page.
+ */
+describe("what the frame reports", () => {
+  const renderFrame = (onStatusChange: (s: CanvasPreviewStatus) => void) => {
+    const rendered = render(
+      <CanvasFrame
+        url="/"
+        width={800}
+        height={600}
+        reloadKey={0}
+        isPicking={false}
+        highlightedPath={null}
+        onStatusChange={onStatusChange}
+      />,
+    );
+    const frame = rendered.container.querySelector("iframe");
+    if (frame === null) throw new Error("the frame did not render");
+    return { rendered, frame };
+  };
+
+  /** The page announcing itself. */
+  const ready = (frame: HTMLIFrameElement, draftMode: boolean) => {
+    const message: ValCanvasPageMessage = {
+      val: VAL_CANVAS_MESSAGE,
+      type: "ready",
+      draftMode,
+      url: "/",
+    };
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          source: frame.contentWindow,
+          data: message,
+        }),
+      );
+    });
+  };
+
+  test("waiting, then what the page said", () => {
+    const seen: CanvasPreviewStatus[] = [];
+    const { frame } = renderFrame((status) => seen.push(status));
+    expect(seen[0]).toBe("connecting");
+    ready(frame, false);
+    expect(seen.at(-1)).toBe("preview-off");
+    ready(frame, true);
+    expect(seen.at(-1)).toBe("live");
+  });
+
+  /**
+   * The canvas must not turn preview mode on by itself.
+   *
+   * `enableKey` is watched by an effect that also depends on `enablePreview`,
+   * which is rebuilt whenever the canvas changes route - so a "skip the first
+   * run" flag let every later run through, and typing a different route
+   * navigated the frame through `/api/val/enable`. That is a cookie being set
+   * on somebody's site because they looked at a second page, and no test above
+   * this level can see it: the canvas comes out working, just more enabled than
+   * anyone asked for.
+   */
+  test("does not enable preview mode on its own when the route changes", () => {
+    const { rendered, frame } = renderFrame(() => undefined);
+    const src = frame.getAttribute("src");
+    rendered.rerender(
+      <CanvasFrame
+        url="/blogs/blog1"
+        width={800}
+        height={600}
+        reloadKey={0}
+        isPicking={false}
+        highlightedPath={null}
+        enableKey={0}
+      />,
+    );
+    const after = rendered.container.querySelector("iframe");
+    expect(after?.getAttribute("src")).not.toContain("/api/val/enable");
+    // And it is the new page, not the old one: the frame still follows `url`.
+    expect(after?.getAttribute("src")).not.toBe(src);
+  });
+
+  test("and does when the key moves", () => {
+    const { rendered, frame } = renderFrame(() => undefined);
+    rendered.rerender(
+      <CanvasFrame
+        url="/"
+        width={800}
+        height={600}
+        reloadKey={0}
+        isPicking={false}
+        highlightedPath={null}
+        enableKey={1}
+      />,
+    );
+    // Assigning `src` is the navigation - the frame is not remounted for it,
+    // so this is the same element with a new location.
+    expect(frame.getAttribute("src")).toContain("/api/val/enable");
+  });
+
+  /**
+   * An enable that never lands must not say "Turning on…" forever. `isEnabling`
+   * is only cleared by the page announcing itself, so a redirect that 404s or a
+   * page that does not come back would sit in that state for the life of the
+   * tab - with no diagnosis and none of the actions that go with one.
+   */
+  test("an enable that never answers gives up like any other attempt", () => {
+    jest.useFakeTimers();
+    try {
+      const seen: CanvasPreviewStatus[] = [];
+      const { rendered } = renderFrame((status) => seen.push(status));
+      rendered.rerender(
+        <CanvasFrame
+          url="/"
+          width={800}
+          height={600}
+          reloadKey={0}
+          isPicking={false}
+          highlightedPath={null}
+          enableKey={1}
+          onStatusChange={(status) => seen.push(status)}
+        />,
+      );
+      expect(seen.at(-1)).toBe("enabling");
+      act(() => {
+        jest.advanceTimersByTime(ANSWER_TIMEOUT_MS);
+      });
+      expect(seen.at(-1)).toBe("no-answer");
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("nothing is rendered over the page", () => {
+    // The frame is the whole of the canvas now: one iframe, no overlay. The
+    // notice lives above the viewport, outside the zoom transform.
+    const { rendered } = renderFrame(() => undefined);
+    expect(rendered.container.textContent).toBe("");
+  });
+});

--- a/packages/ui/spa/components/shell/deploymentRows.test.tsx
+++ b/packages/ui/spa/components/shell/deploymentRows.test.tsx
@@ -1,0 +1,53 @@
+/** @jest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { DeploymentRows } from "./Deployments";
+import { ShellDeployment } from "./types";
+
+/**
+ * The rows of the deploy feed, which are a feed and not an inbox.
+ *
+ * Every row used to carry a dismiss button. That was a control for a list that
+ * GREW - the client accumulated every deployment a session had ever seen, so
+ * without clearing rows the list only got longer - and the feed is bounded now:
+ * the content service returns the last few publishes and the client keeps the
+ * newest few of those. What a row would be dismissed for is that it is old, and
+ * being old is what takes it off the end on its own.
+ */
+const deployment = (
+  overrides: Partial<ShellDeployment> & Pick<ShellDeployment, "commitSha">,
+): ShellDeployment => ({
+  state: "success",
+  message: "Update the hero",
+  timestamp: "12 minutes ago",
+  updatedAt: "2026-08-25T11:48:00Z",
+  isLive: true,
+  ...overrides,
+});
+
+describe("the deploy feed's rows", () => {
+  test("say what happened, and offer nothing to press", () => {
+    render(<DeploymentRows deployments={[deployment({ commitSha: "abc" })]} />);
+    expect(screen.queryByText("Update the hero")).not.toBeNull();
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
+  });
+
+  test("a finished publish has no dismiss control either", () => {
+    // It was only offered on rows that were NOT building, which made the
+    // control appear as a publish landed - just as it stopped being worth
+    // looking at.
+    render(
+      <DeploymentRows
+        deployments={[
+          deployment({ commitSha: "abc", state: "failure", isLive: false }),
+          deployment({ commitSha: "def", state: "pending", isLive: false }),
+        ]}
+      />,
+    );
+    expect(screen.queryByLabelText("Dismiss deployment")).toBeNull();
+  });
+
+  test("an empty feed explains itself rather than showing nothing", () => {
+    render(<DeploymentRows deployments={[]} />);
+    expect(screen.queryByText(/Nothing published yet/)).not.toBeNull();
+  });
+});

--- a/packages/ui/spa/components/shell/deployments.test.ts
+++ b/packages/ui/spa/components/shell/deployments.test.ts
@@ -230,28 +230,47 @@ describe("toDeployments", () => {
  * Whether an unseen commit is worth opening the list for. See
  * `isDeploymentNews` - "not in the previous feed" cannot tell a publish that
  * just happened from one that finished before this tab existed.
+ *
+ * Decided by the clock alone. It used to make anything not LIVE news, which
+ * held while the feed only carried the publishes on the current chain: a row
+ * that was not live was one on its way out. The feed is the last few publishes
+ * now - a push, a merged pull request, a revert, from any time - and Val only
+ * ever observes the current commit serving the site, so "not live" is the
+ * resting state of every superseded publish. Left as it was, opening Val would
+ * pop the list open to announce a build from last Tuesday.
  */
 describe("isDeploymentNews", () => {
-  test("a publish still on its way out is news however old it is", () => {
+  test("nothing an hour old is news, whatever state it is in", () => {
+    for (const state of ["pending", "failure", "success"] as const) {
+      expect(
+        isDeploymentNews(
+          deployment({ commitSha: "a", state, updatedAt: minutesAgo(120) }),
+          NOW,
+        ),
+      ).toBe(false);
+    }
+  });
+
+  test("a publish on its way out is news while it is fresh", () => {
     expect(
       isDeploymentNews(
         deployment({
           commitSha: "a",
           state: "pending",
-          updatedAt: minutesAgo(120),
+          updatedAt: minutesAgo(1),
         }),
         NOW,
       ),
     ).toBe(true);
   });
 
-  test("a failed publish is news however old it is", () => {
+  test("so is one that has just failed", () => {
     expect(
       isDeploymentNews(
         deployment({
           commitSha: "a",
           state: "failure",
-          updatedAt: minutesAgo(120),
+          updatedAt: minutesAgo(1),
         }),
         NOW,
       ),

--- a/packages/ui/spa/components/shell/deployments.test.ts
+++ b/packages/ui/spa/components/shell/deployments.test.ts
@@ -183,6 +183,40 @@ describe("toDeployments", () => {
     ).toBe(true);
   });
 
+  /**
+   * A git message is a subject, a blank line and a body. Val's own messages are
+   * one line, so this only shows up on the deployments Val did not publish -
+   * and the rows truncate, so the whole body arrived as one long line with the
+   * subject lost at the front of it.
+   */
+  test("shows the subject line of a multi-line git message", () => {
+    const [row] = toDeployments(
+      [
+        {
+          ...enriched,
+          commitMessage:
+            "Bump the dependency\n\nThe old one pinned a transitive package we\nno longer use.",
+        },
+      ],
+      new Set(),
+      {},
+      now,
+    );
+    expect(row.message).toBe("Bump the dependency");
+  });
+
+  test("a message that is only whitespace is no message", () => {
+    // Which is what makes the row fall back to the short sha rather than
+    // rendering an empty title.
+    const [row] = toDeployments(
+      [{ ...enriched, commitMessage: "  \n\n" }],
+      new Set(),
+      {},
+      now,
+    );
+    expect(row.message).toBeNull();
+  });
+
   test("keeps the feed short enough to read", () => {
     const many = Array.from({ length: 25 }, (_, index) => ({
       ...enriched,

--- a/packages/ui/spa/components/shell/mockShellData.ts
+++ b/packages/ui/spa/components/shell/mockShellData.ts
@@ -531,6 +531,24 @@ export const mockDeployments: ShellDeployment[] = [
     updatedAt: mockMinutesAgo(60),
     isLive: false,
   },
+  /*
+   * A deployment nobody published from Val: a developer's push, a merged pull
+   * request, a revert. On most projects these are the majority of the feed.
+   *
+   * No `author`, because there is no Val commit and therefore no profile to
+   * resolve - and the message is the SUBJECT of a git message, which is what
+   * `commitSubject` leaves of one that has a body. The row is a single
+   * truncated line, so a body rendered into it arrives as "Subject The body
+   * went on like this…".
+   */
+  {
+    commitSha: "7d4e1b0c58a2946fbb31e70d5c8f2a6391e4c0af",
+    state: "success",
+    message: "Move the pricing table into its own component",
+    timestamp: "3 hours ago",
+    updatedAt: mockMinutesAgo(180),
+    isLive: true,
+  },
 ];
 
 /**

--- a/packages/ui/spa/components/shell/mockShellData.ts
+++ b/packages/ui/spa/components/shell/mockShellData.ts
@@ -423,13 +423,27 @@ export const mockValidationErrors: ShellValidationError[] = [
 ];
 
 /**
- * Recent activity, as `toActivity` builds it: the module's file label followed
- * by the patch path, and the author id resolved to a name where a profile is
- * known. A local dev project has no profiles, which is why the last entry has
- * no author rather than a placeholder one.
+ * Recent activity, as `toActivity` builds it: the edits and the publishes,
+ * interleaved by time.
+ *
+ * A change row is the module's file label followed by the patch path, and the
+ * author id resolved to a name where a profile is known — a local dev project
+ * has no profiles, which is why the last entry has no author rather than a
+ * placeholder one. The deploy rows are the same publishes `mockDeployments`
+ * has, which is what the real mapping does with them.
  */
 export const mockActivity: ShellActivityEntry[] = [
   {
+    kind: "deploy",
+    id: "deploy-9f21c4ae0b7d1e5a3c8f2d6b04e7a915cd83f620",
+    title: "Update hero copy and pricing table",
+    state: "Building",
+    progress: "building",
+    timestamp: "just now",
+    author: "Fredrik Ekholdt",
+  },
+  {
+    kind: "change",
     id: '/app/page.val.ts?p="/"/hero/title-0',
     sourcePath: '/app/page.val.ts?p="/"."hero"."title"',
     title: "page › hero › title",
@@ -437,6 +451,16 @@ export const mockActivity: ShellActivityEntry[] = [
     author: "Fredrik Ekholdt",
   },
   {
+    kind: "deploy",
+    id: "deploy-3ab77c1902ef4d885b16c0da79f3e421ab5c9d08",
+    title: "Add customer story: nordic-retail",
+    state: "Live",
+    progress: "settled",
+    timestamp: "12 minutes ago",
+    author: "Ida Sørensen",
+  },
+  {
+    kind: "change",
     id: '/app/pricing/page.val.ts?p="/pricing"/plans-1',
     sourcePath: '/app/pricing/page.val.ts?p="/pricing"."plans"',
     title: "page › plans",
@@ -444,6 +468,7 @@ export const mockActivity: ShellActivityEntry[] = [
     author: "Fredrik Ekholdt",
   },
   {
+    kind: "change",
     id: "/content/navigation.val.ts?primary-2",
     sourcePath: '/content/navigation.val.ts?p="primary"',
     title: "navigation › primary",
@@ -451,6 +476,16 @@ export const mockActivity: ShellActivityEntry[] = [
     author: "Ida Sørensen",
   },
   {
+    kind: "deploy",
+    id: "deploy-c05e9182aab34f6072d1e5b8c4a09f37e6215dba",
+    title: "Swap footer links",
+    state: "Build failed",
+    progress: "failed",
+    timestamp: "1 hour ago",
+    author: "Fredrik Ekholdt",
+  },
+  {
+    kind: "change",
     id: '/app/blog/[slug]/page.val.ts?p="/blog/why-we-built-val"/text-3',
     sourcePath:
       '/app/blog/[slug]/page.val.ts?p="/blog/why-we-built-val"."text"',

--- a/packages/ui/spa/components/shell/recentActivity.test.tsx
+++ b/packages/ui/spa/components/shell/recentActivity.test.tsx
@@ -1,0 +1,77 @@
+/** @jest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { UtilityPanel } from "./UtilityPanel";
+import { ShellActivityEntry } from "./types";
+
+/**
+ * Recent activity, which is now edits AND publishes.
+ *
+ * The publishes were visible only in the status bar's deploy feed, which is a
+ * live-progress indicator: it empties itself as builds land, so the moment a
+ * publish finished there was nowhere in the Studio that said it had.
+ *
+ * What is pinned here is the two kinds of row being different kinds of thing —
+ * an edit is somewhere to go, a publish is something that happened — because
+ * that is the part a later refactor would flatten.
+ */
+const change: ShellActivityEntry = {
+  kind: "change",
+  id: "change-1",
+  sourcePath: '/content/home.val.ts?p="hero"."title"',
+  title: "home › hero › title",
+  timestamp: "2 minutes ago",
+  author: "Ada",
+};
+
+const deploy: ShellActivityEntry = {
+  kind: "deploy",
+  id: "deploy-abc1234",
+  title: "Update the hero",
+  state: "Live",
+  progress: "settled",
+  timestamp: "12 minutes ago",
+  author: "Ida",
+};
+
+function panel(
+  activity: ShellActivityEntry[],
+  onSelectActivity: () => void = () => undefined,
+) {
+  return (
+    <UtilityPanel
+      breakpoint="desktop"
+      activity={activity}
+      onNewPage={() => undefined}
+      onUploadMedia={() => undefined}
+      onSelectActivity={onSelectActivity}
+      onClose={() => undefined}
+    />
+  );
+}
+
+describe("recent activity", () => {
+  test("lists publishes alongside changes", () => {
+    render(panel([change, deploy]));
+    expect(screen.queryByText("home › hero › title")).not.toBeNull();
+    expect(screen.queryByText("Update the hero")).not.toBeNull();
+  });
+
+  test("says how a publish is doing, and who published it", () => {
+    render(panel([deploy]));
+    expect(screen.queryByText("Live · Ida · 12 minutes ago")).not.toBeNull();
+  });
+
+  test("a change is something to open", () => {
+    const onSelectActivity = jest.fn();
+    render(panel([change], onSelectActivity));
+    screen.getByRole("button", { name: /home › hero › title/ }).click();
+    expect(onSelectActivity).toHaveBeenCalledTimes(1);
+  });
+
+  test("a publish is not - there is nothing in the Studio a commit opens", () => {
+    render(panel([deploy]));
+    expect(
+      screen.queryByRole("button", { name: /Update the hero/ }),
+    ).toBeNull();
+  });
+});

--- a/packages/ui/spa/components/shell/saveIndicator.test.tsx
+++ b/packages/ui/spa/components/shell/saveIndicator.test.tsx
@@ -1,0 +1,42 @@
+/** @jest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { SaveIndicator } from "./StatusBar";
+
+/**
+ * What the status bar says about saving.
+ *
+ * The resting state used to be "All changes saved locally", which against a
+ * project is wrong: the patch is on the content service, which is where it has
+ * to be for a colleague to see it and for Publish to ship it. "Locally" reads
+ * as "still only on this machine" — the one thing an editor would want to know,
+ * said backwards.
+ *
+ * Pinned as copy because that is the whole of the fix, and because the word is
+ * an easy one to put back while "clarifying" the sentence.
+ */
+describe("the save indicator", () => {
+  test("says changes are saved, without claiming where", () => {
+    render(<SaveIndicator saveState="saved" />);
+    expect(screen.queryByText("All changes saved")).not.toBeNull();
+  });
+
+  test("shortens rather than qualifies on a narrow bar", () => {
+    render(<SaveIndicator saveState="saved" breakpoint="tablet" />);
+    expect(screen.queryByText("Saved")).not.toBeNull();
+  });
+
+  test("never says locally", () => {
+    const { container } = render(<SaveIndicator saveState="saved" />);
+    expect(container.textContent).not.toMatch(/local/i);
+  });
+
+  // The other two states are unchanged, and are what the bar is read for when
+  // something is wrong.
+  test("still says when a save is in flight, and when one failed", () => {
+    const { unmount } = render(<SaveIndicator saveState="saving" />);
+    expect(screen.queryByText("Saving…")).not.toBeNull();
+    unmount();
+    render(<SaveIndicator saveState="error" />);
+    expect(screen.queryByText("Could not save")).not.toBeNull();
+  });
+});

--- a/packages/ui/spa/components/shell/shellDataMapping.test.ts
+++ b/packages/ui/spa/components/shell/shellDataMapping.test.ts
@@ -10,7 +10,14 @@ import {
   toValidationErrors,
 } from "./shellDataMapping";
 import { ExplorerItem, SitemapItem } from "../NavMenu/types";
-import { ShellData, ShellDataModule, ShellMediaGallery } from "./types";
+import {
+  ShellActivityEntry,
+  ShellChangeActivity,
+  ShellData,
+  ShellDataModule,
+  ShellDeployment,
+  ShellMediaGallery,
+} from "./types";
 
 /**
  * The provider-to-shell mapping.
@@ -253,10 +260,46 @@ describe("toActivity", () => {
   /** Ten minutes after the timestamps below, so "10 minutes ago" is stable. */
   const now = new Date("2026-08-24T10:10:00Z").getTime();
 
+  /**
+   * A publish, as `toDeployments` produces one. `isLive` false is the state
+   * every publish starts in and the one `state` still speaks for.
+   */
+  const deployment = (
+    overrides: Partial<ShellDeployment> & Pick<ShellDeployment, "commitSha">,
+  ): ShellDeployment => ({
+    state: "success",
+    message: "A publish",
+    timestamp: "just now",
+    updatedAt: "2026-08-24T10:09:00Z",
+    isLive: false,
+    ...overrides,
+  });
+
+  /**
+   * The change rows, narrowed.
+   *
+   * The feed is a union now, so a test that means "the edits" has to say so —
+   * and one that reads `sourcePath` off whatever came first would pass for the
+   * wrong reason the day a publish sorts above it.
+   */
+  const changes = (entries: ShellActivityEntry[]): ShellChangeActivity[] =>
+    entries.filter(
+      (entry): entry is ShellChangeActivity => entry.kind === "change",
+    );
+
   test("reads as a trail from the file to what changed in it", () => {
-    const [entry] = toActivity(
-      [set("/content/home.val.ts", ["hero", "title"], "2026-08-24T10:00:00Z")],
-      now,
+    const [entry] = changes(
+      toActivity(
+        [
+          set(
+            "/content/home.val.ts",
+            ["hero", "title"],
+            "2026-08-24T10:00:00Z",
+          ),
+        ],
+        [],
+        now,
+      ),
     );
     expect(entry.title).toBe("home › hero › title");
     expect(entry.author).toBe("ada");
@@ -267,15 +310,20 @@ describe("toActivity", () => {
   test("carries a source path that resolves", () => {
     // The grammar matters: string keys are quoted, array indices are bare. A
     // hand-joined path looks close enough to work and then opens nothing.
-    const [entry] = toActivity(
-      [set("/content/home.val.ts", ["items", "0", "title"], "x")],
-      now,
+    const [entry] = changes(
+      toActivity(
+        [set("/content/home.val.ts", ["items", "0", "title"], "x")],
+        [],
+        now,
+      ),
     );
     expect(entry.sourcePath).toBe('/content/home.val.ts?p="items".0."title"');
   });
 
   test("a whole-module change points at the module", () => {
-    const [entry] = toActivity([set("/content/home.val.ts", [], "x")], now);
+    const [entry] = changes(
+      toActivity([set("/content/home.val.ts", [], "x")], [], now),
+    );
     expect(entry.sourcePath).toBe("/content/home.val.ts");
   });
 
@@ -283,7 +331,7 @@ describe("toActivity", () => {
     const many = Array.from({ length: 20 }, (_, i) =>
       set("/content/home.val.ts", [`field${i}`], "2026-08-24T10:00:00Z"),
     );
-    const activity = toActivity(many, now);
+    const activity = toActivity(many, [], now);
     expect(activity).toHaveLength(8);
     expect(activity[0].title).toBe("home › field0");
   });
@@ -295,17 +343,144 @@ describe("toActivity", () => {
         set("/content/home.val.ts", ["title"], "2026-08-24T10:00:00Z"),
         set("/content/home.val.ts", ["title"], "2026-08-23T10:00:00Z"),
       ],
+      [],
       now,
     );
     expect(activity[0].id).not.toBe(activity[1].id);
   });
 
   test("survives a patch with no author", () => {
-    const [entry] = toActivity(
-      [{ ...set("/content/home.val.ts", ["title"], "x"), lastUpdatedBy: null }],
-      now,
+    const [entry] = changes(
+      toActivity(
+        [
+          {
+            ...set("/content/home.val.ts", ["title"], "x"),
+            lastUpdatedBy: null,
+          },
+        ],
+        [],
+        now,
+      ),
     );
     expect(entry.author).toBeUndefined();
+  });
+
+  /**
+   * The publishes, which used to be visible only in the status bar's deploy
+   * feed — a live-progress indicator that empties itself as builds land, so
+   * once a publish had finished nothing in the Studio said it had.
+   */
+  describe("publishes", () => {
+    test("show up beside the changes, interleaved by time", () => {
+      const activity = toActivity(
+        [
+          set("/content/home.val.ts", ["title"], "2026-08-24T10:08:00Z"),
+          set("/content/home.val.ts", ["intro"], "2026-08-24T10:00:00Z"),
+        ],
+        [
+          deployment({
+            commitSha: "abc1234def",
+            updatedAt: "2026-08-24T10:05:00Z",
+          }),
+        ],
+        now,
+      );
+      expect(activity.map((entry) => entry.kind)).toEqual([
+        "change",
+        "deploy",
+        "change",
+      ]);
+    });
+
+    test("are named by their commit message", () => {
+      const [entry] = toActivity(
+        [],
+        [deployment({ commitSha: "abc1234def", message: "Update the hero" })],
+        now,
+      );
+      expect(entry.title).toBe("Update the hero");
+    });
+
+    test("fall back to the short sha when there is no message", () => {
+      // Which is what the deploy feed shows for the same publish.
+      const [entry] = toActivity(
+        [],
+        [deployment({ commitSha: "abc1234def5678", message: null })],
+        now,
+      );
+      expect(entry.title).toBe("abc1234");
+    });
+
+    test("say how the publish is doing", () => {
+      const [building, failed, live] = toActivity(
+        [],
+        [
+          deployment({
+            commitSha: "a",
+            state: "pending",
+            updatedAt: "2026-08-24T10:09:00Z",
+          }),
+          deployment({
+            commitSha: "b",
+            state: "failure",
+            updatedAt: "2026-08-24T10:08:00Z",
+          }),
+          deployment({
+            commitSha: "c",
+            state: "success",
+            isLive: true,
+            updatedAt: "2026-08-24T10:07:00Z",
+          }),
+        ],
+        now,
+      );
+      expect(building).toMatchObject({
+        state: "Building",
+        progress: "building",
+      });
+      expect(failed).toMatchObject({
+        state: "Build failed",
+        progress: "failed",
+      });
+      // The site answering with the commit outranks the build state, which is
+      // the deploy feed's rule and has to stay one rule.
+      expect(live).toMatchObject({ state: "Live", progress: "settled" });
+    });
+
+    test("keep the ids apart from the changes'", () => {
+      const [entry] = toActivity([], [deployment({ commitSha: "abc" })], now);
+      expect(entry.id).toBe("deploy-abc");
+    });
+
+    /**
+     * A run of publishes must not push out the edits: this panel exists to get
+     * back to them, and the whole feed is in the status bar's list anyway.
+     */
+    test("never take more than a few of the rows", () => {
+      const activity = toActivity(
+        [set("/content/home.val.ts", ["title"], "2026-08-20T10:00:00Z")],
+        Array.from({ length: 10 }, (_, i) =>
+          deployment({
+            commitSha: `sha${i}`,
+            updatedAt: `2026-08-24T10:0${i % 10}:00Z`,
+          }),
+        ),
+        now,
+      );
+      expect(activity.filter((entry) => entry.kind === "deploy")).toHaveLength(
+        3,
+      );
+      expect(changes(activity)).toHaveLength(1);
+    });
+
+    test("an unreadable timestamp sorts last rather than scrambling the feed", () => {
+      const activity = toActivity(
+        [set("/content/home.val.ts", ["title"], "2026-08-24T10:00:00Z")],
+        [deployment({ commitSha: "abc", updatedAt: "not a date" })],
+        now,
+      );
+      expect(activity.map((entry) => entry.kind)).toEqual(["change", "deploy"]);
+    });
   });
 });
 

--- a/packages/ui/spa/components/shell/shellDataMapping.ts
+++ b/packages/ui/spa/components/shell/shellDataMapping.ts
@@ -3,11 +3,13 @@ import { ExplorerItem, SitemapItem } from "../NavMenu/types";
 import { AvailableRoute } from "../NavMenu/NewPageForm";
 import { routePatternToString } from "../NavMenu/SitemapItem";
 import { ValEnrichedDeployment } from "../../utils/mergeCommitsAndDeployments";
+import { deploymentProgress, describeDeploymentState } from "./Deployments";
 import {
   ShellActivityEntry,
   ShellAdminLinks,
   ShellData,
   ShellDataModule,
+  ShellDeployActivity,
   ShellDeployment,
   ShellDestination,
   ShellExternalPage,
@@ -158,10 +160,29 @@ export function toValidationErrors(
 const ACTIVITY_LIMIT = 8;
 
 /**
- * Recent activity, from the patch sets.
+ * How many of those may be publishes.
+ *
+ * An afternoon of publishing produces a run of deploys — one of yours, one of a
+ * colleague's, a retried build — and a straight merge by time would fill the
+ * whole list with them and push out the edits the panel exists to get back to.
+ * The deploy feed in the status bar has them all; here they are context, so
+ * they get a minority of the rows and never the last edit's place.
+ */
+const DEPLOY_ACTIVITY_LIMIT = 3;
+
+/**
+ * Recent activity: the unpublished edits and the publishes, newest first.
  *
  * Patch sets are already newest first and already grouped by the thing that
- * changed, which is exactly what this list wants.
+ * changed, which is exactly what this list wants. Publishes come in as the rows
+ * the deploy feed renders — same labels, same three states — because a publish
+ * that reads one way in the status bar and another here is two answers to one
+ * question.
+ *
+ * The two are then interleaved by time, which is what makes it a feed rather
+ * than two lists in one box: "I changed the hero, then it went out, then Ida
+ * changed the pricing" is the sentence someone opening this panel is trying to
+ * read.
  */
 export function toActivity(
   patchSets: Array<{
@@ -171,35 +192,92 @@ export function toActivity(
     lastUpdatedBy: string | null;
   }>,
   /**
+   * The publishes, already mapped by {@link toDeployments}.
+   *
+   * Rows rather than the raw feed, so this cannot disagree with the deploy list
+   * about what a publish is called or how it is doing.
+   */
+  deployments: ShellDeployment[],
+  /**
    * A parameter rather than a call to `Date.now()`, so the result is a function
    * of its inputs and can be tested — the same reason `toDeployments` takes one.
    */
   now: number,
 ): ShellActivityEntry[] {
-  return patchSets.slice(0, ACTIVITY_LIMIT).map(
-    (set, index): ShellActivityEntry => ({
-      // The index is load-bearing: two patch sets can share a module and a path,
-      // and React needs them apart. `sourcePath` is the one that means something.
-      id: `${set.moduleFilePath}?${set.patchPath.join("/")}-${index}`,
-      /**
-       * Where the change was, as a real source path.
-       *
-       * Built with `patchPathToModulePath`, which is the only thing that knows
-       * the grammar — string keys are JSON-quoted, array indices are bare — so
-       * `["items", "0", "title"]` becomes `"items".0."title"` and not something
-       * that looks close enough to work and then does not resolve.
-       */
-      sourcePath: Internal.joinModuleFilePathAndModulePath(
-        set.moduleFilePath,
-        Internal.patchPathToModulePath(set.patchPath),
-      ),
-      title: [fileLabel(set.moduleFilePath), ...set.patchPath].join(" › "),
-      // Relative, because this is a "what have I been doing" list and an ISO
-      // timestamp is not an answer to that. It was rendered raw.
-      timestamp: formatRelativeTime(set.lastUpdated, now),
-      author: set.lastUpdatedBy ?? undefined,
+  const changes = patchSets.slice(0, ACTIVITY_LIMIT).map(
+    (set, index): Dated<ShellActivityEntry> => ({
+      at: timeOf(set.lastUpdated),
+      entry: {
+        kind: "change",
+        // The index is load-bearing: two patch sets can share a module and a
+        // path, and React needs them apart. `sourcePath` is the one that means
+        // something.
+        id: `${set.moduleFilePath}?${set.patchPath.join("/")}-${index}`,
+        /**
+         * Where the change was, as a real source path.
+         *
+         * Built with `patchPathToModulePath`, which is the only thing that knows
+         * the grammar — string keys are JSON-quoted, array indices are bare — so
+         * `["items", "0", "title"]` becomes `"items".0."title"` and not something
+         * that looks close enough to work and then does not resolve.
+         */
+        sourcePath: Internal.joinModuleFilePathAndModulePath(
+          set.moduleFilePath,
+          Internal.patchPathToModulePath(set.patchPath),
+        ),
+        title: [fileLabel(set.moduleFilePath), ...set.patchPath].join(" › "),
+        // Relative, because this is a "what have I been doing" list and an ISO
+        // timestamp is not an answer to that. It was rendered raw.
+        timestamp: formatRelativeTime(set.lastUpdated, now),
+        author: set.lastUpdatedBy ?? undefined,
+      },
     }),
   );
+  const deploys = deployments.slice(0, DEPLOY_ACTIVITY_LIMIT).map(
+    (deployment): Dated<ShellActivityEntry> => ({
+      at: timeOf(deployment.updatedAt),
+      entry: toDeployActivity(deployment),
+    }),
+  );
+  return (
+    [...changes, ...deploys]
+      // Newest first. A stable sort, so patch sets that share a timestamp stay
+      // in the order the store gave them — which is the order they happened in.
+      .sort((a, b) => b.at - a.at)
+      .slice(0, ACTIVITY_LIMIT)
+      .map(({ entry }) => entry)
+  );
+}
+
+/** An entry with the instant it is sorted by, which the entry itself has lost. */
+type Dated<T> = { at: number; entry: T };
+
+/**
+ * An ISO timestamp as milliseconds, for sorting only.
+ *
+ * An unreadable one sorts oldest rather than throwing the whole feed off: `NaN`
+ * makes every comparison false, which leaves the sort's output unspecified.
+ */
+function timeOf(iso: string): number {
+  const at = new Date(iso).getTime();
+  return Number.isNaN(at) ? 0 : at;
+}
+
+/** One publish, as an activity row. */
+function toDeployActivity(deployment: ShellDeployment): ShellDeployActivity {
+  return {
+    kind: "deploy",
+    // Prefixed, because a commit sha and a patch set id share one list now.
+    id: `deploy-${deployment.commitSha}`,
+    // The commit message when there is one. Without it there is nothing to say
+    // about the publish but which commit it was, and the short sha is what the
+    // deploy feed shows for the same publish.
+    title: deployment.message ?? deployment.commitSha.slice(0, 7),
+    state: describeDeploymentState(deployment),
+    progress: deploymentProgress(deployment),
+    timestamp: deployment.timestamp,
+    author: deployment.author,
+  };
 }
 
 /** How many publishes the deployment feed keeps. */

--- a/packages/ui/spa/components/shell/shellDataMapping.ts
+++ b/packages/ui/spa/components/shell/shellDataMapping.ts
@@ -2,7 +2,10 @@ import { Internal, ModuleFilePath, SourcePath } from "@valbuild/core";
 import { ExplorerItem, SitemapItem } from "../NavMenu/types";
 import { AvailableRoute } from "../NavMenu/NewPageForm";
 import { routePatternToString } from "../NavMenu/SitemapItem";
-import { ValEnrichedDeployment } from "../../utils/mergeCommitsAndDeployments";
+import {
+  commitSubject,
+  ValEnrichedDeployment,
+} from "../../utils/mergeCommitsAndDeployments";
 import { deploymentProgress, describeDeploymentState } from "./Deployments";
 import {
   ShellActivityEntry,
@@ -300,7 +303,7 @@ export function toDeployments(
     (deployment): ShellDeployment => ({
       commitSha: deployment.commitSha,
       state: deployment.deploymentState,
-      message: deployment.commitMessage,
+      message: commitSubject(deployment.commitMessage),
       author: deployment.creator
         ? profilesByAuthorId[deployment.creator]?.fullName
         : undefined,

--- a/packages/ui/spa/components/shell/stories/CanvasPreviewNotice.stories.tsx
+++ b/packages/ui/spa/components/shell/stories/CanvasPreviewNotice.stories.tsx
@@ -1,0 +1,129 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+  CanvasPreviewNotice,
+  CanvasPreviewStatus,
+} from "../canvas/CanvasPreviewNotice";
+
+/**
+ * What the canvas says when it cannot do its job.
+ *
+ * This replaced a panel over the frame with a blurred backdrop, and the mock
+ * page behind these stories is the point of them: the published page underneath
+ * is real, and worth reading and scrolling, so judge this against the page
+ * rather than on its own. Anything that hides more of it than the pill does is
+ * the old design coming back.
+ *
+ * The severity is a clock, not a state — see `PREVIEW_WARNING_DELAY_MS` — so
+ * each story below is one END of it. The stories force it rather than waiting
+ * twenty seconds, which is what `warning` does.
+ */
+const meta: Meta<typeof CanvasPane> = {
+  title: "Shell/CanvasPreviewNotice",
+  component: CanvasPane,
+  parameters: {
+    layout: "fullscreen",
+    // The pane paints its own canvas colour, and the page inside it is white.
+    backgrounds: { disable: true },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A page, standing in for the site the canvas is showing.
+ *
+ * Deliberately busy at the top, where the notice sits: a pill over an empty
+ * white band proves nothing about how much it is in the way.
+ */
+function MockPage() {
+  return (
+    <div className="h-full overflow-y-auto bg-white text-neutral-900">
+      <header className="flex items-center justify-between border-b border-neutral-200 px-8 py-5">
+        <span className="text-lg font-semibold tracking-tight">northwind</span>
+        <nav className="flex gap-6 text-sm text-neutral-500">
+          <span>Products</span>
+          <span>Pricing</span>
+          <span>Customers</span>
+          <span>Docs</span>
+        </nav>
+      </header>
+      <div className="px-8 py-16">
+        <h1 className="max-w-xl text-4xl font-semibold leading-tight tracking-tight">
+          Everything your warehouse already knew, finally written down
+        </h1>
+        <p className="mt-4 max-w-lg text-neutral-500">
+          Stock, orders and deliveries in one place — and the same numbers in
+          the app your drivers already use.
+        </p>
+        <div className="mt-8 flex gap-3">
+          <span className="rounded-md bg-neutral-900 px-4 py-2 text-sm text-white">
+            Start free
+          </span>
+          <span className="rounded-md border border-neutral-300 px-4 py-2 text-sm">
+            Book a demo
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The canvas pane as `PageWorkspace` builds it: the page, and the notice above
+ * it in the same `relative` box.
+ */
+function CanvasPane({
+  status,
+  warning,
+}: {
+  status: CanvasPreviewStatus;
+  /**
+   * Skip the wait, so the warning end of the clock is reachable in a story.
+   *
+   * The clock runs from when the attempt began and re-mounting only restarts
+   * it, so the delay is a prop with a default rather than something a story
+   * can wait out - twenty seconds is longer than anyone reviewing a design
+   * will sit still for.
+   */
+  warning?: boolean;
+}) {
+  return (
+    <div className="h-screen bg-bg-canvas p-6">
+      <div className="relative h-full overflow-hidden rounded-xl border border-border-float bg-bg-float-raised">
+        <MockPage />
+        <CanvasPreviewNotice
+          status={status}
+          warnAfterMs={warning ? 0 : undefined}
+          onEnable={() => console.log("enable preview mode")}
+          onReload={() => console.log("reload")}
+        />
+      </div>
+    </div>
+  );
+}
+
+/** The first twenty seconds of anything: a spinner, and no accusation. */
+export const NotReadyYet: Story = {
+  render: () => <CanvasPane status="preview-off" />,
+};
+
+/** Past the wait, with the page having answered that draft mode is off. */
+export const PreviewModeOff: Story = {
+  render: () => <CanvasPane status="preview-off" warning />,
+};
+
+/** Past the wait, with nothing having answered at all. */
+export const NoAnswer: Story = {
+  render: () => <CanvasPane status="no-answer" warning />,
+};
+
+/** Between the click and the new document arriving. */
+export const TurningOn: Story = {
+  render: () => <CanvasPane status="enabling" />,
+};
+
+/** Working: the notice is not there at all. */
+export const Live: Story = {
+  render: () => <CanvasPane status="live" />,
+};

--- a/packages/ui/spa/components/shell/stories/Shell.stories.tsx
+++ b/packages/ui/spa/components/shell/stories/Shell.stories.tsx
@@ -146,6 +146,14 @@ type HarnessProps = {
   openPanel: ShellPanel | null;
   selectionId: string | null;
   empty: boolean;
+  /**
+   * Nothing queued, without emptying the project.
+   *
+   * Its own control because "no pending changes" and "a project with nothing
+   * in it" are different stories, and Review is the affordance that has to be
+   * there in both — see `ReviewButton`.
+   */
+  noPendingChanges: boolean;
   withoutRouters: boolean;
   searchOpen: boolean;
   aiEnabled: boolean;
@@ -243,6 +251,7 @@ function ShellHarness({
   openPanel,
   selectionId,
   empty,
+  noPendingChanges,
   withoutRouters,
   aiEnabled,
   searchOpen,
@@ -286,7 +295,7 @@ function ShellHarness({
   return (
     <Shell
       renderSettings={() => <MockSettingsSections />}
-      key={`${openPanel}-${selectionId}-${empty}-${withoutRouters}-${aiEnabled}-${searchOpen}-${isLoading}-${loadError}-${mode}-${deployments}-${deploymentsOpen}-${canvasOpen}-${canvasView}-${canvasReported}`}
+      key={`${openPanel}-${selectionId}-${empty}-${noPendingChanges}-${withoutRouters}-${aiEnabled}-${searchOpen}-${isLoading}-${loadError}-${mode}-${deployments}-${deploymentsOpen}-${canvasOpen}-${canvasView}-${canvasReported}`}
       data={data}
       initialPanel={openPanel}
       initialSelectionId={selectionId}
@@ -294,7 +303,15 @@ function ShellHarness({
       aiEnabled={aiEnabled}
       theme={currentTheme}
       onThemeChange={setCurrentTheme}
-      pendingChanges={empty ? 0 : 12}
+      pendingChanges={empty || noPendingChanges ? 0 : 12}
+      /*
+       * The review view, which every story has and none of them used to.
+       *
+       * Without `onCompare` the top bar renders no Review button at all, so
+       * the one control in the bar that answers "is anything of mine still
+       * unpublished?" could not be seen in Storybook - in either state.
+       */
+      onCompare={() => console.log("open the review view")}
       publishState={publishState}
       saveState={saveState}
       mode={mode}
@@ -364,6 +381,7 @@ export const Default: Story = {
     openPanel: null,
     selectionId: null,
     empty: false,
+    noPendingChanges: false,
     withoutRouters: false,
     searchOpen: false,
     aiEnabled: true,
@@ -380,6 +398,24 @@ export const Default: Story = {
     simulatePublish: false,
     canvasOpen: false,
     canvasView: "normal",
+  },
+};
+
+/**
+ * Nothing queued, in a project that is otherwise full.
+ *
+ * Review is in the bar all the same. It used to be `invisible` here - in the
+ * layout so the bar would not reflow, but unreachable by pointer, keyboard or
+ * screen reader - which made "is anything of mine still unpublished?"
+ * unanswerable from the bar: a hidden button and a button whose data has not
+ * loaded are the same picture. Publish is disabled, which is the difference
+ * between the two controls: one ships work, the other looks at it.
+ */
+export const NothingPendingToReview: Story = {
+  args: {
+    ...Default.args,
+    selectionId: mockSelectionIds.home,
+    noPendingChanges: true,
   },
 };
 

--- a/packages/ui/spa/components/shell/topBarActionOrder.test.tsx
+++ b/packages/ui/spa/components/shell/topBarActionOrder.test.tsx
@@ -63,22 +63,19 @@ describe("Review, Preview, Publish", () => {
     ).toBe(true);
   });
 
-  test("the space Review holds is to the left of Preview too", () => {
-    // Nothing pending: the button is invisible but still in the layout, so the
-    // bar must not reflow when the first change lands. See `ReviewButton`.
-    render(topBar({ pendingChanges: 0, reviewCount: 0 }));
+  test("Review is offered with nothing pending, and still comes first", () => {
     /*
-     * By label, not by role, and this is the one query that works.
-     *
-     * With nothing pending the button carries `aria-hidden`, and the
-     * accessible NAME of an element hidden from the accessibility tree
-     * computes as the empty string — so
-     * `getByRole("button", { name: "Review changes", hidden: true })` matches
-     * nothing, `hidden: true` included: that option widens which elements are
-     * considered, not how their names are computed. `getByLabelText` reads the
-     * `aria-label` attribute itself, which is unaffected.
+     * It used to be `invisible` here - in the layout so the bar would not
+     * reflow, but unreachable and hidden from assistive tech, which made "is
+     * anything of mine still unpublished?" unanswerable from the bar. Queried
+     * by ROLE and NAME, which is what a keyboard or screen reader user gets:
+     * under the old behaviour this query matched nothing at all, `hidden: true`
+     * included, because the accessible name of an `aria-hidden` element
+     * computes as the empty string.
      */
-    const review = screen.getByLabelText("Review changes");
+    render(topBar({ pendingChanges: 0, reviewCount: 0 }));
+    const review = screen.getByRole("button", { name: "Review changes" });
+    expect(review.getAttribute("aria-hidden")).toBeNull();
     expect(
       precedes(review, screen.getByRole("button", { name: "Preview" })),
     ).toBe(true);

--- a/packages/ui/spa/components/shell/types.ts
+++ b/packages/ui/spa/components/shell/types.ts
@@ -157,7 +157,24 @@ export type ShellValidationError = {
   count: number;
 };
 
-export type ShellActivityEntry = {
+/**
+ * One row of Recent activity.
+ *
+ * Two kinds, because "what has been happening here?" has always had two halves
+ * and the panel only ever answered one of them. An edit somebody made is
+ * something to go back to; a publish is something that happened to the site.
+ * Publishes were visible only in the status bar's deploy feed, which is a
+ * live-progress indicator that empties itself as builds land — so the moment a
+ * publish finished there was nowhere in the Studio that said it had.
+ *
+ * Both carry `title` and `timestamp` so the list can be rendered in one pass;
+ * everything that differs is behind `kind`.
+ */
+export type ShellActivityEntry = ShellChangeActivity | ShellDeployActivity;
+
+/** An unpublished edit, from the patch sets. */
+export type ShellChangeActivity = {
+  kind: "change";
   /**
    * A React key, not a target: two patch sets can share a module and a path, so
    * this carries an index to keep them apart. Use `sourcePath` to go anywhere.
@@ -170,6 +187,40 @@ export type ShellActivityEntry = {
   timestamp: string;
   author?: string;
 };
+
+/**
+ * A publish, from the deploy feed.
+ *
+ * Not selectable — there is nothing in the Studio a commit opens — so unlike a
+ * change row this carries no `sourcePath` and the panel renders it as a line
+ * rather than a button. What it does carry is the state, because a publish that
+ * is still building and one that failed are the two things worth reading here.
+ */
+export type ShellDeployActivity = {
+  kind: "deploy";
+  /** The commit sha, prefixed: it is unique per publish. */
+  id: string;
+  /** The commit message, or the short sha when there is none. */
+  title: string;
+  /** What happened to it, e.g. "Live", "Building", "Build failed". */
+  state: string;
+  /**
+   * The state as the row's icon reads it.
+   *
+   * `state` is the sentence and this is the shape: the same three cases the
+   * deploy feed's rows use, so a publish looks the same in both places.
+   */
+  progress: DeploymentProgress;
+  /** Already relative, e.g. "2 minutes ago". */
+  timestamp: string;
+  author?: string;
+};
+
+/**
+ * How a publish is doing, reduced to the three states anything rendering one
+ * cares about. See `deploymentProgress`.
+ */
+export type DeploymentProgress = "building" | "failed" | "settled";
 
 /**
  * A destination: what the left rail switches between.
@@ -261,7 +312,12 @@ export type ShellData = {
    * surface while the bell stays hidden until something populates it.
    */
   notifications?: ShellNotification[];
-  /** Derived from patch sets. Absent while they are still loading. */
+  /**
+   * The edits and the publishes, newest first. See `toActivity`.
+   *
+   * Built from whichever half has arrived: the patch sets and the deploy feed
+   * load separately, and a list that waits for both hides the one it has.
+   */
   activity?: ShellActivityEntry[];
   validationErrors: ShellValidationError[];
   /** Absent until a profile has loaded, and in modes that have none. */

--- a/packages/ui/spa/components/shell/useShellData.ts
+++ b/packages/ui/spa/components/shell/useShellData.ts
@@ -148,10 +148,22 @@ export function useShellData(): ShellDataState {
           ? toDataModules(navData.explorer, modulesWithDrafts)
           : [],
         validationErrors: toValidationErrors(validationErrors),
-        activity:
-          patchSets.status === "success"
-            ? toActivity(patchSets.data, Date.now())
-            : undefined,
+        /*
+         * The publishes ride along: this list is "what has been happening",
+         * and a publish is the other half of that. See `toActivity`.
+         *
+         * Built from whatever is known, rather than only once the PATCH SETS
+         * are. The two halves load separately - patch sets come off a worker
+         * that has to group them, publishes off the stat feed - so gating the
+         * whole list on the first one hid every publish while that worker was
+         * still grouping, and for good if it failed. An empty change list is
+         * the honest input in that state, not a reason to say nothing.
+         */
+        activity: toActivity(
+          patchSets.status === "success" ? patchSets.data : [],
+          shellDeployments,
+          Date.now(),
+        ),
         pendingChanges: currentPatchIds.length - committedPatchIds.size,
         deployments: shellDeployments,
         user: profile

--- a/packages/ui/spa/hooks/useStatus.ts
+++ b/packages/ui/spa/hooks/useStatus.ts
@@ -543,6 +543,11 @@ async function execStat(
                           deploymentState: message.deployment.deploymentState,
                           createdAt: message.deployment.createdAt,
                           updatedAt: message.deployment.updatedAt,
+                          // The git message, where the content service sends
+                          // one. Copied field by field here, so leaving it out
+                          // dropped it as surely as the schema stripping it
+                          // would have. See `ValDeployment`.
+                          commitMessage: message.deployment.commitMessage,
                         }),
                       },
                       waitStart:

--- a/packages/ui/spa/utils/mergeCommitsAndDeployments.test.ts
+++ b/packages/ui/spa/utils/mergeCommitsAndDeployments.test.ts
@@ -380,4 +380,60 @@ describe("mergeCommitsAndDeployments", () => {
     );
     expect(result[0].commitMessage).toBe("Bump the dependency");
   });
+
+  /**
+   * The result is fed back in as `prev` on the next poll, so without a bound
+   * this function is an accumulator: every commit and deployment a session ever
+   * saw stayed in it for as long as the tab was open. That is what the deploy
+   * list's per-row dismiss button was for, and the bound is what replaced it.
+   */
+  it("keeps only the newest few", () => {
+    const deployments: ValDeployment[] = Array.from(
+      { length: 40 },
+      (_, index) => ({
+        commitSha: `sha-${index}`,
+        deploymentId: `deployment-${index}`,
+        deploymentState: "success",
+        createdAt: new Date(2000 + index * 1000).toISOString(),
+        updatedAt: new Date(2000 + index * 1000).toISOString(),
+      }),
+    );
+    const result = mergeCommitsAndDeployments([], [], deployments);
+    expect(result).toHaveLength(25);
+    // Newest first, and it is the NEWEST that survive: the oldest fall off the
+    // end, which is the whole point of the bound.
+    expect(result[0].commitSha).toBe("sha-39");
+    expect(result[result.length - 1].commitSha).toBe("sha-15");
+  });
+
+  it("drops what it already held once newer publishes crowd it out", () => {
+    const at = (index: number) => new Date(2000 + index * 1000).toISOString();
+    const prev: ValEnrichedDeployment[] = Array.from(
+      { length: 25 },
+      (_, index) => ({
+        commitSha: `old-${index}`,
+        deploymentState: "success",
+        commitMessage: null,
+        creator: null,
+        createdAt: at(index),
+        updatedAt: at(index),
+      }),
+    );
+    const result = mergeCommitsAndDeployments(
+      prev,
+      [],
+      [
+        {
+          commitSha: "new",
+          deploymentId: "deployment-new",
+          deploymentState: "pending",
+          createdAt: at(100),
+          updatedAt: at(100),
+        },
+      ],
+    );
+    expect(result).toHaveLength(25);
+    expect(result[0].commitSha).toBe("new");
+    expect(result.some((d) => d.commitSha === "old-0")).toBe(false);
+  });
 });

--- a/packages/ui/spa/utils/mergeCommitsAndDeployments.test.ts
+++ b/packages/ui/spa/utils/mergeCommitsAndDeployments.test.ts
@@ -228,4 +228,156 @@ describe("mergeCommitsAndDeployments", () => {
         .deploymentState,
     ).toBe("success");
   });
+
+  /**
+   * A deployment nobody published from Val: a developer's push, a merged pull
+   * request, a revert. There is no `ValCommit` for it, so the git message can
+   * only come off the deployment - and without it the feed could name the
+   * publish by nothing but its short sha.
+   */
+  it("takes the git message off a deployment that has no Val commit", () => {
+    const result = mergeCommitsAndDeployments(
+      [],
+      [],
+      [
+        {
+          commitSha: "abc123",
+          deploymentId: "deployment-abc123",
+          deploymentState: "success",
+          commitMessage: "Bump the dependency",
+          createdAt: "2023-01-01T00:00:00Z",
+          updatedAt: "2023-01-01T01:00:00Z",
+        },
+      ],
+    );
+    expect(result[0].commitMessage).toBe("Bump the dependency");
+  });
+
+  it("prefers Val's own commit message over the host's", () => {
+    // Val wrote that one, and it is known before any build is reported. The
+    // two describe the same immutable commit either way.
+    const result = mergeCommitsAndDeployments(
+      [],
+      [
+        {
+          commitSha: "abc123",
+          clientCommitSha: "client-abc123",
+          parentCommitSha: "parent-abc123",
+          branch: "main",
+          commitMessage: "Update hero copy",
+          creator: "user1",
+          createdAt: "2023-01-01T00:00:00Z",
+        },
+      ],
+      [
+        {
+          commitSha: "abc123",
+          deploymentId: "deployment-abc123",
+          deploymentState: "success",
+          commitMessage: "val: update hero copy [skip ci]",
+          createdAt: "2023-01-01T00:00:00Z",
+          updatedAt: "2023-01-01T01:00:00Z",
+        },
+      ],
+    );
+    expect(result[0].commitMessage).toBe("Update hero copy");
+  });
+
+  it("survives a content service that reports no messages at all", () => {
+    // The field is optional as well as nullable: absent is an older service,
+    // null is one that has no message for this commit. Both are the short sha.
+    const result = mergeCommitsAndDeployments(
+      [],
+      [],
+      [
+        {
+          commitSha: "abc123",
+          deploymentId: "deployment-abc123",
+          deploymentState: "pending",
+          createdAt: "2023-01-01T00:00:00Z",
+          updatedAt: "2023-01-01T01:00:00Z",
+        },
+        {
+          commitSha: "def456",
+          deploymentId: "deployment-def456",
+          deploymentState: "pending",
+          commitMessage: null,
+          createdAt: "2023-01-01T00:00:00Z",
+          updatedAt: "2023-01-01T00:30:00Z",
+        },
+      ],
+    );
+    expect(result.map((d) => d.commitMessage)).toEqual([null, null]);
+  });
+
+  /**
+   * The deployment side of a commit can arrive FIRST - the socket delivers
+   * whatever happens first, and a build often starts before this client has
+   * fetched the commit that triggered it. The row is then already there when
+   * Val's own commit turns up, and skipping it outright (which is what this
+   * loop used to do) left a publish of Val's own named by whatever the host
+   * had said about the commit, for the whole life of the tab.
+   */
+  it("lets Val's commit message replace a host message already held", () => {
+    const prev: ValEnrichedDeployment[] = [
+      {
+        commitSha: "abc123",
+        deploymentState: "pending",
+        commitMessage: "val: update hero copy [skip ci]",
+        creator: null,
+        createdAt: "2023-01-01T00:00:00Z",
+        updatedAt: "2023-01-01T00:30:00Z",
+      },
+    ];
+    const result = mergeCommitsAndDeployments(
+      prev,
+      [
+        {
+          commitSha: "abc123",
+          clientCommitSha: "client-abc123",
+          parentCommitSha: "parent-abc123",
+          branch: "main",
+          commitMessage: "Update hero copy",
+          creator: "user1",
+          createdAt: "2023-01-01T00:00:00Z",
+        },
+      ],
+      [],
+    );
+    expect(result[0].commitMessage).toBe("Update hero copy");
+    // And the author, which a deployment-only row never has.
+    expect(result[0].creator).toBe("user1");
+    // What the HOST reports is still the host's: the build state and the time
+    // it last moved are not Val's to overwrite.
+    expect(result[0].deploymentState).toBe("pending");
+    expect(result[0].updatedAt).toBe("2023-01-01T00:30:00Z");
+  });
+
+  it("keeps the host's message when Val's commit has none", () => {
+    const result = mergeCommitsAndDeployments(
+      [
+        {
+          commitSha: "abc123",
+          deploymentState: "success",
+          commitMessage: "Bump the dependency",
+          creator: null,
+          createdAt: "2023-01-01T00:00:00Z",
+          updatedAt: "2023-01-01T00:30:00Z",
+        },
+      ],
+      [
+        {
+          commitSha: "abc123",
+          clientCommitSha: "client-abc123",
+          parentCommitSha: "parent-abc123",
+          branch: "main",
+          commitMessage: null,
+          creator: "user1",
+          createdAt: "2023-01-01T00:00:00Z",
+        },
+      ],
+      [],
+    );
+    expect(result[0].commitMessage).toBe("Bump the dependency");
+  });
 });

--- a/packages/ui/spa/utils/mergeCommitsAndDeployments.ts
+++ b/packages/ui/spa/utils/mergeCommitsAndDeployments.ts
@@ -3,6 +3,13 @@ import { ValCommit, ValDeployment } from "@valbuild/shared/internal";
 /**
  * We merge Val commits (which are created by Val and immutable) and
  * deployments which basically comes from GitHub.
+ *
+ * A deployment can arrive with no Val commit behind it at all — a developer's
+ * push, a merged pull request, a revert — and those are the majority on most
+ * projects. Their message therefore has to come off the deployment itself; see
+ * `ValDeployment.commitMessage`. Val's own commit wins where there is one: it
+ * is the message Val wrote, and it is known before any host has reported a
+ * build.
  */
 export type ValEnrichedDeployment = {
   deploymentState: "pending" | "success" | "failure" | "error" | "created";
@@ -25,7 +32,8 @@ export function mergeCommitsAndDeployments(
   }
   for (const commit of commits) {
     // Assumes commits (of a given commit sha) are immutable so if we already found something for this commit sha, we don't need to add it again
-    if (!deploymentsByCommitSha[commit.commitSha]) {
+    const existing = deploymentsByCommitSha[commit.commitSha];
+    if (!existing) {
       deploymentsByCommitSha[commit.commitSha] = {
         commitMessage: commit?.commitMessage || null,
         deploymentState: "created",
@@ -34,7 +42,26 @@ export function mergeCommitsAndDeployments(
         updatedAt: commit.createdAt,
         commitSha: commit.commitSha,
       };
+      continue;
     }
+    /**
+     * Something is already here, and it came from the HOST: the same commit
+     * seen from the deployment side, which can arrive first - the socket
+     * delivers whatever happens first, and a build often starts before this
+     * client has fetched the commit that triggered it.
+     *
+     * Its build state and its timestamps are the host's to report and are left
+     * alone. The message and the author are not: this is the commit Val wrote,
+     * so they win here - which is the precedence claimed above and everywhere
+     * else in this file. Skipping the row outright, as this used to, left a
+     * publish of Val's own named by whatever the host had said about the
+     * commit, for the whole life of the tab.
+     */
+    deploymentsByCommitSha[commit.commitSha] = {
+      ...existing,
+      commitMessage: commit.commitMessage || existing.commitMessage,
+      creator: commit.creator || existing.creator,
+    };
   }
   /**
    * Oldest first, so the newest state for a commit is the one that survives.
@@ -52,8 +79,13 @@ export function mergeCommitsAndDeployments(
     // NOTE: we ignore the deployments without commit sha - this is a new property, in the future they should all have it. We can't really do much useful stuff without knowing the commit?
     if (deployment.commitSha) {
       deploymentsByCommitSha[deployment.commitSha] = {
+        // What we already know first — a Val commit's own message, or a message
+        // an earlier row for this sha carried — then the host's. A commit sha
+        // is immutable, so these cannot be messages for different things.
         commitMessage:
-          deploymentsByCommitSha[deployment.commitSha]?.commitMessage || null,
+          deploymentsByCommitSha[deployment.commitSha]?.commitMessage ||
+          deployment.commitMessage ||
+          null,
         deploymentState:
           deployment.deploymentState as ValEnrichedDeployment["deploymentState"],
         creator: deploymentsByCommitSha[deployment.commitSha]?.creator || null,
@@ -69,4 +101,22 @@ export function mergeCommitsAndDeployments(
   return Object.values(deploymentsByCommitSha).sort((a, b) => {
     return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
   });
+}
+
+/**
+ * The first line of a commit message, which is the whole of what a row shows.
+ *
+ * Val writes single-line messages, so this did nothing until deployments Val
+ * did NOT publish started arriving with their own messages — a push, a merged
+ * pull request — and a git message is a subject, a blank line and a body. The
+ * rows truncate, so the body was rendered as one long line with the subject
+ * lost somewhere at the front of it.
+ *
+ * A message that is only whitespace is no message: `null`, which is what makes
+ * the row fall back to the short sha rather than showing an empty title.
+ */
+export function commitSubject(message: string | null): string | null {
+  if (message === null) return null;
+  const subject = message.split("\n", 1)[0].trim();
+  return subject === "" ? null : subject;
 }

--- a/packages/ui/spa/utils/mergeCommitsAndDeployments.ts
+++ b/packages/ui/spa/utils/mergeCommitsAndDeployments.ts
@@ -98,10 +98,33 @@ export function mergeCommitsAndDeployments(
     }
   }
 
-  return Object.values(deploymentsByCommitSha).sort((a, b) => {
-    return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-  });
+  return (
+    Object.values(deploymentsByCommitSha)
+      .sort((a, b) => {
+        return (
+          new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+        );
+      })
+      // The newest few, and no more. This function's result is fed back in as
+      // `prev` on the next poll, so without a bound it is an accumulator: every
+      // commit and deployment a session ever saw stayed in it for as long as the
+      // tab was open, and the only thing that ever took a row out was the
+      // reader pressing a dismiss button on it. The feed is "what has been
+      // going out lately" - the content service returns a bounded set for
+      // exactly that reason - so the client keeps a bounded set too.
+      .slice(0, MERGED_DEPLOYMENTS_LIMIT)
+  );
 }
+
+/**
+ * How many publishes the merged feed keeps.
+ *
+ * Rows, not publishes: a commit sha is the key here, so this is already folded
+ * per commit - but it is deliberately larger than the ten the Studio SHOWS
+ * (`DEPLOYMENT_LIMIT`), because a commit whose deployment has not been reported
+ * yet is in here as a commit and a poll can bring several at once.
+ */
+const MERGED_DEPLOYMENTS_LIMIT = 25;
 
 /**
  * The first line of a commit message, which is the whole of what a row shows.


### PR DESCRIPTION
**Stack: 7 of 7.** Base is [#651](https://github.com/valbuild/val/pull/651) — review the last commit only. Pairs with [valbuild/home#63](https://github.com/valbuild/home/pull/63), which is the "fetch the last N" half.

Each row in the deploy list had a dismiss button, and **two** layers kept a set of dismissed commit shas to subtract from the feed: `ValProvider`, which also filtered them out of every merge, and `Shell`, which filtered again. The classic layout had a third variant — a five-second `setTimeout` per observed commit that dismissed it from the shared feed, with no cleanup, re-armed on every render.

All of that existed because the list **grew**. `mergeCommitsAndDeployments` takes its own previous result as `prev`, so it is an accumulator: every commit and deployment a session ever saw stayed in it for as long as the tab was open, and the only thing that took a row out was somebody pressing a button on it.

So the feed is bounded instead — the newest 25 rows out of the merge, ten of which the Studio shows — and the dismiss controls are gone. What a row would be dismissed *for* is that it is old, and being old is what takes it off the end of the list now. The list still closes itself once everything has landed, on Escape, on a click outside, and on its header's close button.

### One behaviour had to change with it

`isDeploymentNews` made anything not **live** news, which held while the feed only carried the publishes on the current chain: a row that was not live was one on its way out. Val only ever observes the *current* commit serving the site, so with history in the feed "not live" is the resting state of every superseded publish — and the list would have popped itself open on load to announce a build from last Tuesday. The clock decides it now, which is the question it was always approximating. Its two tests are rewritten to pin the new rule.

### The classic layout

Its own deployments block now shows only the publishes still on their way out, which is what the spinner in its header has always claimed — and it needs no dismissal to empty itself. That whole layout is unrendered today (the shell replaced it; only `TransientErrorsList` is still imported out of the file), but it compiles, and it should not compile around a control that no longer exists.

### Tests

`deploymentRows.test.tsx` pins that a row offers nothing to press, `mergeCommitsAndDeployments.test.ts` that the merge keeps the newest few and drops what it held when newer publishes crowd it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rsb27g1N8ibmWL1iRkdUtc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rsb27g1N8ibmWL1iRkdUtc)_