### PR TITLE
Keep route patterns out of the global search

### DIFF
--- a/.changeset/search-skips-folder-rows.md
+++ b/.changeset/search-skips-folder-rows.md
@@ -1,0 +1,24 @@
+---
+"@valbuild/ui": patch
+---
+
+Global search no longer offers route patterns as pages
+
+Searching (⌘K) listed a row for every node in the site map, including the rows
+that are only path segments. `/blogs` is in the site map because
+`/blogs/blog-1` is; it has no content of its own, and the only URL it has is
+the route PATTERN its children share. So the second row of the search in a
+project with an `/app/blogs/[blog]/page.val.ts` was `/blogs/[blog]` — a page
+that does not exist.
+
+Selecting it made that concrete. Such a row has no source path, so
+`findShellSelection` could not resolve it, and the fallback — which exists for
+content hits, whose id IS a source path — took the row's id (the pattern) and
+navigated to it, landing the Studio on `/val/~/blogs/[blog]`.
+
+These rows are now skipped when the search rows are collected, and their
+children are still walked, so the pages under a folder are found as before. The
+Pages panel is unchanged: there a folder row expands, which is what it is for.
+The fallback is now taken only for the two kinds of row whose id is a source
+path, so an unresolvable navigation row does nothing instead of navigating
+somewhere that is not there.

--- a/packages/ui/spa/components/shell/GlobalSearch.tsx
+++ b/packages/ui/spa/components/shell/GlobalSearch.tsx
@@ -65,12 +65,21 @@ export function collectSearchResults(data: ShellData): SearchResult[] {
   const results: SearchResult[] = [];
   const walkPages = (pages: ShellData["pages"]) => {
     for (const page of pages) {
-      results.push({
-        id: page.id,
-        kind: "page",
-        label: page.name,
-        detail: page.urlPath,
-      });
+      // A row without a source path is a path SEGMENT, not a page: `/blogs`
+      // exists in the site map only because `/blogs/blog-1` does. It has no
+      // content to open, and its `urlPath` is the route pattern
+      // (`/blogs/[blog]`) rather than a URL of the site, so offering it as a
+      // hit offers a page that does not exist. In the tree such a row expands;
+      // here there is nothing to expand into, so it is skipped and its
+      // children are walked anyway.
+      if (page.sourcePath !== undefined) {
+        results.push({
+          id: page.id,
+          kind: "page",
+          label: page.name,
+          detail: page.urlPath,
+        });
+      }
       walkPages(page.children ?? []);
     }
   };

--- a/packages/ui/spa/components/shell/Shell.tsx
+++ b/packages/ui/spa/components/shell/Shell.tsx
@@ -784,8 +784,17 @@ export function Shell({
         select(next);
         return;
       }
-      // A content hit is a path inside a module, which no row can stand for.
-      onOpenSearchResult?.(result);
+      // A content or recent hit is a path inside a module, which no row can
+      // stand for, so it is opened by path instead.
+      //
+      // A NAVIGATION row that resolves to nothing is a different thing: its id
+      // is not a source path, so opening it as one navigates to something that
+      // does not exist. `collectSearchResults` no longer offers those rows;
+      // this makes the fallback say what it means rather than treat every
+      // unresolved id as a path.
+      if (result.kind === "content" || result.kind === "recent") {
+        onOpenSearchResult?.(result);
+      }
     },
     [data, select, onOpenSearchResult],
   );

--- a/packages/ui/spa/components/shell/globalSearchRows.test.ts
+++ b/packages/ui/spa/components/shell/globalSearchRows.test.ts
@@ -1,0 +1,68 @@
+import { collectSearchResults } from "./GlobalSearch";
+import { mockShellData } from "./mockShellData";
+import { ShellData } from "./types";
+
+describe("collectSearchResults", () => {
+  test("does not offer a folder row, which is a route pattern and not a page", () => {
+    // `/blog` is in the site map only because `/blog/why-we-built-val` is. It
+    // has no source path, and the only URL it has is the PATTERN its children
+    // share (`/blog/[slug]`) - so a row for it sends you to a page that does
+    // not exist.
+    const rows = collectSearchResults(mockShellData);
+    const pages = rows.filter((row) => row.kind === "page");
+    expect(pages.some((row) => row.detail.includes("["))).toBe(false);
+    expect(pages.some((row) => row.label === "blog")).toBe(false);
+  });
+
+  test("still offers the pages under a folder row", () => {
+    const rows = collectSearchResults(mockShellData);
+    expect(
+      rows.some(
+        (row) => row.kind === "page" && row.detail === "/blog/why-we-built-val",
+      ),
+    ).toBe(true);
+  });
+
+  test("offers a page that has a source path", () => {
+    const rows = collectSearchResults(mockShellData);
+    const pricing = rows.find((row) => row.detail === "/pricing");
+    expect(pricing?.kind).toBe("page");
+  });
+
+  test("keeps the other kinds of row", () => {
+    const rows = collectSearchResults(mockShellData);
+    for (const kind of ["data", "media", "external"] as const) {
+      expect(rows.some((row) => row.kind === kind)).toBe(true);
+    }
+  });
+
+  test("walks children of a folder row that is itself a page", () => {
+    // A segment can be both: `/docs` has its own module AND pages below it.
+    // The row is offered, and the children are still walked.
+    const data: ShellData = {
+      ...mockShellData,
+      pages: [
+        {
+          id: '/app/docs/page.val.ts?p="/docs"',
+          name: "docs",
+          urlPath: "/docs",
+          sourcePath: '/app/docs/page.val.ts?p="/docs"',
+          isTracked: true,
+          children: [
+            {
+              id: '/app/docs/[page]/page.val.ts?p="/docs/cli"',
+              name: "cli",
+              urlPath: "/docs/cli",
+              sourcePath: '/app/docs/[page]/page.val.ts?p="/docs/cli"',
+              isTracked: true,
+            },
+          ],
+        },
+      ],
+    };
+    const details = collectSearchResults(data)
+      .filter((row) => row.kind === "page")
+      .map((row) => row.detail);
+    expect(details).toEqual(["/docs", "/docs/cli"]);
+  });
+});


### PR DESCRIPTION
A site map row that is only a path segment - `/blogs`, which exists because
`/blogs/blog-1` does - has no source path and no URL of its own: `urlPath`
carries the route pattern its children share. The search listed those rows
anyway, so `/blogs/[blog]` appeared as a page, and selecting it fell through
the content-hit path (which assumes the id is a source path) and navigated to
`/val/~/blogs/[blog]`.

Skip them when collecting the rows, walking their children as before, and take
the fallback only for content and recent rows, whose id really is a source
path. The Pages panel already guarded this - a folder row there expands.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Dfdz32qDY7cKt9LySUPSe6