### PR TITLE
Paint surfaces with tokens the shadow root can actually see

### DIFF
--- a/.changeset/live-surface-tokens.md
+++ b/.changeset/live-surface-tokens.md
@@ -1,0 +1,27 @@
+---
+"@valbuild/ui": patch
+---
+
+Surfaces in the Studio paint the colour they name
+
+Four places named a colour from shadcn's compatibility block — `bg-card`,
+`bg-primary-foreground`, and a gradient's stops. None of those tokens is
+declared anywhere the Studio can see them: they live under `:root` and `.dark`,
+and the Studio renders inside a shadow root (where `:root` matches nothing)
+with `darkMode` set to `[data-mode="dark"]` (so `.dark` never matches either).
+
+The effect is quiet, which is why it lasted: an undefined colour is invalid at
+computed-value time, so the element simply paints nothing and shows whatever is
+behind it. The record list's rows had no background at all, and the fade over a
+truncated list row computed to a gradient from transparent to transparent —
+no fade.
+
+They now name the Studio's own tokens. Nothing changes colour: each surface was
+already showing the page background through the hole, which is the colour it
+now paints deliberately — except the truncation fade, which appears again.
+
+`surfaceTokens.test.ts` holds the line, alongside the focus-ring test that
+covers the same trap for `box-shadow`. It reads the dead tokens out of
+`index.css`, so reviving one lifts the ban on it automatically. The vendored
+`components/designSystem/` copies of shadcn are out of scope and still name the
+dead tokens.

