### PR TITLE
Remove alt text filename suggestion and missing indicator

### DIFF
--- a/.changeset/image-description-not-an-error.md
+++ b/.changeset/image-description-not-an-error.md
@@ -1,0 +1,17 @@
+---
+"@valbuild/ui": patch
+---
+
+An empty image description is no longer marked as an error
+
+The Description field of an image field showed a red **Missing** next to it
+whenever it was empty. Val has no rule that alt text is required, so nothing in
+validation reports that — the badge claimed an error the validator never
+raises, on every image field that had not been given a description. It is gone.
+If a schema ever does require alt text, that arrives through the ordinary
+validation error path, which the field already shows.
+
+The **Use the filename** shortcut next to it is gone with it. It only ever
+appeared alongside the badge, and a filename says what the file is called
+rather than what the picture shows, which is the one thing the field is asking
+for.

--- a/packages/ui/spa/components/fields/ImageField.tsx
+++ b/packages/ui/spa/components/fields/ImageField.tsx
@@ -299,8 +299,10 @@ export function ImageField({
    * The description, as one place rather than inline in the input.
    *
    * The "add, never replace" rule below is the load-bearing part and the reason
-   * this is worth naming: it has to hold for every caller, and there are two now
-   * — typing, and the shortcut that fills it in from the file name.
+   * this is worth naming: it has to hold for every caller. Typing is the only
+   * one today — the shortcut that filled this in from the file name is gone —
+   * and the rule belongs to the patch rather than to the caller, so it holds
+   * for whatever writes here next.
    */
   const altText = typeof source?.alt === "string" ? source.alt : "";
   const setAltText = (alt: string) => {

--- a/packages/ui/spa/components/fields/ImageField.tsx
+++ b/packages/ui/spa/components/fields/ImageField.tsx
@@ -30,7 +30,7 @@ import { array } from "@valbuild/core/fp";
 import { resolveEncodeSettings } from "../../utils/encodeImage";
 import type { ReadImageEncode } from "../../utils/readImage";
 import { useImageUpload } from "./useImageUpload";
-import { MediaSummaryRow, Section, readableFilename } from "./MediaSummaryRow";
+import { MediaSummaryRow, Section } from "./MediaSummaryRow";
 import { HotspotMarker } from "./HotspotMarker";
 import { Dialog, DialogContent, DialogTitle } from "../designSystem/dialog";
 
@@ -478,30 +478,18 @@ export function ImageField({
             <span id={altPath} className="sr-only">
               Description
             </span>
+            {/*
+             * No "Missing" marker and no fill-it-from-the-filename shortcut:
+             * Val has no rule that alt text is required, so an empty field is
+             * not an error and must not be dressed as one. If a schema ever
+             * does require it, the validation error says so through the
+             * normal error path rather than through a badge invented here.
+             */}
             <Input
               value={altText}
               disabled={disabled}
               onChange={(ev) => setAltText(ev.target.value)}
             />
-            <div className="mt-1.5 flex items-center gap-3">
-              {altText === "" && (
-                // Said, not enforced: Val has no rule that alt is required, and
-                // an editor who has not filled it in should be told rather than
-                // blocked.
-                <span className="text-[0.6875rem] text-fg-error-on-surface">
-                  Missing
-                </span>
-              )}
-              {!disabled && fileName && altText === "" && (
-                <button
-                  type="button"
-                  onClick={() => setAltText(readableFilename(fileName))}
-                  className="text-[0.6875rem] text-fg-secondary underline underline-offset-2 hover:text-fg-primary"
-                >
-                  Use the filename
-                </button>
-              )}
-            </div>
           </Section>
         )}
         {source && url && (

--- a/packages/ui/spa/components/fields/MediaSummaryRow.tsx
+++ b/packages/ui/spa/components/fields/MediaSummaryRow.tsx
@@ -204,14 +204,3 @@ export function Section({
     </section>
   );
 }
-
-/** `hero-mountains_a1b2c.jpg` -> `hero mountains` */
-export function readableFilename(name: string): string {
-  const withoutExtension = name.replace(/\.[^.]+$/, "");
-  // The hash Val appends to every uploaded file is not part of what the image
-  // is of, so a description built from the name should not carry it.
-  return withoutExtension
-    .replace(/_[0-9a-f]{5}$/, "")
-    .replace(/[-_]+/g, " ")
-    .trim();
-}

--- a/packages/ui/spa/components/shell/fields/ImageField.tsx
+++ b/packages/ui/spa/components/shell/fields/ImageField.tsx
@@ -175,27 +175,16 @@ export function ImageField({
             fromCollection && !overridesAlt && "text-fg-secondary",
           )}
         />
+        {/*
+         * The counter and nothing else. An empty description is not a
+         * validation error — Val has no rule that alt text is required — so
+         * it gets no "Missing" badge, and no shortcut that fills it with a
+         * filename that describes the file rather than the picture.
+         */}
         <div className="mt-1.5 flex items-center gap-3">
           <span className="text-[0.6875rem] tabular-nums text-fg-secondary-alt">
             {(effectiveAlt ?? "").length} / {ALT_MAX}
           </span>
-          {(!fromCollection || overridesAlt) && (
-            <button
-              type="button"
-              onClick={() =>
-                onChange({ ...value, alt: readableFilename(value.name) })
-              }
-              className="text-[0.6875rem] text-fg-secondary underline underline-offset-2 hover:text-fg-primary"
-            >
-              Use the filename
-            </button>
-          )}
-          {effectiveAlt === null ||
-            (effectiveAlt === "" && (
-              <span className="text-[0.6875rem] text-fg-error-on-surface">
-                Missing
-              </span>
-            ))}
         </div>
       </Section>
 
@@ -306,17 +295,4 @@ export function SecondaryButton({
       {children}
     </button>
   );
-}
-
-/**
- * A filename as a first draft of alt text.
- *
- * Val's filenames carry a content hash — `hero-mountains_a1b2c.jpg` — so the
- * hash and the extension come off before this is offered to anyone.
- */
-export function readableFilename(name: string): string {
-  const withoutExtension = name.replace(/\.[^.]+$/, "");
-  const withoutHash = withoutExtension.replace(/_[0-9a-f]{5}$/, "");
-  const words = withoutHash.replace(/[-_]+/g, " ").trim();
-  return words.charAt(0).toUpperCase() + words.slice(1);
 }


### PR DESCRIPTION
## Summary

Remove the "Use the filename" button and "Missing" badge from alt text fields in image components. Val has no schema rule requiring alt text, so empty alt fields are not validation errors and should not be presented as such.

## Changes

- **Shell ImageField** (`packages/ui/spa/components/shell/fields/ImageField.tsx`):
  - Removed "Use the filename" button that populated alt text from the image filename
  - Removed "Missing" badge that appeared when alt text was empty
  - Removed `readableFilename()` helper function
  - Added clarifying comment explaining that empty alt text is not an error

- **Core ImageField** (`packages/ui/spa/components/fields/ImageField.tsx`):
  - Removed "Use the filename" button and "Missing" badge from alt text section
  - Removed import of `readableFilename` from MediaSummaryRow
  - Added clarifying comment explaining the rationale

- **MediaSummaryRow** (`packages/ui/spa/components/fields/MediaSummaryRow.tsx`):
  - Removed `readableFilename()` export (no longer used anywhere)

## Rationale

Since Val's schema system does not enforce alt text as required, an empty alt field should not be visually marked as an error. If a future schema does require alt text, validation will be handled through the normal error path rather than through UI badges invented in the component. The filename-based suggestion was removed as it conflates the file's technical identifier with a description of the image content.

https://claude.ai/code/session_01HELWTst8SghSqBgMnEjZjj