### PR TITLE
Stop webpack warning about createRequire in every consumer build

### DIFF
--- a/.changeset/hide-create-require-from-webpack.md
+++ b/.changeset/hide-create-require-from-webpack.md
@@ -1,0 +1,22 @@
+---
+"@valbuild/server": patch
+---
+
+`next build` no longer warns `module.createRequire failed parsing argument.`
+
+Every Next app that bundles `@valbuild/server` into its Val API route got this
+on every build, twice, with an import trace that led from `route.ts` down into
+`valbuild-server.esm.js` and stopped there:
+
+```
+⚠ ./node_modules/.../@valbuild/server/dist/valbuild-server.esm.js
+module.createRequire failed parsing argument.
+```
+
+Nothing was wrong. webpack special-cases a `createRequire` binding imported from
+`node:module` and tries to resolve the call's argument at build time; the two
+calls in this package take a path inside the user's project, known only at
+runtime, so there was nothing to resolve and nothing the warning could tell
+anyone. Both now go through a helper that reaches the same function through the
+`Module` class, which that analysis does not tag. Runtime behaviour is
+unchanged, and a lint rule keeps the direct import from coming back.

--- a/architecture/quirks.md
+++ b/architecture/quirks.md
@@ -538,6 +538,23 @@ cleanup cancels, which is the only pass that writes to the editor that survives.
 resolving `dist/`. Also delete `examples/next/.next` — a production build left
 there makes the dev server 500 with `MODULE_NOT_FOUND` on Studio routes.
 