--- a/packages/ui/spa/components/SortableList.tsx
+++ b/packages/ui/spa/components/SortableList.tsx
@@ -292,7 +292,7 @@ export function SortableItemRow({
       <button
         className={cn(
           "flex-grow",
-          "relative flex text-left border rounded-lg border-border bg-card gap-y-2 bg-bg-primary",
+          "relative flex text-left border rounded-lg border-border-primary gap-y-2 bg-bg-primary",
           "hover:bg-bg-secondary-hover",
           "overflow-y-clip",
         )}
@@ -307,8 +307,16 @@ export function SortableItemRow({
       >
         <RefPreview path={path} className="flex-grow w-full" />
         {isTruncated && (
+          /*
+           * The fade into the row's own background, so a clipped preview does
+           * not end on a hard edge. Both stops must be the SAME token the row
+           * paints above — and no alpha modifier: these colours are plain
+           * `var()` values, which Tailwind cannot mix an alpha into, so
+           * `via-bg-primary/90` emits no rule at all and leaves the middle stop
+           * unset. See `surfaceTokens.test.ts`.
+           */
           <div
-            className="absolute bottom-0 left-0 w-full bg-gradient-to-b via-50% from-transparent via-card/90 to-card"
+            className="absolute bottom-0 left-0 w-full bg-gradient-to-b via-50% from-transparent via-bg-primary to-bg-primary"
             style={{ height: 40 }}
           ></div>
         )}

--- a/packages/ui/spa/components/fields/RecordFields.tsx
+++ b/packages/ui/spa/components/fields/RecordFields.tsx
@@ -236,7 +236,7 @@ function RecordCardList({
             <div
               onClick={() => navigate(sourcePathOfItem(path, key))}
               className={classNames(
-                "bg-primary-foreground cursor-pointer min-w-[320px] max-h-[170px] overflow-hidden rounded-md border border-border-primary p-4",
+                "bg-bg-primary cursor-pointer min-w-[320px] max-h-[170px] overflow-hidden rounded-md border border-border-primary p-4",
                 "hover:bg-bg-secondary-hover",
               )}
             >

--- a/packages/ui/spa/fallbackRender.tsx
+++ b/packages/ui/spa/fallbackRender.tsx
@@ -24,7 +24,7 @@ function ErrorContent({
   return (
     <div className="flex absolute top-0 left-0 justify-center items-center w-screen h-screen bg-bg-primary text-fg-primary">
       <div className="p-10 w-full h-full">
-        <div className="overflow-scroll p-10 w-full h-full bg-card text-fg-primary">
+        <div className="overflow-scroll p-10 w-full h-full bg-bg-primary text-fg-primary">
           <div className="flex justify-between items-center">
             <div className="flex items-center gap-[0.5em] text-lg font-bold text-center py-2">
               <Logo /> encountered an error

--- a/packages/ui/spa/surfaceTokens.test.ts
+++ b/packages/ui/spa/surfaceTokens.test.ts
@@ -1,0 +1,149 @@
+import fs from "fs";
+import path from "path";
+
+/**
+ * Every surface names a token a SHADOW ROOT can see.
+ *
+ * The companion to `focusRingTokens.test.ts`, for the other half of the same
+ * trap. The Studio mounts inside a shadow root with `index.css` linked into it,
+ * so a `:root` rule in that stylesheet matches nothing — and `.dark` never
+ * matches either, because `darkMode` is `[data-mode="dark"]`. The shadcn
+ * compatibility block is declared under exactly those two selectors, so
+ * `--card`, `--background`, `--primary-foreground` and the rest are all
+ * undefined at render time.
+ *
+ * In a `box-shadow` that voids the whole declaration, which is what the focus
+ * ring test is about. In a BACKGROUND it degrades quietly, and quietly is the
+ * problem: `background-color: hsl(var(--card))` is invalid at computed-value
+ * time, so the element paints nothing and inherits whatever is behind it. A
+ * card with no surface looks like a card whose surface happens to match the
+ * page — right up until it is put on a different page. `bg-primary-foreground`
+ * on the record list's rows was exactly that, and nobody could see it, because
+ * Storybook imports `index.css` into the DOCUMENT (`.storybook/preview.tsx`)
+ * where `:root` DOES match: there the same class painted the LIGHT value in
+ * dark mode, a white card with white text on it.
+ *
+ * A gradient degrades the same quiet way. Measured in the Studio, the fade over
+ * a truncated list row computed to
+ * `linear-gradient(rgba(0,0,0,0), rgba(0,0,0,0))` — every stop dropped to
+ * transparent, so the element painted a fade from nothing to nothing. Pointed
+ * at a live token it computes to
+ * `linear-gradient(rgba(0,0,0,0), rgb(8,8,10) 50%, rgb(8,8,10))`, which is the
+ * fade that was meant to be there.
+ *
+ * ## Scope: paint utilities, outside the vendored design system
+ *
+ * `bg-`, `from-`, `via-` and `to-` — the utilities that put a colour on a
+ * surface. `text-` and `border-` name the same dead tokens in a handful of
+ * places and are NOT covered: there the value inherits or falls back to the
+ * `* { @apply border-border-primary }` base rule, which is a wrong colour
+ * rather than a missing one, and repointing each is a visual change that wants
+ * its own review.
+ *
+ * `components/designSystem/` is shadcn as it came, and is where the bulk of the
+ * dead names live. Reviving those is the migration `index.css` defers; this
+ * test holds the line at the code we wrote.
+ */
+
+const SPA = __dirname;
+const CSS = fs.readFileSync(path.join(SPA, "index.css"), "utf8");
+
+/** Where shadcn's compatibility block is declared — see `index.css`. */
+const DEAD_SELECTORS = ["\n  :root {", "\n  .dark {"];
+/** Where the Studio's own tokens are declared, which a shadow root can see. */
+const LIVE_SELECTORS = ['*[data-mode="light"]', '*[data-mode="dark"]'];
+
+/** The custom properties declared in the block a selector opens. */
+function tokensIn(selector: string): Set<string> {
+  const start = CSS.indexOf(selector);
+  if (start === -1) throw new Error(`No block for selector ${selector}`);
+  const open = CSS.indexOf("{", start);
+  const body = CSS.slice(open + 1, CSS.indexOf("\n  }", open));
+  const names = new Set<string>();
+  for (const line of body.split("\n")) {
+    const match = line.match(/^\s*--([\w-]+)\s*:/);
+    if (match) names.add(match[1]);
+  }
+  return names;
+}
+
+/**
+ * The token names that are declared ONLY in the dead block, without the `--`.
+ *
+ * Read out of the stylesheet rather than listed here, so that moving a token
+ * into the `[data-mode]` blocks — reviving it — lifts the ban on it by itself.
+ */
+function deadTokenNames(): Set<string> {
+  const live = new Set<string>();
+  for (const selector of LIVE_SELECTORS) {
+    for (const name of tokensIn(selector)) live.add(name);
+  }
+  const dead = new Set<string>();
+  for (const selector of DEAD_SELECTORS) {
+    for (const name of tokensIn(selector)) {
+      if (!live.has(name)) dead.add(name);
+    }
+  }
+  return dead;
+}
+
+function sourceFiles(): string[] {
+  const found: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === "node_modules") continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        // Vendored shadcn — see the scope note above.
+        if (
+          path.relative(SPA, full) === path.join("components", "designSystem")
+        )
+          continue;
+        walk(full);
+      } else if (/\.tsx?$/.test(entry.name)) {
+        found.push(full);
+      }
+    }
+  };
+  walk(SPA);
+  // This file names the forbidden classes in order to look for them.
+  return found.filter((f) => path.resolve(f) !== path.resolve(__filename));
+}
+
+describe("surface tokens", () => {
+  const files = sourceFiles();
+
+  test("the suite is actually looking at the source", () => {
+    expect(files.length).toBeGreaterThan(100);
+  });
+
+  test("the dead block is still dead, and still holds the names we ban", () => {
+    const dead = deadTokenNames();
+    // A sample rather than the whole list: the point is that the block is
+    // there and unreachable, not its exact contents.
+    for (const name of ["card", "background", "primary-foreground", "muted"]) {
+      expect(dead.has(name)).toBe(true);
+    }
+    // And that nothing the Studio actually paints with got swept in.
+    for (const name of ["bg-primary", "bg-secondary", "fg-primary"]) {
+      expect(dead.has(name)).toBe(false);
+    }
+  });
+
+  test("no background or gradient stop names a dead token", () => {
+    const dead = [...deadTokenNames()].sort((a, b) => b.length - a.length);
+    // Anchored at the start of a class, so `bg-bg-primary` is not read as the
+    // dead `bg-primary` sitting inside it.
+    const pattern = new RegExp(
+      `(?:^|[\\s"'\`])((?:bg|from|via|to)-(?:${dead.join("|")}))(?![\\w-])`,
+      "gm",
+    );
+    const offenders: string[] = [];
+    for (const file of files) {
+      for (const match of fs.readFileSync(file, "utf8").matchAll(pattern)) {
+        offenders.push(`${path.relative(SPA, file)}: ${match[1]}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Four places in the Studio named a colour from shadcn's compatibility block — `bg-card`, `bg-primary-foreground`, and a gradient's two stops. Nothing declares those tokens anywhere the Studio can read them: the block is under `:root` and `.dark`, the Studio renders inside a shadow root (whose root is a `DocumentFragment`, so `:root` matches nothing), and `darkMode` is `[data-mode="dark"]`, so `.dark` never matches either. `index.css` already documents the trap — `focusRingTokens.test.ts` exists because the same thing made every focus ring invisible.

Unlike a `box-shadow`, a background degrades quietly, which is why this lasted.

## Measured in the Studio

| class | computed |
| --- | --- |
| `bg-primary-foreground` | `background-color: rgba(0, 0, 0, 0)` |
| `bg-bg-primary` | `background-color: rgb(8, 8, 10)` |
| old fade | `linear-gradient(rgba(0,0,0,0), rgba(0,0,0,0))` |
| new fade | `linear-gradient(rgba(0,0,0,0), rgb(8,8,10) 50%, rgb(8,8,10))` |

So the record list's rows had no background at all and showed the page through the hole, and the fade over a truncated list row was a fade from nothing to nothing.

Storybook is where these components were designed and is exactly where the bug is invisible: it imports `index.css` into the **document**, where `:root` does match — there `bg-primary-foreground` painted the *light* value in dark mode, a white card with white text on it.

## What changes

Nothing changes colour. Each surface was already showing the page background, and `bg-bg-primary` is that colour painted deliberately — which starts to matter the moment one of these is placed on anything else. The exception is the truncation fade, which appears again.

The `/90` on the gradient's middle stop is gone rather than repointed: these colours are plain `var()` values and Tailwind cannot mix an alpha into one, so `via-<token>/90` compiles to no rule at all and leaves the stop unset. Verified against the compiled stylesheet.

## Scope

`surfaceTokens.test.ts` holds the line for `bg-`, `from-`, `via-` and `to-`, the companion to `focusRingTokens.test.ts` for `box-shadow`. It reads the dead names out of `index.css` rather than listing them, so moving a token into the `[data-mode]` blocks lifts the ban on it by itself.

Deliberately **not** covered:

- `text-` and `border-` name the same dead tokens in a handful of app files (`CompressedPath`, `DeleteRecordPopover`, `FilePropertiesModal`, `ToolbarButtonsComponent`, `fallbackRender`). There the value inherits or falls back to the `*` base rule — a wrong colour rather than a missing one — and repointing each is a visual change that wants its own review.
- `components/designSystem/` is shadcn as it came and is where the bulk of the dead names live. Reviving those is the migration `index.css` defers.

## Checks

`lint`, `format`, `-r typecheck`, `test` (3972 passed) all green. The two build jobs (`pnpm run build`, `examples/next && pnpm run build`) have **not** been run on this branch — this is a class-name-only change, but CI will be the first to run them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gbeBAaXkDXsFwEn49rHSR

---
_Generated by [Claude Code](https://claude.ai/code/session_011gbeBAaXkDXsFwEn49rHSR)_