+## `createRequire` is imported in one place in `@valbuild/server`
+
+webpack tries to resolve the argument of any `createRequire` call it can see,
+and warns `module.createRequire failed parsing argument.` when the argument is
+not a literal. `@valbuild/server` calls it twice — `evalValConfigFile` and
+`loadValModules` — and both times the argument is a path inside the user's
+project, known only at runtime. So there was nothing to resolve, nothing to fix,
+and the warning showed up on every `next build` of every app that has a Val API
+route, pointing into a `dist/` file the reader has no way to act on.
+
+`createNodeRequire` reaches the same function through the `Module` class, which
+webpack does not tag, and an eslint rule (`no-restricted-imports`, scoped to
+`packages/server/src`) stops the direct import coming back. It has to stay a
+real `node:module` import: jest hands out its own `node:module`, and a `require`
+obtained around it — through `process.getBuiltinModule`, say — would resolve
+against the real filesystem instead of the registry the tests run in.
+
 ## The `@valbuild/ui` build substitutes placeholders into bundler output
 
 `packages/ui` ships two strings that only get their real values _after_ Vite has

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -77,6 +77,42 @@ module.exports = defineConfig([
     },
   },
   /**
+   * `createRequire` is imported in ONE place, and it is not here.
+   *
+   * webpack tries to resolve the argument of a `createRequire` call it can see,
+   * and warns `module.createRequire failed parsing argument.` when the argument
+   * is not a literal. Ours never is — it is a path in the user's project — so
+   * every Next app that bundles `@valbuild/server` into its Val API route got
+   * that warning on every build, about a call that was doing exactly what it
+   * should. `createNodeRequire` reaches the same function through the `Module`
+   * class, which webpack does not tag, and every call site goes through it.
+   */
+  {
+    files: ["packages/server/src/**/*.ts"],
+    ignores: ["packages/server/src/createNodeRequire.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "node:module",
+              importNames: ["createRequire"],
+              message:
+                "Use createNodeRequire from ./createNodeRequire — a direct createRequire import makes webpack warn in every consumer's build.",
+            },
+            {
+              name: "module",
+              importNames: ["createRequire"],
+              message:
+                "Use createNodeRequire from ./createNodeRequire — a direct createRequire import makes webpack warn in every consumer's build.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  /**
    * An e2e assertion reads a BOUNDARY, never the client's own internals.
    *
    * The rule, and why it is a rule, is in `e2e/README.md`. In short: the DOM,

--- a/packages/server/src/createNodeRequire.ts
+++ b/packages/server/src/createNodeRequire.ts
@@ -1,0 +1,27 @@
+import { Module } from "node:module";
+
+/**
+ * Node's `require`, resolving as if from `filename`.
+ *
+ * Use this instead of importing `createRequire` from `node:module` directly.
+ * webpack special-cases a `createRequire` binding imported from `module` /
+ * `node:module`: it tries to resolve the call's argument at build time, and
+ * when the argument is not a literal it gives up with
+ *
+ *     module.createRequire failed parsing argument.
+ *
+ * Our argument is never a literal — it is a path inside the user's project,
+ * known only at runtime — so there is nothing for that analysis to find, and
+ * nothing the warning can tell anyone. It is emitted on every build of every
+ * Next app that bundles `@valbuild/server` into its Val API route, which is
+ * all of them. Reaching `createRequire` through the `Module` class is the same
+ * function and is not what webpack tags, so the call is invisible to it.
+ *
+ * It has to stay a real `node:module` import: jest's module registry hands out
+ * its own `node:module`, and a `require` obtained around it (via
+ * `process.getBuiltinModule`, say) would resolve against the real filesystem
+ * rather than the registry the tests run in.
+ */
+export function createNodeRequire(filename: string): NodeRequire {
+  return Module.createRequire(filename);
+}

--- a/packages/server/src/evalValConfigFile.ts
+++ b/packages/server/src/evalValConfigFile.ts
@@ -4,7 +4,7 @@ import vm from "node:vm";
 import ts from "typescript"; // TODO: make this dependency optional (only required if the file is val.config.ts not val.config.js)
 import z from "zod";
 import { ValConfig } from "@valbuild/core";
-import { createRequire } from "node:module";
+import { createNodeRequire } from "./createNodeRequire";
 
 /**
  * NOTE: this is intentionally NOT `SharedValConfig` from `@valbuild/shared`.
@@ -104,7 +104,7 @@ export async function evalValConfigFile(
     fileName: valConfigPath,
   });
 
-  const projectRootRequire = createRequire(valConfigPath);
+  const projectRootRequire = createNodeRequire(valConfigPath);
   const exportsObj = {};
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const sandbox: Record<string, any> = {

--- a/packages/server/src/loadValModules.ts
+++ b/packages/server/src/loadValModules.ts
@@ -1,10 +1,10 @@
 import path from "path";
 import fs from "fs";
 import vm from "node:vm";
-import { Module } from "node:module";
 import ts from "typescript";
 import { Internal, type ValModules } from "@valbuild/core";
 import { getCompilerOptions } from "./getCompilerOptions";
+import { createNodeRequire } from "./createNodeRequire";
 
 /**
  * The filesystem seam `loadValModules` reads through.
@@ -173,7 +173,7 @@ function loadModule(
   cache[absPath] = moduleObj;
 
   const dirName = path.dirname(absPath);
-  const realRequire = Module.createRequire(absPath);
+  const realRequire = createNodeRequire(absPath);
   const customRequire = (spec: string): unknown => {
     if (isStubbedSpecifier(spec)) {
       return makeStub(spec);


### PR DESCRIPTION
## The warning

`next build --webpack` printed this, twice, on every app with a Val API route:

```
⚠ ./node_modules/.pnpm/@valbuild+server@0.124.0_.../node_modules/@valbuild/server/dist/valbuild-server.esm.js
module.createRequire failed parsing argument.

Import trace for requested module:
./node_modules/.../@valbuild/server/dist/valbuild-server.esm.js
./node_modules/.../@valbuild/next/server/dist/valbuild-next-server.esm.js
./val/val.server.ts
./app/(val)/api/val/[[...val]]/route.ts
```

Reproduced in `examples/next` (which builds with `--webpack`), where it pointed at
`packages/server/src/evalValConfigFile.ts` instead of the `dist/` file.

## Why it was there, and why it meant nothing

webpack special-cases a `createRequire` binding imported from `module` / `node:module`:
it tries to resolve the call's argument at build time, and gives up with this warning
when the argument is not a literal. Both calls in `@valbuild/server` take a path inside
the **user's** project — `val.config.ts` in `evalValConfigFile`, the module being
evaluated in `loadValModules` — known only at runtime. There was nothing to resolve,
nothing to fix, and the trace bottomed out in a bundled `dist/` file the reader has no
way to act on.

Only `evalValConfigFile` warned. `loadValModules` was already calling
`Module.createRequire(...)`, and webpack tags the named binding, not the static on the
`Module` class. That accident is the fix, made deliberate.

## Changes

- **`packages/server/src/createNodeRequire.ts`** (new) — one helper, reaching
  `createRequire` through `Module`. It stays a real `node:module` import on purpose:
  jest's module registry hands out its own `node:module`, and a `require` obtained
  around it (via `process.getBuiltinModule`, say) would resolve against the real
  filesystem instead of the registry the tests run in.
- **`evalValConfigFile.ts`, `loadValModules.ts`** — both call sites go through it.
- **`eslint.config.js`** — `no-restricted-imports` scoped to `packages/server/src`
  (helper exempt) so the direct import cannot come back and silently re-add the
  warning to every downstream build.
- **`architecture/quirks.md`**, **changeset**.

Runtime behaviour is unchanged: same function, same argument.

## Verification

- `examples/next` build: warning present before, gone after — `✓ Compiled successfully`.
- The rebuilt `dist/valbuild-server.esm.js` now carries `import { Module } from 'node:module'`
  and `Module.createRequire(filename)`, which is the shape that never warned.
- The lint rule was checked against a probe file importing `createRequire` directly, and
  errors as intended.
- `pnpm lint`, `pnpm -w run format`, `pnpm run -r typecheck`, `pnpm test`
  (341 suites / 4029 tests), `pnpm run build`, `examples/next` build — all green.
- `val validate --root ../../examples/next` — modules still load and evaluate
  (`20 valid`); the remaining errors are the example app's known content errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MrD9d14a9bGYTfQEQQRCpG

---
_Generated by [Claude Code](https://claude.ai/code/session_01MrD9d14a9bGYTfQEQQRCpG)_